### PR TITLE
feat(payment): PI-1606 add validateCheckout and loadPaymentMethods to Payment Integration Service

### DIFF
--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -64,6 +64,8 @@ export default function createPaymentIntegrationService(
         new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender)),
     );
 
+    const checkoutValidator = new CheckoutValidator(new CheckoutRequestSender(requestSender));
+
     const hostedFormFactory = new HostedFormFactory(store);
 
     const orderActionCreator = new OrderActionCreator(
@@ -129,6 +131,7 @@ export default function createPaymentIntegrationService(
         store,
         storeProjectionFactory,
         checkoutActionCreator,
+        checkoutValidator,
         hostedFormFactory,
         orderActionCreator,
         billingAddressActionCreator,

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -15,7 +15,7 @@ import {
 
 import { BillingAddressActionCreator } from '../billing';
 import { CartRequestSender } from '../cart';
-import { CheckoutActionCreator, CheckoutStore } from '../checkout';
+import { Checkout, CheckoutActionCreator, CheckoutStore, CheckoutValidator } from '../checkout';
 import { DataStoreProjection } from '../common/data-store';
 import { CustomerActionCreator, CustomerCredentials } from '../customer';
 import { HostedFormFactory } from '../hosted-form';
@@ -41,6 +41,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _store: CheckoutStore,
         private _storeProjectionFactory: PaymentIntegrationStoreProjectionFactory,
         private _checkoutActionCreator: CheckoutActionCreator,
+        private _checkoutValidator: CheckoutValidator,
         private _hostedFormFactory: HostedFormFactory,
         private _orderActionCreator: OrderActionCreator,
         private _billingAddressActionCreator: BillingAddressActionCreator,
@@ -106,6 +107,12 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         await this._store.dispatch(
             this._paymentMethodActionCreator.loadPaymentMethod(methodId, options),
         );
+
+        return this._storeProjection.getState();
+    }
+
+    async loadPaymentMethods(options?: RequestOptions): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethods(options));
 
         return this._storeProjection.getState();
     }
@@ -273,5 +280,9 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         );
 
         return this._storeProjection.getState();
+    }
+
+    async validateCheckout(checkout?: Checkout, options?: RequestOptions): Promise<void> {
+        await this._checkoutValidator.validate(checkout, options);
     }
 }

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -1,5 +1,6 @@
 import { BillingAddressRequestBody } from './billing';
 import { BuyNowCartRequestBody, Cart } from './cart';
+import { Checkout } from './checkout';
 import { CustomerCredentials } from './customer';
 import { HostedForm, HostedFormOptions } from './hosted-form';
 import { OrderRequestBody } from './order';
@@ -37,6 +38,8 @@ export default interface PaymentIntegrationService {
         methodId: string,
         options?: RequestOptions & { useCache?: boolean },
     ): Promise<PaymentIntegrationSelectors>;
+
+    loadPaymentMethods(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
 
     loadCurrentOrder(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
 
@@ -92,4 +95,6 @@ export default interface PaymentIntegrationService {
         methodId: string,
         options?: RequestOptions,
     ): Promise<PaymentIntegrationSelectors>;
+
+    validateCheckout(checkout?: Checkout, options?: RequestOptions): Promise<void>;
 }

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -56,6 +56,7 @@ const initializeOffsitePayment = jest.fn();
 const loadCheckout = jest.fn();
 const loadDefaultCheckout = jest.fn();
 const loadPaymentMethod = jest.fn();
+const loadPaymentMethods = jest.fn();
 const loadShippingCountries = jest.fn(() => state);
 const loadCurrentOrder = jest.fn();
 const submitOrder = jest.fn();
@@ -70,6 +71,7 @@ const applyStoreCredit = jest.fn();
 const verifyCheckoutSpamProtection = jest.fn();
 const updatePaymentProviderCustomer = jest.fn();
 const initializePayment = jest.fn();
+const validateCheckout = jest.fn();
 
 const PaymentIntegrationServiceMock = jest
     .fn<PaymentIntegrationService>()
@@ -86,6 +88,7 @@ const PaymentIntegrationServiceMock = jest
             loadCheckout,
             loadDefaultCheckout,
             loadPaymentMethod,
+            loadPaymentMethods,
             loadShippingCountries,
             loadCurrentOrder,
             submitOrder,
@@ -100,6 +103,7 @@ const PaymentIntegrationServiceMock = jest
             verifyCheckoutSpamProtection,
             updatePaymentProviderCustomer,
             initializePayment,
+            validateCheckout,
         };
     });
 


### PR DESCRIPTION
## What?
Updated `PaymentIntegrationService` to include:

- `validateCheckout` - so the `validate` method from the core package can be used
- `loadPaymentMethods` - to load available payments methods after `forgetCheckout` method is used

## Why?
Needed for moving Afterpay payment strategy to a separate package.

## Testing / Proof
Unit + manual tests.

@bigcommerce/team-checkout @bigcommerce/team-payments
