### PR TITLE
feat(payment): PAYPAL-2520 Add 3d secure iframe window size property

### DIFF
--- a/docs/interfaces/BraintreeThreeDSecureOptions.md
+++ b/docs/interfaces/BraintreeThreeDSecureOptions.md
@@ -10,10 +10,26 @@ through a web page via an iframe provided by the card issuer.
 
 ## Table of contents
 
+### Properties
+
+- [additionalInformation](BraintreeThreeDSecureOptions.md#additionalinformation)
+
 ### Methods
 
 - [addFrame](BraintreeThreeDSecureOptions.md#addframe)
 - [removeFrame](BraintreeThreeDSecureOptions.md#removeframe)
+
+## Properties
+
+### additionalInformation
+
+• `Optional` **additionalInformation**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `acsWindowSize` | ``"01"`` \| ``"02"`` \| ``"03"`` \| ``"04"`` \| ``"05"`` |
 
 ## Methods
 

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -355,6 +355,9 @@ export interface BraintreeThreeDSecureOptions {
     challengeRequested?: boolean;
     showLoader?: boolean;
     bin?: string;
+    additionalInformation?: {
+        acsWindowSize?: '01' | '02' | '03' | '04' | '05';
+    };
     addFrame?(
         error: Error | undefined,
         iframe: HTMLIFrameElement,

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
@@ -123,6 +123,9 @@ export interface BraintreeThreeDSecureOptions {
      * the current page.
      */
     removeFrame(): void;
+    additionalInformation?: {
+        acsWindowSize?: '01' | '02' | '03' | '04' | '05';
+    };
 }
 
 export interface BraintreeFormOptions {

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -439,6 +439,9 @@ describe('BraintreePaymentProcessor', () => {
                 nonce: 'tokenization_nonce',
                 onLookupComplete: expect.any(Function),
                 collectDeviceData: true,
+                additionalInformation: {
+                    acsWindowSize: '01',
+                },
             });
         });
 

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -206,7 +206,7 @@ export default class BraintreePaymentProcessor {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        const { addFrame, removeFrame } = this._threeDSecureOptions;
+        const { addFrame, removeFrame, additionalInformation } = this._threeDSecureOptions;
         const cancelVerifyCard = async () => {
             const response = await threeDSecure.cancelVerifyCard();
 
@@ -231,6 +231,7 @@ export default class BraintreePaymentProcessor {
                     next();
                 },
                 collectDeviceData: true,
+                additionalInformation,
             }),
         );
 

--- a/packages/core/src/payment/strategies/braintree/braintree.mock.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.mock.ts
@@ -231,5 +231,8 @@ export function getThreeDSecureOptionsMock(): BraintreeThreeDSecureOptions {
     return {
         addFrame: jest.fn(),
         removeFrame: jest.fn(),
+        additionalInformation: {
+            acsWindowSize: '01',
+        },
     };
 }

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -416,6 +416,9 @@ export interface BraintreeThreeDSecureOptions {
     removeFrame(): void;
     onLookupComplete(data: BraintreeThreeDSecureVerificationData, next: () => void): void;
     collectDeviceData: boolean;
+    additionalInformation?: {
+        acsWindowSize?: '01' | '02' | '03' | '04' | '05';
+    };
 }
 
 interface BraintreeThreeDSecureVerificationData {


### PR DESCRIPTION
## What?
Add the additionalInformation object containing the acsWindowSize property to the Braintree configuration

## Why?
To allow control of the 3D Secure iframe window size - as per #2520 

## Testing / Proof
Verified with different configurations giving correctly sized iframe

@bigcommerce/team-checkout @bigcommerce/team-payments
