### PR TITLE
refactor(payment): PAYPAL-4070 updated shipping initialise options with braintreefastlane and paypalcommercefastlane options

### DIFF
--- a/packages/core/src/shipping/shipping-request-options.ts
+++ b/packages/core/src/shipping/shipping-request-options.ts
@@ -2,6 +2,7 @@ import { RequestOptions } from '../common/http-request';
 
 import { AmazonPayV2ShippingInitializeOptions } from './strategies/amazon-pay-v2';
 import { BraintreeAcceleratedCheckoutInitializeOptions } from './strategies/braintree';
+import { PayPalCommerceFastlaneShippingInitializeOptions } from './strategies/paypal-commerce';
 import { StripeUPEShippingInitializeOptions } from './strategies/stripe-upe';
 
 /**
@@ -42,7 +43,13 @@ export interface ShippingInitializeOptions<T = {}> extends ShippingRequestOption
 
     /**
      * The options that are required to initialize the shipping step of checkout
-     * when using Braintree Accelerated Checkout.
+     * when using Braintree Fastlane.
      */
-    braintreeacceleratedcheckout?: BraintreeAcceleratedCheckoutInitializeOptions;
+    braintreefastlane?: BraintreeAcceleratedCheckoutInitializeOptions;
+
+    /**
+     * The options that are required to initialize the shipping step of checkout
+     * when using PayPal Commerce Fastlane.
+     */
+    paypalcommercefastlane?: PayPalCommerceFastlaneShippingInitializeOptions;
 }

--- a/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-initialize-options.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-initialize-options.ts
@@ -2,18 +2,13 @@ import { BraintreeConnectStylesOption } from '@bigcommerce/checkout-sdk/braintre
 
 /**
  * A set of options that are required to initialize the shipping step of
- * checkout in order to support Braintree Accelerated Checkout.
+ * checkout in order to support Braintree Fastlane.
  */
-export default interface BraintreeAcceleratedCheckoutShippingInitializeOptions {
+export default interface BraintreeFastlaneShippingInitializeOptions {
     /**
-     * The identifier of the payment method.
-     */
-    methodId: string;
-
-    /**
-     * Is a stylisation options for customizing PayPal Connect components
+     * Is a stylisation options for customizing PayPal Fastlane components
      *
-     * Note: the styles for all Braintree Accelerated Checkout strategies should be the same,
+     * Note: the styles for all Braintree Fastlane strategies should be the same,
      * because they will be provided to PayPal library only for the first strategy initialization
      * no matter what strategy was initialised first
      */

--- a/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.spec.ts
@@ -24,7 +24,6 @@ import { PaymentProviderCustomerActionCreator } from '../../../payment-provider-
 import ConsignmentActionCreator from '../../consignment-action-creator';
 import { getFlatRateOption } from '../../internal-shipping-options.mock';
 
-import BraintreeAcceleratedCheckoutInitializeOptions from './braintree-accelerated-checkout-shipping-initialize-options';
 import BraintreeAcceleratedCheckoutShippingStrategy from './braintree-accelerated-checkout-shipping-strategy';
 
 const BRAINTREE_AXO_METHOD_ID = 'braintreeacceleratedcheckout';
@@ -222,9 +221,7 @@ describe('BraintreeAcceleratedCheckoutShippingStrategy', () => {
     describe('initialize', () => {
         it('throws an error if no method Id in options', async () => {
             const strategy = createStrategy();
-            const response = strategy.initialize(
-                {} as BraintreeAcceleratedCheckoutInitializeOptions,
-            );
+            const response = strategy.initialize({});
 
             return expect(response).rejects.toThrow(InvalidArgumentError);
         });

--- a/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.ts
@@ -31,10 +31,8 @@ import { PaymentProviderCustomerActionCreator } from '../../../payment-provider-
 import { CardInstrument } from '../../../payment/instrument';
 import { UntrustedShippingCardVerificationType } from '../../../payment/instrument/instrument';
 import ConsignmentActionCreator from '../../consignment-action-creator';
-import { ShippingRequestOptions } from '../../shipping-request-options';
+import { ShippingInitializeOptions, ShippingRequestOptions } from '../../shipping-request-options';
 import ShippingStrategy from '../shipping-strategy';
-
-import BraintreeAcceleratedCheckoutShippingInitializeOptions from './braintree-accelerated-checkout-shipping-initialize-options';
 
 export default class BraintreeAcceleratedCheckoutShippingStrategy implements ShippingStrategy {
     private _browserStorage: BrowserStorage;
@@ -70,10 +68,8 @@ export default class BraintreeAcceleratedCheckoutShippingStrategy implements Shi
         return Promise.resolve(this._store.getState());
     }
 
-    async initialize(
-        options: BraintreeAcceleratedCheckoutShippingInitializeOptions,
-    ): Promise<InternalCheckoutSelectors> {
-        const { methodId, styles } = options || {};
+    async initialize(options: ShippingInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId, braintreefastlane } = options || {};
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -90,7 +86,7 @@ export default class BraintreeAcceleratedCheckoutShippingStrategy implements Shi
                 this._paymentMethodActionCreator.loadPaymentMethod(methodId),
             );
 
-            await this._runAuthenticationFlowOrThrow(methodId, styles);
+            await this._runAuthenticationFlowOrThrow(methodId, braintreefastlane?.styles);
         } catch (error) {
             // Info: we should not throw any error here to avoid
             // customer stuck on shipping step due to the payment provider

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-initialization-options.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-initialization-options.ts
@@ -6,11 +6,6 @@ import { PayPalFastlaneStylesOption } from '@bigcommerce/checkout-sdk/paypal-com
  */
 export default interface PayPalCommerceFastlaneShippingInitializeOptions {
     /**
-     * The identifier of the payment method.
-     */
-    methodId: string;
-
-    /**
      * Is a stylisation options for customizing PayPal Fastlane components
      *
      * Note: the styles for all PayPal Commerce Fastlane strategies should be the same,

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
@@ -237,7 +237,7 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
     describe('initialize', () => {
         it('throws an error if method id is not provided', async () => {
             try {
-                await strategy.initialize({ methodId: '' });
+                await strategy.initialize({});
             } catch (error: unknown) {
                 expect(error).toBeInstanceOf(InvalidArgumentError);
             }

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
@@ -14,10 +14,8 @@ import { InvalidArgumentError } from '../../../common/error/errors';
 import { PaymentMethodActionCreator } from '../../../payment';
 import { PaymentProviderCustomerActionCreator } from '../../../payment-provider-customer';
 import ConsignmentActionCreator from '../../consignment-action-creator';
-import { ShippingRequestOptions } from '../../shipping-request-options';
+import { ShippingInitializeOptions, ShippingRequestOptions } from '../../shipping-request-options';
 import ShippingStrategy from '../shipping-strategy';
-
-import PayPalCommerceFastlaneShippingInitializeOptions from './paypal-commerce-fastlane-shipping-initialization-options';
 
 export default class PayPalCommerceFastlaneShippingStrategy implements ShippingStrategy {
     private _isFastlaneEnabled = false;
@@ -52,10 +50,8 @@ export default class PayPalCommerceFastlaneShippingStrategy implements ShippingS
         return Promise.resolve(this._store.getState());
     }
 
-    async initialize(
-        options: PayPalCommerceFastlaneShippingInitializeOptions,
-    ): Promise<InternalCheckoutSelectors> {
-        const { methodId, styles } = options || {};
+    async initialize(options: ShippingInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId, paypalcommercefastlane } = options || {};
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -75,7 +71,7 @@ export default class PayPalCommerceFastlaneShippingStrategy implements ShippingS
 
                 this._isFastlaneEnabled = !!paymentMethod.initializationData.isFastlaneEnabled;
 
-                await this._initializePayPalSdk(methodId, styles);
+                await this._initializePayPalSdk(methodId, paypalcommercefastlane?.styles);
                 await this._runAuthenticationFlowOrThrow(methodId);
             } catch (error) {
                 // Info: we should not throw any error here to avoid customer stuck on


### PR DESCRIPTION
## What?
Updated shipping initialise options with braintreefastlane and paypalcommercefastlane options

## Why?
To be able to pass provider specific options from UI

## Testing / Proof
Unit tests
CI

Checkout and checkout-sdk builds passed successfully:
<img width="1265" alt="Screenshot 2024-04-23 at 12 36 49" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/4b63a4e3-6df5-4366-ab55-e87d29c0c9be">
<img width="517" alt="Screenshot 2024-04-23 at 12 36 42" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/c60d1fa7-d0e7-48e2-acf4-896e14cd2f11">
<img width="854" alt="Screenshot 2024-04-23 at 12 33 18" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/0d08e186-528f-47e9-bee3-69b85249c79b">
