### PR TITLE
feat(payment): PAYPAL-3405 GooglePay not working 404 (iOS devices)

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
@@ -15,6 +15,7 @@ describe('GooglePayGateway', () => {
     let paymentIntegrationService: PaymentIntegrationService;
 
     beforeEach(() => {
+        jest.clearAllMocks();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
 
         jest.spyOn(paymentIntegrationService, 'loadShippingCountries').mockReturnValue(
@@ -99,17 +100,17 @@ describe('GooglePayGateway', () => {
     });
 
     describe('#getTransactionInfo', () => {
-        it('should return transaction info', async () => {
+        it('should return ESTIMATED transaction info', async () => {
             const expectedInfo = {
-                countryCode: 'US',
                 currencyCode: 'USD',
-                totalPriceStatus: 'FINAL',
-                totalPrice: '190.00',
+                totalPriceStatus: 'ESTIMATED',
+                totalPrice: '0',
             };
 
             await gateway.initialize(getGeneric);
 
             expect(gateway.getTransactionInfo()).toStrictEqual(expectedInfo);
+            expect(paymentIntegrationService.getState().getCartOrThrow).toHaveBeenCalled();
         });
 
         it('should return transaction info (Buy Now Flow)', async () => {
@@ -122,25 +123,10 @@ describe('GooglePayGateway', () => {
             await gateway.initialize(getGeneric, true, 'USD');
 
             expect(gateway.getTransactionInfo()).toStrictEqual(expectedInfo);
-        });
-
-        it('should call getCartOrThrow', async () => {
-            await gateway.initialize(getGeneric);
-
-            expect(paymentIntegrationService.getState().getCartOrThrow).toHaveBeenCalled();
-        });
-
-        it('should call getCheckoutOrThrow', async () => {
-            await gateway.initialize(getGeneric);
-
-            expect(paymentIntegrationService.getState().getCheckoutOrThrow).toHaveBeenCalled();
+            expect(paymentIntegrationService.getState().getCartOrThrow).not.toHaveBeenCalled();
         });
 
         describe('should fail if:', () => {
-            test('not initialized', () => {
-                expect(() => gateway.getTransactionInfo()).toThrow(NotInitializedError);
-            });
-
             it('currencyCode is not passed (Buy Now flow)', async () => {
                 try {
                     await gateway.initialize(getGeneric, true);

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -1,5 +1,3 @@
-import { round } from 'lodash';
-
 import {
     AddressRequestBody,
     BillingAddressRequestBody,
@@ -150,26 +148,20 @@ export default class GooglePayGateway {
     }
 
     getTransactionInfo(): GooglePayTransactionInfo {
+        let currencyCode: string;
+
         if (this._isBuyNowFlow) {
-            return {
-                currencyCode: this._getCurrencyCodeOrThrow(),
-                totalPriceStatus: TotalPriceStatusType.ESTIMATED,
-                totalPrice: '0',
-            };
+            currencyCode = this._getCurrencyCodeOrThrow();
+        } else {
+            const { getCartOrThrow } = this._paymentIntegrationService.getState();
+
+            currencyCode = getCartOrThrow().currency.code;
         }
 
-        const { getCheckoutOrThrow, getCartOrThrow } = this._paymentIntegrationService.getState();
-        const countryCode = this.getGooglePayInitializationData().storeCountry;
-        const { code: currencyCode, decimalPlaces } = getCartOrThrow().currency;
-        const totalPrice = round(getCheckoutOrThrow().outstandingBalance, decimalPlaces).toFixed(
-            decimalPlaces,
-        );
-
         return {
-            ...(countryCode && { countryCode }),
             currencyCode,
-            totalPriceStatus: TotalPriceStatusType.FINAL,
-            totalPrice,
+            totalPriceStatus: TotalPriceStatusType.ESTIMATED,
+            totalPrice: '0',
         };
     }
 

--- a/packages/google-pay-integration/src/google-pay-button-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.ts
@@ -219,6 +219,7 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
 
                 return {
                     newTransactionInfo: {
+                        ...(this._countryCode && { countryCode: this._countryCode }),
                         currencyCode: this._getCurrencyCodeOrThrow(),
                         totalPrice: String(cartAmount),
                         totalPriceStatus: TotalPriceStatusType.FINAL,

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
@@ -291,26 +291,6 @@ describe('GooglePayCustomerStrategy', () => {
                     },
                 });
             });
-
-            it('should call getCartOrThrow', async () => {
-                await strategy.initialize(options);
-
-                button.click();
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(paymentIntegrationService.getState().getCartOrThrow).toHaveBeenCalled();
-            });
-
-            it('should call getCheckoutOrThrow', async () => {
-                await strategy.initialize(options);
-
-                button.click();
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(paymentIntegrationService.getState().getCheckoutOrThrow).toHaveBeenCalled();
-            });
         });
     });
 });

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
@@ -1,6 +1,7 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
 
 import {
     CustomerInitializeOptions,
@@ -16,8 +17,14 @@ import { WithGooglePayCustomerInitializeOptions } from './google-pay-customer-in
 import GooglePayCustomerStrategy from './google-pay-customer-strategy';
 import GooglePayPaymentProcessor from './google-pay-payment-processor';
 import GooglePayScriptLoader from './google-pay-script-loader';
+import getCardDataResponse from './mocks/google-pay-card-data-response.mock';
 import { getGeneric } from './mocks/google-pay-payment-method.mock';
-import { GooglePayButtonOptions, GooglePayInitializationData } from './types';
+import {
+    CallbackTriggerType,
+    GooglePayButtonOptions,
+    GooglePayInitializationData,
+    NewTransactionInfo,
+} from './types';
 
 describe('GooglePayCustomerStrategy', () => {
     const CONTAINER_ID = 'my_awesome_google_pay_button_container';
@@ -27,8 +34,11 @@ describe('GooglePayCustomerStrategy', () => {
     let processor: GooglePayPaymentProcessor;
     let strategy: GooglePayCustomerStrategy;
     let options: CustomerInitializeOptions & WithGooglePayCustomerInitializeOptions;
+    let eventEmitter: EventEmitter;
 
     beforeEach(() => {
+        eventEmitter = new EventEmitter();
+
         paymentIntegrationService = new PaymentIntegrationServiceMock();
 
         jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
@@ -207,7 +217,7 @@ describe('GooglePayCustomerStrategy', () => {
     });
 
     describe('#handleClick', () => {
-        it('triggers onClick callback on wallet button click', async () => {
+        beforeEach(() => {
             jest.spyOn(processor, 'addPaymentButton').mockImplementation(
                 (
                     _: string,
@@ -218,7 +228,9 @@ describe('GooglePayCustomerStrategy', () => {
                     return button;
                 },
             );
+        });
 
+        it('triggers onClick callback on wallet button click', async () => {
             await strategy.initialize(options);
 
             button.click();
@@ -226,6 +238,79 @@ describe('GooglePayCustomerStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(options.googlepayworldpayaccess?.onClick).toHaveBeenCalled();
+        });
+
+        describe('#getGooglePayClientOptions', () => {
+            let mockReturnedPaymentDataChangedValue: NewTransactionInfo;
+
+            beforeEach(() => {
+                jest.spyOn(processor, 'initialize').mockImplementation(
+                    (_, googlePayClientOptions) => {
+                        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+                        eventEmitter.on('onPaymentDataChanged', async () => {
+                            mockReturnedPaymentDataChangedValue =
+                                await googlePayClientOptions.paymentDataCallbacks.onPaymentDataChanged(
+                                    {
+                                        callbackTrigger: CallbackTriggerType.INITIALIZE,
+                                    },
+                                );
+                        });
+                    },
+                );
+
+                jest.spyOn(processor, 'showPaymentSheet').mockImplementation(() => {
+                    eventEmitter.emit('onPaymentDataChanged');
+
+                    return getCardDataResponse();
+                });
+            });
+
+            it('should load checkout via onPaymentDataChanged callback', async () => {
+                await strategy.initialize(options);
+
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.loadCheckout).toHaveBeenCalled();
+            });
+
+            it('should return updated transactionInfo', async () => {
+                await strategy.initialize(options);
+
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(mockReturnedPaymentDataChangedValue).toStrictEqual({
+                    newTransactionInfo: {
+                        countryCode: 'US',
+                        currencyCode: 'USD',
+                        totalPriceStatus: 'FINAL',
+                        totalPrice: '190.00',
+                    },
+                });
+            });
+
+            it('should call getCartOrThrow', async () => {
+                await strategy.initialize(options);
+
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.getState().getCartOrThrow).toHaveBeenCalled();
+            });
+
+            it('should call getCheckoutOrThrow', async () => {
+                await strategy.initialize(options);
+
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.getState().getCheckoutOrThrow).toHaveBeenCalled();
+            });
         });
     });
 });

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.ts
@@ -1,3 +1,5 @@
+import { round } from 'lodash';
+
 import {
     CustomerInitializeOptions,
     CustomerStrategy,
@@ -19,11 +21,19 @@ import GooglePayCustomerInitializeOptions, {
 import GooglePayPaymentProcessor from './google-pay-payment-processor';
 import isGooglePayErrorObject from './guards/is-google-pay-error-object';
 import isGooglePayKey from './guards/is-google-pay-key';
-import { GooglePayInitializationData } from './types';
+import {
+    CallbackTriggerType,
+    GooglePayInitializationData,
+    GooglePayPaymentOptions,
+    IntermediatePaymentData,
+    NewTransactionInfo,
+    TotalPriceStatusType,
+} from './types';
 
 export default class GooglePayCustomerStrategy implements CustomerStrategy {
     private _paymentButton?: HTMLElement;
     private _methodId?: keyof WithGooglePayCustomerInitializeOptions;
+    private _countryCode?: string;
 
     constructor(
         private _paymentIntegrationService: PaymentIntegrationService,
@@ -57,8 +67,13 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             paymentMethod = state.getPaymentMethodOrThrow(this._getMethodId());
         }
 
+        this._countryCode = paymentMethod.initializationData?.storeCountry;
+
         try {
-            await this._googlePayPaymentProcessor.initialize(() => paymentMethod);
+            await this._googlePayPaymentProcessor.initialize(
+                () => paymentMethod,
+                this._getGooglePayClientOptions(),
+            );
         } catch {
             return;
         }
@@ -94,6 +109,39 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         this._methodId = undefined;
 
         return Promise.resolve();
+    }
+
+    private _getGooglePayClientOptions(): GooglePayPaymentOptions {
+        return {
+            paymentDataCallbacks: {
+                onPaymentDataChanged: async ({
+                    callbackTrigger,
+                }: IntermediatePaymentData): Promise<NewTransactionInfo | void> => {
+                    if (callbackTrigger !== CallbackTriggerType.INITIALIZE) {
+                        return;
+                    }
+
+                    await this._paymentIntegrationService.loadCheckout();
+
+                    const { getCheckoutOrThrow, getCartOrThrow } =
+                        this._paymentIntegrationService.getState();
+                    const { code: currencyCode, decimalPlaces } = getCartOrThrow().currency;
+                    const totalPrice = round(
+                        getCheckoutOrThrow().outstandingBalance,
+                        decimalPlaces,
+                    ).toFixed(decimalPlaces);
+
+                    return {
+                        newTransactionInfo: {
+                            ...(this._countryCode && { countryCode: this._countryCode }),
+                            currencyCode,
+                            totalPriceStatus: TotalPriceStatusType.FINAL,
+                            totalPrice,
+                        },
+                    };
+                },
+            },
+        };
     }
 
     private _addPaymentButton({
@@ -149,8 +197,6 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
     }
 
     private async _interactWithPaymentSheet(): Promise<void> {
-        await this._paymentIntegrationService.loadCheckout();
-
         const response = await this._googlePayPaymentProcessor.showPaymentSheet();
         const billingAddress =
             this._googlePayPaymentProcessor.mapToBillingAddressRequestBody(response);

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.ts
@@ -33,7 +33,6 @@ import {
 export default class GooglePayCustomerStrategy implements CustomerStrategy {
     private _paymentButton?: HTMLElement;
     private _methodId?: keyof WithGooglePayCustomerInitializeOptions;
-    private _countryCode?: string;
 
     constructor(
         private _paymentIntegrationService: PaymentIntegrationService,
@@ -67,12 +66,10 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             paymentMethod = state.getPaymentMethodOrThrow(this._getMethodId());
         }
 
-        this._countryCode = paymentMethod.initializationData?.storeCountry;
-
         try {
             await this._googlePayPaymentProcessor.initialize(
                 () => paymentMethod,
-                this._getGooglePayClientOptions(),
+                this._getGooglePayClientOptions(paymentMethod.initializationData?.storeCountry),
             );
         } catch {
             return;
@@ -111,7 +108,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         return Promise.resolve();
     }
 
-    private _getGooglePayClientOptions(): GooglePayPaymentOptions {
+    private _getGooglePayClientOptions(countryCode?: string): GooglePayPaymentOptions {
         return {
             paymentDataCallbacks: {
                 onPaymentDataChanged: async ({
@@ -133,7 +130,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
 
                     return {
                         newTransactionInfo: {
-                            ...(this._countryCode && { countryCode: this._countryCode }),
+                            ...(countryCode && { countryCode }),
                             currencyCode,
                             totalPriceStatus: TotalPriceStatusType.FINAL,
                             totalPrice,

--- a/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
@@ -141,11 +141,11 @@ describe('GooglePayPaymentProcessor', () => {
                     merchantName: 'Example Merchant',
                 },
                 transactionInfo: {
-                    countryCode: 'US',
                     currencyCode: 'USD',
-                    totalPrice: '190.00',
-                    totalPriceStatus: 'FINAL',
+                    totalPrice: '0',
+                    totalPriceStatus: 'ESTIMATED',
                 },
+                callbackIntents: ['OFFER'],
             };
 
             await processor.initialize(getGeneric);
@@ -284,13 +284,6 @@ describe('GooglePayPaymentProcessor', () => {
             await expect(processor.showPaymentSheet()).resolves.toBe(clientMocks.cardDataResponse);
         });
 
-        it('should update the transaction info', async () => {
-            await processor.initialize(getGeneric);
-            await processor.showPaymentSheet();
-
-            expect(gateway.getTransactionInfo).toHaveBeenCalledTimes(3);
-        });
-
         it('should load google payment data', async () => {
             const expectedRequest = {
                 allowedPaymentMethods: [
@@ -320,11 +313,11 @@ describe('GooglePayPaymentProcessor', () => {
                     merchantName: 'Example Merchant',
                 },
                 transactionInfo: {
-                    countryCode: 'US',
                     currencyCode: 'USD',
-                    totalPrice: '190.00',
-                    totalPriceStatus: 'FINAL',
+                    totalPrice: '0',
+                    totalPriceStatus: 'ESTIMATED',
                 },
+                callbackIntents: ['OFFER'],
             };
 
             await processor.initialize(getGeneric);

--- a/packages/google-pay-integration/src/google-pay-payment-processor.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.ts
@@ -37,7 +37,6 @@ export default class GooglePayPaymentProcessor {
     private _cardPaymentMethod?: GooglePayCardPaymentMethod;
     private _paymentDataRequest?: GooglePayPaymentDataRequest;
     private _isReadyToPayRequest?: GooglePayIsReadyToPayRequest;
-    private _isBuyNowFlow = false;
 
     constructor(
         private _scriptLoader: GooglePayScriptLoader,
@@ -56,8 +55,6 @@ export default class GooglePayPaymentProcessor {
             getPaymentMethod().config.testMode,
             googlePayPaymentOptions,
         );
-
-        this._isBuyNowFlow = Boolean(isBuyNowFlow);
 
         await this._gateway.initialize(getPaymentMethod, isBuyNowFlow, currencyCode);
 
@@ -98,8 +95,6 @@ export default class GooglePayPaymentProcessor {
 
     async showPaymentSheet(): Promise<GooglePayCardDataResponse> {
         const paymentDataRequest = this._getPaymentDataRequest();
-
-        paymentDataRequest.transactionInfo = this._gateway.getTransactionInfo();
 
         return this._getPaymentsClient().loadPaymentData(paymentDataRequest);
     }
@@ -223,7 +218,7 @@ export default class GooglePayPaymentProcessor {
             transactionInfo: this._gateway.getTransactionInfo(),
             merchantInfo: this._gateway.getMerchantInfo(),
             ...(await this._gateway.getRequiredData()),
-            ...(this._isBuyNowFlow && { callbackIntents: [CallbackIntentsType.OFFER] }),
+            callbackIntents: [CallbackIntentsType.OFFER],
         };
         this._isReadyToPayRequest = {
             ...this._baseRequest,

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -329,26 +329,6 @@ describe('GooglePayPaymentStrategy', () => {
                     },
                 });
             });
-
-            it('should call getCartOrThrow', async () => {
-                await strategy.initialize(options);
-
-                button.click();
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(paymentIntegrationService.getState().getCartOrThrow).toHaveBeenCalled();
-            });
-
-            it('should call getCheckoutOrThrow', async () => {
-                await strategy.initialize(options);
-
-                button.click();
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(paymentIntegrationService.getState().getCheckoutOrThrow).toHaveBeenCalled();
-            });
         });
     });
 

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -34,7 +34,6 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     private _paymentButton?: HTMLElement;
     private _clickListener?: (event: MouseEvent) => unknown;
     private _methodId?: keyof WithGooglePayPaymentInitializeOptions;
-    private _countryCode?: string;
 
     constructor(
         protected _paymentIntegrationService: PaymentIntegrationService,
@@ -66,11 +65,9 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             .getState()
             .getPaymentMethodOrThrow<GooglePayInitializationData>(this._getMethodId());
 
-        this._countryCode = paymentMethod.initializationData?.storeCountry;
-
         await this._googlePayPaymentProcessor.initialize(
             () => paymentMethod,
-            this._getGooglePayClientOptions(),
+            this._getGooglePayClientOptions(paymentMethod.initializationData?.storeCountry),
         );
 
         this._addPaymentButton(walletButton, callbacks);
@@ -188,7 +185,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         );
     }
 
-    protected _getGooglePayClientOptions(): GooglePayPaymentOptions {
+    protected _getGooglePayClientOptions(countryCode?: string): GooglePayPaymentOptions {
         return {
             paymentDataCallbacks: {
                 onPaymentDataChanged: async ({
@@ -210,7 +207,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
                     return {
                         newTransactionInfo: {
-                            ...(this._countryCode && { countryCode: this._countryCode }),
+                            ...(countryCode && { countryCode }),
                             currencyCode,
                             totalPriceStatus: TotalPriceStatusType.FINAL,
                             totalPrice,


### PR DESCRIPTION
## What?

Rewrote the implementation of loading the checkout instance in a different way to avoid opening GP on another page with the error, as this doesn't work in Safari.

## Why?

The reason that it's not working is because Google Pay tries to open a popup window when you call `loadPaymentData` after making the request `loadCheckout`.This is a specific behavior related to how Safari handles actions. In Chrome, we always see a popup and are not redirected to another page

## Testing / Proof

Before

The example shows how the GP button worked on the customer step. The same behavior occurs in other places where we use the GP button

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/e0f5777c-03e6-44fe-b250-30ebda1967bd

After

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/237110ff-8991-46a9-b3d8-1f942f990431


https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/d1fc9fbf-3e72-4457-84bd-6f417d6a2206


https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/b827ce28-e260-4204-8acb-9ff3bcf9ccf8


https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/a607ec5a-1137-4077-811d-f4eac8f863a3




@bigcommerce/team-checkout @bigcommerce/team-payments
