### PR TITLE
fix(payment): CHECKOUT-8132 Fix issue with apple pay button clicked twice

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
@@ -132,6 +132,34 @@ describe('ApplePayCustomerStrategy', () => {
             }
         });
 
+        it('does not start another apple pay session if one is in place already', async () => {
+            const cart = getCart();
+
+            cart.lineItems.physicalItems = [];
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getCartOrThrow').mockReturnValue(
+                cart,
+            );
+
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(
+                    customerInitializeOptions.applepay.container,
+                );
+
+                await strategy.initialize(customerInitializeOptions);
+
+                const button = buttonContainer?.firstChild as HTMLElement;
+
+                button.click();
+
+                button.click();
+
+                expect(applePaySession.begin).toHaveBeenCalledTimes(1);
+            }
+        });
+
         it('throws error when applepay object is empty', async () => {
             const options = {
                 methodId: 'applepay',


### PR DESCRIPTION
## What
Fix issue with apple pay button clicked twice

## Why?
If a user clicks on apple pay button twice it can block the user due to an error `Apple Pay: Page already has an active payment session` as reported here https://help.noibu.com/hc/en-us/articles/11383689403149-Apple-Pay-Page-already-has-an-active-payment-session#:~:text=The%20active%20payment%20session%20error,a%20single%20time%20per%20transaction.

## Testing / Proof
- CI
- Manual

@bigcommerce/team-checkout @bigcommerce/team-payments
