### PR TITLE
feat(payment): PAYPAL-3576 updated paypal-commerce-utils package with PayPal Fastlane support

### DIFF
--- a/packages/paypal-commerce-utils/src/create-paypal-commerce-accelerated-checkout-utils.spec.ts
+++ b/packages/paypal-commerce-utils/src/create-paypal-commerce-accelerated-checkout-utils.spec.ts
@@ -1,6 +1,7 @@
 import createPayPalCommerceAcceleratedCheckoutUtils from './create-paypal-commerce-accelerated-checkout-utils';
 import PayPalCommerceAcceleratedCheckoutUtils from './paypal-commerce-accelerated-checkout-utils';
 
+// TODO: remove this file when PPCP AXO strategies will be moved to PayPal Fastlane
 describe('createPayPalCommerceIntegrationService', () => {
     it('instantiates PayPal Commerce Accelerated Checkout utils class', () => {
         const utilsClass = createPayPalCommerceAcceleratedCheckoutUtils();

--- a/packages/paypal-commerce-utils/src/create-paypal-commerce-accelerated-checkout-utils.ts
+++ b/packages/paypal-commerce-utils/src/create-paypal-commerce-accelerated-checkout-utils.ts
@@ -2,6 +2,7 @@ import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import PayPalCommerceAcceleratedCheckoutUtils from './paypal-commerce-accelerated-checkout-utils';
 
+// TODO: remove this file when PPCP AXO strategies will be moved to PayPal Fastlane
 export default function createPayPalCommerceAcceleratedCheckoutUtils(): PayPalCommerceAcceleratedCheckoutUtils {
     return new PayPalCommerceAcceleratedCheckoutUtils(new BrowserStorage('paypalConnect'));
 }

--- a/packages/paypal-commerce-utils/src/create-paypal-commerce-fastlane-utils.spec.ts
+++ b/packages/paypal-commerce-utils/src/create-paypal-commerce-fastlane-utils.spec.ts
@@ -1,0 +1,10 @@
+import createPayPalCommerceFastlaneUtils from './create-paypal-commerce-fastlane-utils';
+import PayPalCommerceFastlaneUtils from './paypal-commerce-fastlane-utils';
+
+describe('createPayPalCommerceFastlaneUtils', () => {
+    it('instantiates PayPal Commerce Fastlane utils class', () => {
+        const utilsClass = createPayPalCommerceFastlaneUtils();
+
+        expect(utilsClass).toBeInstanceOf(PayPalCommerceFastlaneUtils);
+    });
+});

--- a/packages/paypal-commerce-utils/src/create-paypal-commerce-fastlane-utils.ts
+++ b/packages/paypal-commerce-utils/src/create-paypal-commerce-fastlane-utils.ts
@@ -1,0 +1,7 @@
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+
+import PayPalCommerceFastlaneUtils from './paypal-commerce-fastlane-utils';
+
+export default function createPayPalCommerceFastlaneUtils(): PayPalCommerceFastlaneUtils {
+    return new PayPalCommerceFastlaneUtils(new BrowserStorage('paypalFastlane'));
+}

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane-authentication-result.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane-authentication-result.mock.ts
@@ -1,0 +1,60 @@
+import { PayPalFastlaneAuthenticationState } from '../paypal-commerce-types';
+
+export default function getPayPalFastlaneAuthenticationResultMock() {
+    return {
+        authenticationState: PayPalFastlaneAuthenticationState.SUCCEEDED,
+        profileData: {
+            name: {
+                fullName: 'John Doe',
+                firstName: 'John',
+                lastName: 'Doe',
+            },
+            shippingAddress: {
+                address: {
+                    company: 'BigCommerce',
+                    addressLine1: 'addressLine1',
+                    addressLine2: 'addressLine2',
+                    adminArea1: 'addressState',
+                    adminArea2: 'addressCity',
+                    postalCode: '03004',
+                    countryCode: 'US',
+                },
+                name: {
+                    fullName: 'John Doe',
+                    firstName: 'John',
+                    lastName: 'Doe',
+                },
+                phoneNumber: {
+                    nationalNumber: '5551113344',
+                    countryCode: '1',
+                },
+            },
+            card: {
+                id: 'nonce/token',
+                paymentSource: {
+                    card: {
+                        brand: 'Visa',
+                        expiry: '2030-12',
+                        lastDigits: '1111',
+                        name: 'John Doe',
+                        billingAddress: {
+                            firstName: 'John',
+                            lastName: 'Doe',
+                            company: 'BigCommerce',
+                            addressLine1: 'addressLine1',
+                            addressLine2: 'addressLine2',
+                            adminArea1: 'addressState',
+                            adminArea2: 'addressCity',
+                            postalCode: '03004',
+                            countryCode: 'US',
+                            phone: {
+                                nationalNumber: '5551113344',
+                                countryCode: '1',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+}

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane-sdk.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane-sdk.mock.ts
@@ -1,0 +1,9 @@
+import { PayPalFastlaneSdk } from '../paypal-commerce-types';
+
+import getPayPalFastlane from './get-paypal-fastlane.mock';
+
+export default function getPayPalFastlaneSdk(): PayPalFastlaneSdk {
+    return {
+        Fastlane: () => Promise.resolve(getPayPalFastlane()),
+    };
+}

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
@@ -1,0 +1,26 @@
+import { PayPalFastlane, PayPalFastlaneCardComponentMethods } from '../paypal-commerce-types';
+
+export default function getPayPalFastlane(): PayPalFastlane {
+    const paypalFastlaneCardComponentMethods: PayPalFastlaneCardComponentMethods = {
+        tokenize: jest.fn(() => ({
+            nonce: 'paypal_fastlane_tokenize_nonce',
+        })),
+        render: jest.fn(),
+    };
+
+    return {
+        identity: {
+            lookupCustomerByEmail: jest.fn(),
+            triggerAuthenticationFlow: jest.fn(),
+        },
+        events: {
+            apmSelected: jest.fn(),
+            emailSubmitted: jest.fn(),
+            orderPlaced: jest.fn(),
+        },
+        profile: {
+            showCardSelector: jest.fn(),
+        },
+        FastlaneCardComponent: jest.fn(() => paypalFastlaneCardComponentMethods),
+    };
+}

--- a/packages/paypal-commerce-utils/src/mocks/index.ts
+++ b/packages/paypal-commerce-utils/src/mocks/index.ts
@@ -5,3 +5,6 @@ export {
 export { default as getPayPalAxoSdk } from './get-paypal-axo-sdk.mock';
 export { default as getPayPalConnect } from './get-paypal-connect.mock';
 export { default as getPayPalConnectAuthenticationResultMock } from './get-paypal-connect-authentication-result.mock';
+export { default as getPayPalFastlaneSdk } from './get-paypal-fastlane-sdk.mock';
+export { default as getPayPalFastlane } from './get-paypal-fastlane.mock';
+export { default as getPayPalFastlaneAuthenticationResultMock } from './get-paypal-fastlane-authentication-result.mock';

--- a/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
@@ -6,14 +6,24 @@ import {
     PaymentMethodClientUnavailableError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { getPayPalAxoSdk, getPayPalCommerceAcceleratedCheckoutPaymentMethod } from './mocks';
+import {
+    getPayPalAxoSdk,
+    getPayPalCommerceAcceleratedCheckoutPaymentMethod,
+    getPayPalFastlaneSdk,
+} from './mocks';
 import PayPalCommerceSdk from './paypal-commerce-sdk';
-import { PayPalAxoSdk, PayPalCommerceHostWindow, PayPalMessagesSdk } from './paypal-commerce-types';
+import {
+    PayPalAxoSdk,
+    PayPalCommerceHostWindow,
+    PayPalFastlaneSdk,
+    PayPalMessagesSdk,
+} from './paypal-commerce-types';
 
 describe('PayPalCommerceSdk', () => {
     let loader: ScriptLoader;
     let paymentMethod: PaymentMethod;
     let paypalAxoSdk: PayPalAxoSdk;
+    let paypalFastlaneSdk: PayPalFastlaneSdk;
     let subject: PayPalCommerceSdk;
 
     const paypalMessagesSdk: PayPalMessagesSdk = {
@@ -30,10 +40,12 @@ describe('PayPalCommerceSdk', () => {
         loader = createScriptLoader();
         paymentMethod = getPayPalCommerceAcceleratedCheckoutPaymentMethod();
         paypalAxoSdk = getPayPalAxoSdk();
+        paypalFastlaneSdk = getPayPalFastlaneSdk();
         subject = new PayPalCommerceSdk(loader);
 
         jest.spyOn(loader, 'loadScript').mockImplementation(() => {
             (window as PayPalCommerceHostWindow).paypalAxo = paypalAxoSdk;
+            (window as PayPalCommerceHostWindow).paypalFastlaneSdk = paypalFastlaneSdk;
             (window as PayPalCommerceHostWindow).paypalMessages = paypalMessagesSdk;
 
             return Promise.resolve();
@@ -42,6 +54,7 @@ describe('PayPalCommerceSdk', () => {
 
     afterEach(() => {
         (window as PayPalCommerceHostWindow).paypalAxo = undefined;
+        (window as PayPalCommerceHostWindow).paypalFastlaneSdk = undefined;
         (window as PayPalCommerceHostWindow).paypalMessages = undefined;
 
         jest.clearAllMocks();
@@ -123,6 +136,85 @@ describe('PayPalCommerceSdk', () => {
             const result = await subject.getPayPalAxo(paymentMethod, 'USD');
 
             expect(result).toEqual(paypalAxoSdk);
+        });
+    });
+
+    describe('#getPayPalFastlaneSdk()', () => {
+        it('throws an error if clientId is not defined in payment method while getting configuration for PayPal Sdk', async () => {
+            const mockPaymentMethod = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    clientId: undefined,
+                },
+            };
+
+            try {
+                await subject.getPayPalFastlaneSdk(mockPaymentMethod, 'USD');
+            } catch (error: unknown) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('loads PayPal Fastlane sdk script', async () => {
+            await subject.getPayPalFastlaneSdk(paymentMethod, 'USD');
+
+            expect(loader.loadScript).toHaveBeenCalledWith(
+                'https://www.paypal.com/sdk/js?client-id=abc&merchant-id=JTS4DY7XFSQZE&commit=true&components=fastlane&currency=USD&intent=capture',
+                {
+                    async: true,
+                    attributes: {
+                        'data-client-metadata-id': '123456789',
+                        'data-namespace': 'paypalFastlane',
+                        'data-partner-attribution-id': '1123JLKJASD12',
+                        'data-user-id-token': 'asdcvY7XFSQasd',
+                    },
+                },
+            );
+        });
+
+        // TODO: remove this test when A/B testing will be finished
+        it('loads PayPal Fastlane Sdk script with connectClientToken for paypalcommercecreditcards method', async () => {
+            const mockPaymentMethod = {
+                ...paymentMethod,
+                methodId: 'paypalcommercecreditcards',
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    clientToken: undefined,
+                    connectClientToken: 'connectClientToken123',
+                },
+            };
+
+            await subject.getPayPalFastlaneSdk(mockPaymentMethod, 'USD');
+
+            expect(loader.loadScript).toHaveBeenCalledWith(
+                'https://www.paypal.com/sdk/js?client-id=abc&merchant-id=JTS4DY7XFSQZE&commit=true&components=fastlane&currency=USD&intent=capture',
+                {
+                    async: true,
+                    attributes: {
+                        'data-client-metadata-id': '123456789',
+                        'data-namespace': 'paypalFastlane',
+                        'data-partner-attribution-id': '1123JLKJASD12',
+                        'data-user-id-token': 'connectClientToken123',
+                    },
+                },
+            );
+        });
+
+        it('throws an error if there was an issue with loading PayPal Fastlane Sdk', async () => {
+            jest.spyOn(loader, 'loadScript').mockImplementation(jest.fn());
+
+            try {
+                await subject.getPayPalAxo(paymentMethod, 'USD');
+            } catch (error: unknown) {
+                expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
+            }
+        });
+
+        it('returns PayPal Fastlane Sdk', async () => {
+            const result = await subject.getPayPalFastlaneSdk(paymentMethod, 'USD');
+
+            expect(result).toEqual(paypalFastlaneSdk);
         });
     });
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -19,7 +19,7 @@ export interface PayPalCommerceInitializationData {
     buyerCountry?: string;
     clientId: string;
     clientToken?: string;
-    connectClientToken?: string;
+    connectClientToken?: string; // TODO: remove when PPCP Fastlane A/B test will be finished
     enabledAlternativePaymentMethods: FundingType;
     isDeveloperModeApplicable?: boolean;
     intent?: PayPalCommerceIntent;
@@ -32,7 +32,7 @@ export interface PayPalCommerceInitializationData {
     merchantId?: string;
     orderId?: string;
     shouldRenderFields?: boolean;
-    shouldRunAcceleratedCheckout?: boolean; // PayPal Connect related
+    shouldRunAcceleratedCheckout?: boolean; // TODO: remove when PPCP Fastlane A/B test will be finished
     // paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>; // TODO: PayPalButtonStyleOptions interface will be moved in the future
 }
 
@@ -43,8 +43,10 @@ export interface PayPalCommerceInitializationData {
  *
  */
 export interface PayPalCommerceHostWindow extends Window {
-    paypalAxo?: PayPalAxoSdk;
-    paypalConnect?: PayPalCommerceConnect;
+    paypalAxo?: PayPalAxoSdk; // TODO: remove when PPCP Fastlane experiment will be rolled out to 100%
+    paypalConnect?: PayPalCommerceConnect; // TODO: remove when PPCP Fastlane experiment will be rolled out to 100%
+    paypalFastlane?: PayPalFastlane;
+    paypalFastlaneSdk?: PayPalFastlaneSdk;
     paypalMessages?: PayPalMessagesSdk;
 }
 
@@ -76,7 +78,8 @@ export enum PayPalCommerceIntent {
     CAPTURE = 'capture',
 }
 
-export type PayPalSdkComponents = Array<'connect' | 'messages'>;
+// TODO: remove 'connect' when PPCP Fastlane experiment will be rolled out to 100%
+export type PayPalSdkComponents = Array<'connect' | 'fastlane' | 'messages'>;
 
 /**
  *
@@ -85,6 +88,10 @@ export type PayPalSdkComponents = Array<'connect' | 'messages'>;
  */
 export interface PayPalAxoSdk {
     Connect(options?: PayPalCommerceConnectOptions): Promise<PayPalCommerceConnect>;
+}
+
+export interface PayPalFastlaneSdk {
+    Fastlane(options?: PayPalFastlaneOptions): Promise<PayPalFastlane>;
 }
 
 export interface PayPalMessagesSdk {
@@ -115,7 +122,8 @@ export interface MessagingOptions {
 
 /**
  *
- * PayPal Axo related types
+ * PayPal Connect related types
+ * TODO: remove all PayPal Connect related types when PPCP Fastlane experiment will be rolled out to 100%
  *
  */
 export interface PayPalCommerceConnect {
@@ -325,6 +333,217 @@ export interface PayPalCommerceConnectEmailEnteredEventOptions
 
 export interface PayPalCommerceConnectOrderPlacedEventOptions
     extends PayPalCommerceConnectEventCommonOptions {
+    selected_payment_method: string;
+    currency_code: string;
+}
+
+/**
+ *
+ * PayPal Fastlane related types
+ *
+ */
+export interface PayPalFastlane {
+    identity: PayPalFastlaneIdentity;
+    events: PayPalFastlaneEvents;
+    profile: PayPalFastlaneProfile;
+    FastlaneCardComponent(
+        options: PayPalFastlaneCardComponentOptions,
+    ): PayPalFastlaneCardComponentMethods;
+}
+
+export interface PayPalFastlaneOptions {
+    styles?: PayPalFastlaneStylesOption;
+}
+
+export interface PayPalFastlaneIdentity {
+    lookupCustomerByEmail(email: string): Promise<PayPalFastlaneLookupCustomerByEmailResult>;
+    triggerAuthenticationFlow(
+        customerContextId: string,
+    ): Promise<PayPalFastlaneAuthenticationResult>;
+}
+
+export interface PayPalFastlaneLookupCustomerByEmailResult {
+    customerContextId?: string;
+}
+
+export interface PayPalFastlaneAuthenticationResult {
+    authenticationState?: PayPalFastlaneAuthenticationState;
+    profileData?: PayPalFastlaneProfileData;
+}
+
+export enum PayPalFastlaneAuthenticationState {
+    SUCCEEDED = 'succeeded',
+    FAILED = 'failed',
+    CANCELED = 'cancelled',
+    UNRECOGNIZED = 'unrecognized',
+}
+
+export interface PayPalFastlaneProfileData {
+    name: PayPalFastlaneProfileName;
+    shippingAddress: PayPalFastlaneShippingAddress;
+    card: PayPalFastlaneProfileCard;
+}
+
+export interface PayPalFastlaneProfileName {
+    fullName: string;
+    firstName: string;
+    lastName: string;
+}
+
+export interface PayPalFastlaneProfilePhone {
+    countryCode: string;
+    nationalNumber: string;
+}
+
+export interface PayPalFastlaneShippingAddress {
+    name: PayPalFastlaneProfileName;
+    phoneNumber: PayPalFastlaneProfilePhone;
+    address: PayPalFastlaneAddress;
+}
+
+export interface PayPalFastlaneProfileCard {
+    id: string; // nonce / token
+    paymentSource: PayPalFastlanePaymentSource;
+}
+
+export interface PayPalFastlanePaymentSource {
+    card: PayPalFastlaneCardSource;
+}
+
+export interface PayPalFastlaneCardSource {
+    brand: string;
+    expiry: string; // "YYYY-MM"
+    lastDigits: string; // "1111"
+    name: string;
+    billingAddress: PayPalFastlaneAddress;
+}
+
+export interface PayPalFastlaneAddress {
+    company?: string;
+    addressLine1: string;
+    addressLine2?: string;
+    adminArea1: string; // State
+    adminArea2: string; // City
+    postalCode: string;
+    countryCode?: string;
+}
+
+export interface PayPalFastlaneProfileToBcCustomerDataMappingResult {
+    authenticationState: PayPalFastlaneAuthenticationState;
+    addresses: CustomerAddress[];
+    billingAddress?: CustomerAddress;
+    shippingAddress?: CustomerAddress;
+    instruments: CardInstrument[];
+}
+
+export interface PayPalFastlaneStylesOption {
+    root?: {
+        backgroundColorPrimary?: string;
+        errorColor?: string;
+        fontFamily?: string;
+    };
+    input?: {
+        borderRadius?: string;
+        borderColor?: string;
+        focusBorderColor?: string;
+    };
+    toggle?: {
+        colorPrimary?: string;
+        colorSecondary?: string;
+    };
+    text?: {
+        body?: {
+            color?: string;
+            fontSize?: string;
+        };
+        caption?: {
+            color?: string;
+            fontSize?: string;
+        };
+    };
+    branding?: string; // 'light' | 'dark'
+}
+
+export interface PayPalFastlaneProfile {
+    showCardSelector(): Promise<PayPalFastlaneCardSelectorResponse>;
+}
+
+export interface PayPalFastlaneCardSelectorResponse {
+    selectionChanged: boolean;
+    selectedCard: PayPalFastlaneProfileCard;
+}
+
+export interface PayPalFastlaneCardComponentMethods {
+    tokenize(options: PayPalFastlaneTokenizeOptions): Promise<PayPalFastlaneTokenizeResult>;
+    render(element: string): void;
+}
+
+export interface PayPalFastlaneCardComponentOptions {
+    fields?: PayPalFastlaneCardComponentFields;
+}
+
+export interface PayPalFastlaneCardComponentFields {
+    [key: string]: PayPalFastlaneCardComponentField;
+}
+export interface PayPalFastlaneCardComponentField {
+    placeholder?: string;
+    prefill?: string;
+}
+
+export interface PayPalFastlaneTokenizeResult {
+    nonce: string;
+    details: PayPalFastlaneTokenizeDetails;
+    description: string;
+    type: string;
+}
+
+export interface PayPalFastlaneTokenizeDetails {
+    bin: string;
+    cardType: string;
+    expirationMoth: string;
+    expirationYear: string;
+    cardholderName: string;
+    lastFour: string;
+    lastTwo: string;
+}
+
+export interface PayPalFastlaneTokenizeOptions {
+    billingAddress?: PayPalFastlaneAddress;
+    shippingAddress?: PayPalFastlaneAddress;
+}
+
+export interface PayPalFastlaneEvents {
+    apmSelected: (options: PayPalFastlaneApmSelectedEventOptions) => void;
+    emailSubmitted: (options: PayPalFastlaneEmailEnteredEventOptions) => void;
+    orderPlaced: (options: PayPalFastlaneOrderPlacedEventOptions) => void;
+}
+
+export interface PayPalFastlaneEventCommonOptions {
+    context_type: 'cs_id';
+    context_id: string; // checkout session id
+    page_type: 'checkout_page';
+    page_name: string; // title of the checkout initiation page
+    partner_name: 'bigc';
+    user_type: 'store_member' | 'store_guest'; // type of the user on the merchant site
+    store_id: string;
+    merchant_name: string;
+    experiment: string; // stringify JSON object "[{ treatment_group: 'test' | 'control' }]"
+}
+
+export interface PayPalFastlaneApmSelectedEventOptions extends PayPalFastlaneEventCommonOptions {
+    apm_shown: '0' | '1'; // alternate payment shown on the checkout page
+    apm_list: string; // list of alternate payment shown on checkout page
+    apm_selected: string; // alternate payment method selected / methodId
+    apm_location: 'pre-email section' | 'payment section'; // placement of APM, whether it be above the email entry or in the radio buttons
+}
+
+export interface PayPalFastlaneEmailEnteredEventOptions extends PayPalFastlaneEventCommonOptions {
+    user_email_saved: boolean; // shows whether checkout was loaded with or without a saved email
+    apm_shown: '0' | '1'; // alternate payment shown on the checkout page
+    apm_list: string; // list of alternate payment shown on checkout page 'applepay,googlepay,paypal'
+}
+
+export interface PayPalFastlaneOrderPlacedEventOptions extends PayPalFastlaneEventCommonOptions {
     selected_payment_method: string;
     currency_code: string;
 }

--- a/packages/paypal-commerce-utils/src/utils/index.ts
+++ b/packages/paypal-commerce-utils/src/utils/index.ts
@@ -1,2 +1,5 @@
 export { default as isPayPalCommerceAcceleratedCheckoutCustomer } from './is-paypal-commerce-accelerated-checkout-customer';
 export { default as isPayPalCommerceConnectWindow } from './is-paypal-commerce-connect-window';
+
+export { default as isPayPalCommerceFastlaneWindow } from './is-paypal-fastline-window';
+export { default as isPayPalFastlaneCustomer } from './is-paypal-fastlane-customer';

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-fastlane-customer.spec.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-fastlane-customer.spec.ts
@@ -1,0 +1,21 @@
+import isPayPalFastlaneCustomer from './is-paypal-fastlane-customer';
+
+describe('isPayPalFastlaneCustomer', () => {
+    it('returns true if payment provider customer is PayPal Fastlane related', () => {
+        const paymentProviderCustomer = {
+            authenticationState: 'success',
+            addresses: [],
+            instruments: [],
+        };
+
+        expect(isPayPalFastlaneCustomer(paymentProviderCustomer)).toBe(true);
+    });
+
+    it('returns false if payment provider customer is not PayPal Fastlane related', () => {
+        const paymentProviderCustomer = {
+            stripeLinkAuthenticationState: true,
+        };
+
+        expect(isPayPalFastlaneCustomer(paymentProviderCustomer)).toBe(false);
+    });
+});

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-fastlane-customer.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-fastlane-customer.ts
@@ -1,0 +1,17 @@
+import {
+    PaymentProviderCustomer,
+    PayPalConnectCustomer,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+// TODO: update PayPalConnectCustomer with PayPalFastlaneCustomer
+export default function isPayPalFastlaneCustomer(
+    customer?: PaymentProviderCustomer,
+): customer is PayPalConnectCustomer {
+    if (!customer) {
+        return false;
+    }
+
+    return (
+        'authenticationState' in customer || 'addresses' in customer || 'instruments' in customer
+    );
+}

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-fastlane-window.spec.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-fastlane-window.spec.ts
@@ -1,0 +1,15 @@
+import { PayPalCommerceHostWindow } from '../paypal-commerce-types';
+
+import isPayPalFastlaneWindow from './is-paypal-fastline-window';
+
+describe('isPayPalFastlaneWindow', () => {
+    it('window has paypalFastlane option', () => {
+        expect(isPayPalFastlaneWindow({ paypalFastlane: {} } as PayPalCommerceHostWindow)).toBe(
+            true,
+        );
+    });
+
+    it('window does not have paypalFastlane option', () => {
+        expect(isPayPalFastlaneWindow({} as Window)).toBe(false);
+    });
+});

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-fastline-window.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-fastline-window.ts
@@ -1,0 +1,5 @@
+import { PayPalCommerceHostWindow } from '../paypal-commerce-types';
+
+export default function isPayPalFastlaneWindow(window: Window): window is PayPalCommerceHostWindow {
+    return window.hasOwnProperty('paypalFastlane');
+}


### PR DESCRIPTION
## What?
Updated paypal-commerce-utils package with PayPal Fastlane support:
- added Fastlane interfaces;
- updated PayPal Commerce Sdk configuration with Fastlane script;
- covered all utils methods related to Connect and Fasline into one PayPal Fastline Utils class;

P.s.: we should keep Connect related code while transforming all related code to use Fastlane.
will remove it when Fastlane experiment be rollout to 100%

## Why?
As part of PayPal Connect rebranding to PayPal Fastlane

## Testing / Proof
Unit tests
CI
