### PR TITLE
feat(payment): PAYPAL-3506 moved back PPCP APM polling mechanism

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
@@ -200,7 +200,7 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
         const { resolve, reject } = actions;
 
         if (!this.isNonInstantPaymentMethod(methodId)) {
-            await this.initializePollingMechanism(methodId, gatewayId, paypalOptions);
+            this.initializePollingMechanism(methodId, gatewayId, paypalOptions);
         }
 
         const onValidationPassed = () => {


### PR DESCRIPTION
## What?
Moved back PPCP APM polling mechanism

## Why?
To avoid errors
PR that removed polling mechanism https://github.com/bigcommerce/checkout-sdk-js/pull/2210
## Testing / Proof


@bigcommerce/team-checkout @bigcommerce/team-payments
