### PR TITLE
feat(payment): PAYPAL-3997 PPCP Card fields render method is awaited

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
@@ -235,11 +235,11 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
             this.stylizeInputContainers(fields);
 
             if (isCreditCardFormFields(fields)) {
-                this.renderFields(fields);
+                await this.renderFields(fields);
             }
 
             if (isCreditCardVaultedFormFields(fields)) {
-                this.renderVaultedFields(fields);
+                await this.renderVaultedFields(fields);
             }
         } else {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
@@ -317,56 +317,56 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
      * Rendering Card Fields methods
      *
      */
-    private renderFields(fieldsOptions: HostedCardFieldOptionsMap) {
+    private async renderFields(fieldsOptions: HostedCardFieldOptionsMap) {
         const cardFields = this.getCardFieldsOrThrow();
 
         if (fieldsOptions.cardCode?.containerId) {
             this.cvvField = cardFields.CVVField({
                 placeholder: '',
             });
-            this.cvvField.render(`#${fieldsOptions.cardCode.containerId}`);
+            await this.cvvField.render(`#${fieldsOptions.cardCode.containerId}`);
         }
 
         if (fieldsOptions.cardExpiry?.containerId) {
             this.expiryField = cardFields.ExpiryField();
-            this.expiryField.render(`#${fieldsOptions.cardExpiry.containerId}`);
+            await this.expiryField.render(`#${fieldsOptions.cardExpiry.containerId}`);
         }
 
         if (fieldsOptions.cardName?.containerId) {
             this.nameField = cardFields.NameField({
                 placeholder: '',
             });
-            this.nameField.render(`#${fieldsOptions.cardName.containerId}`);
+            await this.nameField.render(`#${fieldsOptions.cardName.containerId}`);
         }
 
         if (fieldsOptions.cardNumber?.containerId) {
             this.numberField = cardFields.NumberField({
                 placeholder: '',
             });
-            this.numberField.render(`#${fieldsOptions.cardNumber.containerId}`);
+            await this.numberField.render(`#${fieldsOptions.cardNumber.containerId}`);
         }
     }
 
-    private renderVaultedFields(fieldsOptions: HostedStoredCardFieldOptionsMap) {
+    private async renderVaultedFields(fieldsOptions: HostedStoredCardFieldOptionsMap) {
         const cardFields = this.getCardFieldsOrThrow();
 
         if (fieldsOptions.cardCodeVerification?.containerId) {
             this.cvvField = cardFields.CVVField({
                 placeholder: '',
             });
-            this.cvvField.render(`#${fieldsOptions.cardCodeVerification.containerId}`);
+            await this.cvvField.render(`#${fieldsOptions.cardCodeVerification.containerId}`);
         }
 
         if (fieldsOptions.cardExpiryVerification?.containerId) {
             this.expiryField = cardFields.ExpiryField();
-            this.expiryField.render(`#${fieldsOptions.cardExpiryVerification.containerId}`);
+            await this.expiryField.render(`#${fieldsOptions.cardExpiryVerification.containerId}`);
         }
 
         if (fieldsOptions.cardNumberVerification?.containerId) {
             this.numberField = cardFields.NumberField({
                 placeholder: '',
             });
-            this.numberField.render(`#${fieldsOptions.cardNumberVerification.containerId}`);
+            await this.numberField.render(`#${fieldsOptions.cardNumberVerification.containerId}`);
         }
     }
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -71,7 +71,7 @@ export interface PayPalCommerceCardFieldsState {
 }
 
 export interface PayPalCommerceFields {
-    render(container: HTMLElement | string): void;
+    render(container: HTMLElement | string): Promise<void>;
     clear(): void;
     removeClass(className: string): Promise<void>;
     close(): Promise<void>;


### PR DESCRIPTION
## What?
Added `await` for PPCP Card Fields `render` method.

## Why?
Because without await we can see pre-loaders which breaks layout.

## Testing / Proof
Before changes:

https://github.com/bigcommerce/checkout-sdk-js/assets/130665807/8bc1f7af-b342-49ff-a851-25a29ee026f9


After changes:

https://github.com/bigcommerce/checkout-sdk-js/assets/130665807/3baf3196-0ecd-449b-bf93-f4d558403cc9


@bigcommerce/team-checkout @bigcommerce/team-payments
