### PR TITLE
feat(payment): PAYPAL-3881 added collectDeviceData flag to braintree sdk

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -633,6 +633,7 @@ describe('BraintreePaymentProcessor', () => {
                 bin: '123456',
                 nonce: 'tokenization_nonce',
                 onLookupComplete: expect.any(Function),
+                collectDeviceData: true,
             });
         });
 

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -281,6 +281,7 @@ export default class BraintreePaymentProcessor {
                 onLookupComplete: (_data, next) => {
                     next();
                 },
+                collectDeviceData: true,
             }),
         );
 

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -415,6 +415,7 @@ export interface BraintreeThreeDSecureOptions {
     addFrame(error: Error | undefined, iframe: HTMLIFrameElement): void;
     removeFrame(): void;
     onLookupComplete(data: BraintreeThreeDSecureVerificationData, next: () => void): void;
+    collectDeviceData: boolean;
 }
 
 interface BraintreeThreeDSecureVerificationData {


### PR DESCRIPTION
## What?
Added collectDeviceData flag to Braintree sdk

## Why?
Because users getting some 2099 checkout errors with braintree. This is due to a 3DS error because the deviceData was not collected. Braintree support sent us this solution to prevent this errors. Once this is set up, customers won't receive any more 2099 errors during their transactions.

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout @bigcommerce/team-payments
