### PR TITLE
feat(payment): INT-7698 GooglePay: Add button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -53,34 +53,4 @@ describe('createCheckoutButtonRegistry', () => {
     it('returns registry with GooglePay on Adyenv3 Credit registered', () => {
         expect(registry.get('googlepayadyenv3')).toEqual(expect.any(GooglePayButtonStrategy));
     });
-
-    it('returns registry with GooglePay on Authorize.Net Credit registered', () => {
-        expect(registry.get('googlepayauthorizenet')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on Bank of New Zealand Credit registered', () => {
-        expect(registry.get('googlepaybnz')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on CybersourceV2 Credit registered', () => {
-        expect(registry.get('googlepaycybersourcev2')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on Orbital Credit registered', () => {
-        expect(registry.get('googlepayorbital')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on Stripe Credit registered', () => {
-        expect(registry.get('googlepaystripe')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on StripeUPE Credit registered', () => {
-        expect(registry.get('googlepaystripeupe')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on WorldpayAccess Credit registered', () => {
-        expect(registry.get('googlepayworldpayaccess')).toEqual(
-            expect.any(GooglePayButtonStrategy),
-        );
-    });
 });

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -15,13 +15,13 @@ import {
     createGooglePayPaymentProcessor,
     GooglePayAdyenV2Initializer,
     GooglePayAdyenV3Initializer,
-    GooglePayAuthorizeNetInitializer,
-    GooglePayBNZInitializer,
-    GooglePayCheckoutcomInitializer,
-    GooglePayCybersourceV2Initializer,
-    GooglePayOrbitalInitializer,
-    GooglePayStripeInitializer,
-    GooglePayStripeUPEInitializer,
+    // GooglePayAuthorizeNetInitializer,
+    // GooglePayBNZInitializer,
+    // GooglePayCheckoutcomInitializer,
+    // GooglePayCybersourceV2Initializer,
+    // GooglePayOrbitalInitializer,
+    // GooglePayStripeInitializer,
+    // GooglePayStripeUPEInitializer,
     GooglePayWorldpayAccessInitializer,
 } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
@@ -135,93 +135,92 @@ export default function createCheckoutButtonRegistry(
                 cartRequestSender,
             ),
     );
+    // registry.register(
+    //     CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET,
+    //     () =>
+    //         new GooglePayButtonStrategy(
+    //             store,
+    //             formPoster,
+    //             checkoutActionCreator,
+    //             createGooglePayPaymentProcessor(store, new GooglePayAuthorizeNetInitializer()),
+    //             cartRequestSender,
+    //         ),
+    // );
 
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayAuthorizeNetInitializer()),
-                cartRequestSender,
-            ),
-    );
+    // registry.register(
+    //     CheckoutButtonMethodType.GOOGLEPAY_BNZ,
+    //     () =>
+    //         new GooglePayButtonStrategy(
+    //             store,
+    //             formPoster,
+    //             checkoutActionCreator,
+    //             createGooglePayPaymentProcessor(store, new GooglePayBNZInitializer()),
+    //             cartRequestSender,
+    //         ),
+    // );
 
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_BNZ,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayBNZInitializer()),
-                cartRequestSender,
-            ),
-    );
+    // registry.register(
+    //     CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM,
+    //     () =>
+    //         new GooglePayButtonStrategy(
+    //             store,
+    //             formPoster,
+    //             checkoutActionCreator,
+    //             createGooglePayPaymentProcessor(
+    //                 store,
+    //                 new GooglePayCheckoutcomInitializer(requestSender),
+    //             ),
+    //             cartRequestSender,
+    //         ),
+    // );
 
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(
-                    store,
-                    new GooglePayCheckoutcomInitializer(requestSender),
-                ),
-                cartRequestSender,
-            ),
-    );
+    // registry.register(
+    //     CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2,
+    //     () =>
+    //         new GooglePayButtonStrategy(
+    //             store,
+    //             formPoster,
+    //             checkoutActionCreator,
+    //             createGooglePayPaymentProcessor(store, new GooglePayCybersourceV2Initializer()),
+    //             cartRequestSender,
+    //         ),
+    // );
 
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayCybersourceV2Initializer()),
-                cartRequestSender,
-            ),
-    );
+    // registry.register(
+    //     CheckoutButtonMethodType.GOOGLEPAY_ORBITAL,
+    //     () =>
+    //         new GooglePayButtonStrategy(
+    //             store,
+    //             formPoster,
+    //             checkoutActionCreator,
+    //             createGooglePayPaymentProcessor(store, new GooglePayOrbitalInitializer()),
+    //             cartRequestSender,
+    //         ),
+    // );
 
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_ORBITAL,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayOrbitalInitializer()),
-                cartRequestSender,
-            ),
-    );
+    // registry.register(
+    //     CheckoutButtonMethodType.GOOGLEPAY_STRIPE,
+    //     () =>
+    //         new GooglePayButtonStrategy(
+    //             store,
+    //             formPoster,
+    //             checkoutActionCreator,
+    //             createGooglePayPaymentProcessor(store, new GooglePayStripeInitializer()),
+    //             cartRequestSender,
+    //         ),
+    // );
 
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_STRIPE,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayStripeInitializer()),
-                cartRequestSender,
-            ),
-    );
-
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_STRIPEUPE,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayStripeUPEInitializer()),
-                cartRequestSender,
-            ),
-    );
+    // registry.register(
+    //     CheckoutButtonMethodType.GOOGLEPAY_STRIPEUPE,
+    //     () =>
+    //         new GooglePayButtonStrategy(
+    //             store,
+    //             formPoster,
+    //             checkoutActionCreator,
+    //             createGooglePayPaymentProcessor(store, new GooglePayStripeUPEInitializer()),
+    //             cartRequestSender,
+    //         ),
+    // );
 
     registry.register(
         CheckoutButtonMethodType.MASTERPASS,

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -15,13 +15,6 @@ import {
     createGooglePayPaymentProcessor,
     GooglePayAdyenV2Initializer,
     GooglePayAdyenV3Initializer,
-    // GooglePayAuthorizeNetInitializer,
-    // GooglePayBNZInitializer,
-    // GooglePayCheckoutcomInitializer,
-    // GooglePayCybersourceV2Initializer,
-    // GooglePayOrbitalInitializer,
-    // GooglePayStripeInitializer,
-    // GooglePayStripeUPEInitializer,
     GooglePayWorldpayAccessInitializer,
 } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
@@ -135,92 +128,6 @@ export default function createCheckoutButtonRegistry(
                 cartRequestSender,
             ),
     );
-    // registry.register(
-    //     CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET,
-    //     () =>
-    //         new GooglePayButtonStrategy(
-    //             store,
-    //             formPoster,
-    //             checkoutActionCreator,
-    //             createGooglePayPaymentProcessor(store, new GooglePayAuthorizeNetInitializer()),
-    //             cartRequestSender,
-    //         ),
-    // );
-
-    // registry.register(
-    //     CheckoutButtonMethodType.GOOGLEPAY_BNZ,
-    //     () =>
-    //         new GooglePayButtonStrategy(
-    //             store,
-    //             formPoster,
-    //             checkoutActionCreator,
-    //             createGooglePayPaymentProcessor(store, new GooglePayBNZInitializer()),
-    //             cartRequestSender,
-    //         ),
-    // );
-
-    // registry.register(
-    //     CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM,
-    //     () =>
-    //         new GooglePayButtonStrategy(
-    //             store,
-    //             formPoster,
-    //             checkoutActionCreator,
-    //             createGooglePayPaymentProcessor(
-    //                 store,
-    //                 new GooglePayCheckoutcomInitializer(requestSender),
-    //             ),
-    //             cartRequestSender,
-    //         ),
-    // );
-
-    // registry.register(
-    //     CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2,
-    //     () =>
-    //         new GooglePayButtonStrategy(
-    //             store,
-    //             formPoster,
-    //             checkoutActionCreator,
-    //             createGooglePayPaymentProcessor(store, new GooglePayCybersourceV2Initializer()),
-    //             cartRequestSender,
-    //         ),
-    // );
-
-    // registry.register(
-    //     CheckoutButtonMethodType.GOOGLEPAY_ORBITAL,
-    //     () =>
-    //         new GooglePayButtonStrategy(
-    //             store,
-    //             formPoster,
-    //             checkoutActionCreator,
-    //             createGooglePayPaymentProcessor(store, new GooglePayOrbitalInitializer()),
-    //             cartRequestSender,
-    //         ),
-    // );
-
-    // registry.register(
-    //     CheckoutButtonMethodType.GOOGLEPAY_STRIPE,
-    //     () =>
-    //         new GooglePayButtonStrategy(
-    //             store,
-    //             formPoster,
-    //             checkoutActionCreator,
-    //             createGooglePayPaymentProcessor(store, new GooglePayStripeInitializer()),
-    //             cartRequestSender,
-    //         ),
-    // );
-
-    // registry.register(
-    //     CheckoutButtonMethodType.GOOGLEPAY_STRIPEUPE,
-    //     () =>
-    //         new GooglePayButtonStrategy(
-    //             store,
-    //             formPoster,
-    //             checkoutActionCreator,
-    //             createGooglePayPaymentProcessor(store, new GooglePayStripeUPEInitializer()),
-    //             cartRequestSender,
-    //         ),
-    // );
 
     registry.register(
         CheckoutButtonMethodType.MASTERPASS,
@@ -242,18 +149,6 @@ export default function createCheckoutButtonRegistry(
                 new PaypalScriptLoader(scriptLoader),
                 formPoster,
                 host,
-            ),
-    );
-
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayWorldpayAccessInitializer()),
-                cartRequestSender,
             ),
     );
 

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -15,7 +15,6 @@ import {
     createGooglePayPaymentProcessor,
     GooglePayAdyenV2Initializer,
     GooglePayAdyenV3Initializer,
-    GooglePayWorldpayAccessInitializer,
 } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayAuthorizeNetButtonStrategy from './create-google-pay-authorizenet-button-strategy';
+
+describe('createGooglePayAuthorizeNetButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay authorizenet button strategy', () => {
+        const strategy = createGooglePayAuthorizeNetButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayAuthorizeNetGateway from '../../gateways/google-pay-authorizenet-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayAuthorizeNetButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayAuthorizeNetGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayAuthorizeNetButtonStrategy, [
+    { id: 'googlepayauthorizenet' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayCheckoutComButtonStrategy from './create-google-pay-checkoutcom-button-strategy';
+
+describe('createGooglePayCheckoutComButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay checkoutcom button strategy', () => {
+        const strategy = createGooglePayCheckoutComButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.ts
@@ -1,0 +1,32 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayCheckoutComGateway from '../../gateways/google-pay-checkoutcom-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayCheckoutComButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) => {
+    const requestSender = createRequestSender();
+
+    return new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayCheckoutComGateway(paymentIntegrationService, requestSender),
+            requestSender,
+            createFormPoster(),
+        ),
+    );
+};
+
+export default toResolvableModule(createGooglePayCheckoutComButtonStrategy, [
+    { id: 'googlepaycheckoutcom' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayCybersourceButtonStrategy from './create-google-pay-cybersource-button-strategy';
+
+describe('createGooglePayCybersourceButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay cybersource button strategy', () => {
+        const strategy = createGooglePayCybersourceButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.ts
@@ -1,0 +1,30 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayCybersourceGateway from '../../gateways/google-pay-cybersource-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayCybersourceButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayCybersourceGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayCybersourceButtonStrategy, [
+    { id: 'googlepaycybersourcev2' },
+    { id: 'googlepaybnz' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayOrbitalButtonStrategy from './create-google-pay-orbital-button-strategy';
+
+describe('createGooglePayOrbitalButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay orbital button strategy', () => {
+        const strategy = createGooglePayOrbitalButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayOrbitalGateway from '../../gateways/google-pay-orbital-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayOrbitalButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayOrbitalGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayOrbitalButtonStrategy, [
+    { id: 'googlepayorbital' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayStripeButtonStrategy from './create-google-pay-stripe-button-strategy';
+
+describe('createGooglePayStripeButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay stripe button strategy', () => {
+        const strategy = createGooglePayStripeButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.ts
@@ -1,0 +1,30 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayStripeGateway from '../../gateways/google-pay-stripe-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayStripeButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayStripeGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayStripeButtonStrategy, [
+    { id: 'googlepaystripe' },
+    { id: 'googlepaystripeupe' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayWorldpayAccessButtonStrategy from './create-google-pay-worldpayaccess-button-strategy';
+
+describe('createGooglePayWorldpayAccessButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay worldpayaccess button strategy', () => {
+        const strategy = createGooglePayWorldpayAccessButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayWorldpayAccessGateway from '../../gateways/google-pay-worldpayaccess-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayWorldpayAccessButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayWorldpayAccessGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayWorldpayAccessButtonStrategy, [
+    { id: 'googlepayworldpayaccess' },
+]);

--- a/packages/google-pay-integration/src/google-pay-button-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-button-initialize-options.ts
@@ -1,0 +1,34 @@
+import { GooglePayKey } from './google-pay-payment-initialize-options';
+import { GooglePayButtonColor, GooglePayButtonType } from './types';
+
+export default interface GooglePayButtonInitializeOptions {
+    /**
+     * All Google Pay payment buttons exist in two styles: dark (default) and light.
+     * To provide contrast, use dark buttons on light backgrounds and light buttons on dark or colorful backgrounds.
+     */
+    buttonColor?: GooglePayButtonColor;
+
+    /**
+     * Variant buttons:
+     * book: The "Book with Google Pay" payment button.
+     * buy: The "Buy with Google Pay" payment button.
+     * checkout: The "Checkout with Google Pay" payment button.
+     * donate: The "Donate with Google Pay" payment button.
+     * order: The "Order with Google Pay" payment button.
+     * pay: The "Pay with Google Pay" payment button.
+     * plain: The Google Pay payment button without the additional text (default).
+     * subscribe: The "Subscribe with Google Pay" payment button.
+     *
+     * Note: "long" and "short" button types have been renamed to "buy" and "plain", but are still valid button types
+     * for backwards compatability.
+     */
+    buttonType?: GooglePayButtonType;
+}
+
+/**
+ * The options that are required to initialize the GooglePay payment method.
+ * They can be omitted unless you need to support GooglePay.
+ */
+export type WithGooglePayButtonInitializeOptions = {
+    [k in GooglePayKey]?: GooglePayButtonInitializeOptions;
+};

--- a/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
@@ -287,4 +287,19 @@ describe('GooglePayButtonStrategy', () => {
             });
         });
     });
+
+    describe('#deinitialize', () => {
+        it('should deinitialize the strategy', async () => {
+            const deinitialize = buttonStrategy.deinitialize();
+
+            await expect(deinitialize).resolves.toBeUndefined();
+        });
+
+        it('should remove payment button', async () => {
+            await buttonStrategy.initialize(options);
+            await buttonStrategy.deinitialize();
+
+            expect(button.remove).toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/google-pay-integration/src/google-pay-button-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.ts
@@ -32,6 +32,7 @@ import {
 } from './types';
 
 export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
+    private _paymentButton?: HTMLElement;
     private _methodId?: keyof WithGooglePayPaymentInitializeOptions;
     private _buyNowCart?: Cart;
     private _currencyCode?: string;
@@ -107,14 +108,20 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             );
         }
 
-        this._googlePayPaymentProcessor.addPaymentButton(options.containerId, {
-            buttonColor: buttonColor ?? 'default',
-            buttonType: buttonType ?? 'plain',
-            onClick: this._handleClick(onError),
-        });
+        this._paymentButton =
+            this._paymentButton ??
+            this._googlePayPaymentProcessor.addPaymentButton(options.containerId, {
+                buttonColor: buttonColor ?? 'default',
+                buttonType: buttonType ?? 'plain',
+                onClick: this._handleClick(onError),
+            });
     }
 
     deinitialize(): Promise<void> {
+        this._paymentButton?.remove();
+        this._paymentButton = undefined;
+        this._methodId = undefined;
+
         return Promise.resolve();
     }
 

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -1,5 +1,6 @@
 export { WithGooglePayPaymentInitializeOptions } from './google-pay-payment-initialize-options';
 export { WithGooglePayCustomerInitializeOptions } from './google-pay-customer-initialize-options';
+export { WithGooglePayButtonInitializeOptions } from './google-pay-button-initialize-options';
 
 export { default as createGooglePayAuthorizeNetPaymentStrategy } from './factories/payment/create-google-pay-authorizenet-payment-strategy';
 export { default as createGooglePayCheckoutComPaymentStrategy } from './factories/payment/create-google-pay-checkoutcom-payment-strategy';
@@ -23,3 +24,10 @@ export { default as createGooglePayPayPalCommerceCustomerStrategy } from './goog
 
 export { default as createGooglePayBraintreeButtonStrategy } from './factories/button/create-google-pay-braintree-button-strategy';
 export { default as createGooglePayPayPalCommerceButtonStrategy } from './google-pay-paypal-commerce/create-google-pay-paypal-commerce-button-strategy';
+
+export { default as createGooglePayAuthorizeDotNetButtonStrategy } from './factories/button/create-google-pay-authorizenet-button-strategy';
+export { default as createGooglePayCheckoutComButtonStrategy } from './factories/button/create-google-pay-checkoutcom-button-strategy';
+export { default as createGooglePayCybersourceButtonStrategy } from './factories/button/create-google-pay-cybersource-button-strategy';
+export { default as createGooglePayOrbitalButtonStrategy } from './factories/button/create-google-pay-orbital-button-strategy';
+export { default as createGooglePayStripeButtonStrategy } from './factories/button/create-google-pay-stripe-button-strategy';
+export { default as createGooglePayWorldpayAccessButtonStrategy } from './factories/button/create-google-pay-worldpayaccess-button-strategy';


### PR DESCRIPTION
## What? [INT-7698](https://bigcommercecloud.atlassian.net/browse/INT-7698)
Updated version of the https://github.com/bigcommerce/checkout-sdk-js/pull/2037

1. Add Google Pay button strategy for Worldpay Access
2. Refactor existing logic for:
    - Authorize Net
    - Checkout Com
    - Cybersource / BNZ
    - Orbital
    - Stripe v3 / Stripe UPE

## Why?
To checkout using Google Pay through Worldpay Access

## Testing / Proof
Tested manually/units

## Depends on
#1967 and #1994

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 

[INT-7698]: https://bigcommercecloud.atlassian.net/browse/INT-7698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ