### PR TITLE
chore(common): CHECKOUT-00 update cart discountAmount and discount docs

### DIFF
--- a/packages/core/src/cart/cart.ts
+++ b/packages/core/src/cart/cart.ts
@@ -13,10 +13,24 @@ export default interface Cart {
     email: string;
     isTaxIncluded: boolean;
     baseAmount: number;
+
+    /**
+     * This is the total amount of discount applied on line_items.
+     */
     discountAmount: number;
+
     cartAmount: number;
+
+    /**
+     * This is an array of all applied coupons.
+     */
     coupons: Coupon[];
+
+    /**
+     * This is the total amount of discount applied on cart including coupons and line_items discounts.
+     */
     discounts: Discount[];
+
     lineItems: LineItemMap;
     createdTime: string;
     updatedTime: string;


### PR DESCRIPTION
## What?
Update docs per #387

## Why?
To improve understanding that cart.discountAmount is a cart-level discount while cart.discounts is  customer-entered coupons.

## Testing / Proof
Verified update on local build

@bigcommerce/team-checkout @bigcommerce/team-payments
