### PR TITLE
refactor(payment): PAYPAL-3575 updated shipping registry with paypal commerce fastlane shipping strategy instead of accelerated checkout

### DIFF
--- a/packages/core/src/shipping/create-shipping-strategy-registry.spec.ts
+++ b/packages/core/src/shipping/create-shipping-strategy-registry.spec.ts
@@ -7,7 +7,7 @@ import createShippingStrategyRegistry from './create-shipping-strategy-registry'
 import { ShippingStrategy } from './strategies';
 import { AmazonPayV2ShippingStrategy } from './strategies/amazon-pay-v2';
 import { BraintreeAcceleratedCheckoutShippingStrategy } from './strategies/braintree';
-import { PayPalCommerceAcceleratedCheckoutShippingStrategy } from './strategies/paypal-commerce';
+import { PayPalCommerceFastlaneShippingStrategy } from './strategies/paypal-commerce';
 
 describe('CreateShippingStrategyRegistry', () => {
     let registry: Registry<ShippingStrategy>;
@@ -31,9 +31,9 @@ describe('CreateShippingStrategyRegistry', () => {
         expect(shippingStrategy).toBeInstanceOf(BraintreeAcceleratedCheckoutShippingStrategy);
     });
 
-    it('can instantiate paypal commerce accelerated checkout', () => {
+    it('can instantiate paypal commerce fastlane shipping strategy', () => {
         const shippingStrategy = registry.get('paypalcommerceacceleratedcheckout');
 
-        expect(shippingStrategy).toBeInstanceOf(PayPalCommerceAcceleratedCheckoutShippingStrategy);
+        expect(shippingStrategy).toBeInstanceOf(PayPalCommerceFastlaneShippingStrategy);
     });
 });

--- a/packages/core/src/shipping/create-shipping-strategy-registry.ts
+++ b/packages/core/src/shipping/create-shipping-strategy-registry.ts
@@ -7,7 +7,7 @@ import {
     BraintreeScriptLoader,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
-    createPayPalCommerceAcceleratedCheckoutUtils,
+    createPayPalCommerceFastlaneUtils,
     createPayPalCommerceSdk,
 } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
 
@@ -27,7 +27,7 @@ import { ShippingStrategy } from './strategies';
 import { AmazonPayV2ShippingStrategy } from './strategies/amazon-pay-v2';
 import { BraintreeAcceleratedCheckoutShippingStrategy } from './strategies/braintree';
 import { DefaultShippingStrategy } from './strategies/default';
-import { PayPalCommerceAcceleratedCheckoutShippingStrategy } from './strategies/paypal-commerce';
+import { PayPalCommerceFastlaneShippingStrategy } from './strategies/paypal-commerce';
 import { StripeUPEShippingStrategy } from './strategies/stripe-upe';
 
 export default function createShippingStrategyRegistry(
@@ -96,14 +96,14 @@ export default function createShippingStrategyRegistry(
     registry.register(
         'paypalcommerceacceleratedcheckout',
         () =>
-            new PayPalCommerceAcceleratedCheckoutShippingStrategy(
+            new PayPalCommerceFastlaneShippingStrategy(
                 store,
                 billingAddressActionCreator,
                 consignmentActionCreator,
                 paymentMethodActionCreator,
                 new PaymentProviderCustomerActionCreator(),
                 createPayPalCommerceSdk(),
-                createPayPalCommerceAcceleratedCheckoutUtils(),
+                createPayPalCommerceFastlaneUtils(),
             ),
     );
 


### PR DESCRIPTION
## What?
Updated shipping registry with PayPal Commerce Fastlane shipping strategy instead of accelerated checkout

## Why?
As part of PP Connect rebrending process. PayPal Commerce Fastlane shipping strategy contains both Connect and Fastlane features to be able to switch between them based on the value of related experiment

## Testing / Proof
Unit tests
Manual tests
CI
