### PR TITLE
feat(payment): PAYPAL-3560 updated PayPalCommerceAcceleratedCheckoutCustomerStrategy to load it with ppcp credit cards method id

### DIFF
--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -737,7 +737,7 @@ export interface BraintreeConnectStylesOption {
 export enum BraintreeConnectAuthenticationState {
     SUCCEEDED = 'succeeded',
     FAILED = 'failed',
-    CANCELED = 'canceled',
+    CANCELED = 'cancelled',
     UNRECOGNIZED = 'unrecognized',
 }
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/create-paypal-commerce-accelerated-checkout-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/create-paypal-commerce-accelerated-checkout-customer-strategy.ts
@@ -20,4 +20,5 @@ const createPayPalCommerceAcceleratedCheckoutCustomerStrategy: CustomerStrategyF
 
 export default toResolvableModule(createPayPalCommerceAcceleratedCheckoutCustomerStrategy, [
     { id: 'paypalcommerceacceleratedcheckout' },
+    { id: 'paypalcommercecreditcards' },
 ]);

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -150,7 +150,7 @@ export interface PayPalCommerceConnectAuthenticationResult {
 export enum PayPalCommerceConnectAuthenticationState {
     SUCCEEDED = 'succeeded',
     FAILED = 'failed',
-    CANCELED = 'canceled',
+    CANCELED = 'cancelled',
     UNRECOGNIZED = 'unrecognized',
 }
 


### PR DESCRIPTION
## What?
Updated PayPalCommerceAcceleratedCheckoutCustomerStrategy to load it with ppcp credit cards method id

## Why?
Because we could not trigger PayPalCommerceAcceleratedCheckoutCustomerStrategy for cases if PPCP AXO experiment did not rollout to 100% for the store

## Testing / Proof
Unit tests
Manual tests
CI
