### PR TITLE
[investigation] feat(payment): PAYPAL-4064 added shipping options autoselect for PPCP and BT Fastlane implementations in customer strategies

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -228,13 +228,25 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
             instruments,
         });
 
-        if (billingAddress) {
-            await this.paymentIntegrationService.updateBillingAddress(billingAddress);
-        }
-
         // Info: if not a digital item
         if (shippingAddress && cart.lineItems.physicalItems.length > 0) {
             await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
+
+            const state = this.paymentIntegrationService.getState();
+            const consignment = state.getConsignmentsOrThrow()[0];
+
+            const availableShippingOptions = consignment.availableShippingOptions || [];
+            const recommendedShippingOption = availableShippingOptions.find(
+                (option) => option.isRecommended,
+            );
+
+            if (recommendedShippingOption) {
+                await this.paymentIntegrationService.selectShippingOption(recommendedShippingOption.id);
+            }
+        }
+
+        if (billingAddress) {
+            await this.paymentIntegrationService.updateBillingAddress(billingAddress);
         }
     }
 


### PR DESCRIPTION
## What?
Added shipping options autoselect for PPCP and BT Fastlane implementations in customer strategies

## Why?
To speed up the process for users with Fastlane accounts (like one click checkout)

## Testing / Proof
Manual tests

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/7ef8b72b-b988-4da2-aa7e-9a13a13d403e
