### PR TITLE
chore(shipping): PAYPAL-000 updated codeownership by adding paypal team as a codeowner for paypal commerce shipping strategies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,7 @@
 /packages/core/src/checkout-buttons/strategies/paypal @bigcommerce/team-paypal
 /packages/core/src/customer/strategies/braintree @bigcommerce/team-paypal
 /packages/core/src/shipping/strategies/braintree @bigcommerce/team-paypal
+/packages/core/src/shipping/strategies/paypal-commerce @bigcommerce/team-paypal
 /packages/core/src/payment/strategies/braintree @bigcommerce/team-paypal
 /packages/core/src/payment/strategies/paypal @bigcommerce/team-paypal
 


### PR DESCRIPTION
## What?
Updated codeownership by adding paypal team as a codeowner for paypal commerce shipping strategies

## Why?
Checkout team should not be responsible for paypal commerce codebase

## Testing / Proof
-
