### PR TITLE
refactor(payment): PAYPAL-3647 updated PaymentInstrumentPayload interface with generic

### DIFF
--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -44,7 +44,7 @@ export default interface PaymentIntegrationService {
         options?: RequestOptions,
     ): Promise<PaymentIntegrationSelectors>;
 
-    submitPayment(payment: Payment): Promise<PaymentIntegrationSelectors>;
+    submitPayment<FP = unknown>(payment: Payment<FP>): Promise<PaymentIntegrationSelectors>;
 
     finalizeOrder(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
 

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -44,7 +44,7 @@ export default interface PaymentIntegrationService {
         options?: RequestOptions,
     ): Promise<PaymentIntegrationSelectors>;
 
-    submitPayment<FP = unknown>(payment: Payment<FP>): Promise<PaymentIntegrationSelectors>;
+    submitPayment<T = unknown>(payment: Payment<T>): Promise<PaymentIntegrationSelectors>;
 
     finalizeOrder(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
 

--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -3,14 +3,14 @@ import { Omit } from '../util-types';
 
 import PaymentAdditionalAction from './payment-additional-action';
 
-export default interface Payment<FP = unknown> {
+export default interface Payment<T = unknown> {
     methodId: string;
     gatewayId?: string;
-    paymentData?: PaymentInstrumentPayload<FP> & PaymentInstrumentMeta;
+    paymentData?: PaymentInstrumentPayload<T> & PaymentInstrumentMeta;
     additionalAction?: PaymentAdditionalAction;
 }
 
-export type PaymentInstrumentPayload<FP = unknown> =
+export type PaymentInstrumentPayload<T = unknown> =
     | WithEcpInstrument
     | WithSepaInstrument
     | WithIdealInstrument
@@ -41,7 +41,7 @@ export type PaymentInstrumentPayload<FP = unknown> =
           | StripeUPEIntent
           | WithMollieIssuerInstrument
           | PaypalGooglePayInstrument
-          | FP
+          | T
       >
     | HostedInstrument
     | NonceInstrument

--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -3,14 +3,14 @@ import { Omit } from '../util-types';
 
 import PaymentAdditionalAction from './payment-additional-action';
 
-export default interface Payment {
+export default interface Payment<FP = unknown> {
     methodId: string;
     gatewayId?: string;
-    paymentData?: PaymentInstrumentPayload & PaymentInstrumentMeta;
+    paymentData?: PaymentInstrumentPayload<FP> & PaymentInstrumentMeta;
     additionalAction?: PaymentAdditionalAction;
 }
 
-export type PaymentInstrumentPayload =
+export type PaymentInstrumentPayload<FP = unknown> =
     | WithEcpInstrument
     | WithSepaInstrument
     | WithIdealInstrument
@@ -40,8 +40,8 @@ export type PaymentInstrumentPayload =
           | StripeV3FormattedPayload
           | StripeUPEIntent
           | WithMollieIssuerInstrument
-          | WithPayPalConnectInstrument
           | PaypalGooglePayInstrument
+          | FP
       >
     | HostedInstrument
     | NonceInstrument
@@ -97,13 +97,6 @@ export interface WithDocumentInstrument {
 export interface WithMollieIssuerInstrument {
     issuer: string;
     shopper_locale: string;
-}
-
-export interface WithPayPalConnectInstrument {
-    paypal_connect_token: {
-        order_id?: string;
-        token: string;
-    };
 }
 
 export interface WithIdealInstrument {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.ts
@@ -21,6 +21,7 @@ import {
     PayPalCommerceConnectAuthenticationState,
     PayPalCommerceConnectCardComponentMethods,
     PayPalCommerceConnectCardComponentOptions,
+    PayPalCommerceConnectPaymentFormattedPayload,
     PayPalCommerceInitializationData,
     PayPalCommerceSdk,
 } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
@@ -131,7 +132,9 @@ export default class PayPalCommerceAcceleratedCheckoutPaymentStrategy implements
                 : await this.preparePaymentPayload(methodId, orderId, paymentData);
 
         await this.paymentIntegrationService.submitOrder(order, options);
-        await this.paymentIntegrationService.submitPayment(paymentPayload);
+        await this.paymentIntegrationService.submitPayment<PayPalCommerceConnectPaymentFormattedPayload>(
+            paymentPayload,
+        );
 
         this.paypalCommerceAcceleratedCheckoutUtils.updateStorageSessionId(true);
     }
@@ -277,7 +280,7 @@ export default class PayPalCommerceAcceleratedCheckoutPaymentStrategy implements
         methodId: string,
         paypalOrderId: string,
         paymentData: VaultedInstrument,
-    ): Payment {
+    ): Payment<PayPalCommerceConnectPaymentFormattedPayload> {
         const { instrumentId } = paymentData;
 
         return {
@@ -297,7 +300,7 @@ export default class PayPalCommerceAcceleratedCheckoutPaymentStrategy implements
         methodId: string,
         paypalOrderId: string,
         paymentData: OrderPaymentRequestBody['paymentData'],
-    ): Promise<Payment> {
+    ): Promise<Payment<PayPalCommerceConnectPaymentFormattedPayload>> {
         const state = this.paymentIntegrationService.getState();
         const billingAddress = state.getBillingAddressOrThrow();
         // Info: shipping can be unavailable for carts with digital items

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -550,3 +550,10 @@ export interface PayPalFastlaneOrderPlacedEventOptions extends PayPalFastlaneEve
     selected_payment_method: string;
     currency_code: string;
 }
+
+export interface PayPalCommerceConnectPaymentFormattedPayload {
+    paypal_connect_token: {
+        order_id?: string;
+        token: string;
+    };
+}


### PR DESCRIPTION
## What?
Updated PaymentInstrumentPayload interface with generic

## Why?
This feature gives developers an ability to provide custom formatted payload interface to payment submit method from provider specific package. It should help us to keep all custom interfaces inside our own packages and remove all provider specific code from core type packages (payment integration api).

## Testing / Proof
I have build the project in different ways using `npm run build`, `npm run bundle:watch`, `npm run bundle-dts`, different commands to check lint issues and tests and they are all passed successfully

And CI tests as well
