### PR TITLE
fix(payment): PI-1835 add TDBant to supported instruments

### DIFF
--- a/packages/core/src/payment/instrument/supported-payment-instruments.ts
+++ b/packages/core/src/payment/instrument/supported-payment-instruments.ts
@@ -165,6 +165,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'paypalcommerce',
         method: 'paypal',
     },
+    tdonlinemart: {
+        provider: 'tdonlinemart',
+        method: 'credit_card',
+    },
 };
 
 export default supportedInstruments;


### PR DESCRIPTION
## What?
Add TD Online Mart to list of available instruments

## Why?
To use TD Online Mart vaulted instruments on checkout

## Testing / Proof
<img width="690" alt="Screenshot 2024-03-22 at 18 11 16" src="https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/e749a4a1-69d5-497c-9e21-7dce0a71ade4">


@bigcommerce/team-checkout @bigcommerce/team-payments
