### PR TITLE
feat(payment): PAYPAL-4123 Avoiding calling of updateAddress for digitalItems

### DIFF
--- a/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
@@ -163,6 +163,7 @@ describe('GooglePayButtonStrategy', () => {
 
                 expect(paymentIntegrationService.loadCheckout).not.toHaveBeenCalled();
                 expect(paymentIntegrationService.createBuyNowCart).toHaveBeenCalled();
+                expect(paymentIntegrationService.updateShippingAddress).not.toHaveBeenCalled();
             });
         });
 

--- a/packages/google-pay-integration/src/google-pay-button-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.ts
@@ -170,7 +170,7 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             await this._paymentIntegrationService.updateBillingAddress(billingAddress);
         }
 
-        if (shippingAddress) {
+        if (shippingAddress && !this._buyNowCart?.lineItems.digitalItems.length) {
             await this._paymentIntegrationService.updateShippingAddress(shippingAddress);
         }
 


### PR DESCRIPTION
## What?

Avoiding calling of `updateAddress` for `digitalItems`

## Why?

If we try to place order with digital item we get an error by clicking on Pay button in the GP modal window
We need to get rid of `updateAddress` request for  `digitalItems` on PDP

## Testing / Proof

Before

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/d6ff1cb2-f25e-48c5-b103-714f024acdb2

After

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/bfa573de-00b0-4ccd-8531-30804bdb1f42



@bigcommerce/team-checkout @bigcommerce/team-payments
