### PR TITLE
feat(payment): PAYPAL-3453 Added getInstruments to payment integration selectors

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
@@ -219,6 +219,7 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
                         provider: 'braintreeacceleratedcheckout',
                         trustedShippingAddress: false,
                         type: 'card',
+                        untrustedShippingCardVerificationMode: 'pan',
                     },
                 ],
             };
@@ -299,6 +300,7 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
                         provider: 'braintreeacceleratedcheckout',
                         trustedShippingAddress: false,
                         type: 'card',
+                        untrustedShippingCardVerificationMode: 'pan',
                     },
                 ],
             };

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
@@ -19,6 +19,7 @@ import {
     MissingDataErrorType,
     PaymentIntegrationService,
     PaymentMethodClientUnavailableError,
+    UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
@@ -276,6 +277,7 @@ export default class BraintreeAcceleratedCheckoutUtils {
                 provider: methodId,
                 trustedShippingAddress: false,
                 type: 'card',
+                untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
             };
         });
     }

--- a/packages/core/src/payment-integration/create-payment-integration-selectors.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-selectors.ts
@@ -11,7 +11,7 @@ export default function createPaymentIntegrationSelectors({
     consignments: { getConsignments, getConsignmentsOrThrow },
     countries: { getCountries },
     customer: { getCustomer, getCustomerOrThrow },
-    instruments: { getCardInstrument, getCardInstrumentOrThrow },
+    instruments: { getCardInstrument, getCardInstrumentOrThrow, getInstruments },
     order: { getOrder, getOrderOrThrow },
     payment: {
         getPaymentToken,
@@ -52,6 +52,7 @@ export default function createPaymentIntegrationSelectors({
         getCustomer: clone(getCustomer),
         getCustomerOrThrow: clone(getCustomerOrThrow),
         getCardInstrument: clone(getCardInstrument),
+        getInstruments: clone(getInstruments),
         getCardInstrumentOrThrow: clone(getCardInstrumentOrThrow),
         getOrder: clone(getOrder),
         getOrderOrThrow: clone(getOrderOrThrow),

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -147,6 +147,7 @@ export {
     PaypalInstrument,
     FormattedPayload,
     isHostedVaultedInstrument,
+    UntrustedShippingCardVerificationType,
 } from './payment';
 export { default as PaymentIntegrationSelectors } from './payment-integration-selectors';
 export { default as PaymentIntegrationService } from './payment-integration-service';

--- a/packages/payment-integration-api/src/payment-integration-selectors.ts
+++ b/packages/payment-integration-api/src/payment-integration-selectors.ts
@@ -6,7 +6,7 @@ import { Customer } from './customer';
 import { Country } from './geography';
 import { Order } from './order';
 import { PaymentProviderCustomer } from './payment-provider-customer';
-import { CardInstrument } from './payment/instrument';
+import PaymentInstrument, { CardInstrument } from './payment/instrument';
 import PaymentMethod from './payment/payment-method';
 import { Consignment, ShippingAddress } from './shipping';
 
@@ -36,6 +36,8 @@ export default interface PaymentIntegrationSelectors {
 
     getCardInstrument(instrumentId: string): CardInstrument | undefined;
     getCardInstrumentOrThrow(instrumentId: string): CardInstrument;
+
+    getInstruments(): PaymentInstrument[] | undefined;
 
     getOrder(): Order | undefined;
     getOrderOrThrow(): Order;

--- a/packages/payment-integration-api/src/payment/index.ts
+++ b/packages/payment-integration-api/src/payment/index.ts
@@ -1,5 +1,10 @@
 export { default as InitializeOffsitePaymentConfig } from './initialize-offsite-payment-config';
-export { AccountInstrument, CardInstrument } from './instrument';
+export {
+    AccountInstrument,
+    CardInstrument,
+    UntrustedShippingCardVerificationType,
+    PayPalInstrument,
+} from './instrument';
 
 export {
     default as Payment,

--- a/packages/payment-integration-api/src/payment/instrument.ts
+++ b/packages/payment-integration-api/src/payment/instrument.ts
@@ -11,6 +11,11 @@ interface BaseInstrument {
     type: string;
 }
 
+export enum UntrustedShippingCardVerificationType {
+    CVV = 'cvv',
+    PAN = 'pan',
+}
+
 export interface CardInstrument extends BaseInstrument {
     brand: string;
     expiryMonth: string;
@@ -18,16 +23,24 @@ export interface CardInstrument extends BaseInstrument {
     iin: string;
     last4: string;
     type: 'card';
+    untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType;
 }
 
 interface BaseAccountInstrument extends BaseInstrument {
-    externalId: string;
     method: string;
     type: 'account' | 'bank';
 }
 
 export interface PayPalInstrument extends BaseAccountInstrument {
+    externalId: string;
     method: 'paypal';
+}
+
+export interface AchInstrument extends BaseAccountInstrument {
+    issuer: string;
+    accountNumber: string;
+    type: 'bank';
+    method: 'ach' | 'ecp';
 }
 
 export interface BankInstrument extends BaseAccountInstrument {
@@ -38,7 +51,7 @@ export interface BankInstrument extends BaseAccountInstrument {
     type: 'bank';
 }
 
-export type AccountInstrument = PayPalInstrument | BankInstrument;
+export type AccountInstrument = PayPalInstrument | BankInstrument | AchInstrument;
 
 export interface VaultAccessToken {
     vaultAccessToken: string;

--- a/packages/payment-integrations-test-utils/src/test-utils/payments.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payments.mock.ts
@@ -4,6 +4,7 @@ import {
     Payment,
     PaymentMethod,
     PaymentResponseBody,
+    UntrustedShippingCardVerificationType,
     VaultedInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
@@ -53,6 +54,7 @@ export function getCardInstrument(): CardInstrument {
         iin: '1234',
         last4: '1111',
         type: 'card',
+        untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
     };
 }
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.spec.ts
@@ -471,6 +471,7 @@ describe('PayPalCommerceAcceleratedCheckoutPaymentStrategy', () => {
                 provider: 'paypalcommerceacceleratedcheckout',
                 trustedShippingAddress: false,
                 type: 'card',
+                untrustedShippingCardVerificationMode: 'pan',
             });
         });
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-accelerated-checkout-utils.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-accelerated-checkout-utils.spec.ts
@@ -185,6 +185,7 @@ describe('PayPalCommerceAcceleratedCheckoutUtils', () => {
                 provider: 'paypalcommerceacceleratedcheckout',
                 trustedShippingAddress: false,
                 type: 'card',
+                untrustedShippingCardVerificationMode: 'pan',
             };
 
             expect(

--- a/packages/paypal-commerce-utils/src/paypal-commerce-accelerated-checkout-utils.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-accelerated-checkout-utils.ts
@@ -5,6 +5,7 @@ import {
     CardInstrument,
     CustomerAddress,
     PaymentMethodClientUnavailableError,
+    UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
@@ -193,6 +194,7 @@ export default class PayPalCommerceAcceleratedCheckoutUtils {
                 provider: methodId,
                 trustedShippingAddress: false,
                 type: 'card',
+                untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
             },
         ];
     }


### PR DESCRIPTION
## What?

Added `getInstruments` to payment integration selectors

## Why?

To be able to get the instruments

## Testing / Proof

All tests passed

@bigcommerce/team-checkout @bigcommerce/team-payments
