### PR TITLE
feat(payment): PAYPAL-4082 updated PayPalFastlaneComponent with PayPalCardComponent from paypal sdk

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.spec.ts
@@ -185,7 +185,7 @@ describe('BraintreeFastlanePaymentStrategy', () => {
         jest.spyOn(
             braintreeFastlaneUtils,
             'getBraintreeFastlaneComponentOrThrow',
-        ).mockImplementation(() => braintreeFastlaneMock.FastlanePaymentComponent);
+        ).mockImplementation(() => braintreeFastlaneMock.FastlaneCardComponent);
         jest.spyOn(braintreeFastlaneUtils, 'getDeviceSessionId').mockImplementation(
             () => deviceSessionId,
         );
@@ -193,7 +193,7 @@ describe('BraintreeFastlanePaymentStrategy', () => {
             tokenize: () => ({ nonce: 'nonce' }),
             render: jest.fn(),
         }));
-        jest.spyOn(braintreeFastlaneMock, 'FastlanePaymentComponent').mockImplementation(() => ({
+        jest.spyOn(braintreeFastlaneMock, 'FastlaneCardComponent').mockImplementation(() => ({
             tokenize: () => ({ nonce: 'nonce' }),
             render: jest.fn(),
         }));
@@ -487,11 +487,9 @@ describe('BraintreeFastlanePaymentStrategy', () => {
 
             container.id = 'pp-fastlane-container-id';
 
-            jest.spyOn(braintreeFastlaneMock, 'FastlanePaymentComponent').mockImplementation(
-                () => ({
-                    render: renderMethodMock,
-                }),
-            );
+            jest.spyOn(braintreeFastlaneMock, 'FastlaneCardComponent').mockImplementation(() => ({
+                render: renderMethodMock,
+            }));
 
             await strategy.initialize(initializationOptions);
 
@@ -702,12 +700,10 @@ describe('BraintreeFastlanePaymentStrategy', () => {
 
             const tokenizeMethodMock = jest.fn().mockReturnValue({ id: 'nonce' });
 
-            jest.spyOn(braintreeFastlaneMock, 'FastlanePaymentComponent').mockImplementation(
-                () => ({
-                    getPaymentToken: tokenizeMethodMock,
-                    render: jest.fn,
-                }),
-            );
+            jest.spyOn(braintreeFastlaneMock, 'FastlaneCardComponent').mockImplementation(() => ({
+                getPaymentToken: tokenizeMethodMock,
+                render: jest.fn,
+            }));
 
             await strategy.initialize(defaultInitializationOptions);
             await strategy.execute(executeOptions);

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
@@ -115,10 +115,10 @@ export default class BraintreeFastlaneUtils {
         return this.braintreeFastlane;
     }
 
-    getBraintreeFastlaneComponentOrThrow(): BraintreeFastlane['FastlanePaymentComponent'] {
+    getBraintreeFastlaneComponentOrThrow(): BraintreeFastlane['FastlaneCardComponent'] {
         const braintreeFastlane = this.getBraintreeFastlaneOrThrow();
 
-        return braintreeFastlane.FastlanePaymentComponent;
+        return braintreeFastlane.FastlaneCardComponent;
     }
 
     /**

--- a/packages/braintree-integration/src/braintree-fastlane/is-braintree-connect-card-component.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/is-braintree-connect-card-component.ts
@@ -1,10 +1,10 @@
 import {
     BraintreeConnectCardComponent,
-    BraintreeFastlanePaymentComponent,
+    BraintreeFastlaneCardComponent,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 
 export default function isBraintreeConnectCardComponent(
-    cardComponent: BraintreeFastlanePaymentComponent | BraintreeConnectCardComponent,
+    cardComponent: BraintreeFastlaneCardComponent | BraintreeConnectCardComponent,
 ): cardComponent is BraintreeConnectCardComponent {
     return cardComponent.hasOwnProperty('tokenize') && cardComponent.hasOwnProperty('render');
 }

--- a/packages/braintree-integration/src/braintree-fastlane/is-braintree-fastlane-card-component.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/is-braintree-fastlane-card-component.ts
@@ -1,11 +1,11 @@
 import {
     BraintreeConnectCardComponent,
-    BraintreeFastlanePaymentComponent,
+    BraintreeFastlaneCardComponent,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 
 export default function isBraintreeFastlaneCardComponent(
-    cardComponent: BraintreeFastlanePaymentComponent | BraintreeConnectCardComponent,
-): cardComponent is BraintreeFastlanePaymentComponent {
+    cardComponent: BraintreeFastlaneCardComponent | BraintreeConnectCardComponent,
+): cardComponent is BraintreeFastlaneCardComponent {
     return (
         cardComponent.hasOwnProperty('getPaymentToken') && cardComponent.hasOwnProperty('render')
     );

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -761,9 +761,9 @@ export interface BraintreeFastlaneConfig {
 export interface BraintreeFastlane {
     identity: BraintreeFastlaneIdentity;
     profile: BraintreeFastlaneProfile;
-    FastlanePaymentComponent: (
-        options: BraintreeFastlanePaymentComponentOptions,
-    ) => Promise<BraintreeFastlanePaymentComponent>;
+    FastlaneCardComponent: (
+        options: BraintreeFastlaneCardComponentOptions,
+    ) => Promise<BraintreeFastlaneCardComponent>;
     events: BraintreeFastlaneEvents;
 }
 
@@ -879,16 +879,16 @@ export interface BraintreeFastlaneVaultedInstrument {
     paymentSource: BraintreeFastlanePaymentSource;
 }
 
-export interface BraintreeFastlanePaymentComponentOptions {
+export interface BraintreeFastlaneCardComponentOptions {
     styles: BraintreeFastlaneStylesOption;
-    fields: BraintreeFastlanePaymentComponentFields;
+    fields: BraintreeFastlaneCardComponentFields;
 }
 
-export interface BraintreeFastlanePaymentComponentFields {
-    [key: string]: BraintreeFastlanePaymentComponentField;
+export interface BraintreeFastlaneCardComponentFields {
+    [key: string]: BraintreeFastlaneCardComponentField;
 }
 
-export interface BraintreeFastlanePaymentComponentField {
+export interface BraintreeFastlaneCardComponentField {
     placeholder?: string;
     prefill?: string;
 }
@@ -947,8 +947,8 @@ export interface BraintreeFastlaneOrderPlacedEventOptions
     currency_code: string;
 }
 
-export interface BraintreeFastlanePaymentComponent {
-    (options: BraintreeFastlanePaymentComponentOptions): BraintreeFastlanePaymentComponent;
+export interface BraintreeFastlaneCardComponent {
+    (options: BraintreeFastlaneCardComponentOptions): BraintreeFastlaneCardComponent;
     getPaymentToken(
         options: BraintreeFastlaneTokenizeOptions,
     ): Promise<BraintreeFastlaneVaultedInstrument>;

--- a/packages/braintree-utils/src/mocks/braintree.mock.ts
+++ b/packages/braintree-utils/src/mocks/braintree.mock.ts
@@ -219,7 +219,7 @@ export function getFastlaneMock(): BraintreeFastlane {
                     profileData: getBraintreeFastlaneProfileDataMock(),
                 }),
         },
-        FastlanePaymentComponent: jest.fn(),
+        FastlaneCardComponent: jest.fn(),
         events: {
             apmSelected: jest.fn(),
             emailSubmitted: jest.fn(),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -470,7 +470,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
 
                 await strategy.initialize(initializationOptions);
 
-                expect(paypalFastlane.FastlanePaymentComponent).toHaveBeenCalledWith({
+                expect(paypalFastlane.FastlaneCardComponent).toHaveBeenCalledWith({
                     fields: {
                         phoneNumber: {
                             prefill: address.phone,
@@ -699,7 +699,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
 
             onInitCallback(containerId);
 
-            const paypalFastlaneComponent = await paypalFastlane.FastlanePaymentComponent({});
+            const paypalFastlaneComponent = await paypalFastlane.FastlaneCardComponent({});
 
             expect(paypalFastlaneComponent.render).toHaveBeenCalledWith(containerId);
         });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -21,8 +21,8 @@ import {
     PayPalCommerceInitializationData,
     PayPalCommerceSdk,
     PayPalFastlaneAuthenticationState,
-    PayPalFastlanePaymentComponentMethods,
-    PayPalFastlanePaymentComponentOptions,
+    PayPalFastlaneCardComponentMethods,
+    PayPalFastlaneCardComponentOptions,
     PayPalFastlanePaymentFormattedPayload,
 } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
 
@@ -31,7 +31,7 @@ import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
 import { WithPayPalCommerceFastlanePaymentInitializeOptions } from './paypal-commerce-fastlane-payment-initialize-options';
 
 export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStrategy {
-    private paypalComponentMethods?: PayPalFastlanePaymentComponentMethods;
+    private paypalComponentMethods?: PayPalFastlaneCardComponentMethods;
 
     // TODO: remove this line when PayPal Fastlane experiment will be rolled out to 100%
     private isFastlaneEnabled = false;
@@ -264,7 +264,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
         const state = this.paymentIntegrationService.getState();
         const phone = state.getBillingAddress()?.phone;
 
-        const cardComponentOptions: PayPalFastlanePaymentComponentOptions = {
+        const cardComponentOptions: PayPalFastlaneCardComponentOptions = {
             fields: {
                 ...(phone && {
                     phoneNumber: {
@@ -277,7 +277,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
         if (this.isFastlaneEnabled) {
             const paypalFastlane = this.paypalCommerceFastlaneUtils.getPayPalFastlaneOrThrow();
 
-            this.paypalComponentMethods = await paypalFastlane.FastlanePaymentComponent(
+            this.paypalComponentMethods = await paypalFastlane.FastlaneCardComponent(
                 cardComponentOptions,
             );
         } else {
@@ -299,7 +299,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
         paypalComponentMethods.render(container);
     }
 
-    private getPayPalComponentMethodsOrThrow(): PayPalFastlanePaymentComponentMethods {
+    private getPayPalComponentMethodsOrThrow(): PayPalFastlaneCardComponentMethods {
         if (!this.paypalComponentMethods) {
             throw new PaymentMethodClientUnavailableError();
         }

--- a/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
+++ b/packages/paypal-commerce-utils/src/mocks/get-paypal-fastlane.mock.ts
@@ -1,7 +1,7 @@
-import { PayPalFastlane, PayPalFastlanePaymentComponentMethods } from '../paypal-commerce-types';
+import { PayPalFastlane, PayPalFastlaneCardComponentMethods } from '../paypal-commerce-types';
 
 export default function getPayPalFastlane(): PayPalFastlane {
-    const paypalFastlaneComponentMethods: PayPalFastlanePaymentComponentMethods = {
+    const paypalFastlaneComponentMethods: PayPalFastlaneCardComponentMethods = {
         tokenize: jest.fn(() => ({
             nonce: 'paypal_fastlane_tokenize_nonce',
         })),
@@ -43,6 +43,6 @@ export default function getPayPalFastlane(): PayPalFastlane {
         profile: {
             showCardSelector: jest.fn(),
         },
-        FastlanePaymentComponent: jest.fn(() => paypalFastlaneComponentMethods),
+        FastlaneCardComponent: jest.fn(() => paypalFastlaneComponentMethods),
     };
 }

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -350,9 +350,9 @@ export interface PayPalFastlane {
     identity: PayPalFastlaneIdentity;
     events: PayPalFastlaneEvents;
     profile: PayPalFastlaneProfile;
-    FastlanePaymentComponent(
-        options: PayPalFastlanePaymentComponentOptions,
-    ): Promise<PayPalFastlanePaymentComponentMethods>;
+    FastlaneCardComponent(
+        options: PayPalFastlaneCardComponentOptions,
+    ): Promise<PayPalFastlaneCardComponentMethods>;
 }
 
 export interface PayPalFastlaneOptions {
@@ -479,7 +479,7 @@ export interface PayPalFastlaneCardSelectorResponse {
     selectedCard: PayPalFastlaneProfileCard;
 }
 
-export interface PayPalFastlanePaymentComponentMethods {
+export interface PayPalFastlaneCardComponentMethods {
     tokenize(options: PayPalFastlaneTokenizeOptions): Promise<PayPalFastlaneTokenizeResult>; // TODO: remove with PayPal Connect implementation
     getPaymentToken(
         options: PayPalFastlaneGetPaymentTokenOptions,
@@ -487,14 +487,14 @@ export interface PayPalFastlanePaymentComponentMethods {
     render(element: string): void;
 }
 
-export interface PayPalFastlanePaymentComponentOptions {
-    fields?: PayPalFastlanePaymentComponentFields;
+export interface PayPalFastlaneCardComponentOptions {
+    fields?: PayPalFastlaneCardComponentFields;
 }
 
-export interface PayPalFastlanePaymentComponentFields {
-    [key: string]: PayPalFastlanePaymentComponentField;
+export interface PayPalFastlaneCardComponentFields {
+    [key: string]: PayPalFastlaneCardComponentField;
 }
-export interface PayPalFastlanePaymentComponentField {
+export interface PayPalFastlaneCardComponentField {
     placeholder?: string;
     prefill?: string;
 }


### PR DESCRIPTION
## What?
Updated PayPalPaymentComponent with PayPalCardComponent from paypal sdk

## Why?
Because PayPalPaymentComponent renders billing address form on payment step while PayPalCardComponent does not. In short they are almost the same.

## Testing / Proof
Unit tests
Manual tests
CI

Braintree Fastlane Gary and Ryan flows:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/6d9cfacb-b2cc-49ed-af8a-828de3f8f663


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/67503b32-e371-40e2-8a50-6387b2b5365f

PayPal Commerce Fastlane Gary and Ryan flows:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/f6f33207-a740-4b54-aaab-0bb1fb5f90f4


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/8b48c135-cb4f-425f-91ca-4abc3737324c

View of the component for US based customers:

<img width="840" alt="Screenshot 2024-04-25 at 10 33 48" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/e0060c74-a400-41cf-b2c8-3321d7a8331c">

