### PR TITLE
feat(payment): PAYPAL-4068 added BT Fastlane address shipping selector

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
@@ -256,7 +256,9 @@ export default class BraintreeFastlaneUtils {
             const billingAddresses = paypalBillingAddress
                 ? this.mapPayPalToBcAddress([paypalBillingAddress], [phoneNumber])
                 : [];
-            const instruments = profileData.card ? this.mapPayPalToBcInstrument(methodId, [profileData.card]) : [];
+            const instruments = profileData.card
+                ? this.mapPayPalToBcInstrument(methodId, [profileData.card])
+                : [];
             const addresses = this.mergeShippingAndBillingAddresses(
                 shippingAddresses,
                 billingAddresses,
@@ -428,7 +430,7 @@ export default class BraintreeFastlaneUtils {
         }
 
         const { firstName, lastName } = card.paymentSource.card.billingAddress;
-        const { given_name, surname } = name || {};
+        const { firstName: given_name, lastName: surname } = name || {};
         const { shippingAddress } = profileData || {};
         const address = {
             ...card.paymentSource.card.billingAddress,

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
@@ -256,7 +256,7 @@ export default class BraintreeFastlaneUtils {
             const billingAddresses = paypalBillingAddress
                 ? this.mapPayPalToBcAddress([paypalBillingAddress], [phoneNumber])
                 : [];
-            const instruments = this.mapPayPalToBcInstrument(methodId, [profileData.card]) || [];
+            const instruments = profileData.card ? this.mapPayPalToBcInstrument(methodId, [profileData.card]) : [];
             const addresses = this.mergeShippingAndBillingAddresses(
                 shippingAddresses,
                 billingAddresses,

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -774,6 +774,35 @@ export interface BraintreeFastlane {
 
 export interface BraintreeFastlaneProfile {
     showCardSelector(): Promise<BraintreeFastlaneCardSelectorResponse>;
+    showShippingAddressSelector(): Promise<BraintreeFastlaneShippingAddressSelectorResponse>;
+}
+
+export interface BraintreeFastlaneShippingAddressSelectorResponse {
+    selectionChanged: boolean;
+    selectedAddress: BraintreeFastlaneShippingAddress;
+}
+
+export interface BraintreeFastlaneShippingAddress {
+    name: BraintreeFastlaneProfileName;
+    phoneNumber: BraintreeConnectPhone;
+    id?: string;
+    firstName?: string;
+    lastName?: string;
+    company?: string;
+    streetAddress: string;
+    extendedAddress?: string;
+    locality: string;
+    region: string;
+    postalCode: string;
+    countryCodeNumeric?: number;
+    countryCodeAlpha2: string;
+    countryCodeAlpha3?: string;
+}
+
+export interface BraintreeFastlaneProfileName {
+    fullName: string;
+    firstName?: string;
+    lastName?: string;
 }
 
 export interface BraintreeFastlaneCardSelectorResponse {

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -652,10 +652,12 @@ export interface BraintreeConnectProfileData {
     addresses: BraintreeConnectAddress[];
     cards: BraintreeConnectVaultedInstrument[];
     phones: BraintreeConnectPhone[];
-    name: {
-        given_name: string;
-        surname: string;
-    };
+    name: BraintreeConnectName;
+}
+
+export interface BraintreeConnectName {
+    given_name: string;
+    surname: string;
 }
 
 export interface BraintreeConnectAddress {
@@ -784,7 +786,7 @@ export interface BraintreeFastlaneShippingAddressSelectorResponse {
 
 export interface BraintreeFastlaneShippingAddress {
     name: BraintreeFastlaneProfileName;
-    phoneNumber: BraintreeConnectPhone;
+    phoneNumber: string;
     id?: string;
     firstName?: string;
     lastName?: string;
@@ -875,10 +877,12 @@ export interface BraintreeFastlaneProfileData {
     fastlaneCustomerId: string;
     shippingAddress: BraintreeFastlaneAddress;
     card: BraintreeFastlaneVaultedInstrument;
-    name: {
-        given_name: string;
-        surname: string;
-    };
+    name: BraintreeFastlaneName;
+}
+
+export interface BraintreeFastlaneName {
+    firstName: string;
+    lastName: string;
 }
 
 export interface BraintreeFastlaneAddress {

--- a/packages/braintree-utils/src/mocks/braintree.mock.ts
+++ b/packages/braintree-utils/src/mocks/braintree.mock.ts
@@ -210,6 +210,7 @@ export function getFastlaneMock(): BraintreeFastlane {
     return {
         profile: {
             showCardSelector: jest.fn(),
+            showShippingAddressSelector: jest.fn(),
         },
         identity: {
             lookupCustomerByEmail: () => Promise.resolve({ customerContextId: 'customerId' }),
@@ -224,6 +225,65 @@ export function getFastlaneMock(): BraintreeFastlane {
             apmSelected: jest.fn(),
             emailSubmitted: jest.fn(),
             orderPlaced: jest.fn(),
+        },
+    };
+}
+
+export function getBraintreeFastlaneAuthenticationResultMock() {
+    return {
+        authenticationState: BraintreeFastlaneAuthenticationState.SUCCEEDED,
+        profileData: {
+            name: {
+                fullName: 'John Doe',
+                firstName: 'John',
+                lastName: 'Doe',
+            },
+            shippingAddress: {
+                address: {
+                    company: 'BigCommerce',
+                    addressLine1: 'addressLine1',
+                    addressLine2: 'addressLine2',
+                    adminArea1: 'addressState',
+                    adminArea2: 'addressCity',
+                    postalCode: '03004',
+                    countryCode: 'US',
+                },
+                name: {
+                    fullName: 'John Doe',
+                    firstName: 'John',
+                    lastName: 'Doe',
+                },
+                phoneNumber: {
+                    nationalNumber: '5551113344',
+                    countryCode: '1',
+                },
+            },
+            card: {
+                id: 'nonce/token',
+                paymentSource: {
+                    card: {
+                        brand: 'Visa',
+                        expiry: '2030-12',
+                        lastDigits: '1111',
+                        name: 'John Doe',
+                        billingAddress: {
+                            firstName: 'John',
+                            lastName: 'Doe',
+                            company: 'BigCommerce',
+                            addressLine1: 'addressLine1',
+                            addressLine2: 'addressLine2',
+                            adminArea1: 'addressState',
+                            adminArea2: 'addressCity',
+                            postalCode: '03004',
+                            countryCode: 'US',
+                            phone: {
+                                nationalNumber: '5551113344',
+                                countryCode: '1',
+                            },
+                        },
+                    },
+                },
+            },
         },
     };
 }

--- a/packages/braintree-utils/src/mocks/braintree.mock.ts
+++ b/packages/braintree-utils/src/mocks/braintree.mock.ts
@@ -153,8 +153,8 @@ export function getBraintreeFastlaneProfileDataMock(): BraintreeFastlaneProfileD
             },
         },
         name: {
-            given_name: 'John',
-            surname: 'Doe',
+            firstName: 'John',
+            lastName: 'Doe',
         },
     };
 }

--- a/packages/braintree-utils/src/utils/index.ts
+++ b/packages/braintree-utils/src/utils/index.ts
@@ -5,4 +5,5 @@ export { default as isBraintreeError } from './is-braintree-error';
 export { default as isBraintreeFastlaneWindow } from './is-braintree-fastlane-window';
 export { default as isBraintreeFastlaneProfileData } from './is-braintree-fastlane-profile-data';
 export { default as isBraintreeConnectProfileData } from './is-braintree-connect-profile-data';
+export { default as isBraintreeConnectName } from './is-braintree-connect-name';
 export { default as isBraintreeConnectPhone } from './is-braintree-connect-phone';

--- a/packages/braintree-utils/src/utils/is-braintree-connect-name.spec.ts
+++ b/packages/braintree-utils/src/utils/is-braintree-connect-name.spec.ts
@@ -1,0 +1,18 @@
+import isBraintreeConnectName from './is-braintree-connect-name';
+
+describe('isBraintreeConnectName', () => {
+    it('returns false if name is undefined', () => {
+        const name = undefined;
+
+        expect(isBraintreeConnectName(name)).toBe(false);
+    });
+
+    it('returns true if name belongs to connect', () => {
+        const name = {
+            given_name: 'Test',
+            surname: 'Test',
+        };
+
+        expect(isBraintreeConnectName(name)).toBe(true);
+    });
+});

--- a/packages/braintree-utils/src/utils/is-braintree-connect-name.ts
+++ b/packages/braintree-utils/src/utils/is-braintree-connect-name.ts
@@ -1,0 +1,14 @@
+import { BraintreeConnectName, BraintreeFastlaneName } from '../braintree';
+
+export default function isBraintreeConnectName(
+    braintreeConnectName: BraintreeConnectName | BraintreeFastlaneName | undefined,
+): braintreeConnectName is BraintreeConnectName {
+    if (!braintreeConnectName) {
+        return false;
+    }
+
+    return (
+        braintreeConnectName.hasOwnProperty('given_name') &&
+        braintreeConnectName.hasOwnProperty('surname')
+    );
+}

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -516,4 +516,5 @@ export interface BraintreeInitializationData {
     intent?: 'authorize' | 'order' | 'sale';
     isCreditEnabled?: boolean;
     isAcceleratedCheckoutEnabled?: boolean;
+    isFastlaneEnabled?: boolean; // TODO: remove this line when fastlane experiment will be rolled out to 100%
 }

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-initialize-options.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-initialize-options.ts
@@ -1,5 +1,5 @@
 import { BraintreeFastlaneStylesOption } from '@bigcommerce/checkout-sdk/braintree-utils';
-
+import { CustomerAddress } from '@bigcommerce/checkout-sdk/payment-integration-api';
 /**
  * A set of options that are required to initialize the shipping step of
  * checkout in order to support Braintree Fastlane.
@@ -13,4 +13,11 @@ export default interface BraintreeFastlaneShippingInitializeOptions {
      * no matter what strategy was initialised first
      */
     styles?: BraintreeFastlaneStylesOption;
+    /**
+     * Is a callback that shows Braintree Fastlane popup with customer addresses
+     * when get triggered
+     */
+    onPayPalFastlaneAddressChange?: (
+        showBraintreeFastlaneAddressSelector: () => Promise<CustomerAddress | undefined>,
+    ) => void;
 }

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
@@ -786,7 +786,7 @@ describe('BraintreeFastlaneShippingStrategy', () => {
             expect(braintreeIntegrationServiceMock.getBraintreeFastlane).toHaveBeenCalled();
         });
 
-        it('updates customer', async () => {
+        it('updates provider customer data', async () => {
             const updatePaymentProviderCustomerMock = jest.fn();
             const strategy = createStrategy();
             const authenticationResultMock = getBraintreeFastlaneAuthenticationResultMock();

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
@@ -2,7 +2,9 @@ import {
     BraintreeFastlaneAuthenticationState,
     BraintreeIntegrationService,
     getBraintreeConnectProfileDataMock,
+    getBraintreeFastlaneAuthenticationResultMock,
     getBraintreeFastlaneProfileDataMock,
+    getFastlaneMock,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import { PaymentMethod } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
@@ -83,6 +85,7 @@ describe('BraintreeFastlaneShippingStrategy', () => {
         phone: '14085551234',
         customFields: [],
     };
+    const braintreeFastlane = getFastlaneMock();
     const mappedBillingAddress = {
         ...mappedAddress,
         id: '321',
@@ -693,6 +696,159 @@ describe('BraintreeFastlaneShippingStrategy', () => {
             authenticationState: 'authenticationState',
             addresses: [fastlaneMappedBillingAddress, billingAddress],
             instruments: [mappedInstruments],
+        });
+    });
+
+    describe('#handleBraintreeFastlaneShippingAddressChange', () => {
+        beforeEach(() => {
+            const storeConfig = getConfig().storeConfig;
+            const guestCustomer = {
+                ...getCustomer(),
+                isGuest: false,
+            };
+            jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue(
+                guestCustomer,
+            );
+
+            const storeConfigWithAFeature = {
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-4001.braintree_fastlane_stored_member_flow_removal': false,
+                        'PAYPAL-3996.paypal_fastlane_shipping_update': true,
+                    },
+                },
+            };
+            jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeFastlane').mockImplementation(
+                () => braintreeFastlane,
+            );
+            jest.spyOn(
+                store.getState().shippingAddress,
+                'getShippingAddressesOrThrow',
+            ).mockReturnValue([getShippingAddress()]);
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue({
+                clientToken: '123',
+                initializationData: {
+                    isFastlaneEnabled: true,
+                },
+            });
+            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
+                storeConfigWithAFeature,
+            );
+            jest.spyOn(
+                store.getState().paymentProviderCustomer,
+                'getPaymentProviderCustomer',
+            ).mockReturnValue({
+                authenticationState: BraintreeFastlaneAuthenticationState.SUCCEEDED,
+                addresses: [],
+                instruments: [],
+            });
+        });
+
+        it('shows paypal shipping address selector', async () => {
+            const strategy = createStrategy();
+            const authenticationResultMock = getBraintreeFastlaneAuthenticationResultMock();
+            const onPayPalFastlaneAddressChange = jest.fn((showPaypalAddressSelector) => {
+                showPaypalAddressSelector();
+            });
+            jest.spyOn(braintreeFastlane.profile, 'showShippingAddressSelector').mockImplementation(
+                () => ({
+                    selectionChanged: true,
+                    selectedAddress: authenticationResultMock.profileData.shippingAddress,
+                }),
+            );
+
+            await strategy.initialize({
+                ...defaultOptions,
+                braintreefastlane: {
+                    onPayPalFastlaneAddressChange,
+                },
+            });
+
+            expect(braintreeFastlane.profile.showShippingAddressSelector).toHaveBeenCalled();
+        });
+
+        it('loads fastlane sdk', async () => {
+            const strategy = createStrategy();
+            const onPayPalFastlaneAddressChange = jest.fn((showPaypalAddressSelector) => {
+                showPaypalAddressSelector();
+            });
+
+            await strategy.initialize({
+                ...defaultOptions,
+                braintreefastlane: {
+                    onPayPalFastlaneAddressChange,
+                },
+            });
+
+            expect(braintreeIntegrationServiceMock.getBraintreeFastlane).toHaveBeenCalled();
+        });
+
+        it('updates customer', async () => {
+            const updatePaymentProviderCustomerMock = jest.fn();
+            const strategy = createStrategy();
+            const authenticationResultMock = getBraintreeFastlaneAuthenticationResultMock();
+            const braintreeFastlane = getFastlaneMock();
+            const onPayPalFastlaneAddressChange = jest.fn((showPaypalAddressSelector) => {
+                showPaypalAddressSelector();
+            });
+
+            jest.spyOn(braintreeFastlane.profile, 'showShippingAddressSelector').mockImplementation(
+                () => ({
+                    selectionChanged: true,
+                    selectedAddress: authenticationResultMock.profileData.shippingAddress,
+                }),
+            );
+            jest.spyOn(
+                paymentProviderCustomerActionCreator,
+                'updatePaymentProviderCustomer',
+            ).mockImplementation(updatePaymentProviderCustomerMock);
+
+            await strategy.initialize({
+                ...defaultOptions,
+                braintreefastlane: {
+                    onPayPalFastlaneAddressChange,
+                },
+            });
+
+            expect(updatePaymentProviderCustomerMock).toHaveBeenCalled();
+        });
+
+        it('updates address', async () => {
+            const updatePaymentProviderCustomerMock = jest.fn();
+            const updateAction = jest.fn();
+            const strategy = createStrategy();
+            const authenticationResultMock = getBraintreeFastlaneAuthenticationResultMock();
+            const braintreeFastlane = getFastlaneMock();
+            const onPayPalFastlaneAddressChange = jest.fn((showPaypalAddressSelector) => {
+                showPaypalAddressSelector();
+            });
+            jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeFastlane').mockImplementation(
+                () => braintreeFastlane,
+            );
+            jest.spyOn(braintreeFastlane.profile, 'showShippingAddressSelector').mockImplementation(
+                () => ({
+                    selectionChanged: true,
+                    selectedAddress: authenticationResultMock.profileData.shippingAddress,
+                }),
+            );
+            jest.spyOn(
+                paymentProviderCustomerActionCreator,
+                'updatePaymentProviderCustomer',
+            ).mockImplementation(updatePaymentProviderCustomerMock);
+
+            jest.spyOn(consignmentActionCreator, 'updateAddress').mockImplementation(updateAction);
+
+            await strategy.initialize({
+                ...defaultOptions,
+                braintreefastlane: {
+                    onPayPalFastlaneAddressChange,
+                },
+            });
+
+            expect(consignmentActionCreator.updateAddress).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
@@ -229,7 +229,7 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
                 this._mapPayPalToBcAddress([profileData.shippingAddress], countries, []) || [];
             billingAddresses =
                 this._mapPayPalToBcAddress(paypalBillingAddresses, countries, []) || [];
-            instruments = this._mapPayPalToBcInstrument(methodId, [profileData.card]) || [];
+            instruments = profileData.card ? this._mapPayPalToBcInstrument(methodId, [profileData.card]) : [];
         } else if (isBraintreeConnectProfileData(profileData)) {
             shippingAddresses =
                 this._mapPayPalToBcAddress(profileData.addresses, countries, profileData.phones) ||

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
@@ -26,13 +26,14 @@ import {
 } from '../../../common/error/errors';
 import { CustomerAddress } from '../../../customer';
 import { Country } from '../../../geography';
-import { PaymentMethodActionCreator } from '../../../payment';
+import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { PaymentProviderCustomerActionCreator } from '../../../payment-provider-customer';
 import { CardInstrument } from '../../../payment/instrument';
 import { UntrustedShippingCardVerificationType } from '../../../payment/instrument/instrument';
 import ConsignmentActionCreator from '../../consignment-action-creator';
 import { ShippingInitializeOptions, ShippingRequestOptions } from '../../shipping-request-options';
 import ShippingStrategy from '../shipping-strategy';
+import { BraintreeInitializationData } from '../../../payment/strategies/braintree';
 
 export default class BraintreeFastlaneShippingStrategy implements ShippingStrategy {
     private _browserStorage: BrowserStorage;
@@ -70,6 +71,7 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
 
     async initialize(options: ShippingInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { methodId, braintreefastlane } = options || {};
+        const { onPayPalFastlaneAddressChange } = braintreefastlane || {};
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -77,16 +79,27 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
             );
         }
 
-        if (!this._shouldRunAuthenticationFlow()) {
+        if (this._shouldSkipFastlaneForStoredMembers()) {
             return Promise.resolve(this._store.getState());
         }
 
         try {
-            await this._store.dispatch(
-                this._paymentMethodActionCreator.loadPaymentMethod(methodId),
-            );
+            if (this._shouldRunAuthenticationFlow()) {
+                await this._store.dispatch(
+                    this._paymentMethodActionCreator.loadPaymentMethod(methodId),
+                );
 
-            await this._runAuthenticationFlowOrThrow(methodId, braintreefastlane?.styles);
+                await this._runAuthenticationFlowOrThrow(methodId, braintreefastlane?.styles);
+            }
+
+            if (
+                typeof onPayPalFastlaneAddressChange === 'function' &&
+                (await this._shouldUseBraintreeFastlaneShippingComponent(methodId))
+            ) {
+                onPayPalFastlaneAddressChange(() =>
+                    this._handleBraintreeFastlaneShippingAddressChange(),
+                );
+            }
         } catch (error) {
             // Info: we should not throw any error here to avoid
             // customer stuck on shipping step due to the payment provider
@@ -99,8 +112,6 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
     private _shouldRunAuthenticationFlow(): boolean {
         const state = this._store.getState();
         const cartId = state.cart.getCart()?.id;
-        const customer = state.customer.getCustomerOrThrow();
-        const features = state.config.getStoreConfigOrThrow().checkoutSettings.features;
         const paypalFastlaneSessionId = this._browserStorage.getItem('sessionId');
         const paymentProviderCustomer = state.paymentProviderCustomer.getPaymentProviderCustomer();
         const braintreePaymentProviderCustomer = isBraintreeAcceleratedCheckoutCustomer(
@@ -109,10 +120,7 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
             ? paymentProviderCustomer
             : {};
 
-        const shouldSkipFastlaneForStoredMembers =
-            features &&
-            features['PAYPAL-4001.braintree_fastlane_stored_member_flow_removal'] &&
-            !customer.isGuest;
+        const shouldSkipFastlaneForStoredMembers = this._shouldSkipFastlaneForStoredMembers();
 
         if (
             shouldSkipFastlaneForStoredMembers ||
@@ -125,6 +133,19 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
         return (
             !braintreePaymentProviderCustomer?.authenticationState &&
             paypalFastlaneSessionId === cartId
+        );
+    }
+
+    // TODO: remove this method when PAYPAL-4001.paypal_commerce_fastlane_stored_member_flow_removal will be rolled out to 100%
+    private _shouldSkipFastlaneForStoredMembers() {
+        const state = this._store.getState();
+        const customer = state.customer.getCustomerOrThrow();
+        const features = state.config.getStoreConfigOrThrow().checkoutSettings.features;
+
+        return (
+            features &&
+            features['PAYPAL-4001.braintree_fastlane_stored_member_flow_removal'] &&
+            !customer.isGuest
         );
     }
 
@@ -298,12 +319,13 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
         addresses: BraintreeFastlaneAddress[],
         countries: Country[],
         phones: BraintreeConnectPhone[],
+        customFields?: CustomerAddress['customFields'],
     ): CustomerAddress[] | undefined {
         const phoneNumber =
             phones && phones[0] ? phones[0].country_code + phones[0].national_number : '';
 
         return addresses.map((address) => ({
-            id: Number(address.id),
+            id: Number(address.id) || Date.now(),
             type: 'paypal-address',
             firstName: address.firstName || '',
             lastName: address.lastName || '',
@@ -316,8 +338,8 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
             country: this._getCountryNameByCountryCode(address.countryCodeAlpha2, countries),
             countryCode: address.countryCodeAlpha2,
             postalCode: address.postalCode,
-            phone: phoneNumber,
-            customFields: [],
+            phone: phoneNumber || '',
+            customFields: customFields || [],
         }));
     }
 
@@ -371,5 +393,139 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
                 type: 'card',
             };
         });
+    }
+
+    /**
+     *
+     * Braintree Fastlane shipping address change through Fastlane external popup
+     *
+     */
+    private async _handleBraintreeFastlaneShippingAddressChange(): Promise<
+        CustomerAddress | undefined
+    > {
+        const state = this._store.getState();
+        const countries = state.countries.getCountries() || [];
+        const braintreeFastlane = await this._braintreeIntegrationService.getBraintreeFastlane();
+
+        const { selectionChanged, selectedAddress } =
+            await braintreeFastlane.profile.showShippingAddressSelector();
+
+        if (selectionChanged) {
+            const state = this._store.getState();
+            const shipping = state.shippingAddress.getShippingAddressesOrThrow();
+            const paymentProviderCustomer =
+                state.paymentProviderCustomer.getPaymentProviderCustomer();
+            const braintreeFastlaneCustomer = isBraintreeAcceleratedCheckoutCustomer(
+                paymentProviderCustomer,
+            )
+                ? paymentProviderCustomer
+                : {};
+
+            const shippingAddress = this._mapPayPalToBcAddress(
+                [selectedAddress],
+                countries,
+                [selectedAddress.phoneNumber],
+                shipping[0].customFields,
+            );
+
+            if (shippingAddress) {
+                const paymentProviderCustomerAddresses = this._filterAddresses([
+                    shippingAddress[0],
+                    ...(braintreeFastlaneCustomer.addresses || []),
+                ]);
+
+                await this._store.dispatch(
+                    this._paymentProviderCustomerActionCreator.updatePaymentProviderCustomer({
+                        ...braintreeFastlaneCustomer,
+                        addresses: paymentProviderCustomerAddresses,
+                    }),
+                );
+
+                await this._store.dispatch(
+                    this._consignmentActionCreator.updateAddress(shippingAddress[0]),
+                );
+
+                return shippingAddress[0];
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     *
+     * This method is responsible for filtering BT Fastlane addresses if they are the same
+     * and returns an array of addresses to use them for shipping and/or billing address selections
+     * so the customer will be able to use addresses from BT Fastlane in checkout flow
+     *
+     */
+    private _filterAddresses(addresses: Array<CustomerAddress | undefined>): CustomerAddress[] {
+        return addresses.reduce(
+            (customerAddresses: CustomerAddress[], currentAddress: CustomerAddress | undefined) => {
+                if (!currentAddress) {
+                    return customerAddresses;
+                }
+
+                const sameAddressInTheArray = customerAddresses.some((customerAddress) =>
+                    this._isEqualAddresses(customerAddress, currentAddress),
+                );
+
+                return sameAddressInTheArray
+                    ? customerAddresses
+                    : [...customerAddresses, currentAddress];
+            },
+            [],
+        );
+    }
+
+    private _isEqualAddresses(
+        firstAddress: CustomerAddress,
+        secondAddress: CustomerAddress,
+    ): boolean {
+        return isEqual(this._normalizeAddress(firstAddress), this._normalizeAddress(secondAddress));
+    }
+
+    // TODO: reimplement this method when PAYPAL-3996.paypal_fastlane_shipping_update and Fastlane features will be rolled out to 100%
+    private async _shouldUseBraintreeFastlaneShippingComponent(methodId: string): Promise<boolean> {
+        const state = this._store.getState();
+        const features = state.config.getStoreConfigOrThrow().checkoutSettings.features;
+        const paymentProviderCustomer = state.paymentProviderCustomer.getPaymentProviderCustomer();
+        const braintreePaymentProviderCustomer = isBraintreeAcceleratedCheckoutCustomer(
+            paymentProviderCustomer,
+        )
+            ? paymentProviderCustomer
+            : {};
+
+        // Info: to avoid loading payment method we should check for values
+        // that does not require api calls first
+        if (
+            features &&
+            features['PAYPAL-3996.paypal_fastlane_shipping_update'] &&
+            !!braintreePaymentProviderCustomer &&
+            braintreePaymentProviderCustomer !== BraintreeFastlaneAuthenticationState.CANCELED
+        ) {
+            const paymentMethod = await this._getBraintreePaymentMethodOrThrow(methodId);
+
+            return !!paymentMethod?.initializationData?.isFastlaneEnabled;
+        }
+
+        return false;
+    }
+
+    private async _getBraintreePaymentMethodOrThrow(
+        methodId: string,
+    ): Promise<PaymentMethod<BraintreeInitializationData>> {
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+        if (!paymentMethod) {
+            const newState = await this._store.dispatch(
+                this._paymentMethodActionCreator.loadPaymentMethod(methodId),
+            );
+
+            return newState.paymentMethods.getPaymentMethodOrThrow(methodId);
+        }
+
+        return paymentMethod;
     }
 }


### PR DESCRIPTION
## What?
Added BT Fastlane address shipping selector

## Why?
To implement paypal fastlane shipping address selector

## Testing / Proof
Unit tests

**Fastlane User**

https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/dfb3652f-4537-4da9-8b11-87e2eea128cc

**Non Fastlane User**

https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/ee537ed1-e786-4071-ad8e-01db40b26177

**Fastlane Refreshed Page**

https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/1acdb75c-1fb9-4ad9-b1c2-12acbce0c047

**Fastlane Changed To Non Fastlane**

https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/827873f5-f3de-4c71-b512-10c3a88e7c2a

**Canceled OTP**

https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/5236c483-2e88-4b1c-956e-f66fc5ad67d6



@bigcommerce/team-checkout @bigcommerce/team-payments
