### PR TITLE
chore(common): CHECKOUT-0 - Add Gitleaks to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ version: 2.1
 orbs:
   ci: bigcommerce/internal@volatile
   node: bigcommerce/internal-node@volatile
+  security: bigcommerce/internal-security@volatile
 
 jobs:
   test-packages:
@@ -157,6 +158,10 @@ workflows:
           context: "GCR + Artifact Bucket Access"
           requires:
             - ci/build-js-artifact
+      - security/scan:
+          name: "Gitleaks secrets scan"
+          context: org-global
+          GITLEAKS_BLOCK: "false"
 
       # Only release to NPM registry when commits are merged to master and new version is approved
       - approve_npm_release:


### PR DESCRIPTION
## What?
Adding GItleaks (secret scanner).

## Why?
For secrets detection to prevent accidental commits of secrets

## Testing / Proof
Passing of existing CI builds with gitleaks succesfully running as part of the process.

@bigcommerce/team-checkout @bigcommerce/team-payments
