### PR TITLE
feat(payment): PAYPAL-3784 added billing address data to the submit payload for PPCP credit card form action

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
@@ -421,12 +421,28 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
      * */
     private async submitHostedForm() {
         const cardFields = this.getCardFieldsOrThrow();
+        const state = this.paymentIntegrationService.getState();
+        const billingAddress = state.getBillingAddressOrThrow();
 
-        await cardFields.submit().catch(() => {
+        const submitConfig = {
+            billingAddress: {
+                company: billingAddress.company,
+                addressLine1: billingAddress.address1,
+                addressLine2: billingAddress.address2,
+                adminArea1: billingAddress.stateOrProvinceCode,
+                adminArea2: billingAddress.city,
+                postalCode: billingAddress.postalCode,
+                countryCode: billingAddress.countryCode,
+            },
+        };
+
+        try {
+            await cardFields.submit(submitConfig);
+        } catch (_) {
             throw new PaymentMethodFailedError(
                 'Failed authentication. Please try to authorize again.',
             );
-        });
+        }
     }
 
     /**

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -87,8 +87,20 @@ export interface PayPalCommerceCardFields {
     ExpiryField(config?: PayPalCommerceFieldsInitializationData): PayPalCommerceFields;
     NameField(config?: PayPalCommerceFieldsInitializationData): PayPalCommerceFields;
     NumberField(config?: PayPalCommerceFieldsInitializationData): PayPalCommerceFields;
-    submit(): Promise<void>;
+    submit(config?: PayPalCommerceCardFieldsSubmitConfig): Promise<void>;
     getState(): Promise<PayPalCommerceCardFieldsState>;
+}
+
+export interface PayPalCommerceCardFieldsSubmitConfig {
+    billingAddress: {
+        company?: string;
+        addressLine1: string;
+        addressLine2?: string;
+        adminArea1: string; // State
+        adminArea2: string; // City
+        postalCode: string;
+        countryCode?: string;
+    };
 }
 
 export interface PayPalSDK {


### PR DESCRIPTION
## What?
Added billing address data to the submit payload for PPCP credit card form action

## Why?
To avoid different mistakes and detect fraud payments on PayPal side

## Testing / Proof
Unit tests
Manual tests
CI
