### PR TITLE
feat(payment): PI-1916 Added SRI hashes for the adyen styles and scripts

### DIFF
--- a/packages/adyen-utils/src/adyenv2/adyenv2-script-loader.spec.ts
+++ b/packages/adyen-utils/src/adyenv2/adyenv2-script-loader.spec.ts
@@ -26,6 +26,22 @@ describe('AdyenV2ScriptLoader', () => {
         const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js';
         const cssUrl =
             'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css';
+        const cssOptions = {
+            prepend: false,
+            attributes: {
+                integrity:
+                    'sha384-8ofgICZZ/k5cC5N7xegqFZOA73H9RQ7H13439JfAZW8Gj3qjuKL2isaTD3GMIhDE',
+                crossorigin: 'anonymous',
+            },
+        };
+        const jsOptions = {
+            async: true,
+            attributes: {
+                integrity:
+                    'sha384-wG2z9zSQo61EIvyXmiFCo+zB3y0ZB4hsrXVcANmpP8HLthjoQJQPBh7tZKJSV8jA',
+                crossorigin: 'anonymous',
+            },
+        };
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {
@@ -44,8 +60,8 @@ describe('AdyenV2ScriptLoader', () => {
         it('loads the JS and CSS', async () => {
             await adyenV2ScriptLoader.load(configuration);
 
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
-            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl, jsOptions);
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl, cssOptions);
         });
 
         it('returns the JS from the window', async () => {

--- a/packages/adyen-utils/src/adyenv2/adyenv2-script-loader.ts
+++ b/packages/adyen-utils/src/adyenv2/adyenv2-script-loader.ts
@@ -17,11 +17,27 @@ export default class AdyenV2ScriptLoader {
                 `https://checkoutshopper-${
                     configuration.environment ?? ''
                 }.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css`,
+                {
+                    prepend: false,
+                    attributes: {
+                        integrity:
+                            'sha384-8ofgICZZ/k5cC5N7xegqFZOA73H9RQ7H13439JfAZW8Gj3qjuKL2isaTD3GMIhDE',
+                        crossorigin: 'anonymous',
+                    },
+                },
             ),
             this._scriptLoader.loadScript(
                 `https://checkoutshopper-${
                     configuration.environment ?? ''
                 }.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js`,
+                {
+                    async: true,
+                    attributes: {
+                        integrity:
+                            'sha384-wG2z9zSQo61EIvyXmiFCo+zB3y0ZB4hsrXVcANmpP8HLthjoQJQPBh7tZKJSV8jA',
+                        crossorigin: 'anonymous',
+                    },
+                },
             ),
         ]);
 

--- a/packages/adyen-utils/src/adyenv3/adyenv3-script-loader.spec.ts
+++ b/packages/adyen-utils/src/adyenv3/adyenv3-script-loader.spec.ts
@@ -27,6 +27,22 @@ describe('AdyenV3ScriptLoader', () => {
         const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.58.0/adyen.js';
         const cssUrl =
             'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.58.0/adyen.css';
+        const cssOptions = {
+            prepend: false,
+            attributes: {
+                integrity:
+                    'sha384-zgFNrGzbwuX5qJLys75cOUIGru/BoEzhGMyC07I3OSdHqXuhUfoDPVG03G+61oF4',
+                crossorigin: 'anonymous',
+            },
+        };
+        const jsOptions = {
+            async: true,
+            attributes: {
+                integrity:
+                    'sha384-e0EBlzLdOXxOJimp2uut2z1m98HS2cdhQw+OmeJDp7MRCPRNrQhjIWZiWiIscJvf',
+                crossorigin: 'anonymous',
+            },
+        };
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {
@@ -45,8 +61,8 @@ describe('AdyenV3ScriptLoader', () => {
         it('loads the JS and CSS', async () => {
             await adyenV3ScriptLoader.load(configuration);
 
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
-            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl, jsOptions);
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl, cssOptions);
         });
 
         it('returns the JS from the window using originKey', async () => {

--- a/packages/adyen-utils/src/adyenv3/adyenv3-script-loader.ts
+++ b/packages/adyen-utils/src/adyenv3/adyenv3-script-loader.ts
@@ -17,11 +17,27 @@ export default class AdyenV3ScriptLoader {
                 `https://checkoutshopper-${
                     configuration.environment ?? ''
                 }.adyen.com/checkoutshopper/sdk/5.58.0/adyen.css`,
+                {
+                    prepend: false,
+                    attributes: {
+                        integrity:
+                            'sha384-zgFNrGzbwuX5qJLys75cOUIGru/BoEzhGMyC07I3OSdHqXuhUfoDPVG03G+61oF4',
+                        crossorigin: 'anonymous',
+                    },
+                },
             ),
             this._scriptLoader.loadScript(
                 `https://checkoutshopper-${
                     configuration.environment ?? ''
                 }.adyen.com/checkoutshopper/sdk/5.58.0/adyen.js`,
+                {
+                    async: true,
+                    attributes: {
+                        integrity:
+                            'sha384-e0EBlzLdOXxOJimp2uut2z1m98HS2cdhQw+OmeJDp7MRCPRNrQhjIWZiWiIscJvf',
+                        crossorigin: 'anonymous',
+                    },
+                },
             ),
         ]);
 

--- a/packages/core/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -26,6 +26,22 @@ describe('AdyenV2ScriptLoader', () => {
         const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js';
         const cssUrl =
             'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css';
+        const cssOptions = {
+            prepend: false,
+            attributes: {
+                integrity:
+                    'sha384-8ofgICZZ/k5cC5N7xegqFZOA73H9RQ7H13439JfAZW8Gj3qjuKL2isaTD3GMIhDE',
+                crossorigin: 'anonymous',
+            },
+        };
+        const jsOptions = {
+            async: true,
+            attributes: {
+                integrity:
+                    'sha384-wG2z9zSQo61EIvyXmiFCo+zB3y0ZB4hsrXVcANmpP8HLthjoQJQPBh7tZKJSV8jA',
+                crossorigin: 'anonymous',
+            },
+        };
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {
@@ -44,8 +60,8 @@ describe('AdyenV2ScriptLoader', () => {
         it('loads the JS and CSS', async () => {
             await adyenV2ScriptLoader.load(configuration);
 
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
-            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl, jsOptions);
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl, cssOptions);
         });
 
         it('returns the JS from the window using originKey', async () => {

--- a/packages/core/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/packages/core/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -14,10 +14,30 @@ export default class AdyenV2ScriptLoader {
     async load(configuration: AdyenConfiguration): Promise<AdyenClient> {
         await Promise.all([
             this._stylesheetLoader.loadStylesheet(
-                `https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css`,
+                `https://checkoutshopper-${
+                    configuration.environment ?? ''
+                }.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css`,
+                {
+                    prepend: false,
+                    attributes: {
+                        integrity:
+                            'sha384-8ofgICZZ/k5cC5N7xegqFZOA73H9RQ7H13439JfAZW8Gj3qjuKL2isaTD3GMIhDE',
+                        crossorigin: 'anonymous',
+                    },
+                },
             ),
             this._scriptLoader.loadScript(
-                `https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js`,
+                `https://checkoutshopper-${
+                    configuration.environment ?? ''
+                }.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js`,
+                {
+                    async: true,
+                    attributes: {
+                        integrity:
+                            'sha384-wG2z9zSQo61EIvyXmiFCo+zB3y0ZB4hsrXVcANmpP8HLthjoQJQPBh7tZKJSV8jA',
+                        crossorigin: 'anonymous',
+                    },
+                },
             ),
         ]);
 

--- a/packages/core/src/payment/strategies/adyenv3/adyenv3-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/adyenv3/adyenv3-script-loader.spec.ts
@@ -22,9 +22,25 @@ describe('AdyenV3ScriptLoader', () => {
     describe('#load()', () => {
         const adyenClient = getAdyenClient();
         const configuration = getAdyenConfiguration();
-        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.24.0/adyen.js';
+        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.58.0/adyen.js';
         const cssUrl =
-            'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.24.0/adyen.css';
+            'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.58.0/adyen.css';
+        const cssOptions = {
+            prepend: false,
+            attributes: {
+                integrity:
+                    'sha384-zgFNrGzbwuX5qJLys75cOUIGru/BoEzhGMyC07I3OSdHqXuhUfoDPVG03G+61oF4',
+                crossorigin: 'anonymous',
+            },
+        };
+        const jsOptions = {
+            async: true,
+            attributes: {
+                integrity:
+                    'sha384-e0EBlzLdOXxOJimp2uut2z1m98HS2cdhQw+OmeJDp7MRCPRNrQhjIWZiWiIscJvf',
+                crossorigin: 'anonymous',
+            },
+        };
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {
@@ -43,8 +59,8 @@ describe('AdyenV3ScriptLoader', () => {
         it('loads the JS and CSS', async () => {
             await adyenV3ScriptLoader.load(configuration);
 
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
-            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl, jsOptions);
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl, cssOptions);
         });
 
         it('returns the JS from the window', async () => {

--- a/packages/core/src/payment/strategies/adyenv3/adyenv3-script-loader.ts
+++ b/packages/core/src/payment/strategies/adyenv3/adyenv3-script-loader.ts
@@ -14,10 +14,30 @@ export default class AdyenV3ScriptLoader {
     async load(configuration: AdyenConfiguration): Promise<AdyenClient> {
         await Promise.all([
             this._stylesheetLoader.loadStylesheet(
-                `https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/5.24.0/adyen.css`,
+                `https://checkoutshopper-${
+                    configuration.environment ?? ''
+                }.adyen.com/checkoutshopper/sdk/5.58.0/adyen.css`,
+                {
+                    prepend: false,
+                    attributes: {
+                        integrity:
+                            'sha384-zgFNrGzbwuX5qJLys75cOUIGru/BoEzhGMyC07I3OSdHqXuhUfoDPVG03G+61oF4',
+                        crossorigin: 'anonymous',
+                    },
+                },
             ),
             this._scriptLoader.loadScript(
-                `https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/5.24.0/adyen.js`,
+                `https://checkoutshopper-${
+                    configuration.environment ?? ''
+                }.adyen.com/checkoutshopper/sdk/5.58.0/adyen.js`,
+                {
+                    async: true,
+                    attributes: {
+                        integrity:
+                            'sha384-e0EBlzLdOXxOJimp2uut2z1m98HS2cdhQw+OmeJDp7MRCPRNrQhjIWZiWiIscJvf',
+                        crossorigin: 'anonymous',
+                    },
+                },
             ),
         ]);
 


### PR DESCRIPTION
## What?
Added SRI hashes for the adyen styles and scripts

## Why?
Due to the PCI4 requirements

## Testing / Proof
Units/manually
Adyen v2

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/f9b1e510-dcee-4d35-9d66-9434dc4b6454

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/454fc4fd-1f13-43e9-a090-f6b252d010f7


Adyen v3

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/c9e2726a-9aa8-42de-9707-4ce99fa7aeed


https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/0f9c9d14-ebea-4503-aa0c-9ddc09e97bd1





