### PR TITLE
refactor(payment): PI-1558 removed googlepay buttons from checkout button registry v1

### DIFF
--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -12,7 +12,6 @@ import {
     BraintreePaypalCreditButtonStrategy,
     BraintreeVenmoButtonStrategy,
 } from './strategies/braintree';
-import { GooglePayButtonStrategy } from './strategies/googlepay';
 
 describe('createCheckoutButtonRegistry', () => {
     let registry: Registry<CheckoutButtonStrategy>;
@@ -44,35 +43,5 @@ describe('createCheckoutButtonRegistry', () => {
 
     it('returns registry with Braintree Venmo registered', () => {
         expect(registry.get('braintreevenmo')).toEqual(expect.any(BraintreeVenmoButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on Authorize.Net Credit registered', () => {
-        expect(registry.get('googlepayauthorizenet')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on Bank of New Zealand Credit registered', () => {
-        expect(registry.get('googlepaybnz')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on CybersourceV2 Credit registered', () => {
-        expect(registry.get('googlepaycybersourcev2')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on Orbital Credit registered', () => {
-        expect(registry.get('googlepayorbital')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on Stripe Credit registered', () => {
-        expect(registry.get('googlepaystripe')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on StripeUPE Credit registered', () => {
-        expect(registry.get('googlepaystripeupe')).toEqual(expect.any(GooglePayButtonStrategy));
-    });
-
-    it('returns registry with GooglePay on WorldpayAccess Credit registered', () => {
-        expect(registry.get('googlepayworldpayaccess')).toEqual(
-            expect.any(GooglePayButtonStrategy),
-        );
     });
 });

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -12,17 +12,6 @@ import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
 import { BraintreeSDKCreator } from '../payment/strategies/braintree';
-import {
-    createGooglePayPaymentProcessor,
-    GooglePayAuthorizeNetInitializer,
-    GooglePayBNZInitializer,
-    GooglePayCheckoutcomInitializer,
-    GooglePayCybersourceV2Initializer,
-    GooglePayOrbitalInitializer,
-    GooglePayStripeInitializer,
-    GooglePayStripeUPEInitializer,
-    GooglePayWorldpayAccessInitializer,
-} from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 
@@ -34,7 +23,6 @@ import {
     BraintreePaypalCreditButtonStrategy,
     BraintreeVenmoButtonStrategy,
 } from './strategies/braintree';
-import { GooglePayButtonStrategy } from './strategies/googlepay';
 import { MasterpassButtonStrategy } from './strategies/masterpass';
 import { PaypalButtonStrategy } from './strategies/paypal';
 
@@ -114,93 +102,6 @@ export default function createCheckoutButtonRegistry(
     );
 
     registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayAuthorizeNetInitializer()),
-                cartRequestSender,
-            ),
-    );
-
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_BNZ,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayBNZInitializer()),
-                cartRequestSender,
-            ),
-    );
-
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(
-                    store,
-                    new GooglePayCheckoutcomInitializer(requestSender),
-                ),
-                cartRequestSender,
-            ),
-    );
-
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayCybersourceV2Initializer()),
-                cartRequestSender,
-            ),
-    );
-
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_ORBITAL,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayOrbitalInitializer()),
-                cartRequestSender,
-            ),
-    );
-
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_STRIPE,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayStripeInitializer()),
-                cartRequestSender,
-            ),
-    );
-
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_STRIPEUPE,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayStripeUPEInitializer()),
-                cartRequestSender,
-            ),
-    );
-
-    registry.register(
         CheckoutButtonMethodType.MASTERPASS,
         () =>
             new MasterpassButtonStrategy(
@@ -220,18 +121,6 @@ export default function createCheckoutButtonRegistry(
                 new PaypalScriptLoader(scriptLoader),
                 formPoster,
                 host,
-            ),
-    );
-
-    registry.register(
-        CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
-        () =>
-            new GooglePayButtonStrategy(
-                store,
-                formPoster,
-                checkoutActionCreator,
-                createGooglePayPaymentProcessor(store, new GooglePayWorldpayAccessInitializer()),
-                cartRequestSender,
             ),
     );
 

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayAuthorizeNetButtonStrategy from './create-google-pay-authorizenet-button-strategy';
+
+describe('createGooglePayAuthorizeNetButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay authorizenet button strategy', () => {
+        const strategy = createGooglePayAuthorizeNetButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayAuthorizeNetGateway from '../../gateways/google-pay-authorizenet-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayAuthorizeNetButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayAuthorizeNetGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayAuthorizeNetButtonStrategy, [
+    { id: 'googlepayauthorizenet' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayCheckoutComButtonStrategy from './create-google-pay-checkoutcom-button-strategy';
+
+describe('createGooglePayCheckoutComButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay checkoutcom button strategy', () => {
+        const strategy = createGooglePayCheckoutComButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.ts
@@ -1,0 +1,32 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayCheckoutComGateway from '../../gateways/google-pay-checkoutcom-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayCheckoutComButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) => {
+    const requestSender = createRequestSender();
+
+    return new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayCheckoutComGateway(paymentIntegrationService, requestSender),
+            requestSender,
+            createFormPoster(),
+        ),
+    );
+};
+
+export default toResolvableModule(createGooglePayCheckoutComButtonStrategy, [
+    { id: 'googlepaycheckoutcom' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayCybersourceButtonStrategy from './create-google-pay-cybersource-button-strategy';
+
+describe('createGooglePayCybersourceButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay cybersource button strategy', () => {
+        const strategy = createGooglePayCybersourceButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.ts
@@ -1,0 +1,30 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayCybersourceGateway from '../../gateways/google-pay-cybersource-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayCybersourceButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayCybersourceGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayCybersourceButtonStrategy, [
+    { id: 'googlepaycybersourcev2' },
+    { id: 'googlepaybnz' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayOrbitalButtonStrategy from './create-google-pay-orbital-button-strategy';
+
+describe('createGooglePayOrbitalButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay orbital button strategy', () => {
+        const strategy = createGooglePayOrbitalButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayOrbitalGateway from '../../gateways/google-pay-orbital-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayOrbitalButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayOrbitalGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayOrbitalButtonStrategy, [
+    { id: 'googlepayorbital' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayStripeButtonStrategy from './create-google-pay-stripe-button-strategy';
+
+describe('createGooglePayStripeButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay stripe button strategy', () => {
+        const strategy = createGooglePayStripeButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.ts
@@ -1,0 +1,30 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayStripeGateway from '../../gateways/google-pay-stripe-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayStripeButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayStripeGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayStripeButtonStrategy, [
+    { id: 'googlepaystripe' },
+    { id: 'googlepaystripeupe' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayWorldpayAccessButtonStrategy from './create-google-pay-worldpayaccess-button-strategy';
+
+describe('createGooglePayWorldpayAccessButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay worldpayaccess button strategy', () => {
+        const strategy = createGooglePayWorldpayAccessButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayWorldpayAccessGateway from '../../gateways/google-pay-worldpayaccess-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayWorldpayAccessButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayWorldpayAccessGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayWorldpayAccessButtonStrategy, [
+    { id: 'googlepayworldpayaccess' },
+]);

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
@@ -102,6 +102,7 @@ describe('GooglePayGateway', () => {
     describe('#getTransactionInfo', () => {
         it('should return ESTIMATED transaction info', async () => {
             const expectedInfo = {
+                countryCode: 'US',
                 currencyCode: 'USD',
                 totalPriceStatus: 'ESTIMATED',
                 totalPrice: '0',
@@ -115,6 +116,7 @@ describe('GooglePayGateway', () => {
 
         it('should return transaction info (Buy Now Flow)', async () => {
             const expectedInfo = {
+                countryCode: 'US',
                 currencyCode: 'USD',
                 totalPriceStatus: 'ESTIMATED',
                 totalPrice: '0',

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -158,7 +158,10 @@ export default class GooglePayGateway {
             currencyCode = getCartOrThrow().currency.code;
         }
 
+        const countryCode = this.getGooglePayInitializationData().storeCountry;
+
         return {
+            ...(countryCode && { countryCode }),
             currencyCode,
             totalPriceStatus: TotalPriceStatusType.ESTIMATED,
             totalPrice: '0',

--- a/packages/google-pay-integration/src/google-pay-button-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-button-initialize-options.ts
@@ -1,0 +1,34 @@
+import { GooglePayKey } from './google-pay-payment-initialize-options';
+import { GooglePayButtonColor, GooglePayButtonType } from './types';
+
+export default interface GooglePayButtonInitializeOptions {
+    /**
+     * All Google Pay payment buttons exist in two styles: dark (default) and light.
+     * To provide contrast, use dark buttons on light backgrounds and light buttons on dark or colorful backgrounds.
+     */
+    buttonColor?: GooglePayButtonColor;
+
+    /**
+     * Variant buttons:
+     * book: The "Book with Google Pay" payment button.
+     * buy: The "Buy with Google Pay" payment button.
+     * checkout: The "Checkout with Google Pay" payment button.
+     * donate: The "Donate with Google Pay" payment button.
+     * order: The "Order with Google Pay" payment button.
+     * pay: The "Pay with Google Pay" payment button.
+     * plain: The Google Pay payment button without the additional text (default).
+     * subscribe: The "Subscribe with Google Pay" payment button.
+     *
+     * Note: "long" and "short" button types have been renamed to "buy" and "plain", but are still valid button types
+     * for backwards compatability.
+     */
+    buttonType?: GooglePayButtonType;
+}
+
+/**
+ * The options that are required to initialize the GooglePay payment method.
+ * They can be omitted unless you need to support GooglePay.
+ */
+export type WithGooglePayButtonInitializeOptions = {
+    [k in GooglePayKey]?: GooglePayButtonInitializeOptions;
+};

--- a/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
@@ -287,4 +287,19 @@ describe('GooglePayButtonStrategy', () => {
             });
         });
     });
+
+    describe('#deinitialize', () => {
+        it('should deinitialize the strategy', async () => {
+            const deinitialize = buttonStrategy.deinitialize();
+
+            await expect(deinitialize).resolves.toBeUndefined();
+        });
+
+        it('should remove payment button', async () => {
+            await buttonStrategy.initialize(options);
+            await buttonStrategy.deinitialize();
+
+            expect(button.remove).toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/google-pay-integration/src/google-pay-button-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.ts
@@ -32,6 +32,7 @@ import {
 } from './types';
 
 export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
+    private _paymentButton?: HTMLElement;
     private _methodId?: keyof WithGooglePayPaymentInitializeOptions;
     private _buyNowCart?: Cart;
     private _currencyCode?: string;
@@ -107,14 +108,20 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             );
         }
 
-        this._googlePayPaymentProcessor.addPaymentButton(options.containerId, {
-            buttonColor: buttonColor ?? 'default',
-            buttonType: buttonType ?? 'plain',
-            onClick: this._handleClick(onError),
-        });
+        this._paymentButton =
+            this._paymentButton ??
+            this._googlePayPaymentProcessor.addPaymentButton(options.containerId, {
+                buttonColor: buttonColor ?? 'default',
+                buttonType: buttonType ?? 'plain',
+                onClick: this._handleClick(onError),
+            });
     }
 
     deinitialize(): Promise<void> {
+        this._paymentButton?.remove();
+        this._paymentButton = undefined;
+        this._methodId = undefined;
+
         return Promise.resolve();
     }
 

--- a/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
@@ -141,6 +141,7 @@ describe('GooglePayPaymentProcessor', () => {
                     merchantName: 'Example Merchant',
                 },
                 transactionInfo: {
+                    countryCode: 'US',
                     currencyCode: 'USD',
                     totalPrice: '0',
                     totalPriceStatus: 'ESTIMATED',
@@ -313,6 +314,7 @@ describe('GooglePayPaymentProcessor', () => {
                     merchantName: 'Example Merchant',
                 },
                 transactionInfo: {
+                    countryCode: 'US',
                     currencyCode: 'USD',
                     totalPrice: '0',
                     totalPriceStatus: 'ESTIMATED',

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -1,5 +1,6 @@
 export { WithGooglePayPaymentInitializeOptions } from './google-pay-payment-initialize-options';
 export { WithGooglePayCustomerInitializeOptions } from './google-pay-customer-initialize-options';
+export { WithGooglePayButtonInitializeOptions } from './google-pay-button-initialize-options';
 
 export { default as createGooglePayAdyenV2PaymentStrategy } from './factories/payment/create-google-pay-adyenv2-payment-strategy';
 export { default as createGooglePayAdyenV3PaymentStrategy } from './factories/payment/create-google-pay-adyenv3-payment-strategy';
@@ -29,3 +30,10 @@ export { default as createGooglePayBraintreeButtonStrategy } from './factories/b
 export { default as createGooglePayPayPalCommerceButtonStrategy } from './google-pay-paypal-commerce/create-google-pay-paypal-commerce-button-strategy';
 export { default as createGooglePayAdyenV2ButtonStrategy } from './factories/button/create-google-pay-adyenv2-button-strategy';
 export { default as createGooglePayAdyenV3ButtonStrategy } from './factories/button/create-google-pay-adyenv3-button-strategy';
+
+export { default as createGooglePayAuthorizeDotNetButtonStrategy } from './factories/button/create-google-pay-authorizenet-button-strategy';
+export { default as createGooglePayCheckoutComButtonStrategy } from './factories/button/create-google-pay-checkoutcom-button-strategy';
+export { default as createGooglePayCybersourceButtonStrategy } from './factories/button/create-google-pay-cybersource-button-strategy';
+export { default as createGooglePayOrbitalButtonStrategy } from './factories/button/create-google-pay-orbital-button-strategy';
+export { default as createGooglePayStripeButtonStrategy } from './factories/button/create-google-pay-stripe-button-strategy';
+export { default as createGooglePayWorldpayAccessButtonStrategy } from './factories/button/create-google-pay-worldpayaccess-button-strategy';


### PR DESCRIPTION
## What?

Fixed version of the reverted PR https://github.com/bigcommerce/checkout-sdk-js/pull/2432
1. Add Google Pay button strategy for Worldpay Access
2. Refactor existing logic for:
    - Authorize Net
    - Checkout Com
    - Cybersource / BNZ
    - Orbital
    - Stripe v3 / Stripe UPE
    - Worldpay Access

## Why?
Due to the GooglePay refactoring

## Testing / Proof
Tested manually/units



@bigcommerce/checkout @bigcommerce/payments 
