### PR TITLE
feat(payment): PAYPAL-4142 added shipping option autoselect to Braintree Fastlane customer strategy

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
@@ -288,7 +288,7 @@ describe('BraintreeFastlaneCustomerStrategy', () => {
 
             expect(
                 braintreeFastlaneUtils.runPayPalFastlaneAuthenticationFlowOrThrow,
-            ).toHaveBeenCalled();
+            ).toHaveBeenCalledWith(undefined, true);
         });
 
         it('authenticates user with PayPal Fastlane even when Paypal Accelerated checkout enabled', async () => {
@@ -311,7 +311,7 @@ describe('BraintreeFastlaneCustomerStrategy', () => {
 
             expect(
                 braintreeFastlaneUtils.runPayPalFastlaneAuthenticationFlowOrThrow,
-            ).toHaveBeenCalled();
+            ).toHaveBeenCalledWith(undefined, true);
             expect(
                 braintreeFastlaneUtils.runPayPalConnectAuthenticationFlowOrThrow,
             ).not.toHaveBeenCalled();

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -99,7 +99,10 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
             }
 
             if (shouldRunAuthenticationFlow && this.isFastlaneEnabled) {
-                await this.braintreeFastlaneUtils.runPayPalFastlaneAuthenticationFlowOrThrow();
+                await this.braintreeFastlaneUtils.runPayPalFastlaneAuthenticationFlowOrThrow(
+                    undefined,
+                    true,
+                );
             }
         }
 


### PR DESCRIPTION
## What?
Added shipping option autoselect to Braintree Fastlane customer strategy

## Why?
To speed up customer purchase experience by bypassing shipping and billing steps and land customer strait on payment step

## Testing / Proof
Unit tests
Manual tests
CI
