### PR TITLE
feat(payment): PAYPAL-4123 Update address request body by adding digitalItems to lineItems

### DIFF
--- a/packages/core/src/shipping/consignment-action-creator.spec.ts
+++ b/packages/core/src/shipping/consignment-action-creator.spec.ts
@@ -957,6 +957,10 @@ describe('consignmentActionCreator', () => {
                             itemId: 'custom',
                             quantity: 1,
                         },
+                        {
+                            itemId: '667',
+                            quantity: 1,
+                        },
                     ],
                 },
                 options,
@@ -976,6 +980,10 @@ describe('consignmentActionCreator', () => {
                         lineItems: [
                             {
                                 itemId: '666',
+                                quantity: 1,
+                            },
+                            {
+                                itemId: '667',
                                 quantity: 1,
                             },
                         ],

--- a/packages/core/src/shipping/consignment-action-creator.ts
+++ b/packages/core/src/shipping/consignment-action-creator.ts
@@ -427,11 +427,11 @@ export default class ConsignmentActionCreator {
             throw new MissingDataError(MissingDataErrorType.MissingCart);
         }
 
-        const { physicalItems, customItems = [] } = cart.lineItems;
+        const { physicalItems, customItems = [], digitalItems = [] } = cart.lineItems;
 
         return {
             address,
-            lineItems: [...physicalItems, ...customItems].map((item) => ({
+            lineItems: [...physicalItems, ...customItems, ...digitalItems].map((item) => ({
                 itemId: item.id,
                 quantity: item.quantity,
             })),


### PR DESCRIPTION
## What?

Update address request body by adding digitalItems to lineItems

## Why?

If we try to place order with digital item we get an error by clicking on Pay button in the GP modal window
We need to update request body by adding digitalItems to lineItems to avoid this error

## Testing / Proof

Before

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/f6056cfc-7f1d-437c-b0af-aa08e848fbd8

After

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/f45b44de-4340-426f-8042-6367092dcb90

@bigcommerce/team-checkout @bigcommerce/team-payments
