### PR TITLE
feat(payment): PI-1679 toggle Stripe terms text

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
@@ -1,3 +1,5 @@
+import { StripeElementUpdateOptions } from './stripe-upe';
+
 /**
  * A set of options that are required to initialize the Stripe payment method.
  *
@@ -35,6 +37,10 @@ export default interface StripeUPEPaymentInitializeOptions {
     onError?(error?: Error): void;
 
     render(): void;
+
+    initStripeElementUpdateTrigger?(
+        updateTriggerFn: (payload: StripeElementUpdateOptions) => void,
+    ): void;
 }
 
 export interface WithStripeUPEPaymentInitializeOptions {

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.mock.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.mock.ts
@@ -5,6 +5,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { StripePaymentMethodType, StripeUPEClient } from './stripe-upe';
+import { WithStripeUPEPaymentInitializeOptions } from './stripe-upe-initialize-options';
 
 const gatewayId = 'stripeupe';
 
@@ -38,6 +39,7 @@ export function getStripeUPEJsMock(): StripeUPEClient {
                 mount: jest.fn(),
                 unmount: jest.fn(),
                 on: jest.fn((_, callback) => callback()),
+                update: jest.fn(),
             })),
             getElement: jest.fn().mockReturnValue(null),
             update: jest.fn(),
@@ -71,7 +73,7 @@ export function getFailingStripeUPEJsMock(): StripeUPEClient {
 export function getStripeUPEInitializeOptionsMock(
     stripePaymentMethodType: StripePaymentMethodType = StripePaymentMethodType.CreditCard,
     style: { [key: string]: string } = { fieldText: '#ccc' },
-): PaymentInitializeOptions {
+): PaymentInitializeOptions & WithStripeUPEPaymentInitializeOptions {
     return {
         methodId: stripePaymentMethodType,
         gatewayId,

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
@@ -47,6 +47,12 @@ export interface StripeElement {
      * https://stripe.com/docs/js/element/events/on_change?type=paymentElement
      */
     on(event: 'change' | 'ready', handler: (event: StripeEventType) => void): void;
+
+    /**
+     * Updates the options the Payment Element was initialized with. Updates are merged into the existing configuration.
+     * https://docs.stripe.com/js/elements_object/update_payment_element
+     */
+    update(options?: StripeElementsCreateOptions): void;
 }
 
 export interface StripeEvent {
@@ -185,6 +191,10 @@ export interface WalletOptions {
     googlePay?: AutoOrNever;
 }
 
+export interface TermOptions {
+    card?: AutoOrNever;
+}
+
 /**
  * All available options are here https://stripe.com/docs/js/elements_object/create_payment_element
  */
@@ -196,6 +206,7 @@ export interface StripeElementsCreateOptions {
     defaultValues?: ShippingDefaultValues | CustomerDefaultValues;
     validation?: validationElement;
     display?: { name: DisplayName };
+    terms?: TermOptions;
 }
 
 interface validationElement {
@@ -424,4 +435,8 @@ export interface StripeUPEInitializationData {
     stripePublishableKey: string;
     stripeConnectedAccount: string;
     shopperLanguage: string;
+}
+
+export interface StripeElementUpdateOptions {
+    shouldShowTerms?: boolean;
 }


### PR DESCRIPTION
## What?
Add ability to hide Stripe terms text

## Why?
To hide terms text for saving credit card when shopper don't select save credit card option
Checkout-js PR: [https://github.com/bigcommerce/checkout-js/pull/1733](https://github.com/bigcommerce/checkout-js/pull/1733)

## Testing / Proof
Experiment disabled

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/5493da42-f4e4-4813-b2fb-f3f82ceec230

Experiment enabled

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/ff09a364-13cc-4856-9d6c-dffdde66df17




@bigcommerce/team-checkout @bigcommerce/team-payments
