### PR TITLE
feat(payment): PI-1313 stored ecp for bluesnap

### DIFF
--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.spec.ts
@@ -34,6 +34,35 @@ describe('BlueSnapDirectAPMPaymentStrategy', () => {
             await expect(strategy.execute({})).rejects.toThrow(PaymentArgumentInvalidError);
         });
 
+        it('should submit stored instrument payment', async () => {
+            await strategy.initialize();
+
+            const payload = {
+                payment: {
+                    gatewayId: 'bluesnapdirect',
+                    methodId: 'ecp',
+                    paymentData: {
+                        instrumentId: '223344556',
+                        shouldSetAsDefaultInstrument: false,
+                    },
+                },
+            };
+
+            const expectedPayment = {
+                gatewayId: 'bluesnapdirect',
+                methodId: 'ecp',
+                paymentData: {
+                    instrumentId: '223344556',
+                    shouldSetAsDefaultInstrument: false,
+                },
+            };
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        });
+
         it('should submit the ECP payment', async () => {
             await strategy.initialize();
 

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.ts
@@ -1,4 +1,6 @@
 import {
+    isHostedInstrumentLike,
+    isVaultedInstrument,
     OrderFinalizationNotRequiredError,
     OrderRequestBody,
     PaymentArgumentInvalidError,
@@ -61,6 +63,21 @@ export default class BlueSnapDirectAPMPaymentStrategy implements PaymentStrategy
             throw new PaymentArgumentInvalidError(['payment']);
         }
 
+        if (
+            payment.paymentData &&
+            isVaultedInstrument(payment.paymentData) &&
+            isHostedInstrumentLike(payment.paymentData)
+        ) {
+            return {
+                ...payment,
+                paymentData: {
+                    instrumentId: payment.paymentData.instrumentId,
+                    shouldSetAsDefaultInstrument:
+                        !!payment.paymentData.shouldSetAsDefaultInstrument,
+                },
+            };
+        }
+
         if (isEcpInstrument(payment.paymentData)) {
             return {
                 ...payment,
@@ -72,6 +89,9 @@ export default class BlueSnapDirectAPMPaymentStrategy implements PaymentStrategy
                             shopper_permission: payment.paymentData.shopperPermission,
                             routing_number: payment.paymentData.routingNumber,
                         },
+                        vault_payment_instrument: payment.paymentData.shouldSaveInstrument,
+                        set_as_default_stored_instrument:
+                            payment.paymentData.shouldSetAsDefaultInstrument,
                     },
                 },
             };

--- a/packages/core/src/payment/instrument/instrument.ts
+++ b/packages/core/src/payment/instrument/instrument.ts
@@ -40,7 +40,7 @@ export interface AchInstrument extends BaseAccountInstrument {
     issuer: string;
     accountNumber: string;
     type: 'bank';
-    method: 'ach';
+    method: 'ach' | 'ecp';
 }
 
 export interface BankInstrument extends BaseAccountInstrument {

--- a/packages/core/src/payment/instrument/supported-payment-instruments.ts
+++ b/packages/core/src/payment/instrument/supported-payment-instruments.ts
@@ -113,6 +113,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'bluesnapdirect',
         method: 'credit_card',
     },
+    'bluesnapdirect.ecp': {
+        provider: 'bluesnapdirect',
+        method: 'ecp',
+    },
     orbital: {
         provider: 'orbital',
         method: 'credit_card',

--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -258,9 +258,12 @@ export interface WithEcpInstrument {
     accountType: BankAccountType | EcpAccountType;
     shopperPermission: boolean;
     routingNumber: string;
+    shouldSaveInstrument?: boolean;
+    shouldSetAsDefaultInstrument?: boolean;
+    instrumentId?: string;
 }
 
-export interface BlueSnapDirectEcpPayload {
+export interface BlueSnapDirectEcpPayload extends FormattedHostedInstrument {
     ecp: {
         account_number: string;
         account_type: EcpAccountType | BankAccountType;


### PR DESCRIPTION
## What?
Implementation of the stored ACH/ECP for Bluesnap Direct

## Why?
Due to the product requirements

## Testing / Proof

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/957f4cbf-67a2-4a06-8f52-d1738457cd8e


https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/6f7fe20d-27df-4577-90e7-51c9eaa04494


https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/b57589ea-701f-42e5-8691-22bd8ed5e3a7



@bigcommerce/team-checkout @bigcommerce/team-payments
