### PR TITLE
CHECKOUT-8121: Remove queue ID for executing strategies to minimise concurrent requests

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -855,9 +855,7 @@ describe('CheckoutService', () => {
             await checkoutService.initializePayment(options);
 
             expect(paymentStrategyActionCreator.initialize).toHaveBeenCalledWith(options);
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'paymentStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -873,9 +871,7 @@ describe('CheckoutService', () => {
             await checkoutService.deinitializePayment(options);
 
             expect(paymentStrategyActionCreator.deinitialize).toHaveBeenCalledWith(options);
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'paymentStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -927,9 +923,7 @@ describe('CheckoutService', () => {
             await checkoutService.initializeCustomer(options);
 
             expect(customerStrategyActionCreator.initialize).toHaveBeenCalledWith(options);
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'customerStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -945,9 +939,7 @@ describe('CheckoutService', () => {
             await checkoutService.deinitializeCustomer(options);
 
             expect(customerStrategyActionCreator.deinitialize).toHaveBeenCalledWith(options);
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'customerStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -987,9 +979,7 @@ describe('CheckoutService', () => {
                 { email: 'foo@bar.com', password: 'password1' },
                 options,
             );
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'customerStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1005,9 +995,7 @@ describe('CheckoutService', () => {
             await checkoutService.signOutCustomer(options);
 
             expect(customerStrategyActionCreator.signOut).toHaveBeenCalledWith(options);
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'customerStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1031,9 +1019,7 @@ describe('CheckoutService', () => {
             expect(customerStrategyActionCreator.executePaymentMethodCheckout).toHaveBeenCalledWith(
                 options,
             );
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'customerStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1058,9 +1044,7 @@ describe('CheckoutService', () => {
             await checkoutService.initializeShipping(options);
 
             expect(shippingStrategyActionCreator.initialize).toHaveBeenCalledWith(options);
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'shippingStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1076,9 +1060,7 @@ describe('CheckoutService', () => {
             await checkoutService.deinitializeShipping(options);
 
             expect(shippingStrategyActionCreator.deinitialize).toHaveBeenCalledWith(options);
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'shippingStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1101,9 +1083,7 @@ describe('CheckoutService', () => {
                 options,
             );
 
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'shippingStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1130,9 +1110,7 @@ describe('CheckoutService', () => {
                 options,
             );
 
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'shippingStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1164,9 +1142,7 @@ describe('CheckoutService', () => {
                 options,
             );
 
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'shippingStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1198,9 +1174,7 @@ describe('CheckoutService', () => {
                 options,
             );
 
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'shippingStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1226,9 +1200,7 @@ describe('CheckoutService', () => {
                 options,
             );
 
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'shippingStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1248,9 +1220,7 @@ describe('CheckoutService', () => {
                 address,
                 options,
             );
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'shippingStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 
@@ -1270,9 +1240,7 @@ describe('CheckoutService', () => {
                 shippingOptionId,
                 options,
             );
-            expect(store.dispatch).toHaveBeenCalledWith(action, {
-                queueId: 'shippingStrategy',
-            });
+            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });
 

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -298,7 +298,7 @@ export default class CheckoutService {
     submitOrder(payload: OrderRequestBody, options?: RequestOptions): Promise<CheckoutSelectors> {
         const action = this._paymentStrategyActionCreator.execute(payload, options);
 
-        return this._dispatch(action, { queueId: 'paymentStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -334,7 +334,7 @@ export default class CheckoutService {
     finalizeOrderIfNeeded(options?: RequestOptions): Promise<CheckoutSelectors> {
         const action = this._paymentStrategyActionCreator.finalize(options);
 
-        return this._dispatch(action, { queueId: 'paymentStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -436,7 +436,7 @@ export default class CheckoutService {
     initializePayment(options: PaymentInitializeOptions): Promise<CheckoutSelectors> {
         const action = this._paymentStrategyActionCreator.initialize(options);
 
-        return this._dispatch(action, { queueId: 'paymentStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -459,7 +459,7 @@ export default class CheckoutService {
     deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors> {
         const action = this._paymentStrategyActionCreator.deinitialize(options);
 
-        return this._dispatch(action, { queueId: 'paymentStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -599,7 +599,7 @@ export default class CheckoutService {
     initializeCustomer(options?: CustomerInitializeOptions): Promise<CheckoutSelectors> {
         const action = this._customerStrategyActionCreator.initialize(options);
 
-        return this._dispatch(action, { queueId: 'customerStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -622,7 +622,7 @@ export default class CheckoutService {
     deinitializeCustomer(options?: CustomerRequestOptions): Promise<CheckoutSelectors> {
         const action = this._customerStrategyActionCreator.deinitialize(options);
 
-        return this._dispatch(action, { queueId: 'customerStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -778,7 +778,7 @@ export default class CheckoutService {
     ): Promise<CheckoutSelectors> {
         const action = this._customerStrategyActionCreator.signIn(credentials, options);
 
-        return this._dispatch(action, { queueId: 'customerStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -813,7 +813,7 @@ export default class CheckoutService {
     signOutCustomer(options?: CustomerRequestOptions): Promise<CheckoutSelectors> {
         const action = this._customerStrategyActionCreator.signOut(options);
 
-        return this._dispatch(action, { queueId: 'customerStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -838,7 +838,7 @@ export default class CheckoutService {
     ): Promise<CheckoutSelectors> {
         const action = this._customerStrategyActionCreator.executePaymentMethodCheckout(options);
 
-        return this._dispatch(action, { queueId: 'customerStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -886,7 +886,7 @@ export default class CheckoutService {
     initializeShipping(options?: ShippingInitializeOptions): Promise<CheckoutSelectors> {
         const action = this._shippingStrategyActionCreator.initialize(options);
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -909,7 +909,7 @@ export default class CheckoutService {
     deinitializeShipping(options?: ShippingRequestOptions): Promise<CheckoutSelectors> {
         const action = this._shippingStrategyActionCreator.deinitialize(options);
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -935,7 +935,7 @@ export default class CheckoutService {
     ): Promise<CheckoutSelectors> {
         const action = this._shippingStrategyActionCreator.selectOption(shippingOptionId, options);
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -969,7 +969,7 @@ export default class CheckoutService {
     ): Promise<CheckoutSelectors> {
         const action = this._shippingStrategyActionCreator.updateAddress(address, options);
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -1007,7 +1007,7 @@ export default class CheckoutService {
     ): Promise<CheckoutSelectors> {
         const action = this._consignmentActionCreator.createConsignments(consignments, options);
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -1026,7 +1026,7 @@ export default class CheckoutService {
     deleteConsignment(consignmentId: string, options?: RequestOptions): Promise<CheckoutSelectors> {
         const action = this._consignmentActionCreator.deleteConsignment(consignmentId, options);
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -1068,7 +1068,7 @@ export default class CheckoutService {
     ): Promise<CheckoutSelectors> {
         const action = this._consignmentActionCreator.updateConsignment(consignment, options);
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -1088,7 +1088,7 @@ export default class CheckoutService {
     ): Promise<CheckoutSelectors> {
         const action = this._consignmentActionCreator.assignItemsByAddress(consignment, options);
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -1108,7 +1108,7 @@ export default class CheckoutService {
     ): Promise<CheckoutSelectors> {
         const action = this._consignmentActionCreator.unassignItemsByAddress(consignment, options);
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -1145,7 +1145,7 @@ export default class CheckoutService {
             options,
         );
 
-        return this._dispatch(action, { queueId: 'shippingStrategy' });
+        return this._dispatch(action);
     }
 
     /**
@@ -1455,7 +1455,7 @@ export default class CheckoutService {
      * @param action - The action to dispatch.
      * @returns A promise that resolves to the current state.
      */
-    private _dispatch(
+    private async _dispatch(
         action: Action | Observable<Action> | ThunkAction<Action>,
         options?: { queueId?: string },
     ): Promise<CheckoutSelectors> {


### PR DESCRIPTION
## What?
Remove the queue IDs used to execute payment, shipping, and customer strategies to minimise the likelihood of [conflict](https://kibana.bigcommerce.net/goto/dfc2e710-f228-11ee-8e61-2dd683c10ce8) due to concurrent requests. By removing the queue IDs, the calls will be executed sequentially.

## Why?
These strategies could trigger mutations to cart/checkout. They may conflict with each other if they are triggered concurrently.

## Testing / Proof
CircleCI

@bigcommerce/team-checkout
