### PR TITLE
feat(payment): PAYPAL-4140 updated getPaymentToken method payload with customer fullname in PPCP Fastlane Payment strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -585,6 +585,22 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                     cartId: cart.id,
                 });
 
+                const paypalFastlaneComponent = await paypalFastlane.FastlaneCardComponent({});
+
+                expect(paypalFastlaneComponent.getPaymentToken).toHaveBeenCalledWith({
+                    billingAddress: {
+                        addressLine1: address.address1,
+                        addressLine2: address.address2,
+                        adminArea1: address.stateOrProvinceCode,
+                        adminArea2: address.city,
+                        company: address.company,
+                        countryCode: address.countryCode,
+                        postalCode: address.postalCode,
+                    },
+                    name: {
+                        fullName: `${address.firstName} ${address.lastName}`,
+                    },
+                });
                 expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith({}, undefined);
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
                     methodId,

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -373,6 +373,8 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
         // Info: shipping can be unavailable for carts with digital items
         const shippingAddress = state.getShippingAddress();
 
+        const fullName = `${billingAddress.firstName} ${billingAddress.lastName}`.trim();
+
         const { shouldSaveInstrument = false, shouldSetAsDefaultInstrument = false } =
             isHostedInstrumentLike(paymentData) ? paymentData : {};
 
@@ -380,6 +382,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
 
         if (this.isFastlaneEnabled) {
             const { id } = await getPaymentToken({
+                name: { fullName },
                 billingAddress:
                     this.paypalCommerceFastlaneUtils.mapBcToPayPalAddress(billingAddress),
             });
@@ -401,9 +404,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
         }
 
         const { nonce } = await tokenize({
-            name: {
-                fullName: `${billingAddress.firstName} ${billingAddress.lastName}`.trim(),
-            },
+            name: { fullName },
             billingAddress: this.paypalCommerceFastlaneUtils.mapBcToPayPalAddress(billingAddress),
             ...(shippingAddress && {
                 shippingAddress:

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -532,6 +532,7 @@ export interface PayPalFastlaneTokenizeOptions {
 }
 
 export interface PayPalFastlaneGetPaymentTokenOptions {
+    name?: PayPalFastlaneProfileName;
     billingAddress?: PayPalFastlaneAddress;
 }
 


### PR DESCRIPTION
## What?
Updated getPaymentToken method payload with customer fullname in PPCP Fastlane Payment strategy

## Why?
To reduce issues with missing data on PayPal side

## Testing / Proof
Unit tests
Manual tests
CI


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/e0dff09b-f6ac-4da6-90bb-12bfac655497

