### PR TITLE
feat(payment): PAYPAL-4001 added a switch to turn off Fastlane for Store Members

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -76,7 +76,15 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
             );
         }
 
-        if (this.isAcceleratedCheckoutEnabled) {
+        const state = this.paymentIntegrationService.getState();
+        const customer = state.getCustomerOrThrow();
+        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
+        const shouldSkipFastlaneForStoredMembers =
+            features &&
+            features['PAYPAL-4001.braintree_fastlane_stored_member_flow_removal'] &&
+            !customer.isGuest;
+
+        if (this.isAcceleratedCheckoutEnabled && !shouldSkipFastlaneForStoredMembers) {
             const shouldRunAuthenticationFlow = await this.shouldRunAuthenticationFlow();
 
             if (

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -120,7 +120,15 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
             );
         }
 
-        if (this.isAcceleratedCheckoutFeatureEnabled) {
+        const state = this.paymentIntegrationService.getState();
+        const customer = state.getCustomerOrThrow();
+        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
+        const shouldSkipFastlaneForStoredMembers =
+            features &&
+            features['PAYPAL-4001.paypal_commerce_fastlane_stored_member_flow_removal'] &&
+            !customer.isGuest;
+
+        if (this.isAcceleratedCheckoutFeatureEnabled && !shouldSkipFastlaneForStoredMembers) {
             const shouldRunAuthenticationFlow = await this.shouldRunAuthenticationFlow();
 
             if (

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -124,6 +124,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
             );
         }
 
+        // TODO: check for feature flag and that customer is a guest
         if (this.shouldRunAuthenticationFlow()) {
             await this.runPayPalAuthenticationFlowOrThrow(methodId);
         }
@@ -182,16 +183,24 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
     private shouldRunAuthenticationFlow(): boolean {
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
+        const customer = state.getCustomerOrThrow();
+        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
         const paymentProviderCustomer = state.getPaymentProviderCustomer();
         const paypalFastlaneCustomer = isPayPalFastlaneCustomer(paymentProviderCustomer)
             ? paymentProviderCustomer
             : {};
 
+        const shouldSkipFastlaneForStoredMembers =
+            features &&
+            features['PAYPAL-4001.paypal_commerce_fastlane_stored_member_flow_removal'] &&
+            !customer.isGuest;
+
         const paypalFastlaneSessionId = this.paypalCommerceFastlaneUtils.getStorageSessionId();
 
         if (
+            shouldSkipFastlaneForStoredMembers ||
             paypalFastlaneCustomer?.authenticationState ===
-            PayPalFastlaneAuthenticationState.CANCELED
+                PayPalFastlaneAuthenticationState.CANCELED
         ) {
             return false;
         }


### PR DESCRIPTION
## What?
Added a switch to turn off Fastlane for Store Members

## Why?
PayPal team does not have Store Member support for Fastlane in their roadmap, so we should be able to turn off the feature for all stores at once and remove implementation if everything ok.

## Testing / Proof
Unit tests
Manual tests
CI

PayPal Commerce Fastlane:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/df1808a7-64aa-42be-9749-2b8f55837bbc

Braintree Fastlane:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/e42a1a38-284b-4445-ab13-4a8462b5b025


