### PR TITLE
feat(payment): PAYPAL-3896 added try catch to BraintreeFastlaneCustomerStrategy initialize method

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
@@ -208,6 +208,32 @@ describe('BraintreeFastlaneCustomerStrategy', () => {
                 braintreeFastlaneUtils.initializeBraintreeAcceleratedCheckoutOrThrow,
             ).not.toHaveBeenCalled();
         });
+
+        it('does not throw anything if there is an error with Fastlane initialization', async () => {
+            const mockPaymentMethod = {
+                ...paymentMethod,
+                initializationData: {
+                    isFastlaneEnabled: true,
+                    isAcceleratedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(mockPaymentMethod);
+
+            jest.spyOn(
+                braintreeFastlaneUtils,
+                'initializeBraintreeAcceleratedCheckoutOrThrow',
+            ).mockImplementation(() => Promise.reject());
+
+            await strategy.initialize(initializationOptions);
+
+            expect(
+                braintreeFastlaneUtils.initializeBraintreeAcceleratedCheckoutOrThrow,
+            ).toHaveBeenCalled();
+        });
     });
 
     describe('#executePaymentMethodCheckout()', () => {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -39,11 +39,15 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
 
         this.isFastlaneEnabled = !!paymentMethod.initializationData?.isFastlaneEnabled;
 
-        if (this.isAcceleratedCheckoutEnabled) {
-            await this.braintreeFastlaneUtils.initializeBraintreeAcceleratedCheckoutOrThrow(
-                paymentMethod.id,
-                braintreeafastlane?.styles,
-            );
+        try {
+            if (this.isAcceleratedCheckoutEnabled) {
+                await this.braintreeFastlaneUtils.initializeBraintreeAcceleratedCheckoutOrThrow(
+                    paymentMethod.id,
+                    braintreeafastlane?.styles,
+                );
+            }
+        } catch (_) {
+            // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
         }
 
         return Promise.resolve();


### PR DESCRIPTION
## What?
Added try catch to BraintreeFastlaneCustomerStrategy initialize method

## Why?
To catch an error and does not do anything with it to avoid blocking customer from checkout. So when PayPal Fastlane fails to initialize, it does not show an error modal, so the user can continue the checkout.

## Testing / Proof
Unit tests
Manual tests
CI
