### PR TITLE
feat(payment): PAYPAL-3587 Update Braintree Accelerated Checkout shipping strategy to support Fastlane + Connect

### DIFF
--- a/packages/braintree-utils/src/utils/index.ts
+++ b/packages/braintree-utils/src/utils/index.ts
@@ -3,3 +3,5 @@ export { default as isBraintreeAcceleratedCheckoutCustomer } from './is-braintre
 export { default as isBraintreeConnectWindow } from './is-braintree-connect-window';
 export { default as isBraintreeError } from './is-braintree-error';
 export { default as isBraintreeFastlaneWindow } from './is-braintree-fastlane-window';
+export { default as isBraintreeFastlaneProfileData } from './is-braintree-fastlane-profile-data';
+export { default as isBraintreeConnectProfileData } from './is-braintree-connect-profile-data';

--- a/packages/braintree-utils/src/utils/is-braintree-connect-profile-data.spec.ts
+++ b/packages/braintree-utils/src/utils/is-braintree-connect-profile-data.spec.ts
@@ -1,0 +1,17 @@
+import { getBraintreeConnectProfileDataMock } from '../';
+
+import isBraintreeConnectProfileData from './is-braintree-connect-profile-data';
+
+describe('isBraintreeConnectProfileData()', () => {
+    it('returns true if profile data belong to connect', () => {
+        const profileDataMock = getBraintreeConnectProfileDataMock();
+
+        expect(isBraintreeConnectProfileData(profileDataMock)).toBe(true);
+    });
+
+    it('returns false if profile data is not provided', () => {
+        const profileDataMock = undefined;
+
+        expect(isBraintreeConnectProfileData(profileDataMock)).toBe(false);
+    });
+});

--- a/packages/braintree-utils/src/utils/is-braintree-connect-profile-data.ts
+++ b/packages/braintree-utils/src/utils/is-braintree-connect-profile-data.ts
@@ -1,0 +1,18 @@
+import { BraintreeConnectProfileData, BraintreeFastlaneProfileData } from '../';
+
+export default function isBraintreeConnectProfileData(
+    profileData: BraintreeFastlaneProfileData | BraintreeConnectProfileData | undefined,
+): profileData is BraintreeConnectProfileData {
+    if (!profileData) {
+        return false;
+    }
+
+    return (
+        profileData.hasOwnProperty('addresses') &&
+        profileData.hasOwnProperty('cards') &&
+        profileData.hasOwnProperty('phones') &&
+        profileData.hasOwnProperty('connectCustomerId') &&
+        profileData.hasOwnProperty('connectCustomerAuthAssertionToken') &&
+        profileData.hasOwnProperty('name')
+    );
+}

--- a/packages/braintree-utils/src/utils/is-braintree-fastlane-profile-data.spec.ts
+++ b/packages/braintree-utils/src/utils/is-braintree-fastlane-profile-data.spec.ts
@@ -1,0 +1,17 @@
+import { getBraintreeFastlaneProfileDataMock } from '../';
+
+import isBraintreeFastlaneProfileData from './is-braintree-fastlane-profile-data';
+
+describe('isBraintreeFastlaneProfileData()', () => {
+    it('returns true if profile data belong to fastlane', () => {
+        const profileDataMock = getBraintreeFastlaneProfileDataMock();
+
+        expect(isBraintreeFastlaneProfileData(profileDataMock)).toBe(true);
+    });
+
+    it('returns false if profile data is not provided', () => {
+        const profileDataMock = undefined;
+
+        expect(isBraintreeFastlaneProfileData(profileDataMock)).toBe(false);
+    });
+});

--- a/packages/braintree-utils/src/utils/is-braintree-fastlane-profile-data.ts
+++ b/packages/braintree-utils/src/utils/is-braintree-fastlane-profile-data.ts
@@ -1,0 +1,17 @@
+import { BraintreeConnectProfileData, BraintreeFastlaneProfileData } from '../';
+
+export default function isBraintreeFastlaneProfileData(
+    profileData: BraintreeFastlaneProfileData | BraintreeConnectProfileData | undefined,
+): profileData is BraintreeFastlaneProfileData {
+    if (!profileData) {
+        return false;
+    }
+
+    return (
+        profileData.hasOwnProperty('shippingAddress') &&
+        profileData.hasOwnProperty('card') &&
+        profileData.hasOwnProperty('fastlaneCustomerId') &&
+        profileData.hasOwnProperty('fastlaneCustomerAuthAssertionToken') &&
+        profileData.hasOwnProperty('name')
+    );
+}


### PR DESCRIPTION
## What?
Update Braintree Accelerated Checkout shipping strategy to support Fastlane + Connect

## Why?
To integrate fastlane

## Testing / Proof
Unit tests passed

@bigcommerce/team-checkout @bigcommerce/team-payments
