### PR TITLE
fix(embedded-checkout): Handle www redirects on embed checkout links

### DIFF
--- a/packages/core/src/embedded-checkout/resizable-iframe-creator.spec.ts
+++ b/packages/core/src/embedded-checkout/resizable-iframe-creator.spec.ts
@@ -184,4 +184,18 @@ describe('ResizableIframeCreator', () => {
             );
         }
     });
+
+    it('inserts the iframe even if the message comes from the www version of the url', async () => {
+        setTimeout(() => {
+            eventEmitter.emit('message', {
+                origin: 'http://www.mybigcommerce.com',
+                data: { type: EmbeddedCheckoutEventType.FrameLoaded },
+            });
+        });
+
+        const frame = await iframeCreator.createFrame(url, 'checkout');
+
+        expect(frame.tagName).toBe('IFRAME');
+        expect(frame.src).toEqual(url);
+    });
 });

--- a/packages/core/src/embedded-checkout/resizable-iframe-creator.ts
+++ b/packages/core/src/embedded-checkout/resizable-iframe-creator.ts
@@ -1,5 +1,5 @@
 import { IFrameComponent, iframeResizer, isIframeEvent } from '../common/iframe';
-import { parseUrl } from '../common/url';
+import { appendWww, parseUrl } from '../common/url';
 
 import { EmbeddedCheckoutEventType } from './embedded-checkout-events';
 import { NotEmbeddableError, NotEmbeddableErrorType } from './errors';
@@ -51,7 +51,10 @@ export default class ResizableIframeCreator {
             }, timeoutInterval);
 
             const handleMessage = (event: MessageEvent) => {
-                if (event.origin !== parseUrl(iframe.src).origin) {
+                if (
+                    event.origin !== parseUrl(iframe.src).origin &&
+                    event.origin !== appendWww(parseUrl(iframe.src)).origin
+                ) {
                     return;
                 }
 


### PR DESCRIPTION
## What?
Adds support in the `ResizeableIframeCreator` for bare and www versions of the domain passed to `embedCheckout` .

Fixes #2425 

## Why?
If the embed checkout url that is passed to `embedCheckout` is a bare url missing the www subdomain whilst the store loads with a redirect to the www subdomain, the resulting `MessageEvent` that is posted will be ignored by the `ResizeableIframeCreator`.

I used the [`IframeEventListener`'s handling](https://github.com/bigcommerce/checkout-sdk-js/blob/b4e9bee3c0fa999210cca52089f21469679b0663/packages/core/src/common/iframe/iframe-event-listener.ts#L16-L19) of this functionality as a baseline for this change.

## Testing / Proof
The test that has been included as part of this PR fails without the associated change.

@bigcommerce/team-checkout @bigcommerce/team-payments
