### PR TITLE
feat(payment): PAYPAL-3497 updated PPCP AXO SDK option data-client-metadata-id with uuidv4 value

### DIFF
--- a/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
@@ -15,9 +15,16 @@ describe('PayPalCommerceSdk', () => {
     let paymentMethod: PaymentMethod;
     let paypalAxoSdk: PayPalAxoSdk;
     let subject: PayPalCommerceSdk;
+
     const paypalMessagesSdk: PayPalMessagesSdk = {
         Messages: jest.fn(),
     };
+
+    Object.defineProperty(window, 'crypto', {
+        value: {
+            randomUUID: () => '123456789',
+        },
+    });
 
     beforeEach(() => {
         loader = createScriptLoader();
@@ -65,7 +72,7 @@ describe('PayPalCommerceSdk', () => {
                 {
                     async: true,
                     attributes: {
-                        'data-client-metadata-id': 'sandbox',
+                        'data-client-metadata-id': '123456789',
                         'data-namespace': 'paypalAxo',
                         'data-partner-attribution-id': '1123JLKJASD12',
                         'data-user-id-token': 'asdcvY7XFSQasd',
@@ -93,7 +100,7 @@ describe('PayPalCommerceSdk', () => {
                 {
                     async: true,
                     attributes: {
-                        'data-client-metadata-id': 'sandbox',
+                        'data-client-metadata-id': '123456789',
                         'data-namespace': 'paypalAxo',
                         'data-partner-attribution-id': '1123JLKJASD12',
                         'data-user-id-token': 'connectClientToken123',

--- a/packages/paypal-commerce-utils/src/paypal-commerce-sdk.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-sdk.ts
@@ -106,6 +106,11 @@ export default class PayPalCommerceSdk {
             connectClientToken, // TODO: remove when PPCP AXO A/B testing will be finished
         } = initializationData;
 
+        // TODO: remove ts-ignore when typescript version will be 4.6+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const clientMetadataId = crypto.randomUUID().replace(/-/g, '');
+
         return {
             options: {
                 'client-id': clientId,
@@ -116,7 +121,7 @@ export default class PayPalCommerceSdk {
                 intent,
             },
             attributes: {
-                'data-client-metadata-id': 'sandbox', // TODO: should be updated when paypal will be ready for production
+                'data-client-metadata-id': clientMetadataId,
                 'data-namespace': 'paypalAxo',
                 'data-partner-attribution-id': attributionId,
                 'data-user-id-token': connectClientToken || clientToken,


### PR DESCRIPTION
## What?
Updated PPCP AXO SDK option `data-client-metadata-id` with `uuidv4` value

## Why?
This change is required for properly working PayPal Connect on production

## Testing / Proof
Unit tests
Manual tests
CI

Result:
<img width="507" alt="Screenshot 2024-01-30 at 10 50 43" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/b1b39289-a983-4d46-b687-14fa62abe925">

<img width="498" alt="Screenshot 2024-01-30 at 10 50 55" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/363cf911-0023-4f32-bdb2-76f4e0376e71">

