### PR TITLE
feat(payment): PAYPAL-3424 added PayPalCommerceConnectTracker for analytics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@
 ## PayPal team
 
 /packages/core/src/analytics/braintree-connect-tracker
+/packages/core/src/analytics/paypal-commerce-connect-tracker
 /packages/core/src/checkout-buttons/strategies/braintree @bigcommerce/team-paypal
 /packages/core/src/checkout-buttons/strategies/paypal @bigcommerce/team-paypal
 /packages/core/src/customer/strategies/braintree @bigcommerce/team-paypal

--- a/packages/core/src/analytics/index.ts
+++ b/packages/core/src/analytics/index.ts
@@ -5,3 +5,8 @@ export {
     createBraintreeConnectTracker,
     BraintreeConnectTrackerService,
 } from './braintree-connect-tracker';
+
+export {
+    createPayPalCommerceConnectTracker,
+    PayPalCommerceConnectTrackerService,
+} from './paypal-commerce-connect-tracker';

--- a/packages/core/src/analytics/paypal-commerce-connect-tracker/create-paypal-commerce-connect-tracker.spec.ts
+++ b/packages/core/src/analytics/paypal-commerce-connect-tracker/create-paypal-commerce-connect-tracker.spec.ts
@@ -1,0 +1,14 @@
+import { createCheckoutService } from '../../checkout';
+
+import createPayPalCommerceConnectTracker from './create-paypal-commerce-connect-tracker';
+import PayPalCommerceConnectTracker from './paypal-commerce-connect-tracker';
+
+describe('createPayPalCommerceConnectTracker', () => {
+    it('returns instance of PayPalCommerceConnectTracker', () => {
+        const checkoutService = createCheckoutService();
+
+        expect(createPayPalCommerceConnectTracker(checkoutService)).toBeInstanceOf(
+            PayPalCommerceConnectTracker,
+        );
+    });
+});

--- a/packages/core/src/analytics/paypal-commerce-connect-tracker/create-paypal-commerce-connect-tracker.ts
+++ b/packages/core/src/analytics/paypal-commerce-connect-tracker/create-paypal-commerce-connect-tracker.ts
@@ -1,0 +1,27 @@
+import { CheckoutService } from '../../checkout';
+
+import PayPalCommerceConnectTracker from './paypal-commerce-connect-tracker';
+import PayPalCommerceConnectTrackerService from './paypal-commerce-connect-tracker-service';
+
+/**
+ * Creates an instance of `PayPalCommerceConnectTrackerService`.
+ *
+ * @remarks
+ * ```js
+ * const checkoutService = createCheckoutService();
+ * await checkoutService.loadCheckout();
+ * const paypalCommerceConnectTracker = createPayPalCommerceConnectTracker(checkoutService);
+ *
+ * paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+ * paypalCommerceConnectTracker.paymentComplete();
+ * paypalCommerceConnectTracker.selectedPaymentMethod('applepay');
+ * paypalCommerceConnectTracker.walletButtonClick('paypal');
+ * ```
+ *
+ * @returns an instance of `PayPalCommerceConnectTrackerService`.
+ */
+export default function createPayPalCommerceConnectTracker(
+    checkoutService: CheckoutService,
+): PayPalCommerceConnectTrackerService {
+    return new PayPalCommerceConnectTracker(checkoutService);
+}

--- a/packages/core/src/analytics/paypal-commerce-connect-tracker/index.ts
+++ b/packages/core/src/analytics/paypal-commerce-connect-tracker/index.ts
@@ -1,0 +1,2 @@
+export { default as createPayPalCommerceConnectTracker } from './create-paypal-commerce-connect-tracker';
+export { default as PayPalCommerceConnectTrackerService } from './paypal-commerce-connect-tracker-service';

--- a/packages/core/src/analytics/paypal-commerce-connect-tracker/paypal-commerce-connect-tracker-service.ts
+++ b/packages/core/src/analytics/paypal-commerce-connect-tracker/paypal-commerce-connect-tracker-service.ts
@@ -1,0 +1,6 @@
+export default interface PayPalCommerceConnectTrackerService {
+    customerPaymentMethodExecuted(): void;
+    paymentComplete(): void;
+    selectedPaymentMethod(methodId: string): void;
+    walletButtonClick(methodId: string): void;
+}

--- a/packages/core/src/analytics/paypal-commerce-connect-tracker/paypal-commerce-connect-tracker.spec.ts
+++ b/packages/core/src/analytics/paypal-commerce-connect-tracker/paypal-commerce-connect-tracker.spec.ts
@@ -1,0 +1,399 @@
+import {
+    getPayPalCommerceAcceleratedCheckoutPaymentMethod,
+    getPayPalCommercePaymentMethod,
+    getPayPalConnect,
+    PayPalCommerceConnect,
+    PayPalCommerceHostWindow,
+} from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
+
+import { getCart } from '../../cart/carts.mock';
+import { CheckoutService, createCheckoutService } from '../../checkout';
+import { getCheckoutWithCoupons } from '../../checkout/checkouts.mock';
+import { getConfig } from '../../config/configs.mock';
+import { getCustomer } from '../../customer/customers.mock';
+
+import PayPalCommerceConnectTracker from './paypal-commerce-connect-tracker';
+import PayPalCommerceConnectTrackerService from './paypal-commerce-connect-tracker-service';
+
+describe('PayPalCommerceConnectTracker', () => {
+    let paypalCommerceConnectMock: PayPalCommerceConnect;
+    let paypalCommerceConnectWindow: Window & Partial<PayPalCommerceHostWindow>;
+    let paypalCommerceConnectTracker: PayPalCommerceConnectTrackerService;
+    let checkoutService: CheckoutService;
+
+    const getPayPalCommerceAcceleratedCheckout = (isControlGroup: boolean) => ({
+        ...getPayPalCommerceAcceleratedCheckoutPaymentMethod(),
+        id: 'paypalcommerceacceleratedcheckout',
+        initializationData: {
+            isAcceleratedCheckoutEnabled: true,
+            shouldRunAcceleratedCheckout: isControlGroup,
+            isPayPalCommerceAnalyticsV2Enabled: true,
+        },
+    });
+
+    const guestCustomer = {
+        ...getCustomer(),
+        isGuest: true,
+    };
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        paypalCommerceConnectMock = getPayPalConnect();
+        paypalCommerceConnectWindow = window;
+        paypalCommerceConnectWindow.paypalConnect = paypalCommerceConnectMock;
+        paypalCommerceConnectTracker = new PayPalCommerceConnectTracker(checkoutService);
+
+        jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(
+            getCheckoutWithCoupons(),
+        );
+
+        jest.spyOn(checkoutService.getState().data, 'getCustomer').mockReturnValue(getCustomer());
+        jest.spyOn(checkoutService.getState().data, 'getCart').mockReturnValue(getCart());
+
+        jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(
+            getConfig().storeConfig,
+        );
+
+        jest.spyOn(checkoutService.getState().data, 'getPaymentMethods').mockReturnValue([
+            getPayPalCommerceAcceleratedCheckout(true),
+        ]);
+        jest.spyOn(checkoutService.getState().data, 'getPaymentMethod').mockReturnValue(
+            getPayPalCommerceAcceleratedCheckout(false),
+        );
+    });
+
+    describe('customerPaymentMethodExecuted', () => {
+        it('does not trigger anything if paypalConnect is not provided', () => {
+            delete paypalCommerceConnectWindow.paypalConnect;
+
+            paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+
+            expect(paypalCommerceConnectMock.events.emailSubmitted).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger anything if paypal commerce connect analytic feature is disabled', () => {
+            const paymentMethodMock = getPayPalCommerceAcceleratedCheckout(false);
+
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethod').mockReturnValue({
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isPayPalCommerceAnalyticsV2Enabled: false,
+                },
+            });
+
+            paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+
+            expect(paypalCommerceConnectMock.events.emailSubmitted).not.toHaveBeenCalled();
+        });
+
+        it('triggers emailSubmitted callback for store member', () => {
+            paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+
+            expect(paypalCommerceConnectMock.events.emailSubmitted).toHaveBeenCalled();
+        });
+    });
+
+    describe('paymentComplete', () => {
+        it('does not trigger anything if paypalConnect is not provided', () => {
+            delete paypalCommerceConnectWindow.paypalConnect;
+
+            paypalCommerceConnectTracker.paymentComplete();
+
+            expect(paypalCommerceConnectMock.events.orderPlaced).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger anything if paypal commerce connect analytic feature is disabled', () => {
+            const paymentMethodMock = getPayPalCommerceAcceleratedCheckout(false);
+
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethod').mockReturnValue({
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isPayPalCommerceAnalyticsV2Enabled: false,
+                },
+            });
+
+            paypalCommerceConnectTracker.paymentComplete();
+
+            expect(paypalCommerceConnectMock.events.orderPlaced).not.toHaveBeenCalled();
+        });
+
+        it('triggers orderPlaced', () => {
+            paypalCommerceConnectTracker.paymentComplete();
+
+            expect(paypalCommerceConnectMock.events.orderPlaced).toHaveBeenCalled();
+        });
+    });
+
+    describe('selectedPaymentMethod', () => {
+        it('does not trigger anything if paypalConnect is not provided', () => {
+            delete paypalCommerceConnectWindow.paypalConnect;
+
+            paypalCommerceConnectTracker.selectedPaymentMethod('applepay');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger anything if method id is not properly provided', () => {
+            paypalCommerceConnectTracker.selectedPaymentMethod('');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger anything if paypal commerce connect analytic feature is disabled', () => {
+            const paymentMethodMock = getPayPalCommerceAcceleratedCheckout(false);
+
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethod').mockReturnValue({
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isPayPalCommerceAnalyticsV2Enabled: false,
+                },
+            });
+
+            paypalCommerceConnectTracker.selectedPaymentMethod('applepay');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).not.toHaveBeenCalled();
+        });
+
+        it('triggers apm selected event', () => {
+            paypalCommerceConnectTracker.selectedPaymentMethod('applepay');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).toHaveBeenCalled();
+        });
+    });
+
+    describe('walletButtonClick', () => {
+        it('does not trigger anything if paypalConnect is not provided', () => {
+            delete paypalCommerceConnectWindow.paypalConnect;
+
+            paypalCommerceConnectTracker.walletButtonClick('applepay');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger anything if method id is not properly provided', () => {
+            paypalCommerceConnectTracker.walletButtonClick('');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger anything if paypal commerce connect analytic feature is disabled', () => {
+            const paymentMethodMock = getPayPalCommerceAcceleratedCheckout(false);
+
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethod').mockReturnValue({
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isPayPalCommerceAnalyticsV2Enabled: false,
+                },
+            });
+
+            paypalCommerceConnectTracker.walletButtonClick('applepay');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).not.toHaveBeenCalled();
+        });
+
+        it('triggers apm selected event', () => {
+            paypalCommerceConnectTracker.walletButtonClick('applepay');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).toHaveBeenCalled();
+        });
+    });
+
+    describe('#emailSubmitted callback', () => {
+        const emailSubmitEventOptions = {
+            apm_list: 'paypalcommerceacceleratedcheckout',
+            apm_shown: '0',
+            context_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+            context_type: 'cs_id',
+            experiment: '[{"treatment_group":"control"}]',
+            merchant_name: 's1504098821',
+            page_name: '',
+            page_type: 'checkout_page',
+            partner_name: 'bigc',
+            store_id: '1504098821',
+            user_email_saved: false,
+            user_type: 'store_member',
+        };
+
+        it('calls emailSubmitted callback for store member', () => {
+            paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+
+            expect(paypalCommerceConnectMock.events.emailSubmitted).toHaveBeenCalledWith(
+                emailSubmitEventOptions,
+            );
+        });
+
+        it('calls emailSubmitted callback for guest user', () => {
+            jest.spyOn(checkoutService.getState().data, 'getCustomer').mockReturnValue(
+                guestCustomer,
+            );
+
+            paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+
+            expect(paypalCommerceConnectMock.events.emailSubmitted).toHaveBeenCalledWith({
+                ...emailSubmitEventOptions,
+                user_type: 'store_guest', // <-- this option changes based on "guest"/"store member" user
+            });
+        });
+
+        it('calls emailSubmitted callback for users from control group', () => {
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethods').mockReturnValue([
+                getPayPalCommerceAcceleratedCheckout(false),
+            ]);
+
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethod').mockReturnValue(
+                getPayPalCommerceAcceleratedCheckout(false),
+            );
+
+            paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+
+            expect(paypalCommerceConnectMock.events.emailSubmitted).toHaveBeenCalledWith({
+                ...emailSubmitEventOptions,
+                experiment: '[{"treatment_group":"control"}]', // <- user in test group means that BT AXO feature is not available due to A/B testing flow
+            });
+        });
+
+        it('calls emailSubmitted callback for users from test group', () => {
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethods').mockReturnValue([
+                getPayPalCommerceAcceleratedCheckout(true),
+            ]);
+
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethod').mockReturnValue(
+                getPayPalCommerceAcceleratedCheckout(true),
+            );
+
+            paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+
+            expect(paypalCommerceConnectMock.events.emailSubmitted).toHaveBeenCalledWith({
+                ...emailSubmitEventOptions,
+                experiment: '[{"treatment_group":"test"}]',
+            });
+        });
+
+        it('calls emailSubmitted callback and place user in a control group if there was an error loading paypalcommerceacceleratedcheckout payment method', () => {
+            jest.spyOn(
+                checkoutService.getState().errors,
+                'getLoadPaymentMethodError',
+            ).mockReturnValue(Error('asd'));
+
+            paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+
+            expect(paypalCommerceConnectMock.events.emailSubmitted).toHaveBeenCalledWith({
+                ...emailSubmitEventOptions,
+                experiment: '[{"treatment_group":"control"}]',
+            });
+        });
+
+        it('calls emailSubmitted callback with apm options', () => {
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethods').mockReturnValue([
+                getPayPalCommercePaymentMethod(),
+                getPayPalCommerceAcceleratedCheckout(false),
+            ]);
+
+            jest.spyOn(checkoutService.getState().data, 'getPaymentMethod').mockReturnValue(
+                getPayPalCommerceAcceleratedCheckout(false),
+            );
+
+            paypalCommerceConnectTracker.customerPaymentMethodExecuted();
+
+            expect(paypalCommerceConnectMock.events.emailSubmitted).toHaveBeenCalledWith({
+                ...emailSubmitEventOptions,
+                apm_list: 'paypalcommerce,paypalcommerceacceleratedcheckout',
+                apm_shown: '1',
+            });
+        });
+    });
+
+    describe('#paymentComplete callback', () => {
+        const paymentCompleteEventOptions = {
+            context_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+            context_type: 'cs_id',
+            currency_code: 'USD', // <- related to paymentComplete callback
+            experiment: '[{"treatment_group":"control"}]',
+            merchant_name: 's1504098821',
+            page_name: '',
+            page_type: 'checkout_page',
+            partner_name: 'bigc',
+            selected_payment_method: 'applepay', // <- related to paymentComplete callback
+            store_id: '1504098821',
+            user_type: 'store_member',
+        };
+
+        it('triggers paymentComplete with provided selected method', () => {
+            paypalCommerceConnectTracker.selectedPaymentMethod('applepay');
+            paypalCommerceConnectTracker.paymentComplete();
+
+            expect(paypalCommerceConnectMock.events.orderPlaced).toHaveBeenCalledWith(
+                paymentCompleteEventOptions,
+            );
+        });
+
+        it('triggers paymentComplete with provided with different payment method selected method', () => {
+            paypalCommerceConnectTracker.selectedPaymentMethod('paypalcommerceacceleratedcheckout');
+            paypalCommerceConnectTracker.paymentComplete();
+
+            expect(paypalCommerceConnectMock.events.orderPlaced).toHaveBeenCalledWith({
+                ...paymentCompleteEventOptions,
+                selected_payment_method: 'paypalcommerceacceleratedcheckout',
+            });
+        });
+
+        it('triggers paymentComplete with provided with EUR currency code', () => {
+            jest.spyOn(checkoutService.getState().data, 'getCart').mockReturnValue({
+                ...getCart(),
+                currency: {
+                    name: 'Euro',
+                    code: 'EUR',
+                    symbol: '€',
+                    decimalPlaces: 2,
+                },
+            });
+
+            paypalCommerceConnectTracker.selectedPaymentMethod('applepay');
+            paypalCommerceConnectTracker.paymentComplete();
+
+            expect(paypalCommerceConnectMock.events.orderPlaced).toHaveBeenCalledWith({
+                ...paymentCompleteEventOptions,
+                currency_code: 'EUR',
+            });
+        });
+    });
+
+    describe('#apmSelected callback', () => {
+        const apmSelectedEventOptions = {
+            apm_list: 'paypalcommerceacceleratedcheckout',
+            apm_location: 'payment section',
+            apm_selected: 'applepay',
+            apm_shown: '0',
+            context_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+            context_type: 'cs_id',
+            experiment: '[{"treatment_group":"control"}]',
+            merchant_name: 's1504098821',
+            page_name: '',
+            page_type: 'checkout_page',
+            partner_name: 'bigc',
+            store_id: '1504098821',
+            user_type: 'store_member',
+        };
+
+        it('triggers apm selected event from payments list', () => {
+            paypalCommerceConnectTracker.selectedPaymentMethod('applepay');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).toHaveBeenCalledWith(
+                apmSelectedEventOptions,
+            );
+        });
+
+        it('triggers apm selected event as a wallet button', () => {
+            paypalCommerceConnectTracker.walletButtonClick('applepay');
+
+            expect(paypalCommerceConnectMock.events.apmSelected).toHaveBeenCalledWith({
+                ...apmSelectedEventOptions,
+                apm_location: 'pre-email section',
+            });
+        });
+    });
+});

--- a/packages/core/src/analytics/paypal-commerce-connect-tracker/paypal-commerce-connect-tracker.ts
+++ b/packages/core/src/analytics/paypal-commerce-connect-tracker/paypal-commerce-connect-tracker.ts
@@ -15,7 +15,7 @@ import PayPalCommerceConnectTrackerService from './paypal-commerce-connect-track
 export default class PayPalCommerceConnectTracker implements PayPalCommerceConnectTrackerService {
     private _selectedPaymentMethodId = 'paypalcommerceacceleratedcheckout';
 
-    constructor(private checkoutService: CheckoutService) {}
+    constructor(private _checkoutService: CheckoutService) {}
 
     customerPaymentMethodExecuted() {
         if (this._shouldTrackEvent()) {
@@ -46,7 +46,7 @@ export default class PayPalCommerceConnectTracker implements PayPalCommerceConne
     }
 
     private _shouldTrackEvent() {
-        const state = this.checkoutService.getState();
+        const state = this._checkoutService.getState();
         const paymentMethod = state.data.getPaymentMethod('paypalcommerce');
         const isAnalyticEnabled =
             paymentMethod?.initializationData.isPayPalCommerceAnalyticsV2Enabled;
@@ -98,7 +98,7 @@ export default class PayPalCommerceConnectTracker implements PayPalCommerceConne
      *
      */
     private _getEventCommonOptions(): PayPalCommerceConnectEventCommonOptions {
-        const state = this.checkoutService.getState();
+        const state = this._checkoutService.getState();
         const cart = state.data.getCart();
         const storeProfile = state.data.getConfig()?.storeProfile;
         const isGuestCustomer = state.data.getCustomer()?.isGuest;
@@ -129,7 +129,7 @@ export default class PayPalCommerceConnectTracker implements PayPalCommerceConne
     }
 
     private _getEmailSubmittedEventOptions(): PayPalCommerceConnectEmailEnteredEventOptions {
-        const state = this.checkoutService.getState().data;
+        const state = this._checkoutService.getState().data;
         const paymentMethods = state.getPaymentMethods() || [];
         const apmList = paymentMethods.map(({ id }) => id);
 
@@ -145,7 +145,7 @@ export default class PayPalCommerceConnectTracker implements PayPalCommerceConne
         methodId: string,
         isWalletButton: boolean,
     ): PayPalCommerceConnectApmSelectedEventOptions {
-        const state = this.checkoutService.getState().data;
+        const state = this._checkoutService.getState().data;
         const paymentMethods = state.getPaymentMethods() || [];
         const apmList = paymentMethods.map(({ id }) => id);
 
@@ -161,7 +161,7 @@ export default class PayPalCommerceConnectTracker implements PayPalCommerceConne
     private _getOrderPlacedEventOptions(
         methodId: string,
     ): PayPalCommerceConnectOrderPlacedEventOptions {
-        const state = this.checkoutService.getState().data;
+        const state = this._checkoutService.getState().data;
         const cart = state.getCart();
 
         return {

--- a/packages/core/src/analytics/paypal-commerce-connect-tracker/paypal-commerce-connect-tracker.ts
+++ b/packages/core/src/analytics/paypal-commerce-connect-tracker/paypal-commerce-connect-tracker.ts
@@ -1,0 +1,173 @@
+import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    isPayPalCommerceConnectWindow,
+    PayPalCommerceConnectApmSelectedEventOptions,
+    PayPalCommerceConnectEmailEnteredEventOptions,
+    PayPalCommerceConnectEventCommonOptions,
+    PayPalCommerceConnectEvents,
+    PayPalCommerceConnectOrderPlacedEventOptions,
+} from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
+
+import { CheckoutService } from '../../checkout';
+
+import PayPalCommerceConnectTrackerService from './paypal-commerce-connect-tracker-service';
+
+export default class PayPalCommerceConnectTracker implements PayPalCommerceConnectTrackerService {
+    private _selectedPaymentMethodId = 'paypalcommerceacceleratedcheckout';
+
+    constructor(private checkoutService: CheckoutService) {}
+
+    customerPaymentMethodExecuted() {
+        if (this._shouldTrackEvent()) {
+            this._trackEmailSubmitted();
+        }
+    }
+
+    paymentComplete() {
+        if (this._shouldTrackEvent()) {
+            this._trackOrderPlaced(this._selectedPaymentMethodId);
+        }
+    }
+
+    selectedPaymentMethod(methodId: string): void {
+        if (this._shouldTrackEvent() && methodId) {
+            this._selectedPaymentMethodId = methodId;
+
+            this._trackApmSelected(methodId, false);
+        }
+    }
+
+    walletButtonClick(methodId: string) {
+        if (this._shouldTrackEvent() && methodId) {
+            this._selectedPaymentMethodId = methodId;
+
+            this._trackApmSelected(methodId, true);
+        }
+    }
+
+    private _shouldTrackEvent() {
+        const state = this.checkoutService.getState();
+        const paymentMethod = state.data.getPaymentMethod('paypalcommerce');
+        const isAnalyticEnabled =
+            paymentMethod?.initializationData.isPayPalCommerceAnalyticsV2Enabled;
+
+        return (
+            isPayPalCommerceConnectWindow(window) &&
+            window.paypalConnect?.events &&
+            isAnalyticEnabled
+        );
+    }
+
+    private _getPayPalCommerceConnectEventsOrThrow(): PayPalCommerceConnectEvents {
+        if (isPayPalCommerceConnectWindow(window) && window.paypalConnect) {
+            return window.paypalConnect.events;
+        }
+
+        throw new PaymentMethodClientUnavailableError();
+    }
+
+    /**
+     *
+     * PayPal Commerce Connect Event track methods
+     *
+     */
+    private _trackEmailSubmitted(): void {
+        const { emailSubmitted } = this._getPayPalCommerceConnectEventsOrThrow();
+        const eventOptions = this._getEmailSubmittedEventOptions();
+
+        emailSubmitted(eventOptions);
+    }
+
+    private _trackApmSelected(methodId: string, isWalletButton: boolean): void {
+        const { apmSelected } = this._getPayPalCommerceConnectEventsOrThrow();
+        const eventOptions = this._getApmSelectedEventOptions(methodId, isWalletButton);
+
+        apmSelected(eventOptions);
+    }
+
+    private _trackOrderPlaced(methodId: string): void {
+        const { orderPlaced } = this._getPayPalCommerceConnectEventsOrThrow();
+        const eventOptions = this._getOrderPlacedEventOptions(methodId);
+
+        orderPlaced(eventOptions);
+    }
+
+    /**
+     *
+     * Event options methods
+     *
+     */
+    private _getEventCommonOptions(): PayPalCommerceConnectEventCommonOptions {
+        const state = this.checkoutService.getState();
+        const cart = state.data.getCart();
+        const storeProfile = state.data.getConfig()?.storeProfile;
+        const isGuestCustomer = state.data.getCustomer()?.isGuest;
+        const methodId = 'paypalcommerceacceleratedcheckout';
+
+        const paymentMethod = state.data.getPaymentMethod(methodId);
+        const isTestTreatmentGroup =
+            !state.errors.getLoadPaymentMethodError(methodId) &&
+            paymentMethod?.initializationData.shouldRunAcceleratedCheckout;
+
+        const experiments = [
+            {
+                treatment_group: isTestTreatmentGroup ? 'test' : 'control',
+            },
+        ];
+
+        return {
+            context_type: 'cs_id',
+            context_id: cart?.id || '',
+            page_type: 'checkout_page',
+            page_name: window.document.title,
+            partner_name: 'bigc',
+            user_type: isGuestCustomer ? 'store_guest' : 'store_member',
+            store_id: storeProfile?.storeId || '',
+            merchant_name: storeProfile?.storeName || '',
+            experiment: JSON.stringify(experiments),
+        };
+    }
+
+    private _getEmailSubmittedEventOptions(): PayPalCommerceConnectEmailEnteredEventOptions {
+        const state = this.checkoutService.getState().data;
+        const paymentMethods = state.getPaymentMethods() || [];
+        const apmList = paymentMethods.map(({ id }) => id);
+
+        return {
+            ...this._getEventCommonOptions(),
+            user_email_saved: false,
+            apm_shown: apmList.length > 1 ? '1' : '0',
+            apm_list: apmList.join(','),
+        };
+    }
+
+    private _getApmSelectedEventOptions(
+        methodId: string,
+        isWalletButton: boolean,
+    ): PayPalCommerceConnectApmSelectedEventOptions {
+        const state = this.checkoutService.getState().data;
+        const paymentMethods = state.getPaymentMethods() || [];
+        const apmList = paymentMethods.map(({ id }) => id);
+
+        return {
+            ...this._getEventCommonOptions(),
+            apm_shown: apmList.length > 1 ? '1' : '0',
+            apm_list: apmList.join(','),
+            apm_selected: methodId,
+            apm_location: isWalletButton ? 'pre-email section' : 'payment section',
+        };
+    }
+
+    private _getOrderPlacedEventOptions(
+        methodId: string,
+    ): PayPalCommerceConnectOrderPlacedEventOptions {
+        const state = this.checkoutService.getState().data;
+        const cart = state.getCart();
+
+        return {
+            ...this._getEventCommonOptions(),
+            selected_payment_method: methodId,
+            currency_code: cart?.currency.code || '',
+        };
+    }
+}

--- a/packages/core/src/bundles/checkout-sdk.ts
+++ b/packages/core/src/bundles/checkout-sdk.ts
@@ -6,6 +6,10 @@ export { embedCheckout } from '../embedded-checkout';
 export { createEmbeddedCheckoutMessenger } from '../embedded-checkout/iframe-content';
 export { createLanguageService } from '../locale';
 export { createCurrencyService } from '../currency';
-export { createStepTracker, createBraintreeConnectTracker } from '../analytics';
+export {
+    createStepTracker,
+    createBraintreeConnectTracker,
+    createPayPalCommerceConnectTracker,
+} from '../analytics';
 export { createBodlService } from '../bodl';
 export { ExtensionCommandType } from '../extension';

--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.ts
@@ -97,7 +97,6 @@ export default class PayPalCommerceAcceleratedCheckoutCustomerStrategy implement
             if (
                 checkoutPaymentMethodExecuted &&
                 typeof checkoutPaymentMethodExecuted === 'function'
-                // && window.paypal.connect.events // TODO: uncomment when paypal events will be available in pp sdk
             ) {
                 checkoutPaymentMethodExecuted();
             }

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-axo-sdk.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-axo-sdk.mock.ts
@@ -1,29 +1,9 @@
-import {
-    PayPalAxoSdk,
-    PayPalCommerceConnect,
-    PayPalCommerceConnectCardComponentMethods,
-} from '../paypal-commerce-types';
+import { PayPalAxoSdk } from '../paypal-commerce-types';
+
+import getPayPalConnect from './get-paypal-connect.mock';
 
 export default function getPayPalAxoSdk(): PayPalAxoSdk {
-    const paypalConnectCardComponentMethods: PayPalCommerceConnectCardComponentMethods = {
-        tokenize: jest.fn(() => ({
-            nonce: 'paypal_connect_tokenize_nonce',
-        })),
-        render: jest.fn(),
-    };
-
-    const paypalConnectResponse: PayPalCommerceConnect = {
-        identity: {
-            lookupCustomerByEmail: jest.fn(),
-            triggerAuthenticationFlow: jest.fn(),
-        },
-        profile: {
-            showCardSelector: jest.fn(),
-        },
-        ConnectCardComponent: jest.fn(() => paypalConnectCardComponentMethods),
-    };
-
     return {
-        Connect: () => Promise.resolve(paypalConnectResponse),
+        Connect: () => Promise.resolve(getPayPalConnect()),
     };
 }

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-commerce-payment-method.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-commerce-payment-method.mock.ts
@@ -45,6 +45,7 @@ export default function getPayPalCommercePaymentMethod(): PaymentMethod {
             attributionId: '1123JLKJASD12',
             intent: PayPalCommerceIntent.CAPTURE,
             isAcceleratedCheckoutEnabled: false,
+            isPayPalCommerceAnalyticsV2Enabled: false,
             isPayPalCreditAvailable: false,
             isVenmoEnabled: false,
             shouldRenderFields: true,
@@ -65,6 +66,7 @@ export function getPayPalCommerceAcceleratedCheckoutPaymentMethod(): PaymentMeth
             ...paypalCommerceDefaultPaymentMethod.initializationData,
             isAcceleratedCheckoutEnabled: true,
             shouldRunAcceleratedCheckout: true,
+            isPayPalCommerceAnalyticsV2Enabled: true,
         },
     };
 }

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-connect.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-connect.mock.ts
@@ -1,0 +1,29 @@
+import {
+    PayPalCommerceConnect,
+    PayPalCommerceConnectCardComponentMethods,
+} from '../paypal-commerce-types';
+
+export default function getPayPalConnect(): PayPalCommerceConnect {
+    const paypalConnectCardComponentMethods: PayPalCommerceConnectCardComponentMethods = {
+        tokenize: jest.fn(() => ({
+            nonce: 'paypal_connect_tokenize_nonce',
+        })),
+        render: jest.fn(),
+    };
+
+    return {
+        identity: {
+            lookupCustomerByEmail: jest.fn(),
+            triggerAuthenticationFlow: jest.fn(),
+        },
+        events: {
+            apmSelected: jest.fn(),
+            emailSubmitted: jest.fn(),
+            orderPlaced: jest.fn(),
+        },
+        profile: {
+            showCardSelector: jest.fn(),
+        },
+        ConnectCardComponent: jest.fn(() => paypalConnectCardComponentMethods),
+    };
+}

--- a/packages/paypal-commerce-utils/src/mocks/index.ts
+++ b/packages/paypal-commerce-utils/src/mocks/index.ts
@@ -3,4 +3,5 @@ export {
     getPayPalCommerceAcceleratedCheckoutPaymentMethod,
 } from './get-paypal-commerce-payment-method.mock';
 export { default as getPayPalAxoSdk } from './get-paypal-axo-sdk.mock';
+export { default as getPayPalConnect } from './get-paypal-connect.mock';
 export { default as getPayPalConnectAuthenticationResultMock } from './get-paypal-connect-authentication-result.mock';

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -22,15 +22,16 @@ export interface PayPalCommerceInitializationData {
     enabledAlternativePaymentMethods: FundingType;
     isDeveloperModeApplicable?: boolean;
     intent?: PayPalCommerceIntent;
-    isAcceleratedCheckoutEnabled?: boolean;
+    isAcceleratedCheckoutEnabled?: boolean; // PayPal Connect related
     isHostedCheckoutEnabled?: boolean;
+    isPayPalCommerceAnalyticsV2Enabled?: boolean; // PayPal Connect related
     isPayPalCreditAvailable?: boolean;
     isVenmoEnabled?: boolean;
     isGooglePayEnabled?: boolean;
     merchantId?: string;
     orderId?: string;
     shouldRenderFields?: boolean;
-    shouldRunAcceleratedCheckout?: boolean;
+    shouldRunAcceleratedCheckout?: boolean; // PayPal Connect related
     // paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>; // TODO: PayPalButtonStyleOptions interface will be moved in the future
 }
 
@@ -118,6 +119,7 @@ export interface MessagingOptions {
  */
 export interface PayPalCommerceConnect {
     identity: PayPalCommerceConnectIdentity;
+    events: PayPalCommerceConnectEvents;
     profile: PayPalCommerceConnectProfile;
     ConnectCardComponent(
         options: PayPalCommerceConnectCardComponentOptions,
@@ -286,4 +288,43 @@ export interface PayPalCommerceConnectTokenizeDetails {
 export interface PayPalCommerceConnectTokenizeOptions {
     billingAddress?: PayPalCommerceConnectAddress;
     shippingAddress?: PayPalCommerceConnectAddress;
+}
+
+export interface PayPalCommerceConnectEvents {
+    apmSelected: (options: PayPalCommerceConnectApmSelectedEventOptions) => void;
+    emailSubmitted: (options: PayPalCommerceConnectEmailEnteredEventOptions) => void;
+    orderPlaced: (options: PayPalCommerceConnectOrderPlacedEventOptions) => void;
+}
+
+export interface PayPalCommerceConnectEventCommonOptions {
+    context_type: 'cs_id';
+    context_id: string; // checkout session id
+    page_type: 'checkout_page';
+    page_name: string; // title of the checkout initiation page
+    partner_name: 'bigc';
+    user_type: 'store_member' | 'store_guest'; // type of the user on the merchant site
+    store_id: string;
+    merchant_name: string;
+    experiment: string; // stringify JSON object "[{ treatment_group: 'test' | 'control' }]"
+}
+
+export interface PayPalCommerceConnectApmSelectedEventOptions
+    extends PayPalCommerceConnectEventCommonOptions {
+    apm_shown: '0' | '1'; // alternate payment shown on the checkout page
+    apm_list: string; // list of alternate payment shown on checkout page
+    apm_selected: string; // alternate payment method selected / methodId
+    apm_location: 'pre-email section' | 'payment section'; // placement of APM, whether it be above the email entry or in the radio buttons
+}
+
+export interface PayPalCommerceConnectEmailEnteredEventOptions
+    extends PayPalCommerceConnectEventCommonOptions {
+    user_email_saved: boolean; // shows whether checkout was loaded with or without a saved email
+    apm_shown: '0' | '1'; // alternate payment shown on the checkout page
+    apm_list: string; // list of alternate payment shown on checkout page 'applepay,googlepay,paypal'
+}
+
+export interface PayPalCommerceConnectOrderPlacedEventOptions
+    extends PayPalCommerceConnectEventCommonOptions {
+    selected_payment_method: string;
+    currency_code: string;
 }

--- a/packages/paypal-commerce-utils/src/utils/index.ts
+++ b/packages/paypal-commerce-utils/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { default as isPayPalCommerceAcceleratedCheckoutCustomer } from './is-paypal-commerce-accelerated-checkout-customer';
+export { default as isPayPalCommerceConnectWindow } from './is-paypal-commerce-connect-window';

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-connect-window.spec.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-connect-window.spec.ts
@@ -1,0 +1,15 @@
+import { PayPalCommerceHostWindow } from '../paypal-commerce-types';
+
+import isPayPalCommerceConnectWindow from './is-paypal-commerce-connect-window';
+
+describe('isPayPalCommerceConnectWindow', () => {
+    it('window has paypalConnect option', () => {
+        expect(
+            isPayPalCommerceConnectWindow({ paypalConnect: {} } as PayPalCommerceHostWindow),
+        ).toBe(true);
+    });
+
+    it('window does not have paypalConnect option', () => {
+        expect(isPayPalCommerceConnectWindow({} as Window)).toBe(false);
+    });
+});

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-connect-window.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-connect-window.ts
@@ -3,5 +3,5 @@ import { PayPalCommerceHostWindow } from '../paypal-commerce-types';
 export default function isPayPalCommerceConnectWindow(
     window: Window,
 ): window is PayPalCommerceHostWindow {
-    return Boolean(window.hasOwnProperty('paypalConnect'));
+    return window.hasOwnProperty('paypalConnect');
 }

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-connect-window.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-connect-window.ts
@@ -1,0 +1,7 @@
+import { PayPalCommerceHostWindow } from '../paypal-commerce-types';
+
+export default function isPayPalCommerceConnectWindow(
+    window: Window,
+): window is PayPalCommerceHostWindow {
+    return Boolean(window.hasOwnProperty('paypalConnect'));
+}


### PR DESCRIPTION
## What?
Added PayPalCommerceConnectTracker for analytics

## Why?
To be able to track different paypal commerce related events on UI side

## Testing / Proof
Manual tests
Unit tests
CI

Payment method selected event (on a paywall):
<img width="503" alt="Screenshot 2024-01-19 at 11 09 10" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/332c19fd-0e1c-4dbd-a2a6-478e6ee3a096">

Wallet button selected event:
<img width="519" alt="Screenshot 2024-01-19 at 11 09 59" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/fe2a6574-2517-4f1f-870c-c18b67801533">

Email submitted event:
<img width="526" alt="Screenshot 2024-01-19 at 11 11 00" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/08ec14c6-a3a7-403e-9655-65c162ddc0af">

Order placed event:
<img width="503" alt="Screenshot 2024-01-19 at 11 12 12" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/cd64a051-74fe-49bb-8c81-e92bef3ac211">

