### PR TITLE
fix(payment): PAYPAL-3573 updated PayPal to BC instrument mapper with untrustedShippingCardVerificationMode

### DIFF
--- a/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.spec.ts
@@ -1,4 +1,7 @@
-import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    PaymentMethodClientUnavailableError,
+    UntrustedShippingCardVerificationType,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import {
@@ -281,6 +284,7 @@ describe('PayPalCommerceFastlaneUtils', () => {
                 method: 'paypalcommerceacceleratedcheckout',
                 provider: 'paypalcommerceacceleratedcheckout',
                 trustedShippingAddress: false,
+                untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
                 type: 'card',
             };
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.ts
@@ -5,6 +5,7 @@ import {
     CardInstrument,
     CustomerAddress,
     PaymentMethodClientUnavailableError,
+    UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
@@ -257,6 +258,7 @@ export default class PayPalCommerceFastlaneUtils {
                 method: methodId,
                 provider: methodId,
                 trustedShippingAddress: false,
+                untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
                 type: 'card',
             },
         ];


### PR DESCRIPTION
## What?
Updated PayPal to BC instrument mapper with untrustedShippingCardVerificationMode

## Why?
To fix failed merge build

## Testing / Proof
Unit tests
CI
