### PR TITLE
feat(payment): PAYPAL-4137 prepopulate cardholder name with customer billing info on Fastlane Card Component

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -472,6 +472,10 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
 
                 expect(paypalFastlane.FastlaneCardComponent).toHaveBeenCalledWith({
                     fields: {
+                        cardholderName: {
+                            enabled: true,
+                            prefill: 'Test Tester',
+                        },
                         phoneNumber: {
                             prefill: address.phone,
                         },

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -498,11 +498,14 @@ export interface PayPalFastlaneCardComponentOptions {
 }
 
 export interface PayPalFastlaneCardComponentFields {
-    [key: string]: PayPalFastlaneCardComponentField;
-}
-export interface PayPalFastlaneCardComponentField {
-    placeholder?: string;
-    prefill?: string;
+    cardholderName?: {
+        enabled?: boolean;
+        prefill?: string;
+    };
+    phoneNumber?: {
+        placeholder?: string;
+        prefill?: string;
+    };
 }
 
 export interface PayPalFastlaneTokenizeResult {


### PR DESCRIPTION
## What?
Updated PayPalCommerceFastlanePaymentStrategy with a little feature to pre-populate cardholder name with customer fullname from billing info

## Why?
To speed up purchase process with Fastlane

## Testing / Proof
Manual tests
Unit tests
CI


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/6ce066a0-6d3e-419d-9c7a-1927e41f4e91

