### PR TITLE
feat(payment): PI-1648 Make an ability to use initializePayment actio…

### DIFF
--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -25,6 +25,7 @@ import {
     PaymentRequestTransformer,
 } from '../payment';
 import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
+import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 import {
     ConsignmentActionCreator,
     ConsignmentRequestSender,
@@ -119,6 +120,11 @@ export default function createPaymentIntegrationService(
         new ShippingCountryRequestSender(requestSender, { locale: getLocale() }),
     );
 
+    const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
+        new RemoteCheckoutRequestSender(requestSender),
+        checkoutActionCreator,
+    );
+
     return new DefaultPaymentIntegrationService(
         store,
         storeProjectionFactory,
@@ -135,5 +141,6 @@ export default function createPaymentIntegrationService(
         spamProtectionActionCreator,
         paymentProviderCustomerActionCreator,
         shippingCountryActionCreator,
+        remoteCheckoutActionCreator,
     );
 }

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -27,6 +27,7 @@ import { PaymentProviderCustomerActionCreator } from '../payment-provider-custom
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
 import { getPayment } from '../payment/payments.mock';
+import { RemoteCheckoutActionCreator } from '../remote-checkout';
 import { ConsignmentActionCreator, ShippingCountryActionCreator } from '../shipping';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 import { SpamProtectionActionCreator } from '../spam-protection';
@@ -74,6 +75,7 @@ describe('DefaultPaymentIntegrationService', () => {
     let storeCreditActionCreator: Pick<StoreCreditActionCreator, 'applyStoreCredit'>;
     let paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator;
     let shippingCountryActionCreator: Pick<ShippingCountryActionCreator, 'loadCountries'>;
+    let remoteCheckoutActionCreator: Pick<RemoteCheckoutActionCreator, 'initializePayment'>;
 
     beforeEach(() => {
         requestSender = createRequestSender();
@@ -168,6 +170,12 @@ describe('DefaultPaymentIntegrationService', () => {
             ),
         };
 
+        remoteCheckoutActionCreator = {
+            initializePayment: jest.fn(
+                async () => () => createAction('INITIALIZE_REMOTE_PAYMENT_REQUESTED'),
+            ),
+        };
+
         subject = new DefaultPaymentIntegrationService(
             store as CheckoutStore,
             storeProjectionFactory as PaymentIntegrationStoreProjectionFactory,
@@ -184,6 +192,7 @@ describe('DefaultPaymentIntegrationService', () => {
             spamProtectionActionCreator as SpamProtectionActionCreator,
             paymentProviderCustomerActionCreator,
             shippingCountryActionCreator as ShippingCountryActionCreator,
+            remoteCheckoutActionCreator as RemoteCheckoutActionCreator,
         );
     });
 
@@ -458,6 +467,18 @@ describe('DefaultPaymentIntegrationService', () => {
             expect(consignmentActionCreator.deleteConsignment).toHaveBeenCalled();
             expect(store.dispatch).toHaveBeenCalledWith(
                 consignmentActionCreator.deleteConsignment('ID'),
+            );
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#initializePayment', () => {
+        it('initialize payment', async () => {
+            const output = await subject.initializePayment('methodId');
+
+            expect(remoteCheckoutActionCreator.initializePayment).toHaveBeenCalled();
+            expect(store.dispatch).toHaveBeenCalledWith(
+                remoteCheckoutActionCreator.initializePayment('methodId'),
             );
             expect(output).toEqual(paymentIntegrationSelectors);
         });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -26,6 +26,8 @@ import {
 } from '../payment-provider-customer';
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
+import { RemoteCheckoutActionCreator } from '../remote-checkout';
+import { InitializePaymentOptions } from '../remote-checkout/remote-checkout-request-sender';
 import { ConsignmentActionCreator, ShippingCountryActionCreator } from '../shipping';
 import { SpamProtectionActionCreator } from '../spam-protection';
 import { StoreCreditActionCreator } from '../store-credit';
@@ -51,6 +53,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _spamProtectionActionCreator: SpamProtectionActionCreator,
         private _paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator,
         private _shippingCountryActionCreator: ShippingCountryActionCreator,
+        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
     ) {
         this._storeProjection = this._storeProjectionFactory.create(this._store);
     }
@@ -244,6 +247,18 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
     ): Promise<PaymentIntegrationSelectors> {
         await this._store.dispatch(
             this._consignmentActionCreator.deleteConsignment(consignmentId, options),
+        );
+
+        return this._storeProjection.getState();
+    }
+
+    async initializePayment(
+        methodId: string,
+        params?: InitializePaymentOptions,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._remoteCheckoutActionCreator.initializePayment(methodId, params, options),
         );
 
         return this._storeProjection.getState();

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -6,6 +6,7 @@ import { OrderRequestBody } from './order';
 import { InitializeOffsitePaymentConfig, Payment } from './payment';
 import PaymentIntegrationSelectors from './payment-integration-selectors';
 import { PaymentProviderCustomer } from './payment-provider-customer';
+import { InitializePaymentOptions } from './payment/payment-initialize-options';
 import { ShippingAddressRequestBody } from './shipping';
 import { RequestOptions } from './util-types';
 
@@ -80,4 +81,10 @@ export default interface PaymentIntegrationService {
     ): Promise<PaymentIntegrationSelectors>;
 
     loadShippingCountries(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
+
+    initializePayment(
+        methodId: string,
+        params?: InitializePaymentOptions,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors>;
 }

--- a/packages/payment-integration-api/src/payment/payment-initialize-options.ts
+++ b/packages/payment-integration-api/src/payment/payment-initialize-options.ts
@@ -3,3 +3,10 @@ import { PaymentRequestOptions } from './payment-request-options';
 export interface PaymentInitializeOptions extends PaymentRequestOptions {
     [key: string]: unknown;
 }
+
+export interface InitializePaymentOptions {
+    authorizationToken?: string;
+    customerMessage?: string;
+    referenceId?: string;
+    useStoreCredit?: boolean;
+}


### PR DESCRIPTION
…n from core package in integration checkout-sdk packages

## What?
Add `initializePayment` to `PaymentIntegrationService`

## Why?
To get ability to use `remoteCheckoutActionCreator.initializePayment` from `PaymentIntegrationService`

## Testing / Proof
Tested manually
![Zrzut ekranu 2024-02-16 o 16 21 51](https://github.com/bigcommerce/checkout-sdk-js/assets/130039975/454af480-d156-4af3-b674-730659c7b834)

@bigcommerce/team-checkout @bigcommerce/team-payments
