### PR TITLE
fix(payment): PAYPAL-3838 removed hardcoded payment method id value in braintree and paypal commerce analytic trackers

### DIFF
--- a/packages/core/src/analytics/braintree-analytic-tracker/braintree-analytic-tracker.ts
+++ b/packages/core/src/analytics/braintree-analytic-tracker/braintree-analytic-tracker.ts
@@ -14,7 +14,7 @@ import { CheckoutService } from '../../checkout';
 import BraintreeAnalyticTrackerService from './braintree-analytic-tracker-service';
 
 export default class BraintreeAnalyticTracker implements BraintreeAnalyticTrackerService {
-    private _selectedPaymentMethodId = 'braintreeacceleratedcheckout';
+    private _selectedPaymentMethodId = '';
 
     constructor(private checkoutService: CheckoutService) {}
 

--- a/packages/core/src/analytics/paypal-commerce-analytic-tracker/paypal-commerce-analytic-tracker.ts
+++ b/packages/core/src/analytics/paypal-commerce-analytic-tracker/paypal-commerce-analytic-tracker.ts
@@ -14,7 +14,7 @@ import { CheckoutService } from '../../checkout';
 import PayPalCommerceAnalyticTrackerService from './paypal-commerce-analytic-tracker-service';
 
 export default class PayPalCommerceAnalyticTracker implements PayPalCommerceAnalyticTrackerService {
-    private _selectedPaymentMethodId = 'paypalcommerceacceleratedcheckout';
+    private _selectedPaymentMethodId = '';
 
     constructor(private _checkoutService: CheckoutService) {}
 


### PR DESCRIPTION
## What?
Removed hardcoded payment method id value in braintree and paypal commerce analytic trackers

## Why?
To avoid data mistakes in PayPal analytic

## Testing / Proof
Unit tests
CI
