### PR TITLE
refactor(payment): PAYPAL-000 removed hardcoded method id values for paypal and braintree analytics

### DIFF
--- a/packages/core/src/analytics/braintree-connect-tracker/braintree-connect-tracker.ts
+++ b/packages/core/src/analytics/braintree-connect-tracker/braintree-connect-tracker.ts
@@ -13,7 +13,7 @@ import { CheckoutService } from '../../checkout';
 import BraintreeConnectTrackerService from './braintree-connect-tracker-service';
 
 export default class BraintreeConnectTracker implements BraintreeConnectTrackerService {
-    private _selectedPaymentMethodId = 'braintreeacceleratedcheckout';
+    private _selectedPaymentMethodId = '';
 
     constructor(private checkoutService: CheckoutService) {}
 

--- a/packages/core/src/analytics/paypal-commerce-analytic-tracker/paypal-commerce-analytic-tracker.ts
+++ b/packages/core/src/analytics/paypal-commerce-analytic-tracker/paypal-commerce-analytic-tracker.ts
@@ -14,7 +14,7 @@ import { CheckoutService } from '../../checkout';
 import PayPalCommerceAnalyticTrackerService from './paypal-commerce-analytic-tracker-service';
 
 export default class PayPalCommerceAnalyticTracker implements PayPalCommerceAnalyticTrackerService {
-    private _selectedPaymentMethodId = 'paypalcommerceacceleratedcheckout';
+    private _selectedPaymentMethodId = '';
 
     constructor(private _checkoutService: CheckoutService) {}
 


### PR DESCRIPTION
## What?
Removed hardcoded method id values for paypal and braintree analytics

## Why?
This values sometimes creating different mistakes with analytic data on PayPal side

## Testing / Proof
Unit tests
CI
