### PR TITLE
[POC] feat(payment): PAYPAL-3996 updated paypal commerce fastlane shipping strategy with fastlane shipping selector

### DIFF
--- a/packages/core/src/shipping/shipping-request-options.ts
+++ b/packages/core/src/shipping/shipping-request-options.ts
@@ -3,6 +3,7 @@ import { RequestOptions } from '../common/http-request';
 import { AmazonPayV2ShippingInitializeOptions } from './strategies/amazon-pay-v2';
 import { BraintreeAcceleratedCheckoutInitializeOptions } from './strategies/braintree';
 import { StripeUPEShippingInitializeOptions } from './strategies/stripe-upe';
+import { PayPalCommerceFastlaneShippingInitializeOptions } from './strategies/paypal-commerce';
 
 /**
  * A set of options for configuring any requests related to the shipping step of
@@ -45,4 +46,10 @@ export interface ShippingInitializeOptions<T = {}> extends ShippingRequestOption
      * when using Braintree Accelerated Checkout.
      */
     braintreeacceleratedcheckout?: BraintreeAcceleratedCheckoutInitializeOptions;
+
+    /**
+     * The options that are required to initialize the shipping step of checkout
+     * when using PayPal Fastlane.
+     */
+    paypalcommercefastlane?: PayPalCommerceFastlaneShippingInitializeOptions;
 }

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-initialization-options.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-initialization-options.ts
@@ -1,3 +1,4 @@
+import { CustomerAddress } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { PayPalFastlaneStylesOption } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
 
 /**
@@ -6,11 +7,6 @@ import { PayPalFastlaneStylesOption } from '@bigcommerce/checkout-sdk/paypal-com
  */
 export default interface PayPalCommerceFastlaneShippingInitializeOptions {
     /**
-     * The identifier of the payment method.
-     */
-    methodId: string;
-
-    /**
      * Is a stylisation options for customizing PayPal Fastlane components
      *
      * Note: the styles for all PayPal Commerce Fastlane strategies should be the same,
@@ -18,4 +14,12 @@ export default interface PayPalCommerceFastlaneShippingInitializeOptions {
      * no matter what strategy was initialised first
      */
     styles?: PayPalFastlaneStylesOption;
+
+    /**
+     *
+     * Is a callback that shows PayPal Fastlane popup with customer addresses
+     * when get triggered
+     *
+     */
+    onPayPalFastlaneAddressChange?: (showPayPalFastlaneAddressSelector: () => Promise<CustomerAddress | undefined>) => void;
 }

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
@@ -42,6 +42,7 @@ export default function getPayPalFastlane(): PayPalFastlane {
         },
         profile: {
             showCardSelector: jest.fn(),
+            showShippingAddressSelector: jest.fn(),
         },
         FastlaneCardComponent: jest.fn(() => paypalFastlaneCardComponentMethods),
     };

--- a/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.ts
@@ -225,7 +225,7 @@ export default class PayPalCommerceFastlaneUtils {
             ? this.mapPayPalToBcInstrument(methodId, paypalInstrument)
             : [];
 
-        const addresses = this.mergeShippingAndBillingAddresses(shippingAddress, billingAddress);
+        const addresses = this.filterAddresses([shippingAddress, billingAddress]);
 
         return {
             authenticationState:
@@ -276,10 +276,11 @@ export default class PayPalCommerceFastlaneUtils {
         };
     }
 
-    private mapPayPalToBcAddress(
+    mapPayPalToBcAddress(
         address: PayPalCommerceConnectAddress | PayPalFastlaneAddress,
         profileName: PayPalCommerceConnectProfileName | PayPalFastlaneProfileName,
         phone?: PayPalCommerceConnectProfilePhone | PayPalFastlaneProfilePhone,
+        customFields?: CustomerAddress['customFields'],
     ): CustomerAddress {
         const [firstName, lastName] = profileName.fullName.split(' ');
 
@@ -303,7 +304,7 @@ export default class PayPalCommerceFastlaneUtils {
             countryCode: address.countryCode || '',
             postalCode: address.postalCode,
             phone: phoneData.countryCode + phoneData.nationalNumber,
-            customFields: [],
+            customFields: customFields || [],
         };
     }
 
@@ -314,22 +315,26 @@ export default class PayPalCommerceFastlaneUtils {
      * so the customer will be able to use addresses from PP Connect in checkout flow
      *
      */
-    private mergeShippingAndBillingAddresses(
-        shippingAddress?: CustomerAddress,
-        billingAddress?: CustomerAddress,
-    ): CustomerAddress[] {
-        const isBillingEqualsShipping =
-            shippingAddress && billingAddress
-                ? isEqual(
-                      this.normalizeAddress(shippingAddress),
-                      this.normalizeAddress(billingAddress),
-                  )
-                : false;
+    filterAddresses(addresses: Array<CustomerAddress | undefined>): CustomerAddress[] {
+        return addresses.reduce((customerAddresses: CustomerAddress[], currentAddress: CustomerAddress | undefined) => {
+            if (!currentAddress) {
+                return customerAddresses;
+            }
 
-        return [
-            ...(shippingAddress ? [shippingAddress] : []),
-            ...(billingAddress && !isBillingEqualsShipping ? [billingAddress] : []),
-        ];
+            const sameAddressInTheArray = customerAddresses.some(customerAddress => this.isEqualAddresses(
+                customerAddress,
+                currentAddress,
+            ));
+
+            return sameAddressInTheArray ? customerAddresses : [...customerAddresses, currentAddress];
+        }, []);
+    }
+
+    private isEqualAddresses(firstAddress: CustomerAddress, secondAddress: CustomerAddress): boolean {
+        return isEqual(
+            this.normalizeAddress(firstAddress),
+            this.normalizeAddress(secondAddress),
+        );
     }
 
     private normalizeAddress(address: CustomerAddress) {

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -353,6 +353,7 @@ export interface PayPalFastlane {
     FastlaneCardComponent(
         options: PayPalFastlaneCardComponentOptions,
     ): PayPalFastlaneCardComponentMethods;
+
 }
 
 export interface PayPalFastlaneOptions {
@@ -472,6 +473,12 @@ export interface PayPalFastlaneStylesOption {
 
 export interface PayPalFastlaneProfile {
     showCardSelector(): Promise<PayPalFastlaneCardSelectorResponse>;
+    showShippingAddressSelector(): Promise<PayPalFastlaneShippingAddressSelectorResponse>;
+}
+
+export interface PayPalFastlaneShippingAddressSelectorResponse {
+    selectionChanged: boolean;
+    selectedAddress: PayPalFastlaneShippingAddress;
 }
 
 export interface PayPalFastlaneCardSelectorResponse {


### PR DESCRIPTION
## What?
Updated paypal commerce fastlane shipping strategy with fastlane shipping selector

## Why?
To show PayPal Fastlane Popup with shipping options, so guest (Fastlane customer) be able to select shipping address from PayPal Fastlane account from the list.

## Testing / Proof
Manual tests

PayPal Fastlane shipping component:

https://github.com/bigcommerce/checkout-js/assets/25133454/78491e9f-8e2f-489a-815f-5f087962d52a


PayPal Fastlane shipping component with custom fields:

https://github.com/bigcommerce/checkout-js/assets/25133454/1caf5228-d0b4-449a-8b96-3ee69483b37e
