### PR TITLE
QPT-580 Add Context 'GCR + Artifact Bucket Access' to ci/notify-success and ci/notify-failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ workflows:
 
       # Only build and push CDN artifact when commits are merged to canonical repo
       - build_cdn:
+          context: "GCR + Artifact Bucket Access"
           filters:
             branches:
               ignore: /pull\/[0-9]+/
@@ -153,6 +154,7 @@ workflows:
           requires:
             - build_cdn
       - ci/notify-success:
+          context: "GCR + Artifact Bucket Access"
           requires:
             - ci/build-js-artifact
 


### PR DESCRIPTION
## What?

Context `GCR + Artifact Bucket Access` needs to add to jobs `ci/notify-success` and `ci/notify-failure`, as well as any other jobs containing commands `ci/notify-success` and `ci/notify-failure`. This PR is generated by a script. Please ping the owner if something looks quite wrong.

## Why?

So that cipher can be enabled easily in `ci/notify-success` and `ci/notify-failure`.

## Proof of Life

CircleCI workflows triggered by this PR will do.
