### PR TITLE
feat(payment): PAYPAL-3878 added try catch to PayPal Commerce Fastlane Customer Strategy initialization method

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
@@ -368,6 +368,44 @@ describe('PayPalCommerceFastlaneCustomerStrategy', () => {
                 initializationOptions.paypalcommercefastlane.styles,
             );
         });
+
+        it('does not throw anything if there is an error with Connect initialization', async () => {
+            paymentMethod.initializationData.isDeveloperModeApplicable = true;
+            paymentMethod.initializationData.isFastlaneEnabled = false;
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethod);
+
+            jest.spyOn(paypalCommerceSdk, 'getPayPalAxo').mockImplementation(() =>
+                Promise.reject(),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdk.getPayPalAxo).toHaveBeenCalled();
+            expect(paypalCommerceFastlaneUtils.initializePayPalConnect).not.toHaveBeenCalled();
+        });
+
+        it('does not throw anything if there is an error with Fastlane initialization', async () => {
+            paymentMethod.initializationData.isDeveloperModeApplicable = true;
+            paymentMethod.initializationData.isFastlaneEnabled = true;
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethod);
+
+            jest.spyOn(paypalCommerceSdk, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                Promise.reject(),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdk.getPayPalFastlaneSdk).toHaveBeenCalled();
+            expect(paypalCommerceFastlaneUtils.initializePayPalFastlane).not.toHaveBeenCalled();
+        });
     });
 
     describe('#deinitialize()', () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -50,37 +50,41 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
 
         this.isAcceleratedCheckoutFeatureEnabled = !!isAcceleratedCheckoutEnabled;
 
-        if (this.isAcceleratedCheckoutFeatureEnabled) {
-            const state = this.paymentIntegrationService.getState();
-            const cart = state.getCartOrThrow();
-            const currency = state.getCartOrThrow().currency.code;
-            const isTestModeEnabled = !!isDeveloperModeApplicable;
+        try {
+            if (this.isAcceleratedCheckoutFeatureEnabled) {
+                const state = this.paymentIntegrationService.getState();
+                const cart = state.getCartOrThrow();
+                const currency = state.getCartOrThrow().currency.code;
+                const isTestModeEnabled = !!isDeveloperModeApplicable;
 
-            if (isFastlaneEnabled) {
-                const paypalFastlaneSdk = await this.paypalCommerceSdk.getPayPalFastlaneSdk(
-                    paymentMethod,
-                    currency,
-                    cart.id,
-                );
+                if (isFastlaneEnabled) {
+                    const paypalFastlaneSdk = await this.paypalCommerceSdk.getPayPalFastlaneSdk(
+                        paymentMethod,
+                        currency,
+                        cart.id,
+                    );
 
-                await this.paypalCommerceFastlaneUtils.initializePayPalFastlane(
-                    paypalFastlaneSdk,
-                    isTestModeEnabled,
-                    paypalcommercefastlane?.styles,
-                );
-            } else {
-                const paypalAxoSdk = await this.paypalCommerceSdk.getPayPalAxo(
-                    paymentMethod,
-                    currency,
-                    cart.id,
-                );
+                    await this.paypalCommerceFastlaneUtils.initializePayPalFastlane(
+                        paypalFastlaneSdk,
+                        isTestModeEnabled,
+                        paypalcommercefastlane?.styles,
+                    );
+                } else {
+                    const paypalAxoSdk = await this.paypalCommerceSdk.getPayPalAxo(
+                        paymentMethod,
+                        currency,
+                        cart.id,
+                    );
 
-                await this.paypalCommerceFastlaneUtils.initializePayPalConnect(
-                    paypalAxoSdk,
-                    isTestModeEnabled,
-                    paypalcommercefastlane?.styles,
-                );
+                    await this.paypalCommerceFastlaneUtils.initializePayPalConnect(
+                        paypalAxoSdk,
+                        isTestModeEnabled,
+                        paypalcommercefastlane?.styles,
+                    );
+                }
             }
+        } catch (_) {
+            // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
         }
 
         return Promise.resolve();
@@ -190,7 +194,7 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
                 isAuthenticationFlowCanceled,
                 cartId,
             );
-        } catch (error) {
+        } catch (_) {
             // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
         }
     }


### PR DESCRIPTION
## What?
Added try catch to PayPal Commerce Fastlane Customer Strategy initialization method

## Why?
To catch an error and does not do anything with it to avoid blocking customer from checkout. So when PayPal Fastlane fails to initialize, it does not show an error modal, so the user can continue the checkout.

## Testing / Proof
Unit tests
Manual tests
CI
