### PR TITLE
chore(common): CHECKOUT-0 Don't scanned forked

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,9 @@ workflows:
             - ci/build-js-artifact
       - security/scan:
           name: "Gitleaks secrets scan"
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
           context: org-global
           GITLEAKS_BLOCK: "false"
 


### PR DESCRIPTION
## What?
Changing config to not scan forked branches

## Why?
Forked PRs can break how circleci runs

## Testing / Proof
refer to ci test passing

@bigcommerce/team-checkout @bigcommerce/team-payments
