### PR TITLE
fix(payment): PAYPAL-3736 fixed PayPalCommerce Credit Card fields style issue

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.spec.ts
@@ -80,7 +80,7 @@ describe('PayPalCommerceCreditCardsPaymentStrategy', () => {
         },
         style: {
             input: {
-                color: 'gray',
+                color: '#333333',
                 'font-family': 'bigFont',
                 'font-size': '14px',
                 'font-weight': '400',
@@ -92,12 +92,24 @@ describe('PayPalCommerceCreditCardsPaymentStrategy', () => {
                 'font-family': 'bigFont',
                 'font-size': '14px',
                 'font-weight': '400',
+                outline: 'none',
+                padding: '9px 13px',
             },
-            ':focus': {
-                color: 'black',
+            '.valid': {
+                color: '#333333',
                 'font-family': 'bigFont',
                 'font-size': '14px',
                 'font-weight': '400',
+                outline: 'none',
+                padding: '9px 13px',
+            },
+            ':focus': {
+                color: '#333333',
+                'font-family': 'bigFont',
+                'font-size': '14px',
+                'font-weight': '400',
+                outline: 'none',
+                padding: '9px 13px',
             },
         },
         createOrder: expect.any(Function),
@@ -359,19 +371,16 @@ describe('PayPalCommerceCreditCardsPaymentStrategy', () => {
                         fields: paypalCommerceCreditCardsOptions.form.fields,
                         styles: {
                             default: {
-                                color: 'gray',
                                 fontFamily: 'bigFont',
                                 fontSize: '14px',
                                 fontWeight: '400',
                             },
                             error: {
-                                color: 'red',
                                 fontFamily: 'bigFont',
                                 fontSize: '14px',
                                 fontWeight: '400',
                             },
                             focus: {
-                                color: 'black',
                                 fontFamily: 'bigFont',
                                 fontSize: '14px',
                                 fontWeight: '400',

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
@@ -10,7 +10,6 @@ import {
     HostedFieldType,
     HostedFieldValidateEventData,
     HostedFormOptions,
-    HostedInputStyles,
     HostedInputValidateErrorData,
     HostedInputValidateErrorDataMap,
     HostedInstrument,
@@ -22,7 +21,6 @@ import {
     isVaultedInstrument,
     NotInitializedError,
     NotInitializedErrorType,
-    objectWithKebabCaseKeys,
     OrderFinalizationNotRequiredError,
     OrderPaymentRequestBody,
     OrderRequestBody,
@@ -585,25 +583,6 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
 
     /**
      *
-     * Styles mappers
-     *
-     */
-    private mapStyleOptions(
-        styles: HostedFieldStylesMap,
-    ): PayPalCommerceHostedFieldsRenderOptions['styles'] {
-        return {
-            input: this.mapStyles(styles.default),
-            '.invalid': this.mapStyles(styles.error),
-            ':focus': this.mapStyles(styles.focus),
-        };
-    }
-
-    private mapStyles(styles: HostedInputStyles = {}): { [key: string]: string } {
-        return omitBy(objectWithKebabCaseKeys(styles), isNil);
-    }
-
-    /**
-     *
      * Utils
      *
      */
@@ -618,27 +597,24 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
     private getInputStyles(
         styles?: HostedFieldStylesMap,
     ): PayPalCommerceHostedFieldsRenderOptions['styles'] {
-        const defaultStyles = {
-            input: {
-                'font-size': '1rem',
-                'font-family': 'Montserrat, Arial, Helvetica, sans-serif',
-                color: '#5f5f5f',
-                outline: 'none',
-                padding: '9px 13px',
-            },
+        const commonStyles = {
+            'font-size': styles?.default?.fontSize || '1rem',
+            'font-family':
+                styles?.default?.fontFamily || 'Montserrat, Arial, Helvetica, sans-serif',
+            'font-weight': styles?.default?.fontWeight || '400',
+            outline: 'none',
+            padding: '9px 13px',
         };
-        const mappedStyles = styles ? this.mapStyleOptions(styles) : null;
 
-        return mappedStyles
-            ? {
-                  ...mappedStyles,
-                  input: {
-                      ...mappedStyles.input,
-                      outline: 'none',
-                      padding: '9px 13px',
-                  },
-              }
-            : defaultStyles;
+        const defaultStyles = { ...commonStyles, color: '#333333' };
+        const errorStyles = { ...commonStyles, color: 'red' };
+
+        return {
+            input: defaultStyles,
+            '.invalid': errorStyles,
+            '.valid': defaultStyles,
+            ':focus': defaultStyles,
+        };
     }
 
     private stylizeInputContainers(
@@ -673,7 +649,6 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
      * Input events methods
      *
      */
-
     private onChangeHandler(
         formOptions: HostedFormOptions,
         event: PayPalCommerceCardFieldsState,


### PR DESCRIPTION
## What?
There was an issue with Credit Card fields text styling. For dark theme text had white color, so for fields with white background the text was "invisible" for customers. Unfortunately, **PayPal does not support background-color for field styling**, so we decided to change text color to black (for default, valid and focus field state) and red (for invalid field state).

## Why?
Customers does not see white text on a field with white background

## Testing / Proof
Unit tests
Manual tests
CI

Before:
<img width="818" alt="Screenshot 2024-04-08 at 20 24 11" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/e301c93a-b432-417f-b7bb-3f0de32341d7">
<img width="804" alt="Screenshot 2024-04-08 at 20 24 16" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/eb823ea0-8fa1-4172-973d-a9c8064dba03">

After:
<img width="660" alt="Screenshot 2024-04-08 at 21 22 56" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/4ba326f3-fb67-4d53-ba70-427bcd22d56d">
<img width="633" alt="Screenshot 2024-04-08 at 21 23 26" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/5def00c6-dffc-4926-a94d-112fa301c7a0">


