### PR TITLE
fix(payment): PI-1899 additional token for instrument verification

### DIFF
--- a/packages/td-bank-integration/src/td-online-mart-payment-strategy.ts
+++ b/packages/td-bank-integration/src/td-online-mart-payment-strategy.ts
@@ -118,11 +118,16 @@ export default class TDOnlineMartPaymentStrategy implements PaymentStrategy {
             isVaultedInstrument(paymentData) &&
             paymentData.instrumentId
         ) {
+            const shouldAddVerificationToken = !this.isTrustedVaultingInstrument(
+                paymentData.instrumentId,
+            );
+
             return {
                 methodId,
                 paymentData: {
                     ...commonPaymentData,
                     instrumentId: paymentData.instrumentId,
+                    ...(shouldAddVerificationToken ? { nonce: paymentData.instrumentId } : {}),
                 },
             };
         }
@@ -242,5 +247,14 @@ export default class TDOnlineMartPaymentStrategy implements PaymentStrategy {
             style,
             classes,
         };
+    }
+
+    private isTrustedVaultingInstrument(instrumentId: string): boolean {
+        const instruments = this.paymentIntegrationService.getState().getInstruments();
+
+        const { trustedShippingAddress } =
+            instruments?.find(({ bigpayToken }) => bigpayToken === instrumentId) || {};
+
+        return !!trustedShippingAddress;
     }
 }


### PR DESCRIPTION
## What?
Add nonce value for TD Bank vaulted instruments with untrusted shipping address

## Why?
To skip verification by card number, because TD Online Mart does not support it

## Testing / Proof
Vaulted instruments:
<img width="762" alt="Screenshot 2024-04-01 at 15 18 12" src="https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/ddbd05af-c2f9-4c08-ba07-b8233cf6669a">

Instrument with trusted shipping address:
<img width="758" alt="Screenshot 2024-04-01 at 16 14 34" src="https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/2add52fa-a3db-421c-b1bd-b306a4b2cec2">

Instrument with untrusted shipping address:
<img width="761" alt="Screenshot 2024-04-01 at 16 15 55" src="https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/f98b5ee9-6649-41eb-a4ea-e9b01b8e9d63">


@bigcommerce/team-checkout @bigcommerce/team-payments
