### PR TITLE
feat(payment): PAYPAL-3744 updated execute tokenize method with getPaymentToken in paypal-commerce-fastlane-payment-strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -518,7 +518,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                         formattedPayload: {
                             paypal_fastlane_token: {
                                 order_id: paypalOrderId,
-                                token: 'paypal_fastlane_tokenize_nonce',
+                                token: 'paypal_fastlane_instrument_id_nonce',
                             },
                         },
                     },

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-connect.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-connect.mock.ts
@@ -8,6 +8,28 @@ export default function getPayPalConnect(): PayPalCommerceConnect {
         tokenize: jest.fn(() => ({
             nonce: 'paypal_connect_tokenize_nonce',
         })),
+        getPaymentToken: jest.fn(() => ({
+            id: 'paypal_connect_instrument_id_nonce',
+            paymentSource: {
+                card: {
+                    brand: 'Visa',
+                    expiry: '2030-12',
+                    lastDigits: '1111',
+                    name: 'John Doe',
+                    billingAddress: {
+                        firstName: 'John',
+                        lastName: 'Doe',
+                        company: 'BigCommerce',
+                        streetAddress: 'addressLine1',
+                        extendedAddress: 'addressLine2',
+                        locality: 'addressCity',
+                        region: 'addressState',
+                        postalCode: '03004',
+                        countryCodeAlpha2: 'US',
+                    },
+                },
+            },
+        })),
         render: jest.fn(),
     };
 

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
@@ -5,6 +5,28 @@ export default function getPayPalFastlane(): PayPalFastlane {
         tokenize: jest.fn(() => ({
             nonce: 'paypal_fastlane_tokenize_nonce',
         })),
+        getPaymentToken: jest.fn(() => ({
+            id: 'paypal_fastlane_instrument_id_nonce',
+            paymentSource: {
+                card: {
+                    brand: 'Visa',
+                    expiry: '2030-12',
+                    lastDigits: '1111',
+                    name: 'John Doe',
+                    billingAddress: {
+                        firstName: 'John',
+                        lastName: 'Doe',
+                        company: 'BigCommerce',
+                        streetAddress: 'addressLine1',
+                        extendedAddress: 'addressLine2',
+                        locality: 'addressCity',
+                        region: 'addressState',
+                        postalCode: '03004',
+                        countryCodeAlpha2: 'US',
+                    },
+                },
+            },
+        })),
         render: jest.fn(),
     };
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -262,6 +262,9 @@ export interface PayPalCommerceConnectCardComponentMethods {
     tokenize(
         options: PayPalCommerceConnectTokenizeOptions,
     ): Promise<PayPalCommerceConnectTokenizeResult>;
+    getPaymentToken(
+        options: PayPalFastlaneGetPaymentTokenOptions,
+    ): Promise<PayPalFastlaneProfileCard>; // TODO: this method does not support by PayPal Connect
     render(element: string): void;
 }
 
@@ -477,7 +480,10 @@ export interface PayPalFastlaneCardSelectorResponse {
 }
 
 export interface PayPalFastlaneCardComponentMethods {
-    tokenize(options: PayPalFastlaneTokenizeOptions): Promise<PayPalFastlaneTokenizeResult>;
+    tokenize(options: PayPalFastlaneTokenizeOptions): Promise<PayPalFastlaneTokenizeResult>; // TODO: remove with PayPal Connect implementation
+    getPaymentToken(
+        options: PayPalFastlaneGetPaymentTokenOptions,
+    ): Promise<PayPalFastlaneProfileCard>;
     render(element: string): void;
 }
 
@@ -514,6 +520,10 @@ export interface PayPalFastlaneTokenizeOptions {
     name?: PayPalFastlaneProfileName;
     billingAddress?: PayPalFastlaneAddress;
     shippingAddress?: PayPalFastlaneAddress;
+}
+
+export interface PayPalFastlaneGetPaymentTokenOptions {
+    billingAddress?: PayPalFastlaneAddress;
 }
 
 export interface PayPalFastlaneEvents {


### PR DESCRIPTION
## What?
Updated execute tokenize method with getPaymentToken in paypal-commerce-fastlane-payment-strategy

## Why?
PayPal Commerce Fastlane does not have tokenize sdk method as Connect had due to refactoring on PayPal side

## Testing / Proof
Unit tests
Manual tests
CI
