### PR TITLE
feat(payment): PAYPAL-3493 updated PPCP AXO credit card component form background transparent

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.spec.ts
@@ -226,7 +226,11 @@ describe('PayPalCommerceAcceleratedCheckoutCustomerStrategy', () => {
 
             expect(
                 paypalCommerceAcceleratedCheckoutUtils.initializePayPalConnect,
-            ).toHaveBeenCalledWith(paypalAxoSdk, false);
+            ).toHaveBeenCalledWith(
+                paypalAxoSdk,
+                false,
+                initializationOptions.paypalcommerceacceleratedcheckout.styles,
+            );
         });
 
         it('loads paypal sdk and initialises paypal connect in test mode', async () => {
@@ -246,7 +250,11 @@ describe('PayPalCommerceAcceleratedCheckoutCustomerStrategy', () => {
 
             expect(
                 paypalCommerceAcceleratedCheckoutUtils.initializePayPalConnect,
-            ).toHaveBeenCalledWith(paypalAxoSdk, true);
+            ).toHaveBeenCalledWith(
+                paypalAxoSdk,
+                true,
+                initializationOptions.paypalcommerceacceleratedcheckout.styles,
+            );
         });
     });
 
@@ -360,7 +368,7 @@ describe('PayPalCommerceAcceleratedCheckoutCustomerStrategy', () => {
 
             expect(
                 paypalCommerceAcceleratedCheckoutUtils.triggerAuthenticationFlowOrThrow,
-            ).toHaveBeenCalledWith(customerContextIdMock, undefined);
+            ).toHaveBeenCalledWith(customerContextIdMock);
             expect(
                 paypalCommerceAcceleratedCheckoutUtils.mapPayPalConnectProfileToBcCustomerData,
             ).toHaveBeenCalledWith(methodId, authenticationResultMock);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.ts
@@ -11,7 +11,6 @@ import {
     PayPalCommerceAcceleratedCheckoutUtils,
     PayPalCommerceConnectAuthenticationResult,
     PayPalCommerceConnectAuthenticationState,
-    PayPalCommerceConnectStylesOption,
     PayPalCommerceInitializationData,
     PayPalCommerceSdk,
 } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
@@ -19,8 +18,6 @@ import {
 import { WithPayPalCommerceAcceleratedCheckoutCustomerInitializeOptions } from './paypal-commerce-accelerated-checkout-customer-initialize-options';
 
 export default class PayPalCommerceAcceleratedCheckoutCustomerStrategy implements CustomerStrategy {
-    private paypalConnectStyles?: PayPalCommerceConnectStylesOption;
-
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
         private paypalCommerceSdk: PayPalCommerceSdk,
@@ -47,14 +44,13 @@ export default class PayPalCommerceAcceleratedCheckoutCustomerStrategy implement
             const paymentMethod =
                 state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
 
-            this.paypalConnectStyles = paypalcommerceacceleratedcheckout?.styles;
-
             const paypalAxoSdk = await this.paypalCommerceSdk.getPayPalAxo(paymentMethod, currency);
             const isTestModeEnabled = !!paymentMethod.initializationData?.isDeveloperModeApplicable;
 
             await this.paypalCommerceAcceleratedCheckoutUtils.initializePayPalConnect(
                 paypalAxoSdk,
                 isTestModeEnabled,
+                paypalcommerceacceleratedcheckout?.styles,
             );
         }
 
@@ -153,7 +149,6 @@ export default class PayPalCommerceAcceleratedCheckoutCustomerStrategy implement
             const authenticationResult =
                 await this.paypalCommerceAcceleratedCheckoutUtils.triggerAuthenticationFlowOrThrow(
                     customerContextId,
-                    this.paypalConnectStyles,
                 );
 
             const isAuthenticationFlowCanceled =

--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.spec.ts
@@ -197,7 +197,7 @@ describe('PayPalCommerceAcceleratedCheckoutPaymentStrategy', () => {
 
             expect(
                 paypalCommerceAcceleratedCheckoutUtils.initializePayPalConnect,
-            ).toHaveBeenCalledWith(paypalAxoSdk, false);
+            ).toHaveBeenCalledWith(paypalAxoSdk, false, undefined);
         });
 
         it('initializes paypal connect in test mode', async () => {
@@ -212,7 +212,7 @@ describe('PayPalCommerceAcceleratedCheckoutPaymentStrategy', () => {
 
             expect(
                 paypalCommerceAcceleratedCheckoutUtils.initializePayPalConnect,
-            ).toHaveBeenCalledWith(paypalAxoSdk, true);
+            ).toHaveBeenCalledWith(paypalAxoSdk, true, undefined);
         });
 
         it('does not trigger lookup method if the customer already authenticated with PayPal Connect', async () => {
@@ -253,7 +253,7 @@ describe('PayPalCommerceAcceleratedCheckoutPaymentStrategy', () => {
             ).toHaveBeenCalledWith(customer.email);
             expect(
                 paypalCommerceAcceleratedCheckoutUtils.triggerAuthenticationFlowOrThrow,
-            ).toHaveBeenCalledWith(customerContextId, undefined);
+            ).toHaveBeenCalledWith(customerContextId);
             expect(
                 paypalCommerceAcceleratedCheckoutUtils.mapPayPalConnectProfileToBcCustomerData,
             ).toHaveBeenCalledWith(methodId, authenticationResultMock);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.ts
@@ -21,7 +21,6 @@ import {
     PayPalCommerceConnectAuthenticationState,
     PayPalCommerceConnectCardComponentMethods,
     PayPalCommerceConnectCardComponentOptions,
-    PayPalCommerceConnectStylesOption,
     PayPalCommerceInitializationData,
     PayPalCommerceSdk,
 } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
@@ -31,7 +30,6 @@ import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
 import { WithPayPalCommerceAcceleratedCheckoutPaymentInitializeOptions } from './paypal-commerce-accelerated-checkout-payment-initialize-options';
 
 export default class PayPalCommerceAcceleratedCheckoutPaymentStrategy implements PaymentStrategy {
-    private paypalConnectStyles?: PayPalCommerceConnectStylesOption;
     private paypalConnectCardComponentMethods?: PayPalCommerceConnectCardComponentMethods;
 
     constructor(
@@ -89,13 +87,12 @@ export default class PayPalCommerceAcceleratedCheckoutPaymentStrategy implements
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
 
-        this.paypalConnectStyles = paypalcommerceacceleratedcheckout.styles;
-
         const paypalAxoSdk = await this.paypalCommerceSdk.getPayPalAxo(paymentMethod, currencyCode);
 
         await this.paypalCommerceAcceleratedCheckoutUtils.initializePayPalConnect(
             paypalAxoSdk,
             !!paymentMethod.initializationData?.isDeveloperModeApplicable,
+            paypalcommerceacceleratedcheckout.styles,
         );
 
         if (this.shouldRunAuthenticationFlow()) {
@@ -197,7 +194,6 @@ export default class PayPalCommerceAcceleratedCheckoutPaymentStrategy implements
             const authenticationResult =
                 await this.paypalCommerceAcceleratedCheckoutUtils.triggerAuthenticationFlowOrThrow(
                     customerContextId,
-                    this.paypalConnectStyles,
                 );
 
             const { authenticationState, addresses, instruments } =

--- a/packages/paypal-commerce-utils/src/paypal-commerce-accelerated-checkout-utils.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-accelerated-checkout-utils.spec.ts
@@ -90,23 +90,14 @@ describe('PayPalCommerceAcceleratedCheckoutUtils', () => {
 
     describe('#triggerAuthenticationFlowOrThrow', () => {
         const customerContextIdMock = 'ryanRecognised123';
-        const paypalConnectStylesMock = {
-            root: {
-                backgroundColorPrimary: 'white',
-            },
-        };
 
         it('successfully triggers authentication flow with provided customer id and styles', async () => {
             const paypalConnectMock = await subject.initializePayPalConnect(paypalAxoSdk, false);
 
-            await subject.triggerAuthenticationFlowOrThrow(
-                customerContextIdMock,
-                paypalConnectStylesMock,
-            );
+            await subject.triggerAuthenticationFlowOrThrow(customerContextIdMock);
 
             expect(paypalConnectMock.identity.triggerAuthenticationFlow).toHaveBeenCalledWith(
                 customerContextIdMock,
-                { styles: paypalConnectStylesMock },
             );
         });
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-accelerated-checkout-utils.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-accelerated-checkout-utils.ts
@@ -33,13 +33,22 @@ export default class PayPalCommerceAcceleratedCheckoutUtils {
     async initializePayPalConnect(
         paypalAxoSdk: PayPalAxoSdk,
         isTestModeEnabled: boolean,
+        styles?: PayPalCommerceConnectStylesOption,
     ): Promise<PayPalCommerceConnect> {
         if (isTestModeEnabled) {
             window.localStorage.setItem('axoEnv', 'sandbox');
         }
 
         if (!this.window.paypalConnect) {
-            this.window.paypalConnect = await paypalAxoSdk.Connect();
+            const defaultStyles = {
+                root: {
+                    backgroundColorPrimary: 'transparent',
+                },
+            };
+
+            this.window.paypalConnect = await paypalAxoSdk.Connect({
+                styles: styles || defaultStyles,
+            });
         }
 
         return this.window.paypalConnect;
@@ -75,7 +84,6 @@ export default class PayPalCommerceAcceleratedCheckoutUtils {
      */
     async triggerAuthenticationFlowOrThrow(
         customerContextId?: string,
-        styles?: PayPalCommerceConnectStylesOption,
     ): Promise<PayPalCommerceConnectAuthenticationResult> {
         if (!customerContextId) {
             return {};
@@ -83,7 +91,7 @@ export default class PayPalCommerceAcceleratedCheckoutUtils {
 
         const paypalConnect = this.getPayPalConnectOrThrow();
 
-        return paypalConnect.identity.triggerAuthenticationFlow(customerContextId, { styles });
+        return paypalConnect.identity.triggerAuthenticationFlow(customerContextId);
     }
 
     /**

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -83,7 +83,7 @@ export type PayPalSdkComponents = Array<'connect' | 'messages'>;
  *
  */
 export interface PayPalAxoSdk {
-    Connect(): Promise<PayPalCommerceConnect>;
+    Connect(options?: PayPalCommerceConnectOptions): Promise<PayPalCommerceConnect>;
 }
 
 export interface PayPalMessagesSdk {
@@ -126,11 +126,14 @@ export interface PayPalCommerceConnect {
     ): PayPalCommerceConnectCardComponentMethods;
 }
 
+export interface PayPalCommerceConnectOptions {
+    styles?: PayPalCommerceConnectStylesOption;
+}
+
 export interface PayPalCommerceConnectIdentity {
     lookupCustomerByEmail(email: string): Promise<PayPalCommerceConnectLookupCustomerByEmailResult>;
     triggerAuthenticationFlow(
         customerContextId: string,
-        options?: PayPalCommerceConnectAuthenticationOptions,
     ): Promise<PayPalCommerceConnectAuthenticationResult>;
 }
 
@@ -206,10 +209,6 @@ export interface PayPalConnectProfileToBcCustomerDataMappingResult {
     billingAddress?: CustomerAddress;
     shippingAddress?: CustomerAddress;
     instruments: CardInstrument[];
-}
-
-export interface PayPalCommerceConnectAuthenticationOptions {
-    styles?: PayPalCommerceConnectStylesOption;
 }
 
 export interface PayPalCommerceConnectStylesOption {


### PR DESCRIPTION
## What?
Updated PPCP AXO credit card component form background transparent

## Why?
PP have white background for PP Connect Card Component that does not fit for us, because cornerstone has light gray background and the customer may see white color of the form. It might be an issue for different themes, so it might be better to make them transparent.

## Testing / Proof
Unit tests
Manual tests

Before:
<img width="658" alt="Screenshot 2024-01-24 at 19 02 18" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/1aa03fde-b76c-477a-aa7d-df9347196edb">

After:
<img width="765" alt="Screenshot 2024-01-24 at 19 02 44" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/3402e772-6486-4b95-9e08-6d00ecb038a9">