### PR TITLE
feat(payment): PAYPAL-4032 PPCP Card Fields shouldSetAsDefaultInstrument flag send

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.spec.ts
@@ -519,6 +519,7 @@ describe('PayPalCommerceCreditCardsPaymentStrategy', () => {
                 paymentData: {
                     shouldSaveInstrument: false,
                     shouldSetAsDefaultInstrument: false,
+                    instrumentId: 'bc_instrument_id',
                     formattedPayload: {
                         bigpay_token: {
                             verification_nonce: 'vaultSetupToken',


### PR DESCRIPTION
## What?
Sending `set_as_default_stored_instrument` flag with already vaulted instrument

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout @bigcommerce/team-payments
