### PR TITLE
feat(payment): PI-429 [Adyen] Improve FE validation for APMs on checkout

### DIFF
--- a/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -325,6 +325,37 @@ describe('AdyenV2PaymentStrategy', () => {
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(0);
             });
 
+            it('throws an error when card fields empty with SEPA', async () => {
+                const adyenInvalidPaymentComponent = {
+                    mount: jest.fn(),
+                    unmount: jest.fn(),
+                    componentRef: {
+                        showValidation: jest.fn(),
+                    },
+                    state: {
+                        data: { ownerName: '  ', ibanNumber: 'NL13 TEST 0123 4567 89' },
+                    },
+                    props: {
+                        type: 'sepadirectdebit',
+                    },
+                };
+
+                jest.spyOn(adyenCheckout, 'create').mockReturnValueOnce(
+                    adyenInvalidPaymentComponent,
+                );
+
+                await strategy.initialize(options);
+
+                await expect(strategy.execute(getOrderRequestBody())).rejects.toThrow(
+                    PaymentInvalidFormError,
+                );
+                expect(
+                    adyenInvalidPaymentComponent.componentRef.showValidation,
+                ).toHaveBeenCalledTimes(1);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(0);
+            });
+
             it('calls submitPayment when paying with vaulted instrument', async () => {
                 jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
                     submitPaymentAction,
@@ -584,6 +615,7 @@ describe('AdyenV2PaymentStrategy', () => {
 
                 await strategy.initialize(options);
                 await strategy.execute(getOrderRequestBody(AdyenPaymentMethodType.ACH));
+
                 expect(adyenCheckout.create).toHaveBeenCalledTimes(1);
                 expect(adyenCheckout.create).toHaveBeenCalledWith('ach', {
                     hasHolderName: expect.any(Boolean),

--- a/packages/adyen-integration/src/adyenv3/adyenv3-script-loader.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-script-loader.spec.ts
@@ -23,9 +23,9 @@ describe('AdyenV3ScriptLoader', () => {
         const adyenClient = getAdyenClient();
         const configuration = getAdyenConfiguration();
         const configurationWithClientKey = getAdyenConfiguration(false);
-        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.24.0/adyen.js';
+        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.58.0/adyen.js';
         const cssUrl =
-            'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.24.0/adyen.css';
+            'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.58.0/adyen.css';
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {

--- a/packages/adyen-integration/src/adyenv3/adyenv3-script-loader.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-script-loader.ts
@@ -16,12 +16,12 @@ export default class AdyenV3ScriptLoader {
             this._stylesheetLoader.loadStylesheet(
                 `https://checkoutshopper-${
                     configuration.environment ?? ''
-                }.adyen.com/checkoutshopper/sdk/5.24.0/adyen.css`,
+                }.adyen.com/checkoutshopper/sdk/5.58.0/adyen.css`,
             ),
             this._scriptLoader.loadScript(
                 `https://checkoutshopper-${
                     configuration.environment ?? ''
-                }.adyen.com/checkoutshopper/sdk/5.24.0/adyen.js`,
+                }.adyen.com/checkoutshopper/sdk/5.58.0/adyen.js`,
             ),
         ]);
 


### PR DESCRIPTION
## What?
FE validation of Blik and SEPA Direct Debit APM’s allow to trigger /payment request when empty strings are provided, so I added a check for empty values for adyenv2. The submit button is blocked from sending a request. 
In adyenv3 updating to new adyen-web version improved validation, no need to block the submit button.

## Testing / Proof

before:
![image](https://github.com/bigcommerce/checkout-sdk-js/assets/130754705/fe83d6cd-1bf7-47f4-9d2d-8a7a2cc75392)

now: 
adyenv3:
<img width="852" alt="Screenshot 2024-02-23 at 16 27 28" src="https://github.com/bigcommerce/checkout-sdk-js/assets/130754705/e7f67b59-56cf-4544-b809-4ab485619c3c">

adyenv2:
![image](https://github.com/bigcommerce/checkout-sdk-js/assets/130754705/9458d66b-8da7-4df4-8fd6-94bb3e0bdfbe)


...

@bigcommerce/team-checkout @bigcommerce/team-payments
