### PR TITLE
feat(payment): PAYPAL-4111 Update Braintree SDK commit parameter

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-customer-strategy.spec.ts
@@ -277,6 +277,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
                     currency: 'USD',
                     isCreditEnabled: true,
                     intent: undefined,
+                    commit: false,
                 },
                 expect.any(Function),
                 expect.any(Function),
@@ -303,7 +304,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
                 style: {
                     height: DefaultCheckoutButtonHeight,
@@ -319,7 +319,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.CREDIT,
                 style: {
                     height: DefaultCheckoutButtonHeight,
@@ -347,7 +346,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
                 style: {
                     height: DefaultCheckoutButtonHeight,
@@ -361,7 +359,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).not.toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.CREDIT,
                 style: {
                     height: DefaultCheckoutButtonHeight,
@@ -385,7 +382,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
                 style: {
                     color: PaypalButtonStyleColorOption.BLUE,
@@ -414,7 +410,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
                 style: {
                     color: PaypalButtonStyleColorOption.BLUE,
@@ -430,7 +425,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.CREDIT,
                 style: {
                     color: PaypalButtonStyleColorOption.BLUE,

--- a/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-customer-strategy.ts
@@ -89,6 +89,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
             currency: currencyCode,
             intent: initializationData.intent,
             isCreditEnabled: initializationData.isCreditEnabled,
+            commit: false,
         };
 
         const paypalCheckoutSuccessCallback = (
@@ -150,7 +151,6 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
                 if (!hasRenderedSmartButton) {
                     const paypalButtonRender = paypal.Buttons({
                         env: testMode ? 'sandbox' : 'production',
-                        commit: false,
                         fundingSource,
                         style: buttonStyles,
                         createOrder: () =>

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
@@ -265,6 +265,7 @@ describe('BraintreePaypalCustomerStrategy', () => {
                     currency: 'USD',
                     isCreditEnabled: true,
                     intent: undefined,
+                    commit: false,
                 },
                 expect.any(Function),
                 expect.any(Function),
@@ -291,7 +292,6 @@ describe('BraintreePaypalCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.PAYPAL,
                 style: {
                     color: PaypalButtonStyleColorOption.BLUE,
@@ -318,7 +318,6 @@ describe('BraintreePaypalCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.PAYPAL,
                 style: {
                     color: PaypalButtonStyleColorOption.BLUE,
@@ -342,7 +341,6 @@ describe('BraintreePaypalCustomerStrategy', () => {
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
-                commit: false,
                 fundingSource: paypalSdkMock.FUNDING.PAYPAL,
                 style: {
                     color: PaypalButtonStyleColorOption.BLUE,

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
@@ -89,6 +89,7 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
             currency: currencyCode,
             intent: initializationData.intent,
             isCreditEnabled: initializationData.isCreditEnabled,
+            commit: false,
         };
 
         const paypalCheckoutSuccessCallback = (
@@ -146,7 +147,6 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
         if (paypal && fundingSource) {
             const paypalButtonRender = paypal.Buttons({
                 env: this.braintreeIntegrationService.getBraintreeEnv(testMode),
-                commit: false,
                 fundingSource,
                 style: { ...buttonStyles, height: DefaultCheckoutButtonHeight },
                 createOrder: () =>

--- a/packages/braintree-utils/src/braintree-integration-service.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.ts
@@ -201,6 +201,7 @@ export default class BraintreeIntegrationService {
                 ...(config.isCreditEnabled && { 'enable-funding': 'paylater' }),
                 components: PAYPAL_COMPONENTS.toString(),
                 intent: config.intent,
+                commit: config.commit ?? true,
             };
 
             if (!this.braintreeHostWindow.paypal) {

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -527,6 +527,7 @@ export interface BraintreePaypalSdkCreatorConfig {
     currency?: string;
     intent?: string;
     isCreditEnabled?: boolean;
+    commit?: boolean;
 }
 
 /**

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -400,7 +400,6 @@ describe('BraintreePaypalButtonStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYPAL,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -166,7 +166,6 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
 
             const paypalButtonRender = paypal.Buttons({
                 env: testMode ? 'sandbox' : 'production',
-                commit: false,
                 fundingSource,
                 style: validButtonStyle,
                 createOrder: () =>

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
@@ -378,7 +378,6 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
@@ -390,7 +389,6 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
             });
 
             expect(paypalSdkMock.Buttons).not.toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.CREDIT,
@@ -413,7 +411,6 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
@@ -427,7 +424,6 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.CREDIT,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -155,7 +155,6 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
                 if (!hasRenderedSmartButton) {
                     const paypalButtonRender = paypal.Buttons({
                         env: testMode ? 'sandbox' : 'production',
-                        commit: false,
                         fundingSource,
                         style: buttonStyle,
                         createOrder: () =>

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
@@ -333,7 +333,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
@@ -346,7 +345,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
             });
 
             expect(paypalSdkMock.Buttons).not.toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.CREDIT,
@@ -369,7 +367,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
             });
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
@@ -392,7 +389,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
@@ -407,7 +403,6 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
-                commit: false,
                 createOrder: expect.any(Function),
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.CREDIT,

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -176,7 +176,6 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
                 if (!hasRenderedSmartButton) {
                     const paypalButtonRender = paypal.Buttons({
                         env: testMode ? 'sandbox' : 'production',
-                        commit: false,
                         fundingSource,
                         style: buttonStyle,
                         createOrder: () =>

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -221,6 +221,7 @@ export default class BraintreeSDKCreator {
             ...(config.isCreditEnabled && { 'enable-funding': 'paylater' }),
             components: PAYPAL_COMPONENTS.toString(),
             intent: config.intent,
+            commit: false,
         };
     }
 }


### PR DESCRIPTION
## What?

Update Braintree SDK commit parameter

## Why?

According to the new ways of passing parameters for correct initialization process. According to a upgraded PayPal documentation

## Testing / Proof

Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
