### PR TITLE
feat(payment): PAYPAL-4051 Apple Pay throws an error in checkout due to attempting to load Braintree information

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -556,6 +556,8 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
 
     private async _initializeBraintreeIntegrationService() {
         try {
+            // TODO: temporary solution to initialize the braintree payment method to get a clientToken to create a braintree client instance
+            // TODO: this approach should be removed in the future
             await this._paymentIntegrationService.loadPaymentMethod(ApplePayGatewayType.BRAINTREE);
 
             const state = this._paymentIntegrationService.getState();

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -575,7 +575,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
                 storeConfig,
             );
         } catch (_) {
-            return noop();
+            // we don't need to do anything in this block
         }
     }
 }

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -543,15 +543,25 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
     }
 
     private async _getBraintreeDeviceData() {
-        const data = await this._braintreeIntegrationService.getDataCollector();
+        const braintreePaymentMethod: PaymentMethod = this._paymentIntegrationService
+            .getState()
+            .getPaymentMethodOrThrow(ApplePayGatewayType.BRAINTREE);
 
-        return data.deviceData;
+        if (braintreePaymentMethod.clientToken) {
+            const data = await this._braintreeIntegrationService.getDataCollector();
+
+            return data.deviceData;
+        }
     }
 
     private async _initializeBraintreeIntegrationService() {
-        const state = await this._paymentIntegrationService.loadPaymentMethod(
-            ApplePayGatewayType.BRAINTREE,
-        );
+        try {
+            await this._paymentIntegrationService.loadPaymentMethod(ApplePayGatewayType.BRAINTREE);
+        } catch (_) {
+            return;
+        }
+
+        const state = this._paymentIntegrationService.getState();
 
         const storeConfig = state.getStoreConfigOrThrow();
 

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -558,6 +558,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         try {
             // TODO: temporary solution to initialize the braintree payment method to get a clientToken to create a braintree client instance
             // TODO: this approach should be removed in the future
+            // TODO: Jira ticket for tracking purpose: https://bigcommercecloud.atlassian.net/browse/PAYPAL-4122
             await this._paymentIntegrationService.loadPaymentMethod(ApplePayGatewayType.BRAINTREE);
 
             const state = this._paymentIntegrationService.getState();

--- a/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
@@ -1,5 +1,4 @@
 import { RequestSender } from '@bigcommerce/request-sender';
-import { noop } from 'lodash';
 
 import { BraintreeIntegrationService } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
@@ -300,7 +299,7 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
                 storeConfig,
             );
         } catch (_) {
-            return noop();
+            // we don't need to do anything in this block
         }
     }
 }

--- a/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
@@ -1,4 +1,5 @@
 import { RequestSender } from '@bigcommerce/request-sender';
+import { noop } from 'lodash';
 
 import { BraintreeIntegrationService } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
@@ -267,11 +268,11 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
     }
 
     private async _getBraintreeDeviceData() {
-        const braintreePaymentMethod: PaymentMethod = this._paymentIntegrationService
+        const braintreePaymentMethod = this._paymentIntegrationService
             .getState()
-            .getPaymentMethodOrThrow(ApplePayGatewayType.BRAINTREE);
+            .getPaymentMethod(ApplePayGatewayType.BRAINTREE);
 
-        if (braintreePaymentMethod.clientToken) {
+        if (braintreePaymentMethod?.clientToken) {
             const data = await this._braintreeIntegrationService.getDataCollector();
 
             return data.deviceData;
@@ -281,25 +282,25 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
     private async _initializeBraintreeIntegrationService() {
         try {
             await this._paymentIntegrationService.loadPaymentMethod(ApplePayGatewayType.BRAINTREE);
+
+            const state = this._paymentIntegrationService.getState();
+
+            const storeConfig = state.getStoreConfigOrThrow();
+
+            const braintreePaymentMethod: PaymentMethod = state.getPaymentMethodOrThrow(
+                ApplePayGatewayType.BRAINTREE,
+            );
+
+            if (!braintreePaymentMethod.clientToken || !braintreePaymentMethod.initializationData) {
+                return;
+            }
+
+            this._braintreeIntegrationService.initialize(
+                braintreePaymentMethod.clientToken,
+                storeConfig,
+            );
         } catch (_) {
-            return;
+            return noop();
         }
-
-        const state = this._paymentIntegrationService.getState();
-
-        const storeConfig = state.getStoreConfigOrThrow();
-
-        const braintreePaymentMethod: PaymentMethod = state.getPaymentMethodOrThrow(
-            ApplePayGatewayType.BRAINTREE,
-        );
-
-        if (!braintreePaymentMethod.clientToken || !braintreePaymentMethod.initializationData) {
-            return;
-        }
-
-        this._braintreeIntegrationService.initialize(
-            braintreePaymentMethod.clientToken,
-            storeConfig,
-        );
     }
 }

--- a/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
@@ -267,15 +267,25 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
     }
 
     private async _getBraintreeDeviceData() {
-        const data = await this._braintreeIntegrationService.getDataCollector();
+        const braintreePaymentMethod: PaymentMethod = this._paymentIntegrationService
+            .getState()
+            .getPaymentMethodOrThrow(ApplePayGatewayType.BRAINTREE);
 
-        return data.deviceData;
+        if (braintreePaymentMethod.clientToken) {
+            const data = await this._braintreeIntegrationService.getDataCollector();
+
+            return data.deviceData;
+        }
     }
 
     private async _initializeBraintreeIntegrationService() {
-        const state = await this._paymentIntegrationService.loadPaymentMethod(
-            ApplePayGatewayType.BRAINTREE,
-        );
+        try {
+            await this._paymentIntegrationService.loadPaymentMethod(ApplePayGatewayType.BRAINTREE);
+        } catch (_) {
+            return;
+        }
+
+        const state = this._paymentIntegrationService.getState();
 
         const storeConfig = state.getStoreConfigOrThrow();
 


### PR DESCRIPTION
## What?

Added `try {} catch {}` to solve the applepay issue with braintree initialization process when credit card feature is disabled

## Why?

To get the collect data the credit card feature must to be enabled otherwise the request for getting braintree data will be failed. In this case we can not be able to use braintree integration for collecting data because we do not have clientToken for correct initialization

This is a temporary solution for a quick fix

## Testing / Proof

Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
