### PR TITLE
feat(payment): PAYPAL-4067 added paypal fastlane shipping selector implementation to paypal commerce fastlane shipping strategy

### DIFF
--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-initialization-options.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-initialization-options.ts
@@ -1,3 +1,4 @@
+import { CustomerAddress } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { PayPalFastlaneStylesOption } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
 
 /**
@@ -13,4 +14,12 @@ export default interface PayPalCommerceFastlaneShippingInitializeOptions {
      * no matter what strategy was initialised first
      */
     styles?: PayPalFastlaneStylesOption;
+
+    /**
+     * Is a callback that shows PayPal Fastlane popup with customer addresses
+     * when get triggered
+     */
+    onPayPalFastlaneAddressChange?: (
+        showPayPalFastlaneAddressSelector: () => Promise<CustomerAddress | undefined>,
+    ) => void;
 }

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-commerce-payment-method.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-commerce-payment-method.mock.ts
@@ -51,6 +51,7 @@ export default function getPayPalCommercePaymentMethod(): PaymentMethod {
             shouldRenderFields: true,
             shouldRunAcceleratedCheckout: false,
             isHostedCheckoutEnabled: false,
+            isDeveloperModeApplicable: false,
         },
         type: 'PAYMENT_TYPE_API',
     };

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
@@ -42,6 +42,7 @@ export default function getPayPalFastlane(): PayPalFastlane {
         },
         profile: {
             showCardSelector: jest.fn(),
+            showShippingAddressSelector: jest.fn(),
         },
         FastlanePaymentComponent: jest.fn(() => paypalFastlaneComponentMethods),
     };

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -472,6 +472,12 @@ export interface PayPalFastlaneStylesOption {
 
 export interface PayPalFastlaneProfile {
     showCardSelector(): Promise<PayPalFastlaneCardSelectorResponse>;
+    showShippingAddressSelector(): Promise<PayPalFastlaneShippingAddressSelectorResponse>;
+}
+
+export interface PayPalFastlaneShippingAddressSelectorResponse {
+    selectionChanged: boolean;
+    selectedAddress: PayPalFastlaneShippingAddress;
 }
 
 export interface PayPalFastlaneCardSelectorResponse {


### PR DESCRIPTION
## What?
Added paypal fastlane shipping selector implementation to paypal commerce fastlane shipping strategy

## Why?
To be able to use PayPal Fastlane shipping selector on the UI, so the customer will be able to select between addresses from Fastlane address book.

## Testing / Proof
Unit tests
Manual tests
CI

How it works:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/cf646690-0022-40eb-979c-10f7bb380445

The flow should not work for customers who canceled authentication:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/af03bc1b-d028-40c7-ae99-457191ecb8af

