### PR TITLE
feat(payment): PAYPAL-4108 preselect billing with firstName and lastName for only digital items in cart

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
@@ -778,6 +778,37 @@ describe('BraintreeFastlaneUtils', () => {
 
             expect(paymentIntegrationService.updateShippingAddress).not.toHaveBeenCalled();
         });
+
+        it('preselects billing with shipping firstName and lastName if the cart contains only digital items', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCartOrThrow').mockReturnValue({
+                ...cart,
+                lineItems: {
+                    ...cart.lineItems,
+                    physicalItems: [],
+                },
+            });
+
+            await subject.initializeBraintreeAcceleratedCheckoutOrThrow(methodId);
+            await subject.runPayPalFastlaneAuthenticationFlowOrThrow();
+
+            expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith({
+                id: 1,
+                type: 'paypal-address',
+                firstName: 'John',
+                lastName: 'Doe',
+                company: '',
+                address1: 'Hello World Address',
+                address2: '',
+                city: 'Bellingham',
+                stateOrProvince: 'WA',
+                stateOrProvinceCode: 'WA',
+                country: 'United States',
+                countryCode: 'US',
+                postalCode: '98225',
+                phone: '',
+                customFields: [],
+            });
+        });
     });
 
     describe('#getDeviceSessionId', () => {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
@@ -267,8 +267,24 @@ export default class BraintreeFastlaneUtils {
                 instruments,
             });
 
-            if (billingAddresses.length > 0) {
+            if (billingAddresses.length > 0 && cart.lineItems.physicalItems.length > 0) {
                 await this.paymentIntegrationService.updateBillingAddress(billingAddresses[0]);
+            }
+
+            // Prefill billing form if only digital items in cart with billing data and firstName and lastName
+            // from shippingAddresses because there are empty in billing
+            if (
+                billingAddresses.length > 0 &&
+                cart.lineItems.digitalItems.length > 0 &&
+                cart.lineItems.physicalItems.length === 0
+            ) {
+                const { firstName, lastName } = addresses[0];
+                const digitalItemBilling = {
+                    ...billingAddresses[0],
+                    firstName,
+                    lastName,
+                };
+                await this.paymentIntegrationService.updateBillingAddress(digitalItemBilling);
             }
 
             if (shippingAddresses.length > 0 && cart.lineItems.physicalItems.length > 0) {


### PR DESCRIPTION
## What?
Preselect billing with firstName and lastName for only digital items in cart

## Why?
To preselect all needed data for digital items

## Testing / Proof
Unit tests
**Before**
https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/793fb326-1bf5-4f41-a1b8-dc2ba01b6869

**Digital Item Only**
https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/3b7a30cc-cfb5-4b87-a7fb-d92af20ad7b5

**Physical Item Only**
https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/16ff1343-7c0d-4623-81c5-25127a0b58cc

**Physical and Digital Items**
https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/1ce5f06e-a97e-48fd-8b70-2ffdaec4fc3f



@bigcommerce/team-checkout @bigcommerce/team-payments
