### PR TITLE
feat(payment): PAYPAL-3976 Broken validation of card fields if the Name on Card field was not filled out

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
@@ -446,6 +446,13 @@ describe('BraintreeHostedForm', () => {
                                 type: 'required',
                             },
                         ],
+                        cardName: [
+                            {
+                                fieldType: 'cardName',
+                                message: 'Full name is required',
+                                type: 'required',
+                            },
+                        ],
                     },
                     isValid: false,
                 });

--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -323,12 +323,19 @@ export default class BraintreeHostedForm {
                 ],
             };
 
+            const cardNameValidation = {
+                [this._mapFieldType('cardholderName')]: [
+                    this._createRequiredError(this._mapFieldType('cardholderName')),
+                ],
+            };
+
             return isStoredCard
                 ? cvvValidation
                 : {
                       ...cvvValidation,
                       ...expirationDateValidation,
                       ...cardNumberValidation,
+                      ...cardNameValidation,
                   };
         }
 
@@ -423,6 +430,13 @@ export default class BraintreeHostedForm {
                     fieldType,
                     message: 'Invalid card number',
                     type: 'invalid_card_number',
+                };
+
+            case BraintreeFormFieldType.CardName:
+                return {
+                    fieldType,
+                    message: 'Invalid card name',
+                    type: 'invalid_card_name',
                 };
 
             default:

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -294,6 +294,7 @@ export interface BraintreeHostedFieldsState {
         expirationYear?: BraintreeHostedFieldsFieldData;
         cvv?: BraintreeHostedFieldsFieldData;
         postalCode?: BraintreeHostedFieldsFieldData;
+        cardholderName?: BraintreeHostedFieldsFieldData;
     };
 }
 


### PR DESCRIPTION
## What?

Added validation for credit card name field

## Why?

Buyer cannot checkout via Credit Card if the Name on Card field was not filled out. And we didn't get/show any information about it for the customers.

## Testing / Proof

Before:

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/27bbaded-8602-4d62-b2fb-a22e1ebf6a5e

After:

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/5d187235-8dec-4048-ade4-becab2162f2f


@bigcommerce/team-checkout @bigcommerce/team-payments
