### PR TITLE
fix(payment): PI-1841 Check fields containers before mount

### DIFF
--- a/packages/td-bank-integration/src/td-online-mart.ts
+++ b/packages/td-bank-integration/src/td-online-mart.ts
@@ -20,6 +20,12 @@ export enum FieldType {
     EXPIRY = 'expiry',
 }
 
+export interface TDOnlineMartInput {
+    id: string;
+    fieldType: FieldType;
+    inputElement?: TdOnlineMartElement;
+}
+
 interface CreateTokenResponse {
     code: string;
     error?: CreateTokenError;
@@ -36,11 +42,6 @@ export interface CreateTokenError {
 }
 
 /* eslint-disable @typescript-eslint/naming-convention */
-export interface TdOnlineMartPaymentTokens {
-    token: string;
-    profile_token?: string;
-}
-
 export interface TdOnlineMartThreeDSErrorBody {
     errors?: Array<{ code: string }>;
     three_ds_result?: {


### PR DESCRIPTION
## What?
Add checks of input container existing before mounting TD Bank card fields
Remove unused token for credit card saving

## Why?
To fix issues with fields validation and update payloads after BE refactoring

## Testing / Proof
Unit test and manually tested

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/a625f9d0-0547-44d5-aef3-0899e82a847a



@bigcommerce/team-checkout @bigcommerce/team-payments
