### PR TITLE
fix(payment): PI-1823 Add shop path to the remote checkout request

### DIFF
--- a/packages/klarna-integration/src/klarnav2/create-klarnav2-payment-strategy.ts
+++ b/packages/klarna-integration/src/klarnav2/create-klarnav2-payment-strategy.ts
@@ -20,6 +20,7 @@ const createKlarnaV2PaymentStrategy: PaymentStrategyFactory<KlarnaV2PaymentStrat
         paymentIntegrationService,
         new KlarnaV2ScriptLoader(getScriptLoader()),
         new KlarnaV2TokenUpdater(requestSender),
+        requestSender,
     );
 };
 

--- a/packages/klarna-integration/src/klarnav2/klarnav2-payment-strategy.spec.ts
+++ b/packages/klarna-integration/src/klarnav2/klarnav2-payment-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { Action, createAction } from '@bigcommerce/data-store';
-import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { omit } from 'lodash';
 import { noop, Observable, of } from 'rxjs';
@@ -48,25 +48,32 @@ describe('KlarnaV2PaymentStrategy', () => {
     let klarnaPayments: KlarnaPayments;
     let payload: OrderRequestBody;
     let paymentMethod: PaymentMethod;
-    let requestSender: RequestSender;
     let scriptLoader: KlarnaV2ScriptLoader;
     let strategy: KlarnaV2PaymentStrategy;
     let paymentMethodMock: PaymentMethod;
     let klarnav2TokenUpdater: KlarnaV2TokenUpdater;
     let paymentIntegrationService: PaymentIntegrationService;
+    let requestSenderMock: RequestSender;
 
-    beforeEach(() => {
-        paymentIntegrationService = new PaymentIntegrationServiceMock();
-
-        requestSender = createRequestSender();
-
-        scriptLoader = new KlarnaV2ScriptLoader(createScriptLoader());
-        klarnav2TokenUpdater = new KlarnaV2TokenUpdater(requestSender);
-        strategy = new KlarnaV2PaymentStrategy(
+    const createStrategy = () => {
+        return new KlarnaV2PaymentStrategy(
             paymentIntegrationService,
             scriptLoader,
             klarnav2TokenUpdater,
+            requestSenderMock,
         );
+    };
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        requestSenderMock = {
+            get: jest.fn(),
+        } as unknown as RequestSender;
+
+        scriptLoader = new KlarnaV2ScriptLoader(createScriptLoader());
+        klarnav2TokenUpdater = new KlarnaV2TokenUpdater(requestSenderMock);
+        strategy = createStrategy();
 
         initializePaymentAction = of(
             createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested),
@@ -274,11 +281,7 @@ describe('KlarnaV2PaymentStrategy', () => {
         it('loads widget in EU', async () => {
             const euBillingAddress = { data: getEUBillingAddress(), errors: {}, statuses: {} };
 
-            strategy = new KlarnaV2PaymentStrategy(
-                paymentIntegrationService,
-                scriptLoader,
-                klarnav2TokenUpdater,
-            );
+            strategy = createStrategy();
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',
@@ -310,11 +313,7 @@ describe('KlarnaV2PaymentStrategy', () => {
         it('loads widget in OC', async () => {
             const ocBillingAddress = { data: getOCBillingAddress(), errors: {}, statuses: {} };
 
-            strategy = new KlarnaV2PaymentStrategy(
-                paymentIntegrationService,
-                scriptLoader,
-                klarnav2TokenUpdater,
-            );
+            strategy = createStrategy();
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',
@@ -350,11 +349,7 @@ describe('KlarnaV2PaymentStrategy', () => {
                 statuses: {},
             };
 
-            strategy = new KlarnaV2PaymentStrategy(
-                paymentIntegrationService,
-                scriptLoader,
-                klarnav2TokenUpdater,
-            );
+            strategy = createStrategy();
 
             jest.spyOn(
                 paymentIntegrationService.getState(),
@@ -411,6 +406,42 @@ describe('KlarnaV2PaymentStrategy', () => {
             expect(paymentIntegrationService.initializePayment).toHaveBeenCalledWith('klarna', {
                 authorizationToken: 'bar',
             });
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                { ...payload, payment: omit(payload.payment, 'paymentData'), useStoreCredit: true },
+                undefined,
+            );
+        });
+
+        it('submits authorization token with store path', async () => {
+            const requestSenderGetMock = jest.fn();
+
+            requestSenderMock.get = requestSenderGetMock;
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                checkoutSettings: {
+                    features: {
+                        'PI-1823.Klarna_add_store_path_to_remote_checkout_request': true,
+                    },
+                },
+                storeProfile: {
+                    shopPath: 'shopPath',
+                },
+            });
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.initializePayment).not.toHaveBeenCalled();
+            expect(requestSenderGetMock).toHaveBeenCalledWith(
+                'shopPath/remote-checkout/klarna/payment',
+                expect.objectContaining({
+                    params: {
+                        authorizationToken: 'bar',
+                    },
+                }),
+            );
 
             expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
                 { ...payload, payment: omit(payload.payment, 'paymentData'), useStoreCredit: true },


### PR DESCRIPTION
## What?
Add current store path for Klarna remote checkout request

## Why?
To fix issue with headless store redirection

## Testing / Proof
Without experiment

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/527b6098-d286-4483-85a9-471b988f7390

With experiment enabled

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/8b910732-b5a8-4e5b-9edc-9bd13909d195



@bigcommerce/team-checkout @bigcommerce/team-payments
