### PR TITLE
feat(payment): PAYPAL-3683 updated paypal-commerce-credit-cards-payment-strategy to support PayPal Connect and Fastlane initialization

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/create-paypal-commerce-credit-cards-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/create-paypal-commerce-credit-cards-payment-strategy.ts
@@ -3,7 +3,7 @@ import {
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
-    createPayPalCommerceAcceleratedCheckoutUtils,
+    createPayPalCommerceFastlaneUtils,
     createPayPalCommerceSdk,
 } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
 
@@ -18,7 +18,7 @@ const createPaypalCommerceCreditCardsPaymentStrategy: PaymentStrategyFactory<
         paymentIntegrationService,
         createPayPalCommerceIntegrationService(paymentIntegrationService),
         createPayPalCommerceSdk(),
-        createPayPalCommerceAcceleratedCheckoutUtils(),
+        createPayPalCommerceFastlaneUtils(),
     );
 
 export default toResolvableModule(createPaypalCommerceCreditCardsPaymentStrategy, [

--- a/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
@@ -162,7 +162,7 @@ describe('PayPalCommerceSdk', () => {
                     async: true,
                     attributes: {
                         'data-client-metadata-id': expectedSessionId,
-                        'data-namespace': 'paypalFastlane',
+                        'data-namespace': 'paypalFastlaneSdk',
                         'data-partner-attribution-id': '1123JLKJASD12',
                         'data-user-id-token': 'asdcvY7XFSQasd',
                     },
@@ -190,7 +190,7 @@ describe('PayPalCommerceSdk', () => {
                     async: true,
                     attributes: {
                         'data-client-metadata-id': expectedSessionId,
-                        'data-namespace': 'paypalFastlane',
+                        'data-namespace': 'paypalFastlaneSdk',
                         'data-partner-attribution-id': '1123JLKJASD12',
                         'data-user-id-token': 'connectClientToken123',
                     },

--- a/packages/paypal-commerce-utils/src/paypal-commerce-sdk.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-sdk.ts
@@ -181,7 +181,7 @@ export default class PayPalCommerceSdk {
             },
             attributes: {
                 'data-client-metadata-id': sessionId.replace(/-/g, ''),
-                'data-namespace': 'paypalFastlane',
+                'data-namespace': 'paypalFastlaneSdk',
                 'data-partner-attribution-id': attributionId,
                 'data-user-id-token': connectClientToken || clientToken,
             },


### PR DESCRIPTION
## What?
Updated paypal-commerce-credit-cards-payment-strategy to support PayPal Connect and Fastlane initialization

## Why?
As part of PayPal Connect to Fastlane rebranding

## Testing / Proof
Unit tests
CI
