### PR TITLE
feat(payment): PI-1584 move Cardinal to separate package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@
 /packages/amazon-pay-utils @bigcommerce/team-integrations
 /packages/bluesnap-direct-integration @bigcommerce/team-integrations
 /packages/bolt-integration @bigcommerce/team-integrations
+/packages/cardinal-integration @bigcommerce/team-integrations
 /packages/checkoutcom-custom-integration @bigcommerce/team-integrations
 /packages/mollie-integration @bigcommerce/team-integrations
 /packages/squarev2-integration @bigcommerce/team-integrations

--- a/packages/cardinal-integration/.eslintrc.json
+++ b/packages/cardinal-integration/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.spec.ts", "*.spec.tsx"],
+            "rules": {
+                "jest/no-conditional-expect": "off",
+                "@typescript-eslint/naming-convention": "off",
+                "@typescript-eslint/no-unsafe-member-access": "off"
+            }
+        }
+    ]
+}

--- a/packages/cardinal-integration/.eslintrc.json
+++ b/packages/cardinal-integration/.eslintrc.json
@@ -15,6 +15,7 @@
             "files": ["*.spec.ts", "*.spec.tsx"],
             "rules": {
                 "jest/no-conditional-expect": "off",
+                "@typescript-eslint/consistent-type-assertions": "off",
                 "@typescript-eslint/no-explicit-any": "off",
                 "@typescript-eslint/no-floating-promises": "off",
                 "@typescript-eslint/no-unsafe-call": "off"

--- a/packages/cardinal-integration/.eslintrc.json
+++ b/packages/cardinal-integration/.eslintrc.json
@@ -3,11 +3,21 @@
     "ignorePatterns": ["!**/*"],
     "overrides": [
         {
-            "files": ["*.ts", "*.tsx", "*.spec.ts", "*.spec.tsx"],
+            "files": ["*.ts", "*.tsx"],
+            "rules": {
+                "@typescript-eslint/naming-convention": "off",
+                "@typescript-eslint/no-unsafe-argument": "off",
+                "@typescript-eslint/no-unsafe-assignment": "off",
+                "@typescript-eslint/no-unsafe-member-access": "off"
+            }
+        },
+        {
+            "files": ["*.spec.ts", "*.spec.tsx"],
             "rules": {
                 "jest/no-conditional-expect": "off",
-                "@typescript-eslint/naming-convention": "off",
-                "@typescript-eslint/no-unsafe-member-access": "off"
+                "@typescript-eslint/no-explicit-any": "off",
+                "@typescript-eslint/no-floating-promises": "off",
+                "@typescript-eslint/no-unsafe-call": "off"
             }
         }
     ]

--- a/packages/cardinal-integration/README.md
+++ b/packages/cardinal-integration/README.md
@@ -1,0 +1,20 @@
+# cardinal-integration
+
+This package contains the integration layer for [Cardinal](https://cardinalcommerce.com/).
+This library was generated with [Nx](https://nx.dev).
+
+# Cardinal
+
+For additional information on Cardinal API, please refer to [Cardinal Virtual SDK API documentation](https://cardinaldocs.atlassian.net/wiki/spaces/VSDK/overview).
+
+## Running unit tests
+
+This package uses [Jest](https://jestjs.io) for testing.
+
+Run `nx test cardinal-integration` to execute all the unit tests for this package.
+
+Run `nx test cardinal-integration --testFile="<FILE_NAME>"` to execute unit tests for a single file.
+
+## Running lint
+
+Run `nx lint cardinal-integration` to execute the lint via [ESLint](https://eslint.org/)

--- a/packages/cardinal-integration/README.md
+++ b/packages/cardinal-integration/README.md
@@ -1,7 +1,6 @@
 # cardinal-integration
 
 This package contains the integration layer for [Cardinal](https://cardinalcommerce.com/).
-This library was generated with [Nx](https://nx.dev).
 
 # Cardinal
 

--- a/packages/cardinal-integration/jest.config.js
+++ b/packages/cardinal-integration/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    displayName: "cardinal-integration",
+    preset: "../../jest.preset.js",
+    globals: {
+        "ts-jest": {
+            tsconfig: "<rootDir>/tsconfig.spec.json",
+            diagnostics: false,
+        },
+    },
+    setupFilesAfterEnv: ["../../jest-setup.js"],
+    coverageDirectory: "../../coverage/packages/cardinal-integration",
+};

--- a/packages/cardinal-integration/project.json
+++ b/packages/cardinal-integration/project.json
@@ -1,0 +1,23 @@
+{
+    "root": "packages/cardinal-integration",
+    "sourceRoot": "packages/cardinal-integration/src",
+    "projectType": "library",
+    "targets": {
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/cardinal-integration/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["coverage/packages/cardinal-integration"],
+            "options": {
+                "jestConfig": "packages/cardinal-integration/jest.config.js",
+                "passWithNoTests": true
+            }
+        }
+    },
+    "tags": ["scope:shared"]
+}

--- a/packages/cardinal-integration/src/cardinal-client.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-client.spec.ts
@@ -55,17 +55,15 @@ describe('CardinalClient', () => {
         let validated: (data: CardinalValidatedData, jwt: string) => void;
 
         beforeEach(() => {
-            sdk.on = jest.fn(
-                (type: CardinalEventType, callback) => {
-                    if (type.toString() === CardinalEventType.SetupCompleted) {
-                        completed = callback;
-                    }
-
-                    if (type.toString() === CardinalEventType.Validated) {
-                        validated = callback;
-                    }
+            sdk.on = jest.fn((type: CardinalEventType, callback) => {
+                if (type.toString() === CardinalEventType.SetupCompleted) {
+                    completed = callback;
                 }
-            );
+
+                if (type.toString() === CardinalEventType.Validated) {
+                    validated = callback;
+                }
+            });
         });
 
         describe('#successfully', () => {
@@ -127,7 +125,7 @@ describe('CardinalClient', () => {
 
             await client.load('provider', true);
 
-            return expect(client.configure('token')).rejects.toThrow(MissingDataError);
+            await expect(client.configure('token')).rejects.toThrow(MissingDataError);
         });
     });
 

--- a/packages/cardinal-integration/src/cardinal-client.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-client.spec.ts
@@ -16,7 +16,6 @@ import {
 
 import {
     CardinalClient,
-    CardinalEventMap,
     CardinalEventType,
     CardinalInitializationType,
     CardinalPaymentType,
@@ -52,14 +51,12 @@ describe('CardinalClient', () => {
     });
 
     describe('#configure', () => {
-        //let completed: () => void;
-        //let validated: (data: CardinalValidatedData, jwt: string) => void;
-        let completed: CardinalEventMap[CardinalEventType];
-        let validated: CardinalEventMap[CardinalEventType];
+        let completed: () => void;
+        let validated: (data: CardinalValidatedData, jwt: string) => void;
 
         beforeEach(() => {
             sdk.on = jest.fn(
-                (type: CardinalEventType, callback: CardinalEventMap[CardinalEventType]) => {
+                (type: CardinalEventType, callback) => {
                     if (type.toString() === CardinalEventType.SetupCompleted) {
                         completed = callback;
                     }

--- a/packages/cardinal-integration/src/cardinal-client.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-client.spec.ts
@@ -1,0 +1,394 @@
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    MissingDataError,
+    NotInitializedError,
+    PaymentMethodFailedError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import {
+    getCardinalBinProcessResponse,
+    getCardinalOrderData,
+    getCardinalSDK,
+    getCardinalThreeDSResult,
+    getCardinalValidatedData,
+} from './cardinal.mock';
+
+import {
+    CardinalClient,
+    CardinalEventMap,
+    CardinalEventType,
+    CardinalInitializationType,
+    CardinalPaymentType,
+    CardinalScriptLoader,
+    CardinalSDK,
+    CardinalSignatureVerification,
+    CardinalTriggerEvents,
+    CardinalValidatedAction,
+    CardinalValidatedData,
+} from './index';
+
+describe('CardinalClient', () => {
+    let client: CardinalClient;
+    let cardinalScriptLoader: CardinalScriptLoader;
+    let sdk: CardinalSDK;
+    let setupCall: () => void;
+    let validatedCall: (data: CardinalValidatedData, jwt: string) => void;
+
+    beforeEach(() => {
+        cardinalScriptLoader = new CardinalScriptLoader(createScriptLoader());
+        sdk = getCardinalSDK();
+        client = new CardinalClient(cardinalScriptLoader);
+
+        jest.spyOn(cardinalScriptLoader, 'load').mockReturnValue(Promise.resolve(sdk));
+    });
+
+    describe('#initialize', () => {
+        it('loads the cardinal sdk correctly', async () => {
+            await client.load('provider', false);
+
+            expect(cardinalScriptLoader.load).toHaveBeenCalled();
+        });
+    });
+
+    describe('#configure', () => {
+        //let completed: () => void;
+        //let validated: (data: CardinalValidatedData, jwt: string) => void;
+        let completed: CardinalEventMap[CardinalEventType];
+        let validated: CardinalEventMap[CardinalEventType];
+
+        beforeEach(() => {
+            sdk.on = jest.fn(
+                (type: CardinalEventType, callback: CardinalEventMap[CardinalEventType]) => {
+                    if (type.toString() === CardinalEventType.SetupCompleted) {
+                        completed = callback;
+                    }
+
+                    if (type.toString() === CardinalEventType.Validated) {
+                        validated = callback;
+                    }
+                }
+            );
+        });
+
+        describe('#successfully', () => {
+            beforeEach(async () => {
+                jest.spyOn(sdk, 'setup').mockImplementation(() => {
+                    completed();
+                });
+
+                await client.load('provider', true);
+            });
+
+            it('completes the setup process', async () => {
+                await client.configure('token');
+
+                expect(sdk.on).toHaveBeenCalledWith(
+                    CardinalEventType.SetupCompleted,
+                    expect.any(Function),
+                );
+                expect(sdk.setup).toHaveBeenCalledWith(CardinalInitializationType.Init, {
+                    jwt: 'token',
+                });
+            });
+
+            it('reconfigures the cardinal sdk', async () => {
+                await client.configure('firstToken');
+                await client.configure('secondToken');
+
+                expect(cardinalScriptLoader.load).toHaveBeenNthCalledWith(
+                    2,
+                    expect.stringMatching(/^provider/),
+                    true,
+                );
+                expect(sdk.on).toHaveBeenCalledTimes(4);
+                expect(sdk.setup).toHaveBeenCalledTimes(2);
+            });
+
+            it("does not reconfigure the cardinal sdk if it's the same token", async () => {
+                await client.configure('sameToken');
+                await client.configure('sameToken');
+
+                expect(cardinalScriptLoader.load).toHaveBeenNthCalledWith(1, 'provider', true);
+                expect(sdk.on).toHaveBeenCalledTimes(2);
+                expect(sdk.setup).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        it('throws an error if cardinal sdk is not defined', () => {
+            expect(() => client.configure('token')).toThrow(NotInitializedError);
+
+            expect(cardinalScriptLoader.load).not.toHaveBeenCalled();
+            expect(sdk.on).not.toHaveBeenCalled();
+            expect(sdk.setup).not.toHaveBeenCalled();
+        });
+
+        it('completes the setup process with error', async () => {
+            jest.spyOn(sdk, 'setup').mockImplementation(() => {
+                validated(getCardinalValidatedData(CardinalValidatedAction.Error, false, 1020), '');
+            });
+
+            await client.load('provider', true);
+
+            return expect(client.configure('token')).rejects.toThrow(MissingDataError);
+        });
+    });
+
+    describe('#runBinProcess', () => {
+        beforeEach(async () => {
+            sdk.on = jest.fn((type, callback) => {
+                if (type.toString() === CardinalEventType.SetupCompleted) {
+                    setupCall = callback;
+                }
+            });
+
+            jest.spyOn(sdk, 'setup').mockImplementation(() => {
+                setupCall();
+            });
+
+            await client.load('provider', true);
+            await client.configure('token');
+        });
+
+        it('collects the data correctly', async () => {
+            jest.spyOn(sdk, 'trigger').mockReturnValue(
+                Promise.resolve(getCardinalBinProcessResponse(true)),
+            );
+
+            await client.runBinProcess('123456');
+
+            expect(sdk.trigger).toHaveBeenCalledWith(CardinalTriggerEvents.BinProcess, '123456');
+        });
+
+        it('throws an error if data was not collected correctly', async () => {
+            jest.spyOn(sdk, 'trigger').mockReturnValue(
+                Promise.resolve(getCardinalBinProcessResponse(false)),
+            );
+
+            try {
+                await client.runBinProcess('');
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+            }
+        });
+
+        it('throws an error if cardinal throws an exception', async () => {
+            jest.spyOn(sdk, 'trigger').mockImplementation(() => {
+                return Promise.reject(new Error('Error'));
+            });
+
+            try {
+                await client.runBinProcess('');
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+            }
+        });
+    });
+
+    describe('#getThreeDSecureData', () => {
+        beforeEach(async () => {
+            sdk.on = jest.fn((type, callback) => {
+                if (type.toString() === CardinalEventType.SetupCompleted) {
+                    setupCall = callback;
+                } else {
+                    validatedCall = callback;
+                }
+            });
+
+            jest.spyOn(sdk, 'setup').mockImplementation(() => {
+                setupCall();
+            });
+
+            await client.load('provider', true);
+            await client.configure('token');
+        });
+
+        it('returns a valid token', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(
+                    getCardinalValidatedData(CardinalValidatedAction.Success, true),
+                    'token',
+                );
+            });
+
+            const promise = await client.getThreeDSecureData(
+                getCardinalThreeDSResult(),
+                getCardinalOrderData(),
+            );
+
+            expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.Validated, expect.any(Function));
+            expect(promise).toEqual({ token: 'token' });
+        });
+
+        it('returns a no action code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(
+                    getCardinalValidatedData(CardinalValidatedAction.NoAction, false, 0),
+                    'token',
+                );
+            });
+
+            const promise = await client.getThreeDSecureData(
+                getCardinalThreeDSResult(),
+                getCardinalOrderData(),
+            );
+
+            expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.Validated, expect.any(Function));
+            expect(promise).toEqual({ token: 'token' });
+        });
+
+        it('returns an error and a no action code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(
+                    getCardinalValidatedData(CardinalValidatedAction.NoAction, false, 3002),
+                    'token',
+                );
+            });
+
+            try {
+                await client.getThreeDSecureData(
+                    getCardinalThreeDSResult(),
+                    getCardinalOrderData(),
+                );
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
+            }
+        });
+
+        it('returns a signature validation error and a no action code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                const data = {
+                    ...getCardinalValidatedData(CardinalValidatedAction.NoAction, false, 0),
+                    Payment: {
+                        ExtendedData: {
+                            SignatureVerification: CardinalSignatureVerification.No,
+                        },
+                        ProcessorTransactionId: '',
+                        Type: CardinalPaymentType.CCA,
+                    },
+                };
+
+                validatedCall(data, 'token');
+            });
+
+            try {
+                await client.getThreeDSecureData(
+                    getCardinalThreeDSResult(),
+                    getCardinalOrderData(),
+                );
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
+            }
+        });
+
+        it('returns an error code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(
+                    getCardinalValidatedData(CardinalValidatedAction.Error, false, 3004),
+                    'token',
+                );
+            });
+
+            try {
+                await client.getThreeDSecureData(
+                    getCardinalThreeDSResult(),
+                    getCardinalOrderData(),
+                );
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
+            }
+        });
+
+        it('returns a failure code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(
+                    getCardinalValidatedData(CardinalValidatedAction.Failure, false, 3004),
+                    'token',
+                );
+            });
+
+            try {
+                await client.getThreeDSecureData(
+                    getCardinalThreeDSResult(),
+                    getCardinalOrderData(),
+                );
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
+                expect(error.message).toBe(
+                    'User failed authentication or an error was encountered while processing the transaction.',
+                );
+            }
+        });
+
+        it('does not return an action code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                const data = {
+                    ErrorDescription: '',
+                    ErrorNumber: 0,
+                    Validated: true,
+                    Payment: {
+                        ProcessorTransactionId: '',
+                        Type: CardinalPaymentType.CCA,
+                        ExtendedData: {},
+                    },
+                };
+
+                validatedCall(data, 'token');
+            });
+
+            const promise = await client.getThreeDSecureData(
+                getCardinalThreeDSResult(),
+                getCardinalOrderData(),
+            );
+
+            expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.Validated, expect.any(Function));
+            expect(promise).toEqual({ token: 'token' });
+        });
+
+        it('returns an error without an action code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                const data = {
+                    ErrorDescription: 'Custom error',
+                    ErrorNumber: 1533,
+                    Validated: true,
+                    Payment: {
+                        ProcessorTransactionId: '',
+                        Type: CardinalPaymentType.CCA,
+                        ExtendedData: {},
+                    },
+                };
+
+                validatedCall(data, 'token');
+            });
+
+            const promise = await client.getThreeDSecureData(
+                getCardinalThreeDSResult(),
+                getCardinalOrderData(),
+            );
+
+            expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.Validated, expect.any(Function));
+            expect(promise).toEqual({ token: 'token' });
+        });
+
+        it('returns a response without a jwt', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(
+                    getCardinalValidatedData(CardinalValidatedAction.Error, false, 100),
+                    '',
+                );
+            });
+
+            try {
+                await client.getThreeDSecureData(
+                    getCardinalThreeDSResult(),
+                    getCardinalOrderData(),
+                );
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
+                expect(error.message).toBe(
+                    'An error was encountered while processing the transaction.',
+                );
+            }
+        });
+    });
+});

--- a/packages/cardinal-integration/src/cardinal-client.ts
+++ b/packages/cardinal-integration/src/cardinal-client.ts
@@ -1,0 +1,271 @@
+import { includes, noop } from 'lodash';
+
+import {
+    Address,
+    BillingAddress,
+    CreditCardInstrument,
+    MissingDataError,
+    MissingDataErrorType,
+    NotInitializedError,
+    NotInitializedErrorType,
+    PaymentMethodFailedError,
+    ThreeDSecureToken,
+    ThreeDsResult,
+    VaultedInstrument,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import {
+    CardinalAccount,
+    CardinalAddress,
+    CardinalConsumer,
+    CardinalEventType,
+    CardinalInitializationType,
+    CardinalPartialOrder,
+    CardinalPaymentBrand,
+    CardinalSDK,
+    CardinalSignatureValidationErrors,
+    CardinalSignatureVerification,
+    CardinalTriggerEvents,
+    CardinalValidatedAction,
+    CardinalValidatedData,
+} from './cardinal';
+import CardinalScriptLoader from './cardinal-script-loader';
+
+export type CardinalSupportedPaymentInstrument = CreditCardInstrument | VaultedInstrument;
+
+export interface CardinalOrderData {
+    billingAddress: BillingAddress;
+    shippingAddress?: Address;
+    currencyCode: string;
+    id: string;
+    amount: number;
+    paymentData?: CreditCardInstrument;
+}
+
+export default class CardinalClient {
+    private _provider = '';
+    private _testMode = false;
+    private _sdk?: Promise<CardinalSDK>;
+    private _configurationToken = '';
+
+    constructor(private _scriptLoader: CardinalScriptLoader) {}
+
+    load(provider: string, testMode = false): Promise<void> {
+        this._provider = provider;
+        this._testMode = testMode;
+
+        if (!this._sdk) {
+            this._sdk = this._scriptLoader.load(provider, testMode);
+        }
+
+        return this._sdk.then(noop);
+    }
+
+    configure(clientToken: string): Promise<void> {
+        if (this._configurationToken) {
+            if (this._configurationToken === clientToken) {
+                return Promise.resolve();
+            }
+
+            this._sdk = this._scriptLoader.load(`${this._provider}.${Date.now()}`, this._testMode);
+        }
+
+        return this._getClientSDK().then(
+            (client) =>
+                new Promise<void>((resolve, reject) => {
+                    client.on(CardinalEventType.SetupCompleted, () => {
+                        client.off(CardinalEventType.SetupCompleted);
+                        client.off(CardinalEventType.Validated);
+
+                        this._configurationToken = clientToken;
+
+                        resolve();
+                    });
+
+                    client.on(CardinalEventType.Validated, (data: CardinalValidatedData) => {
+                        client.off(CardinalEventType.SetupCompleted);
+                        client.off(CardinalEventType.Validated);
+
+                        switch (data.ActionCode) {
+                            case CardinalValidatedAction.Error:
+                                if (includes(CardinalSignatureValidationErrors, data.ErrorNumber)) {
+                                    reject(
+                                        new MissingDataError(
+                                            MissingDataErrorType.MissingPaymentMethod,
+                                        ),
+                                    );
+                                }
+
+                                reject(new PaymentMethodFailedError(data.ErrorDescription));
+                                break;
+                        }
+                    });
+
+                    client.setup(CardinalInitializationType.Init, {
+                        jwt: clientToken,
+                    });
+                }),
+        );
+    }
+
+    runBinProcess(binNumber: string): Promise<void> {
+        return this._getClientSDK()
+            .then((client) =>
+                client.trigger(CardinalTriggerEvents.BinProcess, binNumber).catch(noop),
+            )
+            .then((result) => {
+                if (!result || !result.Status) {
+                    throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+                }
+            });
+    }
+
+    getThreeDSecureData(
+        threeDSecureData: ThreeDsResult,
+        orderData: CardinalOrderData,
+    ): Promise<ThreeDSecureToken> {
+        return this._getClientSDK().then((client) => {
+            return new Promise<ThreeDSecureToken>((resolve, reject) => {
+                client.on(
+                    CardinalEventType.Validated,
+                    (data: CardinalValidatedData, jwt?: string) => {
+                        client.off(CardinalEventType.Validated);
+
+                        if (!jwt) {
+                            return reject(
+                                new PaymentMethodFailedError(
+                                    data.ErrorDescription
+                                        ? data.ErrorDescription
+                                        : 'An error was encountered while processing the transaction.',
+                                ),
+                            );
+                        }
+
+                        if (!data.ActionCode) {
+                            return resolve({ token: jwt });
+                        }
+
+                        switch (data.ActionCode) {
+                            case CardinalValidatedAction.Success:
+                                return resolve({ token: jwt });
+
+                            case CardinalValidatedAction.NoAction:
+                                if (data.ErrorNumber > 0) {
+                                    return reject(
+                                        new PaymentMethodFailedError(data.ErrorDescription),
+                                    );
+                                } else if (
+                                    !data.Payment ||
+                                    !data.Payment.ExtendedData ||
+                                    data.Payment.ExtendedData.SignatureVerification !==
+                                        CardinalSignatureVerification.Yes
+                                ) {
+                                    return reject(
+                                        new PaymentMethodFailedError(
+                                            'Transaction signature could not be validated.',
+                                        ),
+                                    );
+                                }
+
+                                return resolve({ token: jwt });
+
+                            case CardinalValidatedAction.Failure:
+                                return reject(
+                                    new PaymentMethodFailedError(
+                                        'User failed authentication or an error was encountered while processing the transaction.',
+                                    ),
+                                );
+
+                            case CardinalValidatedAction.Error:
+                                return reject(new PaymentMethodFailedError(data.ErrorDescription));
+                        }
+                    },
+                );
+
+                const continueObject = {
+                    AcsUrl: threeDSecureData.acs_url,
+                    Payload: threeDSecureData.merchant_data,
+                };
+
+                const partialOrder = this._mapToPartialOrder(
+                    orderData,
+                    threeDSecureData.payer_auth_request,
+                );
+
+                client.continue(CardinalPaymentBrand.CCA, continueObject, partialOrder);
+            });
+        });
+    }
+
+    private _mapToPartialOrder(
+        orderData: CardinalOrderData,
+        transactionId: string,
+    ): CardinalPartialOrder {
+        const consumer: CardinalConsumer = {
+            BillingAddress: this._mapToCardinalAddress(orderData.billingAddress),
+        };
+
+        if (orderData.paymentData) {
+            consumer.Account = this._mapToCardinalAccount(orderData.paymentData);
+        }
+
+        if (orderData.billingAddress.email) {
+            consumer.Email1 = orderData.billingAddress.email;
+        }
+
+        if (orderData.shippingAddress) {
+            consumer.ShippingAddress = this._mapToCardinalAddress(orderData.shippingAddress);
+        }
+
+        return {
+            Consumer: consumer,
+            OrderDetails: {
+                OrderNumber: orderData.id,
+                Amount: orderData.amount,
+                CurrencyCode: orderData.currencyCode,
+                OrderChannel: 'S',
+                TransactionId: transactionId,
+            },
+        };
+    }
+
+    private _mapToCardinalAccount(paymentData: CreditCardInstrument): CardinalAccount {
+        return {
+            AccountNumber: Number(paymentData.ccNumber),
+            ExpirationMonth: Number(paymentData.ccExpiry.month),
+            ExpirationYear: Number(paymentData.ccExpiry.year),
+            NameOnAccount: paymentData.ccName,
+            CardCode: Number(paymentData.ccCvv),
+        };
+    }
+
+    private _mapToCardinalAddress(address: Address): CardinalAddress {
+        const cardinalAddress: CardinalAddress = {
+            FirstName: address.firstName,
+            LastName: address.lastName,
+            Address1: address.address1,
+            City: address.city,
+            State: address.stateOrProvince,
+            PostalCode: address.postalCode,
+            CountryCode: address.countryCode,
+        };
+
+        if (address.address2) {
+            cardinalAddress.Address2 = address.address2;
+        }
+
+        if (address.phone) {
+            cardinalAddress.Phone1 = address.phone;
+        }
+
+        return cardinalAddress;
+    }
+
+    private _getClientSDK(): Promise<CardinalSDK> {
+        if (!this._sdk) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this._sdk;
+    }
+}

--- a/packages/cardinal-integration/src/cardinal-script-loader.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-script-loader.spec.ts
@@ -1,0 +1,63 @@
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { getCardinalScriptMock } from './cardinal.mock';
+
+import { CardinalScriptLoader, CardinalWindow } from './index';
+
+describe('CardinalScriptLoader', () => {
+    const cardinalWindow: CardinalWindow = window;
+    const scriptLoader = createScriptLoader();
+    const scriptMock = getCardinalScriptMock();
+    const loadScript = jest.spyOn(scriptLoader, 'loadScript');
+    let cardinalScriptLoader: CardinalScriptLoader;
+
+    beforeEach(() => {
+        cardinalScriptLoader = new CardinalScriptLoader(scriptLoader, cardinalWindow);
+    });
+
+    it('loads widget test script', () => {
+        const testMode = true;
+
+        cardinalScriptLoader.load('provider', testMode);
+
+        expect(loadScript).toHaveBeenCalledWith(
+            'https://songbirdstag.cardinalcommerce.com/edge/v1/songbird.js?v=provider',
+        );
+    });
+
+    it('loads widget production script', () => {
+        const testMode = false;
+
+        cardinalScriptLoader.load('provider', testMode);
+
+        expect(loadScript).toHaveBeenCalledWith(
+            'https://songbird.cardinalcommerce.com/edge/v1/songbird.js?v=provider',
+        );
+    });
+
+    it('returns script from the window', async () => {
+        scriptLoader.loadScript = jest.fn(() => {
+            cardinalWindow.Cardinal = scriptMock.Cardinal;
+
+            return Promise.resolve();
+        });
+
+        const script = await cardinalScriptLoader.load('provider');
+
+        expect(script).toBe(cardinalWindow.Cardinal);
+    });
+
+    it('throws error to inform that order finalization is not required', async () => {
+        scriptLoader.loadScript = jest.fn(() => {
+            throw new PaymentMethodClientUnavailableError();
+        });
+
+        try {
+            await cardinalScriptLoader.load('provider');
+        } catch (error) {
+            expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
+        }
+    });
+});

--- a/packages/cardinal-integration/src/cardinal-script-loader.ts
+++ b/packages/cardinal-integration/src/cardinal-script-loader.ts
@@ -1,0 +1,24 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { CardinalSDK, CardinalWindow } from './cardinal';
+
+const SDK_TEST_URL = 'https://songbirdstag.cardinalcommerce.com/edge/v1/songbird.js';
+const SDK_PROD_URL = 'https://songbird.cardinalcommerce.com/edge/v1/songbird.js';
+
+export default class CardinalScriptLoader {
+    constructor(private _scriptLoader: ScriptLoader, private _window: CardinalWindow = window) {}
+
+    load(provider: string, testMode?: boolean): Promise<CardinalSDK> {
+        const url = testMode ? SDK_TEST_URL : SDK_PROD_URL;
+
+        return this._scriptLoader.loadScript(`${url}?v=${provider}`).then(() => {
+            if (!this._window.Cardinal) {
+                throw new PaymentMethodClientUnavailableError();
+            }
+
+            return this._window.Cardinal;
+        });
+    }
+}

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.spec.ts
@@ -15,6 +15,7 @@ import {
     getCheckout,
     getOrder,
     getOrderRequestBody,
+    getPaymentMethod,
     getResponse,
     getShippingAddress,
     PaymentIntegrationServiceMock,
@@ -22,7 +23,6 @@ import {
 
 import CardinalClient from './cardinal-client';
 import CardinalThreeDSecureFlowV2 from './cardinal-three-d-secure-flow-v2';
-import { getBarclays } from './cardinal.mock';
 
 describe('CardinalBarclaysThreeDSecureFlow', () => {
     let cardinalClient: Pick<
@@ -34,7 +34,7 @@ describe('CardinalBarclaysThreeDSecureFlow', () => {
     let paymentIntegrationService: PaymentIntegrationService;
 
     beforeEach(() => {
-        paymentMethod = getBarclays();
+        paymentMethod = getPaymentMethod();
 
         cardinalClient = {
             configure: jest.fn(() => Promise.resolve()),
@@ -49,6 +49,10 @@ describe('CardinalBarclaysThreeDSecureFlow', () => {
             paymentIntegrationService,
             cardinalClient as CardinalClient,
         );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 
     describe('#prepare', () => {

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.spec.ts
@@ -47,7 +47,6 @@ describe('CardinalBarclaysThreeDSecureFlow', () => {
 
         threeDSecureFlow = new CardinalThreeDSecureFlowV2(
             paymentIntegrationService,
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             cardinalClient as CardinalClient,
         );
     });

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.spec.ts
@@ -1,0 +1,198 @@
+import { Response } from '@bigcommerce/request-sender';
+import { merge } from 'lodash';
+
+import {
+    HostedForm,
+    OrderRequestBody,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentRequestOptions,
+    PaymentStrategy,
+    RequestError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getBillingAddress,
+    getCheckout,
+    getOrder,
+    getOrderRequestBody,
+    getResponse,
+    getShippingAddress,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import CardinalClient from './cardinal-client';
+import CardinalThreeDSecureFlowV2 from './cardinal-three-d-secure-flow-v2';
+import { getBarclays } from './cardinal.mock';
+
+describe('CardinalBarclaysThreeDSecureFlow', () => {
+    let cardinalClient: Pick<
+        CardinalClient,
+        'configure' | 'getThreeDSecureData' | 'load' | 'runBinProcess'
+    >;
+    let threeDSecureFlow: CardinalThreeDSecureFlowV2;
+    let paymentMethod: PaymentMethod;
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentMethod = getBarclays();
+
+        cardinalClient = {
+            configure: jest.fn(() => Promise.resolve()),
+            getThreeDSecureData: jest.fn(() => Promise.resolve()),
+            load: jest.fn(() => Promise.resolve()),
+            runBinProcess: jest.fn(() => Promise.resolve()),
+        };
+
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        threeDSecureFlow = new CardinalThreeDSecureFlowV2(
+            paymentIntegrationService,
+            cardinalClient as CardinalClient,
+        );
+    });
+
+    describe('#prepare', () => {
+        it('loads Cardinal client', async () => {
+            await threeDSecureFlow.prepare(paymentMethod);
+
+            expect(cardinalClient.load).toHaveBeenCalledWith(
+                paymentMethod.id,
+                paymentMethod.config.testMode,
+            );
+        });
+    });
+
+    describe('#start', () => {
+        let execute: PaymentStrategy['execute'];
+        let form: Pick<HostedForm, 'getBin' | 'submit'>;
+        let options: PaymentRequestOptions;
+        let payload: OrderRequestBody;
+
+        beforeEach(() => {
+            execute = jest.fn(() => Promise.resolve());
+            options = { methodId: paymentMethod.id };
+
+            form = {
+                getBin: jest.fn(() => '411111'),
+                submit: jest.fn(),
+            };
+
+            payload = merge({}, getOrderRequestBody(), {
+                payment: {
+                    methodId: paymentMethod.id,
+                    gatewayId: paymentMethod.gateway,
+                },
+            });
+        });
+
+        it('executes order submission', async () => {
+            await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+            expect(execute).toHaveBeenCalledWith(payload, options);
+        });
+
+        describe('if additional action is required', () => {
+            let additionalActionRequired: Response<any>;
+
+            beforeEach(() => {
+                additionalActionRequired = getResponse({
+                    status: 'additional_action_required',
+                    additional_action_required: { data: { token: 'JWT123' } },
+                    three_ds_result: { payer_auth_request: 'TOKEN123' },
+                });
+
+                execute = jest.fn(() => Promise.reject(new RequestError(additionalActionRequired)));
+            });
+
+            it('configures Cardinal client', async () => {
+                await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                expect(cardinalClient.configure).toHaveBeenCalledWith('JWT123');
+            });
+
+            it('runs BIN detection process if defined', async () => {
+                await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                expect(cardinalClient.runBinProcess).toHaveBeenCalledWith(form.getBin());
+            });
+
+            it('submits XID token using hosted form if provided', async () => {
+                await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                expect(form.submit).toHaveBeenCalledWith(
+                    merge({}, payload.payment, {
+                        paymentData: { threeDSecure: { xid: 'TOKEN123' } },
+                    }),
+                );
+            });
+
+            it('submits XID token directly if hosted form is not provided', async () => {
+                await threeDSecureFlow.start(execute, payload, options);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                    merge({}, payload.payment, {
+                        paymentData: { threeDSecure: { xid: 'TOKEN123' } },
+                    }),
+                );
+            });
+
+            describe('if 3DS is required', () => {
+                let threeDSecureRequired: Response<any>;
+
+                beforeEach(() => {
+                    threeDSecureRequired = getResponse({
+                        errors: [{ code: 'three_d_secure_required' }],
+                        three_ds_result: {
+                            acs_url: 'https://foo.com',
+                            payer_auth_request: 'TOKEN345',
+                            merchant_data: 'qwerty123...',
+                            callback_url: null,
+                        },
+                    });
+
+                    jest.spyOn(form, 'submit').mockRejectedValueOnce(
+                        new RequestError(threeDSecureRequired),
+                    );
+                    jest.spyOn(paymentIntegrationService, 'submitPayment').mockRejectedValueOnce(
+                        new RequestError(threeDSecureRequired),
+                    );
+                });
+
+                it('handles 3DS error and prompts shopper to authenticate', async () => {
+                    await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                    expect(cardinalClient.getThreeDSecureData).toHaveBeenCalledWith(
+                        threeDSecureRequired.body.three_ds_result,
+                        {
+                            billingAddress: getBillingAddress(),
+                            shippingAddress: getShippingAddress(),
+                            currencyCode: getCheckout().cart.currency.code,
+                            id: getOrder().orderId.toString(),
+                            amount: getCheckout().cart.cartAmount,
+                        },
+                    );
+                });
+
+                it('submits 3DS token using hosted form if provided', async () => {
+                    await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                    expect(form.submit).toHaveBeenCalledWith(
+                        merge({}, payload.payment, {
+                            paymentData: { threeDSecure: { token: 'TOKEN345' } },
+                        }),
+                    );
+                });
+
+                it('submits 3DS token directly if hosted form is not provided', async () => {
+                    await threeDSecureFlow.start(execute, payload, options);
+
+                    expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                        merge({}, payload.payment, {
+                            paymentData: { threeDSecure: { token: 'TOKEN345' } },
+                        }),
+                    );
+                });
+            });
+        });
+    });
+});

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.ts
@@ -33,17 +33,21 @@ export default class CardinalThreeDSecureFlowV2 {
         options?: PaymentRequestOptions,
         hostedForm?: HostedForm,
     ): Promise<void> {
+        console.log(1);
         const { getCardInstrument } = this._paymentIntegrationService.getState();
         const { payment = { methodId: '' } } = payload;
         const { paymentData = {} } = payment;
 
         try {
+            console.log(2);
             return await execute(payload, options);
         } catch (error) {
+            console.log(3);
             if (
                 error instanceof RequestError &&
                 error.body.status === 'additional_action_required'
             ) {
+                console.log(4);
                 const token = error.body.additional_action_required?.data?.token;
                 const xid = error.body.three_ds_result?.payer_auth_request;
 
@@ -52,16 +56,20 @@ export default class CardinalThreeDSecureFlowV2 {
                 const bin = this._getBin(paymentData, getCardInstrument, hostedForm);
 
                 if (bin) {
+                    console.log(5);
                     await this._cardinalClient.runBinProcess(bin);
                 }
 
                 try {
+                    console.log(6);
                     return await this._submitPayment(payment, { xid }, hostedForm);
                 } catch (error) {
+                    console.log(7);
                     if (
                         error instanceof RequestError &&
                         some(error.body.errors, { code: 'three_d_secure_required' })
                     ) {
+                        console.log(8);
                         const threeDsResult = error.body.three_ds_result;
                         const token = threeDsResult?.payer_auth_request;
 

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.ts
@@ -57,13 +57,12 @@ export default class CardinalThreeDSecureFlowV2 {
 
                 try {
                     return await this._submitPayment(payment, { xid }, hostedForm);
-                    // eslint-disable-next-line @typescript-eslint/no-shadow
-                } catch (error) {
+                } catch (err) {
                     if (
-                        error instanceof RequestError &&
-                        some(error.body.errors, { code: 'three_d_secure_required' })
+                        err instanceof RequestError &&
+                        some(err.body.errors, { code: 'three_d_secure_required' })
                     ) {
-                        const threeDsResult = error.body.three_ds_result;
+                        const threeDsResult = err.body.three_ds_result;
                         const threeDsToken = threeDsResult?.payer_auth_request;
 
                         await this._cardinalClient.getThreeDSecureData(
@@ -74,7 +73,7 @@ export default class CardinalThreeDSecureFlowV2 {
                         return this._submitPayment(payment, { token: threeDsToken }, hostedForm);
                     }
 
-                    throw error;
+                    throw err;
                 }
             }
 

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.ts
@@ -1,0 +1,125 @@
+import { merge, some } from 'lodash';
+
+import {
+    HostedForm,
+    isCreditCardLike,
+    isVaultedInstrument,
+    OrderPaymentRequestBody,
+    OrderRequestBody,
+    PaymentIntegrationSelectors,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentRequestOptions,
+    PaymentStrategy,
+    RequestError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { CardinalThreeDSecureToken } from './cardinal';
+import CardinalClient, { CardinalOrderData } from './cardinal-client';
+
+export default class CardinalThreeDSecureFlowV2 {
+    constructor(
+        private _paymentIntegrationService: PaymentIntegrationService,
+        private _cardinalClient: CardinalClient,
+    ) {}
+
+    async prepare(method: PaymentMethod): Promise<void> {
+        await this._cardinalClient.load(method.id, method.config.testMode);
+    }
+
+    async start(
+        execute: PaymentStrategy['execute'],
+        payload: OrderRequestBody,
+        options?: PaymentRequestOptions,
+        hostedForm?: HostedForm,
+    ): Promise<void> {
+        const { getCardInstrument } = this._paymentIntegrationService.getState();
+        const { payment = { methodId: '' } } = payload;
+        const { paymentData = {} } = payment;
+
+        try {
+            return await execute(payload, options);
+        } catch (error) {
+            if (
+                error instanceof RequestError &&
+                error.body.status === 'additional_action_required'
+            ) {
+                const token = error.body.additional_action_required?.data?.token;
+                const xid = error.body.three_ds_result?.payer_auth_request;
+
+                await this._cardinalClient.configure(token);
+
+                const bin = this._getBin(paymentData, getCardInstrument, hostedForm);
+
+                if (bin) {
+                    await this._cardinalClient.runBinProcess(bin);
+                }
+
+                try {
+                    return await this._submitPayment(payment, { xid }, hostedForm);
+                } catch (error) {
+                    if (
+                        error instanceof RequestError &&
+                        some(error.body.errors, { code: 'three_d_secure_required' })
+                    ) {
+                        const threeDsResult = error.body.three_ds_result;
+                        const token = threeDsResult?.payer_auth_request;
+
+                        await this._cardinalClient.getThreeDSecureData(
+                            threeDsResult,
+                            this._getOrderData(),
+                        );
+
+                        return await this._submitPayment(payment, { token }, hostedForm);
+                    }
+
+                    throw error;
+                }
+            }
+
+            throw error;
+        }
+    }
+
+    private _getOrderData(): CardinalOrderData {
+        const store = this._paymentIntegrationService.getState();
+        const billingAddress = store.getBillingAddressOrThrow();
+        const shippingAddress = store.getShippingAddress();
+        const {
+            cart: {
+                currency: { code: currencyCode },
+                cartAmount: amount,
+            },
+        } = store.getCheckoutOrThrow();
+        const id = store.getOrderOrThrow().orderId.toString();
+
+        return { billingAddress, shippingAddress, currencyCode, id, amount };
+    }
+
+    private async _submitPayment(
+        payment: OrderPaymentRequestBody,
+        threeDSecure: CardinalThreeDSecureToken,
+        hostedForm?: HostedForm,
+    ): Promise<void> {
+        const paymentPayload = merge({}, payment, { paymentData: { threeDSecure } });
+
+        if (!hostedForm) {
+            await this._paymentIntegrationService.submitPayment(paymentPayload);
+        }
+
+        await hostedForm?.submit(paymentPayload);
+    }
+
+    private _getBin(
+        paymentData: NonNullable<OrderPaymentRequestBody['paymentData']>,
+        getCardInstrument: PaymentIntegrationSelectors['getCardInstrument'],
+        hostedForm?: HostedForm,
+    ): string {
+        const instrument =
+            isVaultedInstrument(paymentData) && getCardInstrument(paymentData.instrumentId);
+        const ccNumber = isCreditCardLike(paymentData) && paymentData.ccNumber;
+        const bin = instrument ? instrument.iin : hostedForm ? hostedForm.getBin() : ccNumber;
+
+        return bin || '';
+    }
+}

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
@@ -1,0 +1,201 @@
+import { Response } from '@bigcommerce/request-sender';
+import { merge } from 'lodash';
+import {
+    HostedForm,
+    OrderRequestBody,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentRequestOptions,
+    PaymentStrategy,
+    RequestError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getBillingAddress,
+    getCheckout,
+    getOrder,
+    getOrderRequestBody,
+    getResponse,
+    getShippingAddress,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import CardinalClient from './cardinal-client';
+import CardinalThreeDSecureFlow from './cardinal-three-d-secure-flow';
+import { getCybersource } from './cardinal.mock';
+
+describe('CardinalThreeDSecureFlow', () => {
+    let cardinalClient: Pick<
+        CardinalClient,
+        'configure' | 'getThreeDSecureData' | 'load' | 'runBinProcess'
+    >;
+    let threeDSecureFlow: CardinalThreeDSecureFlow;
+    let paymentMethod: PaymentMethod;
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentMethod = {
+            ...getCybersource(),
+            clientToken: 'foo',
+        };
+
+        cardinalClient = {
+            configure: jest.fn(() => Promise.resolve()),
+            getThreeDSecureData: jest.fn(() => Promise.resolve()),
+            load: jest.fn(() => Promise.resolve()),
+            runBinProcess: jest.fn(() => Promise.resolve()),
+        };
+
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethod,
+        );
+
+        threeDSecureFlow = new CardinalThreeDSecureFlow(
+            paymentIntegrationService,
+            cardinalClient as CardinalClient,
+        );
+    });
+
+    describe('#prepare', () => {
+        it('loads Cardinal client', async () => {
+            await threeDSecureFlow.prepare(paymentMethod);
+
+            expect(cardinalClient.load).toHaveBeenCalledWith(
+                paymentMethod.id,
+                paymentMethod.config.testMode,
+            );
+        });
+
+        it('configures Cardinal client', async () => {
+            await threeDSecureFlow.prepare(paymentMethod);
+
+            expect(cardinalClient.configure).toHaveBeenCalledWith(paymentMethod.clientToken);
+        });
+
+        it('reloads payment method if client token is undefined', async () => {
+            paymentMethod = {
+                ...getCybersource(),
+                clientToken: '',
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(), 
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethod);
+
+            await threeDSecureFlow.prepare(paymentMethod);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
+                paymentMethod.id,
+            );
+        });
+
+        it('does not reload payment method if client token is defined', async () => {
+            await threeDSecureFlow.prepare(paymentMethod);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('#start', () => {
+        let execute: PaymentStrategy['execute'];
+        let form: Pick<HostedForm, 'getBin' | 'submit'>;
+        let options: PaymentRequestOptions;
+        let payload: OrderRequestBody;
+
+        beforeEach(() => {
+            execute = jest.fn(() => Promise.resolve());
+            options = { methodId: paymentMethod.id };
+
+            form = {
+                getBin: jest.fn(() => '411111'),
+                submit: jest.fn(),
+            };
+
+            payload = merge({}, getOrderRequestBody(), {
+                payment: {
+                    methodId: paymentMethod.id,
+                    gatewayId: paymentMethod.gateway,
+                },
+            });
+        });
+
+        it('runs BIN detection process if defined', async () => {
+            await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+            expect(cardinalClient.runBinProcess).toHaveBeenCalledWith(form.getBin());
+        });
+
+        it('executes order submission with client token', async () => {
+            await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+            expect(execute).toHaveBeenCalledWith(
+                merge(payload, {
+                    payment: {
+                        paymentData: {
+                            threeDSecure: { token: paymentMethod.clientToken },
+                        },
+                    },
+                }),
+                options,
+            );
+        });
+
+        describe('if 3DS is required', () => {
+            let response: Response<any>;
+
+            beforeEach(() => {
+                response = getResponse({
+                    errors: [{ code: 'three_d_secure_required' }],
+                    three_ds_result: {},
+                });
+
+                execute = jest.fn(() => Promise.reject(new RequestError(response)));
+            });
+
+            it('handles 3DS error and prompts shopper to authenticate', async () => {
+                await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                expect(cardinalClient.getThreeDSecureData).toHaveBeenCalledWith(
+                    response.body.three_ds_result,
+                    {
+                        billingAddress: getBillingAddress(),
+                        shippingAddress: getShippingAddress(),
+                        currencyCode: getCheckout().cart.currency.code,
+                        id: getOrder().orderId.toString(),
+                        amount: getCheckout().cart.cartAmount,
+                    },
+                );
+            });
+
+            it('submits 3DS token using hosted form if provided', async () => {
+                jest.spyOn(cardinalClient, 'getThreeDSecureData').mockResolvedValue(
+                    'three_d_secure',
+                );
+
+                await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                expect(form.submit).toHaveBeenCalledWith(
+                    merge(payload.payment, {
+                        paymentData: { threeDSecure: 'three_d_secure' },
+                    }),
+                );
+            });
+
+            it('submits 3DS token directly if hosted form is not provided', async () => {
+                jest.spyOn(cardinalClient, 'getThreeDSecureData').mockResolvedValue(
+                    'three_d_secure',
+                );
+
+                await threeDSecureFlow.start(execute, payload, options);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                    merge(payload.payment, {
+                        paymentData: { threeDSecure: 'three_d_secure' },
+                    }),
+                );
+            });
+        });
+    });
+});

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
@@ -57,6 +57,10 @@ describe('CardinalThreeDSecureFlow', () => {
         );
     });
 
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
     describe('#prepare', () => {
         it('loads Cardinal client', async () => {
             await threeDSecureFlow.prepare(paymentMethod);

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
@@ -15,6 +15,7 @@ import {
     getCheckout,
     getOrder,
     getOrderRequestBody,
+    getPaymentMethod,
     getResponse,
     getShippingAddress,
     PaymentIntegrationServiceMock,
@@ -22,7 +23,6 @@ import {
 
 import CardinalClient from './cardinal-client';
 import CardinalThreeDSecureFlow from './cardinal-three-d-secure-flow';
-import { getCybersource } from './cardinal.mock';
 
 describe('CardinalThreeDSecureFlow', () => {
     let cardinalClient: Pick<
@@ -35,7 +35,7 @@ describe('CardinalThreeDSecureFlow', () => {
 
     beforeEach(() => {
         paymentMethod = {
-            ...getCybersource(),
+            ...getPaymentMethod(),
             clientToken: 'foo',
         };
 
@@ -81,7 +81,7 @@ describe('CardinalThreeDSecureFlow', () => {
 
         it('reloads payment method if client token is undefined', async () => {
             paymentMethod = {
-                ...getCybersource(),
+                ...getPaymentMethod(),
                 clientToken: '',
             };
 

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
@@ -54,7 +54,6 @@ describe('CardinalThreeDSecureFlow', () => {
 
         threeDSecureFlow = new CardinalThreeDSecureFlow(
             paymentIntegrationService,
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             cardinalClient as CardinalClient,
         );
     });

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow.ts
@@ -89,11 +89,11 @@ export default class CardinalThreeDSecureFlow {
             return method.clientToken;
         }
 
-        const { getPaymentMethodOrThrow } = await this._paymentIntegrationService.loadPaymentMethod(
-            method.id,
-        );
+        await this._paymentIntegrationService.loadPaymentMethod(method.id);
 
-        return getPaymentMethodOrThrow(method.id).clientToken || '';
+        const paymentMethod = this._paymentIntegrationService.getState().getPaymentMethodOrThrow(method.id);
+
+        return paymentMethod.clientToken || '';
     }
 
     private _getOrderData(): CardinalOrderData {
@@ -102,6 +102,9 @@ export default class CardinalThreeDSecureFlow {
         const shippingAddress = state.getShippingAddress();
         const checkout = state.getCheckoutOrThrow();
         const order = state.getOrderOrThrow();
+
+        console.log(billingAddress)
+        console.log(shippingAddress)
 
         return {
             billingAddress,

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow.ts
@@ -1,0 +1,114 @@
+import { merge, some } from 'lodash';
+
+import {
+    HostedForm,
+    isVaultedInstrument,
+    OrderRequestBody,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentRequestOptions,
+    PaymentStrategy,
+    RequestError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import CardinalClient, { CardinalOrderData } from './cardinal-client';
+
+export default class CardinalThreeDSecureFlow {
+    constructor(
+        private _paymentIntegrationService: PaymentIntegrationService,
+        private _cardinalClient: CardinalClient,
+    ) {}
+
+    async prepare(method: PaymentMethod): Promise<void> {
+        await this._cardinalClient.load(method.id, method.config.testMode);
+        await this._cardinalClient.configure(await this._getClientToken(method));
+    }
+
+    async start(
+        execute: PaymentStrategy['execute'],
+        payload: OrderRequestBody,
+        options?: PaymentRequestOptions,
+        hostedForm?: HostedForm,
+    ): Promise<void> {
+        const { getCardInstrument, getPaymentMethodOrThrow } =
+            this._paymentIntegrationService.getState();
+
+        const { payment: { methodId = '', paymentData = {} } = {} } = payload;
+        const instrument =
+            isVaultedInstrument(paymentData) && getCardInstrument(paymentData.instrumentId);
+        const bin = instrument ? instrument.iin : hostedForm && hostedForm.getBin();
+
+        if (bin) {
+            await this._cardinalClient.runBinProcess(bin);
+        }
+
+        try {
+            return await execute(
+                merge(payload, {
+                    payment: {
+                        paymentData: {
+                            threeDSecure: { token: getPaymentMethodOrThrow(methodId).clientToken },
+                        },
+                    },
+                }),
+                options,
+            );
+        } catch (error) {
+            if (
+                !(error instanceof RequestError) ||
+                !some(error.body.errors, { code: 'three_d_secure_required' })
+            ) {
+                throw error;
+            }
+
+            const threeDSecure = await this._cardinalClient.getThreeDSecureData(
+                error.body.three_ds_result,
+                this._getOrderData(),
+            );
+
+            if (!hostedForm) {
+                await this._paymentIntegrationService.submitPayment(
+                    merge(payload.payment, {
+                        paymentData: { threeDSecure },
+                    }),
+                );
+
+                return;
+            }
+
+            await hostedForm.submit(
+                merge(payload.payment, {
+                    paymentData: { threeDSecure },
+                }),
+            );
+        }
+    }
+
+    private async _getClientToken(method: PaymentMethod): Promise<string> {
+        if (method.clientToken) {
+            return method.clientToken;
+        }
+
+        const { getPaymentMethodOrThrow } = await this._paymentIntegrationService.loadPaymentMethod(
+            method.id,
+        );
+
+        return getPaymentMethodOrThrow(method.id).clientToken || '';
+    }
+
+    private _getOrderData(): CardinalOrderData {
+        const state = this._paymentIntegrationService.getState();
+        const billingAddress = state.getBillingAddressOrThrow();
+        const shippingAddress = state.getShippingAddress();
+        const checkout = state.getCheckoutOrThrow();
+        const order = state.getOrderOrThrow();
+
+        return {
+            billingAddress,
+            shippingAddress,
+            currencyCode: checkout.cart.currency.code,
+            id: order.orderId.toString(),
+            amount: checkout.cart.cartAmount,
+        };
+    }
+}

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow.ts
@@ -91,7 +91,9 @@ export default class CardinalThreeDSecureFlow {
 
         await this._paymentIntegrationService.loadPaymentMethod(method.id);
 
-        const paymentMethod = this._paymentIntegrationService.getState().getPaymentMethodOrThrow(method.id);
+        const paymentMethod = this._paymentIntegrationService
+            .getState()
+            .getPaymentMethodOrThrow(method.id);
 
         return paymentMethod.clientToken || '';
     }
@@ -102,9 +104,6 @@ export default class CardinalThreeDSecureFlow {
         const shippingAddress = state.getShippingAddress();
         const checkout = state.getCheckoutOrThrow();
         const order = state.getOrderOrThrow();
-
-        console.log(billingAddress)
-        console.log(shippingAddress)
 
         return {
             billingAddress,

--- a/packages/cardinal-integration/src/cardinal.mock.ts
+++ b/packages/cardinal-integration/src/cardinal.mock.ts
@@ -1,4 +1,4 @@
-import { PaymentMethod, ThreeDsResult } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { ThreeDsResult } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBillingAddress,
     getCreditCardInstrument,
@@ -84,37 +84,5 @@ export function getCardinalOrderData(): CardinalOrderData {
         id: '123-abc',
         amount: 12000,
         paymentData: getCreditCardInstrument(),
-    };
-}
-
-export function getCybersource(): PaymentMethod {
-    return {
-        id: 'cybersource',
-        logoUrl: '',
-        method: 'credit-card',
-        supportedCards: [],
-        config: {
-            displayName: 'Cybersource',
-            is3dsEnabled: true,
-            testMode: true,
-        },
-        type: 'PAYMENT_TYPE_API',
-        clientToken: 'cyberToken',
-    };
-}
-
-export function getBarclays(): PaymentMethod {
-    return {
-        id: 'barclays',
-        logoUrl: '',
-        method: 'credit-card',
-        supportedCards: [],
-        config: {
-            displayName: 'Barclaycard Smartpay',
-            is3dsEnabled: true,
-            testMode: true,
-        },
-        type: 'PAYMENT_TYPE_API',
-        clientToken: 'barclaysToken',
     };
 }

--- a/packages/cardinal-integration/src/cardinal.mock.ts
+++ b/packages/cardinal-integration/src/cardinal.mock.ts
@@ -1,0 +1,120 @@
+import { PaymentMethod, ThreeDsResult } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getBillingAddress,
+    getCreditCardInstrument,
+    getShippingAddress,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import {
+    CardinalBinProcessResponse,
+    CardinalOrderData,
+    CardinalPaymentType,
+    CardinalSDK,
+    CardinalSignatureVerification,
+    CardinalValidatedAction,
+    CardinalValidatedData,
+    CardinalWindow,
+} from '.';
+
+const CardinalWindowMock: CardinalWindow = window;
+
+export function getCardinalScriptMock(): CardinalWindow {
+    return {
+        ...CardinalWindowMock,
+        Cardinal: getCardinalSDK(),
+    };
+}
+
+export function getCardinalSDK(): CardinalSDK {
+    return {
+        configure: jest.fn(),
+        on: jest.fn(),
+        setup: jest.fn(),
+        trigger: jest.fn(),
+        continue: jest.fn(),
+        off: jest.fn(),
+        start: jest.fn(),
+    };
+}
+
+export function getCardinalBinProcessResponse(status: boolean): CardinalBinProcessResponse {
+    return {
+        Status: status,
+    };
+}
+
+export function getCardinalValidatedData(
+    actionCode: CardinalValidatedAction,
+    status: boolean,
+    errorNumber?: number,
+): CardinalValidatedData {
+    return {
+        ActionCode: actionCode,
+        ErrorDescription: '',
+        ErrorNumber: errorNumber || 0,
+        Validated: status,
+        Payment: {
+            ExtendedData: {
+                SignatureVerification: CardinalSignatureVerification.Yes,
+            },
+            ProcessorTransactionId: '',
+            Type: CardinalPaymentType.CCA,
+        },
+    };
+}
+
+export function getCardinalThreeDSResult(): ThreeDsResult {
+    return {
+        acs_url: 'https://',
+        payer_auth_request: 'auth_request',
+        merchant_data: 'merchant_data',
+        callback_url: '',
+    };
+}
+
+export function getCardinalOrderData(): CardinalOrderData {
+    const billingAddress = getBillingAddress();
+
+    billingAddress.address2 = 'Address 2';
+
+    return {
+        billingAddress,
+        shippingAddress: getShippingAddress(),
+        currencyCode: 'USD',
+        id: '123-abc',
+        amount: 12000,
+        paymentData: getCreditCardInstrument(),
+    };
+}
+
+export function getCybersource(): PaymentMethod {
+    return {
+        id: 'cybersource',
+        logoUrl: '',
+        method: 'credit-card',
+        supportedCards: [],
+        config: {
+            displayName: 'Cybersource',
+            is3dsEnabled: true,
+            testMode: true,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'cyberToken',
+    };
+}
+
+export function getBarclays(): PaymentMethod {
+    return {
+        id: 'barclays',
+        logoUrl: '',
+        method: 'credit-card',
+        supportedCards: [],
+        config: {
+            displayName: 'Barclaycard Smartpay',
+            is3dsEnabled: true,
+            testMode: true,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'barclaysToken',
+    };
+}

--- a/packages/cardinal-integration/src/cardinal.ts
+++ b/packages/cardinal-integration/src/cardinal.ts
@@ -1,0 +1,193 @@
+import { ThreeDSecure, ThreeDSecureToken } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export const CardinalSignatureValidationErrors = [100004, 1010, 1011, 1020];
+
+export interface CardinalSDK {
+    configure(params: CardinalConfiguration): void;
+    on(params: CardinalEventType, callback: CardinalEventMap[CardinalEventType]): void;
+    off(params: CardinalEventType): void;
+    setup<K extends keyof CardinalInitializationDataMap>(
+        initializationType: K,
+        initializationData: CardinalInitializationDataMap[K],
+    ): void;
+    trigger(
+        event: CardinalTriggerEvents,
+        data?: string,
+    ): Promise<CardinalBinProcessResponse | void>;
+    continue(
+        paymentBrand: CardinalPaymentBrand,
+        continueObject: CardinalContinue,
+        order: CardinalPartialOrder,
+    ): void;
+    start(paymentBrand: CardinalPaymentBrand, order: CardinalPartialOrder, jwt?: string): void;
+}
+
+export interface CardinalWindow extends Window {
+    Cardinal?: CardinalSDK;
+}
+
+export enum CardinalEventType {
+    SetupCompleted = 'payments.setupComplete',
+    Validated = 'payments.validated',
+}
+
+export interface CardinalEventMap {
+    [CardinalEventType.SetupCompleted](setupCompleteData: CardinalSetupCompletedData): void;
+    [CardinalEventType.Validated](data: CardinalValidatedData, jwt?: string): void;
+}
+
+export type CardinalConfiguration = Partial<{
+    logging: {
+        level: string;
+    };
+    payment: {
+        view: string;
+        framework: string;
+        displayLoading: boolean;
+    };
+}>;
+
+export interface CardinalSetupCompletedData {
+    sessionId: string;
+    modules: CardinalModuleState[];
+}
+
+export interface CardinalModuleState {
+    loaded: boolean;
+    module: string;
+}
+
+export enum CardinalInitializationType {
+    Init = 'init',
+    Complete = 'complete',
+    Confirm = 'confirm',
+}
+
+export interface CardinalInitializationDataMap {
+    [CardinalInitializationType.Init]: CardinalInitTypeData;
+    [CardinalInitializationType.Complete]: CardinalCompleteTypeData;
+    [CardinalInitializationType.Confirm]: CardinalConfirmTypeData;
+}
+
+export interface CardinalInitTypeData {
+    jwt: string;
+}
+
+export interface CardinalCompleteTypeData {
+    Status: string;
+}
+
+export interface CardinalConfirmTypeData {
+    jwt: string;
+    cardinalResponseJwt: string;
+}
+
+export interface CardinalValidatedData {
+    ActionCode?: CardinalValidatedAction;
+    ErrorDescription: string;
+    ErrorNumber: number;
+    Validated?: boolean;
+    Payment?: CardinalPayment;
+}
+
+export interface CardinalPayment {
+    ExtendedData?: CardinalCCAExtendedData;
+    ProcessorTransactionId: string;
+    Type: CardinalPaymentType;
+}
+
+export interface CardinalBinProcessResponse {
+    Status: boolean;
+}
+
+export interface CardinalContinue {
+    AcsUrl: string;
+    Payload: string;
+}
+
+export interface CardinalPartialOrder {
+    OrderDetails: CardinalOrderDetails;
+    Consumer?: CardinalConsumer;
+}
+
+export interface CardinalConsumer {
+    Email1?: string;
+    Email2?: string;
+    ShippingAddress?: CardinalAddress;
+    BillingAddress?: CardinalAddress;
+    Account?: CardinalAccount;
+}
+
+export interface CardinalAccount {
+    AccountNumber: number;
+    ExpirationMonth: number;
+    ExpirationYear: number;
+    NameOnAccount: string;
+    CardCode: number;
+}
+
+export interface CardinalAddress {
+    FullName?: string;
+    FirstName: string;
+    MiddleName?: string;
+    LastName: string;
+    Address1: string;
+    Address2?: string;
+    Address3?: string;
+    City: string;
+    State: string;
+    PostalCode: string;
+    CountryCode: string;
+    Phone1?: string;
+    Phone2?: string;
+}
+
+export interface CardinalOrderDetails {
+    OrderNumber: string;
+    Amount: number;
+    CurrencyCode: string;
+    OrderDescription?: string;
+    OrderChannel: string;
+    TransactionId?: string;
+}
+
+export type CardinalCCAExtendedData = Partial<{
+    CAVV: string;
+    ECIFlag: string;
+    PAResStatus: string;
+    SignatureVerification: string;
+    XID: string;
+    UCAFIndicator: string;
+    ChallengeCancel: string;
+}>;
+
+export enum CardinalValidatedAction {
+    Success = 'SUCCESS',
+    NoAction = 'NOACTION',
+    Failure = 'FAILURE',
+    Error = 'ERROR',
+}
+
+export enum CardinalPaymentType {
+    CCA = 'CCA',
+    Paypal = 'Paypal',
+    Wallet = 'Wallet',
+    VisaCheckout = 'VisaCheckout',
+    ApplePay = 'ApplePay',
+    DiscoverWallet = 'DiscoverWallet',
+}
+
+export enum CardinalTriggerEvents {
+    BinProcess = 'bin.process',
+}
+
+export enum CardinalPaymentBrand {
+    CCA = 'cca',
+}
+
+export enum CardinalSignatureVerification {
+    Yes = 'Y',
+    No = 'N',
+}
+
+export type CardinalThreeDSecureToken = Pick<ThreeDSecure, 'xid'> | ThreeDSecureToken;

--- a/packages/cardinal-integration/src/index.ts
+++ b/packages/cardinal-integration/src/index.ts
@@ -1,0 +1,10 @@
+export * from './cardinal';
+
+export { default as CardinalThreeDSecureFlow } from './cardinal-three-d-secure-flow';
+export { default as CardinalThreeDSecureFlowV2 } from './cardinal-three-d-secure-flow-v2';
+export { default as CardinalScriptLoader } from './cardinal-script-loader';
+export {
+    default as CardinalClient,
+    CardinalOrderData,
+    CardinalSupportedPaymentInstrument,
+} from './cardinal-client';

--- a/packages/cardinal-integration/tsconfig.json
+++ b/packages/cardinal-integration/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.base.json"
+}

--- a/packages/cardinal-integration/tsconfig.lib.json
+++ b/packages/cardinal-integration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": []
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.spec.ts"]
+}

--- a/packages/cardinal-integration/tsconfig.spec.json
+++ b/packages/cardinal-integration/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.test.js",
+        "**/*.spec.js",
+        "**/*.test.jsx",
+        "**/*.spec.jsx",
+        "**/*.d.ts"
+    ]
+}

--- a/packages/core/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.ts
+++ b/packages/core/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.ts
@@ -32,6 +32,7 @@ export default class CardinalThreeDSecureFlowV2 {
         options?: PaymentRequestOptions,
         hostedForm?: HostedForm,
     ): Promise<InternalCheckoutSelectors> {
+        console.log(1);
         const {
             instruments: { getCardInstrument },
         } = this._store.getState();
@@ -39,12 +40,15 @@ export default class CardinalThreeDSecureFlowV2 {
         const { paymentData = {} } = payment;
 
         try {
+            console.log(2);
             return await execute(payload, options);
         } catch (error) {
+            console.log(3);
             if (
                 error instanceof RequestError &&
                 error.body.status === 'additional_action_required'
             ) {
+                console.log(4);
                 const token = error.body.additional_action_required?.data?.token;
                 const xid = error.body.three_ds_result?.payer_auth_request;
 
@@ -53,16 +57,20 @@ export default class CardinalThreeDSecureFlowV2 {
                 const bin = this._getBin(paymentData, getCardInstrument, hostedForm);
 
                 if (bin) {
+                    console.log(5);
                     await this._cardinalClient.runBinProcess(bin);
                 }
 
                 try {
+                    console.log(6);
                     return await this._submitPayment(payment, { xid }, hostedForm);
                 } catch (error) {
+                    console.log(7);
                     if (
                         error instanceof RequestError &&
                         some(error.body.errors, { code: 'three_d_secure_required' })
                     ) {
+                        console.log(8);
                         const threeDsResult = error.body.three_ds_result;
                         const token = threeDsResult?.payer_auth_request;
 

--- a/packages/core/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.ts
+++ b/packages/core/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.ts
@@ -32,7 +32,6 @@ export default class CardinalThreeDSecureFlowV2 {
         options?: PaymentRequestOptions,
         hostedForm?: HostedForm,
     ): Promise<InternalCheckoutSelectors> {
-        console.log(1);
         const {
             instruments: { getCardInstrument },
         } = this._store.getState();
@@ -40,15 +39,12 @@ export default class CardinalThreeDSecureFlowV2 {
         const { paymentData = {} } = payment;
 
         try {
-            console.log(2);
             return await execute(payload, options);
         } catch (error) {
-            console.log(3);
             if (
                 error instanceof RequestError &&
                 error.body.status === 'additional_action_required'
             ) {
-                console.log(4);
                 const token = error.body.additional_action_required?.data?.token;
                 const xid = error.body.three_ds_result?.payer_auth_request;
 
@@ -57,20 +53,16 @@ export default class CardinalThreeDSecureFlowV2 {
                 const bin = this._getBin(paymentData, getCardInstrument, hostedForm);
 
                 if (bin) {
-                    console.log(5);
                     await this._cardinalClient.runBinProcess(bin);
                 }
 
                 try {
-                    console.log(6);
                     return await this._submitPayment(payment, { xid }, hostedForm);
                 } catch (error) {
-                    console.log(7);
                     if (
                         error instanceof RequestError &&
                         some(error.body.errors, { code: 'three_d_secure_required' })
                     ) {
-                        console.log(8);
                         const threeDsResult = error.body.three_ds_result;
                         const token = threeDsResult?.payer_auth_request;
 

--- a/packages/payment-integrations-test-utils/src/test-utils/address.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/address.mock.ts
@@ -23,6 +23,5 @@ export function getBillingAddress(): BillingAddress {
     return {
         ...getAddress(),
         id: '55c96cda6f04c',
-        // email: 'test@bigcommerce.com',
     };
 }

--- a/packages/payment-integrations-test-utils/src/test-utils/address.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/address.mock.ts
@@ -23,5 +23,6 @@ export function getBillingAddress(): BillingAddress {
     return {
         ...getAddress(),
         id: '55c96cda6f04c',
+        // email: 'test@bigcommerce.com',
     };
 }

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -1,6 +1,7 @@
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { getAddress, getBillingAddress } from './address.mock';
+import { getAddress/*, getBillingAddress*/ } from './address.mock';
+import getBillingAddress from './billing-address.mock';
 import getCart from './carts.mock';
 import getCheckout from './checkouts.mock';
 import getConfig from './config.mock';

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -1,6 +1,6 @@
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { getAddress/*, getBillingAddress*/ } from './address.mock';
+import { getAddress } from './address.mock';
 import getBillingAddress from './billing-address.mock';
 import getCart from './carts.mock';
 import getCheckout from './checkouts.mock';

--- a/packages/squarev2-integration/src/squarev2-payment-processor.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-processor.spec.ts
@@ -236,6 +236,7 @@ describe('SquareV2PaymentProcessor', () => {
                     phone: '555-555-5555',
                     postalCode: '95555',
                     state: 'CA',
+                    email: 'test@bigcommerce.com',
                 },
                 currencyCode: 'USD',
                 intent: 'CHARGE',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -49,6 +49,9 @@
                 "packages/braintree-integration/src/index.ts"
             ],
             "@bigcommerce/checkout-sdk/braintree-utils": ["packages/braintree-utils/src/index.ts"],
+            "@bigcommerce/checkout-sdk/cardinal-integration": [
+                "packages/cardinal-integration/src/index.ts"
+            ],
             "@bigcommerce/checkout-sdk/checkoutcom-custom-integration": [
                 "packages/checkoutcom-custom-integration/src/index.ts"
             ],

--- a/workspace.json
+++ b/workspace.json
@@ -12,6 +12,7 @@
         "bolt-integration": "packages/bolt-integration",
         "braintree-integration": "packages/braintree-integration",
         "braintree-utils": "packages/braintree-utils",
+        "cardinal-integration": "packages/cardinal-integration",
         "checkoutcom-custom-integration": "packages/checkoutcom-custom-integration",
         "core": "packages/core",
         "credit-card-integration": "packages/credit-card-integration",


### PR DESCRIPTION
## What?
Refactored Cardinal to use Payment Integration API and created a separate package.
Note: due to differences in types/interfaces, the strategies in core package still need to use the non-refactored Cardinal.

## Why?

- For better separation between payment integrations and core Checkout SDK
- As a preparation for refactoring Cardinal-dependent strategies (eg. Cybersource)

## Testing / Proof
<img width="546" alt="Screenshot 2024-05-03 at 09 25 42" src="https://github.com/bigcommerce/checkout-sdk-js/assets/138816572/3bc18715-8a5a-407a-bf35-010bdf21df42">
<img width="351" alt="Screenshot 2024-05-03 at 10 40 22" src="https://github.com/bigcommerce/checkout-sdk-js/assets/138816572/d7c385be-4d80-4412-b4e4-f22e6ed35b32">


@bigcommerce/team-checkout @bigcommerce/team-payments
