### PR TITLE
CHECKOUT-8284 Create new hosted-form package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 /packages/core @bigcommerce/team-checkout
 /packages/payment-integration @bigcommerce/team-checkout
 /packages/payment-integration-test-utils @bigcommerce/team-checkout
+/packages/hosted-form-v2 @bigcommerce/team-checkout
 
 
 ## Integrations team

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -63,7 +63,8 @@
                 "commands": [
                     "tsc --outDir ../../temp --declaration --emitDeclarationOnly",
                     "api-extractor run --config api-extractor/checkout-sdk.json & api-extractor run --config api-extractor/checkout-button.json & api-extractor run --config api-extractor/embedded-checkout.json & api-extractor run --config api-extractor/internal-mappers.json",
-                    "rm -rf ../../temp"
+                    "rm -rf ../../temp",
+                    "nx run hosted-form-v2:build-dts"
                 ]
             }
         },

--- a/packages/hosted-form-v2/.eslintrc.json
+++ b/packages/hosted-form-v2/.eslintrc.json
@@ -1,0 +1,65 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {
+                "@typescript-eslint/no-empty-function": "off",
+                "@typescript-eslint/no-empty-interface": "off",
+                "@typescript-eslint/ban-types": "off",
+                "@typescript-eslint/naming-convention": "off",
+                "@typescript-eslint/no-unsafe-assignment": "off",
+                "@typescript-eslint/no-misused-promises": "off",
+                "@typescript-eslint/no-unsafe-member-access": "off",
+                "@typescript-eslint/restrict-template-expressions": "off",
+                "@typescript-eslint/require-await": "off",
+                "@typescript-eslint/no-unsafe-argument": "off",
+                "@typescript-eslint/default-param-last": "off",
+                "@typescript-eslint/no-unsafe-call": "off",
+                "@typescript-eslint/consistent-type-assertions": "off",
+                "@typescript-eslint/no-unsafe-return": "off",
+                "@typescript-eslint/no-unnecessary-condition": "off",
+                "@typescript-eslint/no-shadow": "off",
+                "complexity": "off",
+                "no-plusplus": "off",
+                "@typescript-eslint/no-explicit-any": "off",
+                "jsdoc/check-tag-names": "off",
+                "no-return-await": "off",
+                "@typescript-eslint/no-use-before-define": "off",
+                "no-param-reassign": "off",
+                "@typescript-eslint/no-floating-promises": "off",
+                "no-nested-ternary": "off",
+                "@typescript-eslint/no-unused-vars": "off",
+                "@typescript-eslint/await-thenable": "off",
+                "@typescript-eslint/no-unused-expressions": "off",
+                "@typescript-eslint/member-ordering": "off",
+                "@typescript-eslint/unified-signatures": "off",
+                "jsdoc/require-param-type": "off",
+                "jsdoc/require-returns-type": "off",
+                "jsdoc/check-param-names": "off",
+                "no-restricted-globals": "off",
+                "no-underscore-dangle": "off",
+                "import/no-named-default": "off",
+                "no-restricted-syntax": "off",
+                "eqeqeq": "off",
+                "no-continue": "off",
+                "@typescript-eslint/no-throw-literal": "off",
+                "max-classes-per-file": "off",
+                "global-require": "off",
+                "no-multi-assign": "off",
+                "no-restricted-properties": "off",
+                "no-proto": "off",
+                "no-throw-literal": "off"
+            }
+        },
+        {
+            "files": ["*.spec.ts"],
+            "rules": {
+                "@typescript-eslint/no-non-null-assertion": "off",
+                "jest/no-restricted-matchers": "off",
+                "jest/no-conditional-expect": "off"
+            }
+        }
+    ]
+}

--- a/packages/hosted-form-v2/README.md
+++ b/packages/hosted-form-v2/README.md
@@ -1,0 +1,11 @@
+# Hosted Form
+
+This library is for creating a hosted form that can be used outside of the checkout page.
+
+## Running unit tests
+
+Run `nx test hosted-form-v2` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint hosted-form-v2` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/hosted-form-v2/api-extractor/hosted-form-v2-iframe-content.json
+++ b/packages/hosted-form-v2/api-extractor/hosted-form-v2-iframe-content.json
@@ -1,0 +1,22 @@
+{
+    "compiler": {
+        "configType": "tsconfig",
+        "rootFolder": "."
+    },
+    "project": {
+        "entryPointSourceFile": "../../temp/hosted-form-v2/src/bundles/hosted-form-v2-iframe-content.d.ts"
+    },
+    "validationRules": {
+        "missingReleaseTags": "allow"
+    },
+    "apiReviewFile": {
+        "enabled": false
+    },
+    "apiJsonFile": {
+        "enabled": false
+    },
+    "dtsRollup": {
+        "enabled": true,
+        "mainDtsRollupPath": "hosted-form-v2-iframe-content.d.ts"
+    }
+}

--- a/packages/hosted-form-v2/api-extractor/hosted-form-v2-iframe-host.json
+++ b/packages/hosted-form-v2/api-extractor/hosted-form-v2-iframe-host.json
@@ -1,0 +1,22 @@
+{
+    "compiler": {
+        "configType": "tsconfig",
+        "rootFolder": "."
+    },
+    "project": {
+        "entryPointSourceFile": "../../temp/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.d.ts"
+    },
+    "validationRules": {
+        "missingReleaseTags": "allow"
+    },
+    "apiReviewFile": {
+        "enabled": false
+    },
+    "apiJsonFile": {
+        "enabled": false
+    },
+    "dtsRollup": {
+        "enabled": true,
+        "mainDtsRollupPath": "hosted-form-v2-iframe-host.d.ts"
+    }
+}

--- a/packages/hosted-form-v2/jest.config.js
+++ b/packages/hosted-form-v2/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    displayName: 'hosted-form-v2',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+            diagnostics: false,
+        },
+    },
+    setupFilesAfterEnv: ['../../jest-setup.js'],
+    coverageDirectory: '../../coverage/packages/hosted-form-v2',
+};

--- a/packages/hosted-form-v2/project.json
+++ b/packages/hosted-form-v2/project.json
@@ -1,0 +1,35 @@
+{
+    "root": "packages/hosted-form-v2",
+    "sourceRoot": "packages/hosted-form-v2/src",
+    "projectType": "library",
+    "targets": {
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/hosted-form-v2/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["coverage/packages/hosted-form-v2"],
+            "options": {
+                "jestConfig": "packages/hosted-form-v2/jest.config.js",
+                "passWithNoTests": true
+            }
+        },
+        "build-dts": {
+            "executor": "@nrwl/workspace:run-commands",
+            "options": {
+                "cwd": "packages/hosted-form-v2",
+                "parallel": false,
+                "commands": [
+                    "tsc --outDir ../../temp --declaration --emitDeclarationOnly",
+                    "api-extractor run --config api-extractor/hosted-form-v2-iframe-content.json & api-extractor run --config api-extractor/hosted-form-v2-iframe-host.json",
+                    "rm -rf ../../temp"
+                ]
+            }
+        }
+    },
+    "tags": ["scope:shared"]
+}

--- a/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-content.ts
+++ b/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-content.ts
@@ -1,0 +1,1 @@
+export { initializeHostedInput, notifyInitializeError } from '../iframe-content';

--- a/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.ts
+++ b/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.ts
@@ -1,0 +1,1 @@
+export { createHostedFormService } from '../create-hosted-form-service';

--- a/packages/hosted-form-v2/src/common/dom/detachment-observer.spec.ts
+++ b/packages/hosted-form-v2/src/common/dom/detachment-observer.spec.ts
@@ -1,0 +1,61 @@
+import { EventEmitter } from 'events';
+import { noop } from 'lodash';
+
+import DetachmentObserver from './detachment-observer';
+import { UnexpectedDetachmentError } from './errors';
+import { MutationObserverFactory } from './mutation-observer';
+
+describe('DetachmentObserver', () => {
+    let mutationEventEmitter: EventEmitter;
+    let mutationObserver: Pick<MutationObserver, 'disconnect' | 'observe'>;
+    let mutationObserverFactory: Pick<MutationObserverFactory, 'create'>;
+    let subject: DetachmentObserver;
+
+    beforeEach(() => {
+        mutationEventEmitter = new EventEmitter();
+
+        mutationObserver = {
+            observe: jest.fn(),
+            disconnect: jest.fn(),
+        };
+
+        mutationObserverFactory = {
+            create: jest.fn((callback) => {
+                mutationEventEmitter.on('remove', callback);
+
+                return mutationObserver;
+            }),
+        };
+
+        subject = new DetachmentObserver(mutationObserverFactory as MutationObserverFactory);
+    });
+
+    it('throws error and stops observing if targetted element is removed before promise is resolved', async () => {
+        const element = document.createElement('div');
+        const promise = new Promise(noop);
+        const output = subject.ensurePresence([element], promise);
+
+        mutationEventEmitter.emit('remove', [{ removedNodes: [element] }]);
+
+        try {
+            await output;
+        } catch (error) {
+            expect(error).toEqual(expect.any(UnexpectedDetachmentError));
+
+            expect(mutationObserver.disconnect).toHaveBeenCalled();
+        }
+    });
+
+    it('returns promised value and stops observing if targetted element is not removed before promise is resolved', async () => {
+        const eventEmitter = new EventEmitter();
+        const element = document.createElement('div');
+        const promise = new Promise((resolve) => eventEmitter.on('resolve', resolve));
+        const output = subject.ensurePresence([element], promise);
+
+        eventEmitter.emit('resolve', 'foobar');
+
+        expect(await output).toBe('foobar');
+
+        expect(mutationObserver.disconnect).toHaveBeenCalled();
+    });
+});

--- a/packages/hosted-form-v2/src/common/dom/detachment-observer.ts
+++ b/packages/hosted-form-v2/src/common/dom/detachment-observer.ts
@@ -1,0 +1,40 @@
+import { CancellablePromise } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { UnexpectedDetachmentError } from './errors';
+import { MutationObserverFactory } from './mutation-observer';
+
+export default class DetachmentObserver {
+    constructor(private _mutationObserver: MutationObserverFactory) {}
+
+    async ensurePresence<T>(targets: Node[], promise: Promise<T>): Promise<T> {
+        const cancellable = new CancellablePromise(promise);
+
+        const observer = this._mutationObserver.create((mutationsList) => {
+            mutationsList.forEach((mutation) => {
+                const removedTargets = Array.from(mutation.removedNodes).filter((node) =>
+                    targets.some((target) => node === target || node.contains(target)),
+                );
+
+                if (removedTargets.length === 0) {
+                    return;
+                }
+
+                cancellable.cancel(new UnexpectedDetachmentError());
+            });
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        try {
+            const output = await cancellable.promise;
+
+            observer.disconnect();
+
+            return output;
+        } catch (error) {
+            observer.disconnect();
+
+            throw error;
+        }
+    }
+}

--- a/packages/hosted-form-v2/src/common/dom/errors/index.ts
+++ b/packages/hosted-form-v2/src/common/dom/errors/index.ts
@@ -1,0 +1,1 @@
+export { default as UnexpectedDetachmentError } from './unexpected-detachment-error';

--- a/packages/hosted-form-v2/src/common/dom/errors/unexpected-detachment-error.ts
+++ b/packages/hosted-form-v2/src/common/dom/errors/unexpected-detachment-error.ts
@@ -1,0 +1,13 @@
+import { StandardError } from '../../errors';
+
+export default class UnexpectedDetachmentError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message ||
+                'Unable to proceed because the required element is unexpectedly detached from the page.',
+        );
+
+        this.name = 'UnexpectedDetachmentError';
+        this.type = 'unexpected_detachment';
+    }
+}

--- a/packages/hosted-form-v2/src/common/dom/index.ts
+++ b/packages/hosted-form-v2/src/common/dom/index.ts
@@ -1,0 +1,3 @@
+export * from './mutation-observer';
+
+export { default as DetachmentObserver } from './detachment-observer';

--- a/packages/hosted-form-v2/src/common/dom/mutation-observer.ts
+++ b/packages/hosted-form-v2/src/common/dom/mutation-observer.ts
@@ -1,0 +1,16 @@
+export interface MutationObeserverCreator {
+    prototype: MutationObserver;
+    new (callback: MutationCallback): MutationObserver;
+}
+
+export interface MutationObserverWindow extends Window {
+    MutationObserver: MutationObeserverCreator;
+}
+
+export class MutationObserverFactory {
+    constructor(private _window: MutationObserverWindow = window as MutationObserverWindow) {}
+
+    create(callback: MutationCallback): MutationObserver {
+        return new this._window.MutationObserver(callback);
+    }
+}

--- a/packages/hosted-form-v2/src/common/errors/custom-error.ts
+++ b/packages/hosted-form-v2/src/common/errors/custom-error.ts
@@ -1,0 +1,9 @@
+export default interface CustomError extends Error {
+    message: string;
+    type: string;
+    subtype?: string;
+}
+
+export function isCustomError(error: unknown): error is CustomError {
+    return typeof error === 'object' && error !== null && 'message' in error && 'type' in error;
+}

--- a/packages/hosted-form-v2/src/common/errors/index.ts
+++ b/packages/hosted-form-v2/src/common/errors/index.ts
@@ -1,0 +1,7 @@
+export { default as CustomError, isCustomError } from './custom-error';
+export { default as InvalidArgumentError } from './invalid-argument-error';
+export { default as NotInitializedError, NotInitializedErrorType } from './not-initialized-error';
+export { default as RequestError } from './request-error';
+export { default as StandardError } from './standard-error';
+
+export { default as mapFromPaymentErrorResponse } from './map-from-payment-error-response';

--- a/packages/hosted-form-v2/src/common/errors/invalid-argument-error.spec.ts
+++ b/packages/hosted-form-v2/src/common/errors/invalid-argument-error.spec.ts
@@ -1,0 +1,9 @@
+import InvalidArgumentError from './invalid-argument-error';
+
+describe('InvalidArgumentError', () => {
+    it('returns error name', () => {
+        const error = new InvalidArgumentError();
+
+        expect(error.name).toBe('InvalidArgumentError');
+    });
+});

--- a/packages/hosted-form-v2/src/common/errors/invalid-argument-error.ts
+++ b/packages/hosted-form-v2/src/common/errors/invalid-argument-error.ts
@@ -1,0 +1,15 @@
+import StandardError from './standard-error';
+
+/**
+ * This error should be thrown when a method is unable to proceed because the
+ * caller has not provided all the arguments according to their requirements,
+ * i.e.: if an argument is missing or it is not the expected data type.
+ */
+export default class InvalidArgumentError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Invalid arguments have been provided.');
+
+        this.name = 'InvalidArgumentError';
+        this.type = 'invalid_argument';
+    }
+}

--- a/packages/hosted-form-v2/src/common/errors/map-from-payment-error-response.spec.ts
+++ b/packages/hosted-form-v2/src/common/errors/map-from-payment-error-response.spec.ts
@@ -1,0 +1,47 @@
+import { Response } from '@bigcommerce/request-sender';
+
+import { PaymentErrorResponseBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { getErrorResponse } from '../http-request/responses.mock';
+
+import mapFromPaymentErrorResponse from './map-from-payment-error-response';
+import RequestError from './request-error';
+
+describe('mapFromPaymentErrorResponse()', () => {
+    let error: RequestError<PaymentErrorResponseBody>;
+    let response: Response<PaymentErrorResponseBody>;
+
+    beforeEach(() => {
+        response = getErrorResponse({
+            status: '',
+            errors: [
+                { code: 'invalid_cvv', message: undefined },
+                { code: 'invalid_number', message: 'Invalid number' },
+                { code: 'invalid_empty', message: '' },
+                { code: 'invalid_account', message: 'Invalid account.' },
+            ],
+        });
+
+        error = mapFromPaymentErrorResponse(response);
+    });
+
+    it('keeps original body', () => {
+        expect(error.body).toEqual(response.body);
+    });
+
+    it('keeps original headers', () => {
+        expect(error.headers).toEqual(response.headers);
+    });
+
+    it('keeps original status', () => {
+        expect(error.status).toEqual(response.status);
+    });
+
+    it('creates an array of error objects', () => {
+        expect(error.errors).toEqual(response.body.errors);
+    });
+
+    it('concatenates all errors, ignoring empty ones', () => {
+        expect(error.message).toBe('Invalid number Invalid account.');
+    });
+});

--- a/packages/hosted-form-v2/src/common/errors/map-from-payment-error-response.ts
+++ b/packages/hosted-form-v2/src/common/errors/map-from-payment-error-response.ts
@@ -1,0 +1,34 @@
+import { Response } from '@bigcommerce/request-sender';
+
+import { PaymentErrorResponseBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import RequestError from './request-error';
+
+export default function mapFromPaymentErrorResponse(
+    response: Response<PaymentErrorResponseBody>,
+    message?: string,
+): RequestError {
+    const { body } = response;
+    const { errors = [] } = body;
+
+    return new RequestError(response, {
+        message: joinErrors(errors) || message,
+        errors,
+    });
+}
+
+function joinErrors(errors: Array<{ code: string; message?: string }>): string | undefined {
+    if (!Array.isArray(errors)) {
+        return;
+    }
+
+    return errors
+        .reduce((result: string[], error) => {
+            if (error && error.message) {
+                return [...result, error.message];
+            }
+
+            return result;
+        }, [])
+        .join(' ');
+}

--- a/packages/hosted-form-v2/src/common/errors/not-initialized-error.spec.ts
+++ b/packages/hosted-form-v2/src/common/errors/not-initialized-error.spec.ts
@@ -1,0 +1,9 @@
+import NotInitializedError, { NotInitializedErrorType } from './not-initialized-error';
+
+describe('NotInitializedError', () => {
+    it('returns error name', () => {
+        const error = new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+
+        expect(error.name).toBe('NotInitializedError');
+    });
+});

--- a/packages/hosted-form-v2/src/common/errors/not-initialized-error.ts
+++ b/packages/hosted-form-v2/src/common/errors/not-initialized-error.ts
@@ -1,0 +1,42 @@
+import StandardError from './standard-error';
+
+export enum NotInitializedErrorType {
+    CheckoutButtonNotInitialized,
+    CustomerNotInitialized,
+    PaymentNotInitialized,
+    ShippingNotInitialized,
+    SpamProtectionNotInitialized,
+}
+
+/**
+ * Throw this error if a method requires a certain initialization call to be
+ * made first. Some objects can be constructed but they cannot be used until a
+ * separate initialization call is made.
+ */
+export default class NotInitializedError extends StandardError {
+    constructor(public subtype: NotInitializedErrorType) {
+        super(getErrorMessage(subtype));
+
+        this.name = 'NotInitializedError';
+        this.type = 'not_initialized';
+    }
+}
+
+function getErrorMessage(type: NotInitializedErrorType): string {
+    switch (type) {
+        case NotInitializedErrorType.CustomerNotInitialized:
+            return 'Unable to proceed because the customer step of checkout has not been initialized.';
+
+        case NotInitializedErrorType.PaymentNotInitialized:
+            return 'Unable to proceed because the payment step of checkout has not been initialized.';
+
+        case NotInitializedErrorType.ShippingNotInitialized:
+            return 'Unable to proceed because the shipping step of checkout has not been initialized.';
+
+        case NotInitializedErrorType.SpamProtectionNotInitialized:
+            return 'Unable to proceed because the checkout spam protection has not been initialized.';
+
+        default:
+            return 'Unable to proceed because the required component has not been initialized.';
+    }
+}

--- a/packages/hosted-form-v2/src/common/errors/request-error.spec.ts
+++ b/packages/hosted-form-v2/src/common/errors/request-error.spec.ts
@@ -1,0 +1,40 @@
+import { getErrorResponse } from '../http-request/responses.mock';
+
+import RequestError from './request-error';
+
+describe('RequestError', () => {
+    it('sets type', () => {
+        const error = new RequestError(getErrorResponse());
+
+        expect(error.type).toBe('request');
+    });
+
+    it('sets name', () => {
+        const error = new RequestError(getErrorResponse());
+
+        expect(error.name).toBe('RequestError');
+    });
+
+    it('sets body', () => {
+        const response = getErrorResponse();
+        const error = new RequestError(response);
+
+        expect(error.body).toEqual(response.body);
+    });
+
+    it('sets status', () => {
+        const response = getErrorResponse();
+        const error = new RequestError(response);
+
+        expect(error.status).toEqual(response.status);
+    });
+
+    it('sets default data when none provided', () => {
+        const error = new RequestError();
+
+        expect(error.message).toBe('An unexpected error has occurred.');
+        expect(error.status).toBe(0);
+        expect(error.body).toEqual({});
+        expect(error.headers).toEqual({});
+    });
+});

--- a/packages/hosted-form-v2/src/common/errors/request-error.ts
+++ b/packages/hosted-form-v2/src/common/errors/request-error.ts
@@ -1,0 +1,42 @@
+import { Response } from '@bigcommerce/request-sender';
+
+import StandardError from './standard-error';
+
+const DEFAULT_RESPONSE = {
+    body: {},
+    headers: {},
+    status: 0,
+};
+
+/**
+ * Throw this error if we are unable to make a request to the server. It wraps
+ * any server response into a JS error object.
+ */
+export default class RequestError<TBody = any> extends StandardError {
+    body: TBody | {};
+    headers: { [key: string]: any };
+    errors: Array<{ code: string; message?: string }>;
+    status: number;
+
+    constructor(
+        response?: Response<TBody | {}>,
+        {
+            message,
+            errors,
+        }: {
+            message?: string;
+            errors?: Array<{ code: string; message?: string }>;
+        } = {},
+    ) {
+        const { body, headers, status } = response || DEFAULT_RESPONSE;
+
+        super(message || 'An unexpected error has occurred.');
+
+        this.name = 'RequestError';
+        this.type = 'request';
+        this.body = body;
+        this.headers = headers;
+        this.status = status;
+        this.errors = errors || [];
+    }
+}

--- a/packages/hosted-form-v2/src/common/errors/standard-error.spec.ts
+++ b/packages/hosted-form-v2/src/common/errors/standard-error.spec.ts
@@ -1,0 +1,18 @@
+import StandardError from './standard-error';
+
+describe('StandardError', () => {
+    class TestError extends StandardError {}
+
+    it('returns error name', () => {
+        const error = new TestError();
+
+        expect(error.name).toBe('StandardError');
+    });
+
+    it('sets error message if provided', () => {
+        const message = 'Hello world';
+        const error = new TestError(message);
+
+        expect(error.message).toEqual(message);
+    });
+});

--- a/packages/hosted-form-v2/src/common/errors/standard-error.ts
+++ b/packages/hosted-form-v2/src/common/errors/standard-error.ts
@@ -1,0 +1,24 @@
+import { setPrototypeOf } from '../utility';
+
+import CustomError from './custom-error';
+
+/**
+ * This error type should not be constructed directly. It is a base class for
+ * all custom errors thrown in this library.
+ */
+export default abstract class StandardError extends Error implements CustomError {
+    name = 'StandardError';
+    type = 'standard';
+
+    constructor(message?: string) {
+        super(message || 'An unexpected error has occurred.');
+
+        setPrototypeOf(this, new.target.prototype);
+
+        if (typeof Error.captureStackTrace === 'function') {
+            Error.captureStackTrace(this, new.target);
+        } else {
+            this.stack = new Error(this.message).stack;
+        }
+    }
+}

--- a/packages/hosted-form-v2/src/common/http-request/responses.mock.ts
+++ b/packages/hosted-form-v2/src/common/http-request/responses.mock.ts
@@ -1,0 +1,30 @@
+import { Response } from '@bigcommerce/request-sender';
+
+import { ErrorResponseBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export function getErrorResponse(
+    body = getErrorResponseBody(),
+    headers = {},
+    status = 400,
+    statusText = 'Bad Request',
+): Response<any> {
+    return {
+        body,
+        status,
+        statusText,
+        headers: {
+            'content-type': 'application/json',
+            ...headers,
+        },
+    };
+}
+
+export function getErrorResponseBody(error?: any): ErrorResponseBody {
+    return {
+        detail: 'Something went wrong',
+        errors: ['Bad Request'],
+        status: 400,
+        title: 'Error',
+        ...error,
+    };
+}

--- a/packages/hosted-form-v2/src/common/iframe/iframe-event-listener.spec.ts
+++ b/packages/hosted-form-v2/src/common/iframe/iframe-event-listener.spec.ts
@@ -1,0 +1,121 @@
+import { EventEmitter } from 'events';
+
+import IframeEventListener from './iframe-event-listener';
+
+enum TestEventType {
+    Loaded = 'LOADED',
+    Complete = 'COMPLETE',
+    Error = 'ERROR',
+}
+
+interface TestEventMap {
+    [TestEventType.Loaded]: { type: TestEventType.Loaded };
+    [TestEventType.Complete]: { type: TestEventType.Complete };
+    [TestEventType.Error]: { type: TestEventType.Error };
+}
+
+describe('IframeEventListener', () => {
+    let origin: string;
+    let eventEmitter: EventEmitter;
+    let listener: IframeEventListener<TestEventMap>;
+    let handleLoaded: () => void;
+    let handleComplete: () => void;
+
+    beforeEach(() => {
+        origin = document.location.origin;
+        listener = new IframeEventListener(origin);
+        eventEmitter = new EventEmitter();
+        handleLoaded = jest.fn();
+        handleComplete = jest.fn();
+
+        jest.spyOn(window, 'addEventListener').mockImplementation((type, listener) => {
+            return eventEmitter.addListener(type, listener);
+        });
+
+        jest.spyOn(window, 'removeEventListener').mockImplementation((type, listener) => {
+            return eventEmitter.removeListener(type, listener);
+        });
+
+        listener.listen();
+        listener.addListener(TestEventType.Loaded, handleLoaded);
+        listener.addListener(TestEventType.Complete, handleComplete);
+    });
+
+    it('triggers relevant listeners after receiving `message` event', () => {
+        eventEmitter.emit('message', { origin, data: { type: TestEventType.Loaded } });
+
+        expect(handleLoaded).toHaveBeenCalled();
+        expect(handleComplete).not.toHaveBeenCalled();
+    });
+
+    it('triggers relevant listeners with context data if provided', () => {
+        eventEmitter.emit('message', {
+            origin,
+            data: { type: TestEventType.Loaded, context: { id: '123' } },
+        });
+
+        expect(handleLoaded).toHaveBeenCalledWith({ type: TestEventType.Loaded }, { id: '123' });
+    });
+
+    it('responds to event with www subdomain', () => {
+        eventEmitter.emit('message', {
+            origin: origin.replace('http://', 'http://www.'),
+            data: { type: TestEventType.Loaded },
+        });
+
+        expect(handleLoaded).toHaveBeenCalled();
+        expect(handleComplete).not.toHaveBeenCalled();
+    });
+
+    it('does not respond to event with unrecognized origin', () => {
+        eventEmitter.emit('message', {
+            origin: 'https://foobar.com',
+            data: {
+                type: TestEventType.Loaded,
+            },
+        });
+
+        expect(handleLoaded).not.toHaveBeenCalled();
+    });
+
+    it('triggers relevant listeners when origin URL has trailing slash', () => {
+        listener = new IframeEventListener(`${origin}/`);
+        listener.listen();
+        listener.addListener(TestEventType.Loaded, handleLoaded);
+
+        eventEmitter.emit('message', { origin, data: { type: TestEventType.Loaded } });
+
+        expect(handleLoaded).toHaveBeenCalled();
+    });
+
+    it('does not respond to invalid event', () => {
+        eventEmitter.emit('message', { origin, data: { type: 'FOOBAR' } });
+
+        expect(handleLoaded).not.toHaveBeenCalled();
+        expect(handleComplete).not.toHaveBeenCalled();
+    });
+
+    it('stops listening to `message` event', () => {
+        listener.stopListen();
+
+        eventEmitter.emit('message', { origin, data: { type: TestEventType.Loaded } });
+        eventEmitter.emit('message', { origin, data: { type: TestEventType.Complete } });
+
+        expect(handleLoaded).not.toHaveBeenCalled();
+        expect(handleComplete).not.toHaveBeenCalled();
+    });
+
+    it('removes specific event listener', () => {
+        listener.removeListener(TestEventType.Loaded, handleLoaded);
+
+        eventEmitter.emit('message', { origin, data: { type: TestEventType.Loaded } });
+        eventEmitter.emit('message', { origin, data: { type: TestEventType.Complete } });
+
+        expect(handleLoaded).not.toHaveBeenCalled();
+        expect(handleComplete).toHaveBeenCalled();
+    });
+
+    it('does nothing if trying to remove non-existent listener', () => {
+        expect(() => listener.removeListener(TestEventType.Error, () => {})).not.toThrow();
+    });
+});

--- a/packages/hosted-form-v2/src/common/iframe/iframe-event-listener.ts
+++ b/packages/hosted-form-v2/src/common/iframe/iframe-event-listener.ts
@@ -1,0 +1,103 @@
+import { appendWww, parseUrl } from '../url';
+import { bindDecorator as bind } from '../utility';
+
+import { IframeEventMap } from './iframe-event';
+import isIframeEvent from './is-iframe-event';
+
+export default class IframeEventListener<
+    TEventMap extends IframeEventMap<keyof TEventMap>,
+    TContext = undefined,
+> {
+    private _isListening: boolean;
+    private _listeners: EventListeners<TEventMap, TContext>;
+    private _sourceOrigins: string[];
+
+    constructor(sourceOrigin: string) {
+        this._sourceOrigins = [
+            parseUrl(sourceOrigin).origin,
+            appendWww(parseUrl(sourceOrigin)).origin,
+        ];
+        this._isListening = false;
+        this._listeners = {};
+    }
+
+    listen(): void {
+        if (this._isListening) {
+            return;
+        }
+
+        this._isListening = true;
+
+        window.addEventListener('message', this._handleMessage);
+    }
+
+    stopListen(): void {
+        if (!this._isListening) {
+            return;
+        }
+
+        this._isListening = false;
+
+        window.removeEventListener('message', this._handleMessage);
+    }
+
+    addListener<TType extends keyof TEventMap>(
+        type: TType,
+        listener: (event: TEventMap[TType], context?: TContext) => void,
+    ): void {
+        let listeners = this._listeners[type];
+
+        if (!listeners) {
+            this._listeners[type] = listeners = [];
+        }
+
+        if (listeners.indexOf(listener) === -1) {
+            listeners.push(listener);
+        }
+    }
+
+    removeListener<TType extends keyof TEventMap>(
+        type: TType,
+        listener: (event: TEventMap[TType], context?: TContext) => void,
+    ): void {
+        const listeners = this._listeners[type];
+
+        if (!listeners) {
+            return;
+        }
+
+        const index = listeners.indexOf(listener);
+
+        if (index >= 0) {
+            listeners.splice(index, 1);
+        }
+    }
+
+    trigger<TType extends keyof TEventMap>(event: TEventMap[TType], context?: TContext): void {
+        const listeners = this._listeners[event.type];
+
+        if (!listeners) {
+            return;
+        }
+
+        listeners.forEach((listener) => (context ? listener(event, context) : listener(event)));
+    }
+
+    @bind
+    private _handleMessage(messageEvent: MessageEvent): void {
+        if (
+            this._sourceOrigins.indexOf(messageEvent.origin) === -1 ||
+            !isIframeEvent(messageEvent.data as TEventMap[keyof TEventMap], messageEvent.data.type)
+        ) {
+            return;
+        }
+
+        const { context, ...event } = messageEvent.data;
+
+        this.trigger(event, context);
+    }
+}
+
+type EventListeners<TEventMap, TContext = undefined> = {
+    [key in keyof TEventMap]?: Array<(event: TEventMap[key], context?: TContext) => void>;
+};

--- a/packages/hosted-form-v2/src/common/iframe/iframe-event-poster.spec.ts
+++ b/packages/hosted-form-v2/src/common/iframe/iframe-event-poster.spec.ts
@@ -1,0 +1,133 @@
+import { EventEmitter } from 'events';
+
+import IframeEvent from './iframe-event';
+import IframeEventPoster from './iframe-event-poster';
+
+describe('IframeEventPoster', () => {
+    let eventEmitter: EventEmitter;
+    let origin: string;
+
+    beforeEach(() => {
+        eventEmitter = new EventEmitter();
+        origin = 'https://mybigcommerce.com';
+
+        jest.spyOn(window, 'addEventListener').mockImplementation((type, listener) => {
+            eventEmitter.addListener(type, listener);
+        });
+    });
+
+    it('posts event to target window', () => {
+        const message = { type: 'FOOBAR' };
+        const targetWindow = Object.create(window);
+        const poster = new IframeEventPoster<IframeEvent>(origin, targetWindow);
+
+        jest.spyOn(targetWindow, 'postMessage');
+
+        poster.post(message);
+
+        expect(targetWindow.postMessage).toHaveBeenCalledWith(message, origin);
+    });
+
+    it('posts event with context data if provided', () => {
+        const message = { type: 'FOOBAR' };
+        const targetWindow = Object.create(window);
+        const poster = new IframeEventPoster<IframeEvent, { id: string }>(origin, targetWindow);
+
+        jest.spyOn(targetWindow, 'postMessage');
+
+        poster.setContext({ id: '123' });
+        poster.post(message);
+
+        expect(targetWindow.postMessage).toHaveBeenCalledWith(
+            { ...message, context: { id: '123' } },
+            origin,
+        );
+    });
+
+    it('strips out irrelevant information from origin URL', () => {
+        const message = { type: 'FOOBAR' };
+        const targetWindow = Object.create(window);
+        const poster = new IframeEventPoster<IframeEvent>(`${origin}/url/path`, targetWindow);
+
+        jest.spyOn(targetWindow, 'postMessage');
+
+        poster.post(message);
+
+        expect(targetWindow.postMessage).toHaveBeenCalledWith(message, origin);
+    });
+
+    it('does not post event to target window if it is same as current window', () => {
+        const message = { type: 'FOOBAR' };
+        const targetWindow = window;
+        const poster = new IframeEventPoster<IframeEvent>(origin, targetWindow);
+
+        jest.spyOn(window, 'postMessage');
+
+        poster.post(message);
+
+        expect(window.postMessage).not.toHaveBeenCalledWith(message, origin);
+    });
+
+    it('returns nothing if success / error event type is not provided', () => {
+        const targetWindow = Object.create(window);
+        const poster = new IframeEventPoster<IframeEvent>(origin, targetWindow);
+
+        expect(poster.post({ type: 'FOOBAR_REQUEST' })).toBeUndefined();
+    });
+
+    it('returns promise if success / error event type is provided', () => {
+        const targetWindow = Object.create(window);
+        const poster = new IframeEventPoster<IframeEvent>(origin, targetWindow);
+
+        expect(
+            poster.post(
+                { type: 'FOOBAR_REQUEST' },
+                { errorType: 'FOOBAR_ERROR', successType: 'FOOBAR_SUCCESS' },
+            ),
+        ).toBeInstanceOf(Promise);
+    });
+
+    it('resolves promise if success event is received', async () => {
+        const targetWindow = Object.create(window);
+        const poster = new IframeEventPoster<IframeEvent>(origin, targetWindow);
+
+        jest.spyOn(targetWindow, 'postMessage').mockImplementation((message) => {
+            if (message.type === 'FOOBAR_REQUEST') {
+                eventEmitter.emit('message', {
+                    origin,
+                    data: { type: 'FOOBAR_SUCCESS', payload: '123' },
+                });
+            }
+        });
+
+        expect(
+            await poster.post(
+                { type: 'FOOBAR_REQUEST' },
+                { errorType: 'FOOBAR_ERROR', successType: 'FOOBAR_SUCCESS' },
+            ),
+        ).toEqual({ type: 'FOOBAR_SUCCESS', payload: '123' });
+    });
+
+    it('rejects promise if error event is received', async () => {
+        const targetWindow = Object.create(window);
+        const poster = new IframeEventPoster<IframeEvent>(origin, targetWindow);
+
+        jest.spyOn(targetWindow, 'postMessage').mockImplementation((message) => {
+            if (message.type === 'FOOBAR_REQUEST') {
+                eventEmitter.emit('message', {
+                    origin,
+                    data: { type: 'FOOBAR_ERROR', payload: 'Unexpected error' },
+                });
+            }
+        });
+
+        try {
+            await poster.post(
+                { type: 'FOOBAR_REQUEST' },
+                { errorType: 'FOOBAR_ERROR', successType: 'FOOBAR_SUCCESS' },
+            );
+        } catch (event) {
+            expect(event).toEqual({ type: 'FOOBAR_ERROR', payload: 'Unexpected error' });
+        }
+    });
+});

--- a/packages/hosted-form-v2/src/common/iframe/iframe-event-poster.ts
+++ b/packages/hosted-form-v2/src/common/iframe/iframe-event-poster.ts
@@ -1,0 +1,83 @@
+import { fromEvent } from 'rxjs';
+import { filter, map, take } from 'rxjs/operators';
+
+import { parseUrl } from '../url';
+
+import IframeEvent from './iframe-event';
+import isIframeEvent from './is-iframe-event';
+
+export interface IframeEventPostOptions<
+    TSuccessEvent extends IframeEvent,
+    TErrorEvent extends IframeEvent,
+> {
+    errorType?: TErrorEvent['type'];
+    successType?: TSuccessEvent['type'];
+}
+
+export default class IframeEventPoster<TEvent, TContext = undefined> {
+    private _targetOrigin: string;
+
+    constructor(targetOrigin: string, private _targetWindow?: Window, private _context?: TContext) {
+        this._targetOrigin = targetOrigin === '*' ? '*' : parseUrl(targetOrigin).origin;
+    }
+
+    post(event: TEvent): void;
+    post<
+        TSuccessEvent extends IframeEvent = IframeEvent,
+        TErrorEvent extends IframeEvent = IframeEvent,
+    >(
+        event: TEvent,
+        options: IframeEventPostOptions<TSuccessEvent, TErrorEvent>,
+    ): Promise<TSuccessEvent>;
+    post<
+        TSuccessEvent extends IframeEvent = IframeEvent,
+        TErrorEvent extends IframeEvent = IframeEvent,
+    >(
+        event: TEvent,
+        options?: IframeEventPostOptions<TSuccessEvent, TErrorEvent>,
+    ): Promise<TSuccessEvent> | void {
+        const targetWindow = this._targetWindow;
+
+        if (window === targetWindow) {
+            return;
+        }
+
+        if (!targetWindow) {
+            throw new Error('Unable to post message because target window is not set.');
+        }
+
+        const result =
+            options &&
+            fromEvent<MessageEvent>(window, 'message')
+                .pipe(
+                    filter(
+                        (event) =>
+                            event.origin === this._targetOrigin &&
+                            isIframeEvent(event.data, event.data.type) &&
+                            [options.successType, options.errorType].indexOf(event.data.type) !==
+                                -1,
+                    ),
+                    map((event) => {
+                        if (options.errorType === event.data.type) {
+                            throw event.data;
+                        }
+
+                        return event.data;
+                    }),
+                    take(1),
+                )
+                .toPromise();
+
+        targetWindow.postMessage({ ...event, context: this._context }, this._targetOrigin);
+
+        return result;
+    }
+
+    setTarget(window: Window) {
+        this._targetWindow = window;
+    }
+
+    setContext(context: TContext) {
+        this._context = context;
+    }
+}

--- a/packages/hosted-form-v2/src/common/iframe/iframe-event.ts
+++ b/packages/hosted-form-v2/src/common/iframe/iframe-event.ts
@@ -1,0 +1,8 @@
+export default interface IframeEvent<TType = string, TPayload = any> {
+    type: TType;
+    payload?: TPayload;
+}
+
+export type IframeEventMap<TType extends string | number | symbol = string> = {
+    [key in TType]: IframeEvent<TType>;
+};

--- a/packages/hosted-form-v2/src/common/iframe/index.ts
+++ b/packages/hosted-form-v2/src/common/iframe/index.ts
@@ -1,0 +1,4 @@
+export { default as IframeEventListener } from './iframe-event-listener';
+export { default as IframeEventPoster } from './iframe-event-poster';
+export { default as IframeEvent } from './iframe-event';
+export { default as isIframeEvent } from './is-iframe-event';

--- a/packages/hosted-form-v2/src/common/iframe/is-iframe-event.spec.ts
+++ b/packages/hosted-form-v2/src/common/iframe/is-iframe-event.spec.ts
@@ -1,0 +1,11 @@
+import isIframeEvent from './is-iframe-event';
+
+describe('isIframeEvent()', () => {
+    it('returns true if object has matching `type`', () => {
+        expect(isIframeEvent({ type: 'FOOBAR' }, 'FOOBAR')).toBe(true);
+    });
+
+    it('returns false if object does not have matching `type`', () => {
+        expect(isIframeEvent({ type: 'FOOBAR' }, 'FOO')).toBe(false);
+    });
+});

--- a/packages/hosted-form-v2/src/common/iframe/is-iframe-event.ts
+++ b/packages/hosted-form-v2/src/common/iframe/is-iframe-event.ts
@@ -1,0 +1,8 @@
+import IframeEvent from './iframe-event';
+
+export default function isIframeEvent<TEvent extends IframeEvent<TType>, TType extends string>(
+    object: any,
+    type: TType,
+): object is TEvent {
+    return object.type === type;
+}

--- a/packages/hosted-form-v2/src/common/types/card-validator.d.ts
+++ b/packages/hosted-form-v2/src/common/types/card-validator.d.ts
@@ -1,0 +1,40 @@
+import 'card-validator';
+
+// Merge @types/card-validator with missing methods. We probably don't need this
+// once the official package is updated with the latest type definitions.
+declare module 'card-validator' {
+    type CardBrand =
+        | 'american-express'
+        | 'diners-club'
+        | 'discover'
+        | 'jcb'
+        | 'maestro'
+        | 'mastercard'
+        | 'unionpay'
+        | 'visa'
+        | 'mada';
+
+    interface CreditCardTypeInfo {
+        patterns?: Array<number | [number, number]>;
+        niceType?: string;
+        type?: CardBrand;
+        prefixPattern?: RegExp;
+        exactPattern?: RegExp;
+        gaps?: number[];
+        lengths?: number[];
+        code?: {
+            name?: string;
+            size?: number;
+        };
+    }
+
+    interface CreditCardType {
+        types: { [type: string]: string };
+        (cardNumber: string): CreditCardTypeInfo[];
+        getTypeInfo(type: string): CreditCardTypeInfo;
+        updateCard(type: string, updates: Partial<CreditCardTypeInfo>): void;
+        addCard(config: Partial<CreditCardTypeInfo>): void;
+    }
+
+    export const creditCardType: CreditCardType;
+}

--- a/packages/hosted-form-v2/src/common/types/webpack.d.ts
+++ b/packages/hosted-form-v2/src/common/types/webpack.d.ts
@@ -1,0 +1,8 @@
+declare const LIBRARY_NAME: string;
+declare const LIBRARY_VERSION: string;
+declare const MANIFEST_JSON: AssetManifest;
+
+interface AssetManifest {
+    version: string;
+    js: string[];
+}

--- a/packages/hosted-form-v2/src/common/url/append-www.spec.ts
+++ b/packages/hosted-form-v2/src/common/url/append-www.spec.ts
@@ -1,0 +1,38 @@
+import appendWww from './append-www';
+
+describe('appendWww', () => {
+    it('appends www to URL', () => {
+        const url = {
+            hash: '',
+            hostname: 'foobar.com',
+            href: 'https://foobar.com:8080/bar?foo=foo',
+            origin: 'https://foobar.com:8080',
+            pathname: '/bar',
+            port: '8080',
+            protocol: 'https:',
+            search: '?foo=foo',
+        };
+
+        expect(appendWww(url)).toEqual({
+            ...url,
+            origin: 'https://www.foobar.com:8080',
+            hostname: 'www.foobar.com',
+            href: 'https://www.foobar.com:8080/bar?foo=foo',
+        });
+    });
+
+    it('does not www to URL if already has www', () => {
+        const url = {
+            hash: '',
+            hostname: 'www.foobar.com',
+            href: 'https://www.foobar.com:8080/bar?foo=foo',
+            origin: 'https://www.foobar.com:8080',
+            pathname: '/bar',
+            port: '8080',
+            protocol: 'https:',
+            search: '?foo=foo',
+        };
+
+        expect(appendWww(url)).toEqual(url);
+    });
+});

--- a/packages/hosted-form-v2/src/common/url/append-www.ts
+++ b/packages/hosted-form-v2/src/common/url/append-www.ts
@@ -1,0 +1,10 @@
+import parseUrl from './parse-url';
+import Url from './url';
+
+export default function appendWww(url: Url): Url {
+    return parseUrl(
+        url.hostname.indexOf('www') === 0
+            ? url.href
+            : url.href.replace(url.hostname, `www.${url.hostname}`),
+    );
+}

--- a/packages/hosted-form-v2/src/common/url/index.ts
+++ b/packages/hosted-form-v2/src/common/url/index.ts
@@ -1,0 +1,3 @@
+export { default as appendWww } from './append-www';
+export { default as parseUrl } from './parse-url';
+export { default as Url } from './url';

--- a/packages/hosted-form-v2/src/common/url/parse-url.spec.ts
+++ b/packages/hosted-form-v2/src/common/url/parse-url.spec.ts
@@ -1,0 +1,22 @@
+import { InvalidArgumentError } from '../errors';
+
+import parseUrl from './parse-url';
+
+describe('parseUrl()', () => {
+    it('parses URL string', () => {
+        expect(parseUrl('https://foobar.com:8080/hello/world?foo=1&bar=2#heading')).toEqual({
+            hash: '#heading',
+            hostname: 'foobar.com',
+            href: 'https://foobar.com:8080/hello/world?foo=1&bar=2#heading',
+            origin: 'https://foobar.com:8080',
+            pathname: '/hello/world',
+            port: '8080',
+            protocol: 'https:',
+            search: '?foo=1&bar=2',
+        });
+    });
+
+    it('throws error if URL is not absolute', () => {
+        expect(() => parseUrl('/hello/world')).toThrow(InvalidArgumentError);
+    });
+});

--- a/packages/hosted-form-v2/src/common/url/parse-url.ts
+++ b/packages/hosted-form-v2/src/common/url/parse-url.ts
@@ -1,0 +1,30 @@
+import { InvalidArgumentError } from '../errors';
+
+import Url from './url';
+
+export default function parseUrl(url: string): Url {
+    if (!/^(https?:)?\/\//.test(url)) {
+        throw new InvalidArgumentError('The provided URL must be absolute.');
+    }
+
+    // new URL() is not supported in IE11, use anchor tag instead
+    const anchor = document.createElement('a');
+
+    anchor.href = url;
+
+    // IE11 returns 80 or 443 for the port number depending on the URL scheme,
+    // even if the port number is not specified in the URL.
+    const port =
+        anchor.port && url.indexOf(`${anchor.hostname}:${anchor.port}`) !== -1 ? anchor.port : '';
+
+    return {
+        hash: anchor.hash,
+        hostname: anchor.hostname,
+        href: anchor.href,
+        origin: `${anchor.protocol}//${anchor.hostname}${port ? `:${port}` : ''}`,
+        pathname: anchor.pathname,
+        port,
+        protocol: anchor.protocol,
+        search: anchor.search,
+    };
+}

--- a/packages/hosted-form-v2/src/common/url/url.ts
+++ b/packages/hosted-form-v2/src/common/url/url.ts
@@ -1,0 +1,10 @@
+export default interface Url {
+    hash: string;
+    hostname: string;
+    href: string;
+    origin: string;
+    pathname: string;
+    port: string;
+    protocol: string;
+    search: string;
+}

--- a/packages/hosted-form-v2/src/common/utility/bind-decorator.spec.ts
+++ b/packages/hosted-form-v2/src/common/utility/bind-decorator.spec.ts
@@ -1,0 +1,34 @@
+import { default as bind } from './bind-decorator';
+
+describe('bindDecorator()', () => {
+    @bind
+    class Foo {
+        constructor(private name: string) {}
+
+        getName(): string {
+            return this.name;
+        }
+    }
+
+    // tslint:disable-next-line:max-classes-per-file
+    class Bar {
+        constructor(private name: string) {}
+
+        @bind
+        getName(): string {
+            return this.name;
+        }
+    }
+
+    it('binds all methods of class to instance', () => {
+        const { getName } = new Foo('foo');
+
+        expect(getName()).toBe('foo');
+    });
+
+    it('binds method to instance', () => {
+        const { getName } = new Bar('bar');
+
+        expect(getName()).toBe('bar');
+    });
+});

--- a/packages/hosted-form-v2/src/common/utility/bind-decorator.ts
+++ b/packages/hosted-form-v2/src/common/utility/bind-decorator.ts
@@ -1,0 +1,78 @@
+/**
+ * Decorates a class or a method by binding all its prototype methods or itself
+ * to the calling instance respectively.
+ */
+function bindDecorator<T extends Method>(
+    target: object,
+    key: string,
+    descriptor: TypedPropertyDescriptor<T>,
+): TypedPropertyDescriptor<T>;
+function bindDecorator<T extends Constructor<object>>(target: T): T;
+
+function bindDecorator(target: any, key?: any, descriptor?: any): any {
+    if (!key || !descriptor) {
+        return bindClassDecorator(target);
+    }
+
+    return bindMethodDecorator(target, key, descriptor);
+}
+
+export default bindDecorator;
+
+/**
+ * Decorates a class by binding all its prototype methods to the calling
+ * instance.
+ */
+export function bindClassDecorator<T extends Constructor<object>>(target: T): T {
+    const decoratedTarget = class extends target {};
+
+    Object.getOwnPropertyNames(target.prototype).forEach((key) => {
+        const descriptor = Object.getOwnPropertyDescriptor(target.prototype, key);
+
+        if (!descriptor || key === 'constructor') {
+            return;
+        }
+
+        Object.defineProperty(
+            decoratedTarget.prototype,
+            key,
+            bindMethodDecorator(target.prototype, key, descriptor),
+        );
+    });
+
+    return decoratedTarget;
+}
+
+/**
+ * Decorates a method by binding it to the calling instance.
+ */
+export function bindMethodDecorator<T extends Method>(
+    _: object,
+    key: string,
+    descriptor: TypedPropertyDescriptor<T>,
+): TypedPropertyDescriptor<T> {
+    if (typeof descriptor.value !== 'function') {
+        return descriptor;
+    }
+
+    let method: T = descriptor.value;
+
+    return {
+        get() {
+            const boundMethod = method.bind(this) as T;
+
+            Object.defineProperty(this, key, {
+                ...descriptor,
+                value: boundMethod,
+            });
+
+            return boundMethod;
+        },
+        set(value) {
+            method = value;
+        },
+    };
+}
+
+export type Constructor<T> = new (...args: any[]) => T;
+export type Method = (...args: any[]) => any;

--- a/packages/hosted-form-v2/src/common/utility/index.ts
+++ b/packages/hosted-form-v2/src/common/utility/index.ts
@@ -1,0 +1,2 @@
+export { default as bindDecorator } from './bind-decorator';
+export { default as setPrototypeOf } from './set-prototype-of';

--- a/packages/hosted-form-v2/src/common/utility/set-prototype-of.spec.ts
+++ b/packages/hosted-form-v2/src/common/utility/set-prototype-of.spec.ts
@@ -1,0 +1,15 @@
+import setPrototypeOf from './set-prototype-of';
+
+describe('setPrototypeOf', () => {
+    it('assigns prototype to object', () => {
+        class CustomError extends Error {}
+
+        const error = new CustomError();
+
+        expect(error instanceof CustomError).toBeFalsy();
+
+        setPrototypeOf(error, CustomError.prototype);
+
+        expect(error instanceof CustomError).toBeTruthy();
+    });
+});

--- a/packages/hosted-form-v2/src/common/utility/set-prototype-of.ts
+++ b/packages/hosted-form-v2/src/common/utility/set-prototype-of.ts
@@ -1,0 +1,9 @@
+export default function setPrototypeOf(object: any, prototype: object) {
+    if (Object.setPrototypeOf) {
+        Object.setPrototypeOf(object, prototype);
+    } else {
+        object.__proto__ = prototype;
+    }
+
+    return object;
+}

--- a/packages/hosted-form-v2/src/create-hosted-form-service.ts
+++ b/packages/hosted-form-v2/src/create-hosted-form-service.ts
@@ -1,0 +1,13 @@
+import HostedFormFactory from './hosted-form-factory';
+import HostedFormService from './hosted-form-service';
+
+/**
+ * Creates an instance of `HostedFormService`.
+ *
+ *
+ * @param host - Host url string parameter.
+ * @returns An instance of `HostedFormService`.
+ */
+export function createHostedFormService(host: string) {
+    return new HostedFormService(host, new HostedFormFactory());
+}

--- a/packages/hosted-form-v2/src/errors/index.ts
+++ b/packages/hosted-form-v2/src/errors/index.ts
@@ -1,0 +1,3 @@
+export { default as InvalidHostedFormConfigError } from './invalid-hosted-form-config-error';
+export { default as InvalidHostedFormError } from './invalid-hosted-form-error';
+export { default as InvalidHostedFormValueError } from './invalid-hosted-form-value-error';

--- a/packages/hosted-form-v2/src/errors/invalid-hosted-form-config-error.ts
+++ b/packages/hosted-form-v2/src/errors/invalid-hosted-form-config-error.ts
@@ -1,0 +1,13 @@
+import { StandardError } from '../common/errors';
+
+export default class InvalidHostedFormConfigError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message ||
+                'Unable to proceed due to invalid configuration provided for the hosted payment form.',
+        );
+
+        this.name = 'InvalidHostedFormConfigError';
+        this.type = 'invalid_hosted_form_config';
+    }
+}

--- a/packages/hosted-form-v2/src/errors/invalid-hosted-form-error.ts
+++ b/packages/hosted-form-v2/src/errors/invalid-hosted-form-error.ts
@@ -1,0 +1,10 @@
+import { StandardError } from '../common/errors';
+
+export default class InvalidHostedFormError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unable to proceed due to an unknown error with the hosted payment form.');
+
+        this.name = 'InvalidHostedFormError';
+        this.type = 'invalid_hosted_form';
+    }
+}

--- a/packages/hosted-form-v2/src/errors/invalid-hosted-form-value-error.ts
+++ b/packages/hosted-form-v2/src/errors/invalid-hosted-form-value-error.ts
@@ -1,0 +1,20 @@
+import { flatMap, map, values } from 'lodash';
+
+import { StandardError } from '../common/errors';
+import { HostedInputValidateErrorDataMap } from '../iframe-content';
+
+export default class InvalidHostedFormValueError extends StandardError {
+    constructor(public errors: HostedInputValidateErrorDataMap) {
+        super(
+            [
+                'Unable to proceed due to invalid user input values',
+                ...flatMap(values(errors), (fieldErrors) =>
+                    map(fieldErrors, ({ message }) => message),
+                ),
+            ].join('. '),
+        );
+
+        this.name = 'InvalidHostedFormValueError';
+        this.type = 'invalid_hosted_form_value';
+    }
+}

--- a/packages/hosted-form-v2/src/hosted-field-events.ts
+++ b/packages/hosted-form-v2/src/hosted-field-events.ts
@@ -1,0 +1,44 @@
+import HostedFieldType from './hosted-field-type';
+import { HostedFieldStylesMap } from './hosted-form-options';
+import HostedFormOrderData from './hosted-form-order-data';
+
+export enum HostedFieldEventType {
+    AttachRequested = 'HOSTED_FIELD:ATTACH_REQUESTED',
+    SubmitRequested = 'HOSTED_FIELD:SUBMITTED_REQUESTED',
+    ValidateRequested = 'HOSTED_FIELD:VALIDATE_REQUESTED',
+}
+
+export interface HostedFieldEventMap {
+    [HostedFieldEventType.AttachRequested]: HostedFieldAttachEvent;
+    [HostedFieldEventType.SubmitRequested]: HostedFieldSubmitRequestEvent;
+    [HostedFieldEventType.ValidateRequested]: HostedFieldValidateRequestEvent;
+}
+
+export type HostedFieldEvent =
+    | HostedFieldAttachEvent
+    | HostedFieldSubmitRequestEvent
+    | HostedFieldValidateRequestEvent;
+
+export interface HostedFieldAttachEvent {
+    type: HostedFieldEventType.AttachRequested;
+    payload: {
+        accessibilityLabel?: string;
+        fontUrls?: string[];
+        placeholder?: string;
+        styles?: HostedFieldStylesMap;
+        origin?: string;
+        type: HostedFieldType;
+    };
+}
+
+export interface HostedFieldSubmitRequestEvent {
+    type: HostedFieldEventType.SubmitRequested;
+    payload: {
+        data: HostedFormOrderData;
+        fields: HostedFieldType[];
+    };
+}
+
+export interface HostedFieldValidateRequestEvent {
+    type: HostedFieldEventType.ValidateRequested;
+}

--- a/packages/hosted-form-v2/src/hosted-field-type.ts
+++ b/packages/hosted-form-v2/src/hosted-field-type.ts
@@ -1,0 +1,8 @@
+enum HostedFieldType {
+    CardCode = 'cardCode',
+    CardExpiry = 'cardExpiry',
+    CardName = 'cardName',
+    CardNumber = 'cardNumber',
+}
+
+export default HostedFieldType;

--- a/packages/hosted-form-v2/src/hosted-field.ts
+++ b/packages/hosted-form-v2/src/hosted-field.ts
@@ -1,0 +1,186 @@
+import { values } from 'lodash';
+import { fromEvent } from 'rxjs';
+import { switchMap, take } from 'rxjs/operators';
+
+import { DetachmentObserver } from './common/dom';
+import { mapFromPaymentErrorResponse } from './common/errors';
+import { IframeEventListener, IframeEventPoster } from './common/iframe';
+import { parseUrl } from './common/url';
+import {
+    InvalidHostedFormConfigError,
+    InvalidHostedFormError,
+    InvalidHostedFormValueError,
+} from './errors';
+import { HostedFieldEvent, HostedFieldEventType } from './hosted-field-events';
+import HostedFieldType from './hosted-field-type';
+import { HostedFieldStylesMap } from './hosted-form-options';
+import HostedFormOrderData from './hosted-form-order-data';
+import {
+    HostedInputEventMap,
+    HostedInputEventType,
+    HostedInputSubmitErrorEvent,
+    HostedInputSubmitSuccessEvent,
+    HostedInputValidateEvent,
+} from './iframe-content';
+
+export const RETRY_INTERVAL = 60 * 1000;
+export const LAST_RETRY_KEY = 'lastRetry';
+
+export default class HostedField {
+    private _iframe: HTMLIFrameElement;
+
+    constructor(
+        private _type: HostedFieldType,
+        private _containerId: string,
+        private _placeholder: string,
+        private _accessibilityLabel: string,
+        private _styles: HostedFieldStylesMap,
+        private _eventPoster: IframeEventPoster<HostedFieldEvent>,
+        private _eventListener: IframeEventListener<HostedInputEventMap>,
+        private _detachmentObserver: DetachmentObserver,
+    ) {
+        this._iframe = document.createElement('iframe');
+
+        this._iframe.src = `/checkout/payment/hosted-field?version=${LIBRARY_VERSION}`;
+        this._iframe.style.border = 'none';
+        this._iframe.style.height = '100%';
+        this._iframe.style.overflow = 'hidden';
+        this._iframe.style.width = '100%';
+    }
+
+    getType(): HostedFieldType {
+        return this._type;
+    }
+
+    async attach(): Promise<void> {
+        const container = document.getElementById(this._containerId);
+
+        if (!container) {
+            throw new InvalidHostedFormConfigError(
+                'Unable to proceed because the provided container ID is not valid.',
+            );
+        }
+
+        container.appendChild(this._iframe);
+        this._eventListener.listen();
+
+        const promise = fromEvent(this._iframe, 'load')
+            .pipe(
+                switchMap(async ({ target }) => {
+                    const contentWindow = target && (target as HTMLIFrameElement).contentWindow;
+
+                    if (!contentWindow) {
+                        throw new Error('The content window of the iframe cannot be accessed.');
+                    }
+
+                    this._eventPoster.setTarget(contentWindow);
+
+                    await this._eventPoster.post(
+                        {
+                            type: HostedFieldEventType.AttachRequested,
+                            payload: {
+                                accessibilityLabel: this._accessibilityLabel,
+                                fontUrls: this._getFontUrls(),
+                                placeholder: this._placeholder,
+                                styles: this._styles,
+                                origin: document.location.origin,
+                                type: this._type,
+                            },
+                        },
+                        {
+                            successType: HostedInputEventType.AttachSucceeded,
+                            errorType: HostedInputEventType.AttachFailed,
+                        },
+                    );
+                }),
+                take(1),
+            )
+            .toPromise();
+
+        await this._detachmentObserver.ensurePresence([this._iframe], promise);
+    }
+
+    detach(): void {
+        if (!this._iframe.parentElement) {
+            return;
+        }
+
+        this._iframe.parentElement.removeChild(this._iframe);
+        this._eventListener.stopListen();
+    }
+
+    async submitForm(
+        fields: HostedFieldType[],
+        data: HostedFormOrderData,
+    ): Promise<HostedInputSubmitSuccessEvent> {
+        try {
+            const promise = this._eventPoster.post<HostedInputSubmitSuccessEvent>(
+                {
+                    type: HostedFieldEventType.SubmitRequested,
+                    payload: { fields, data },
+                },
+                {
+                    successType: HostedInputEventType.SubmitSucceeded,
+                    errorType: HostedInputEventType.SubmitFailed,
+                },
+            );
+
+            return await this._detachmentObserver.ensurePresence([this._iframe], promise);
+        } catch (event) {
+            if (this._isSubmitErrorEvent(event)) {
+                if (event.payload.error.code === 'hosted_form_error') {
+                    throw new InvalidHostedFormError(event.payload.error.message);
+                }
+
+                if (event.payload.response) {
+                    throw mapFromPaymentErrorResponse(event.payload.response);
+                }
+
+                throw new Error(event.payload.error.message);
+            }
+
+            throw event;
+        }
+    }
+
+    async validateForm(): Promise<void> {
+        const promise = this._eventPoster.post<HostedInputValidateEvent>(
+            {
+                type: HostedFieldEventType.ValidateRequested,
+            },
+            {
+                successType: HostedInputEventType.Validated,
+            },
+        );
+
+        const { payload } = await this._detachmentObserver.ensurePresence([this._iframe], promise);
+
+        if (!payload.isValid) {
+            throw new InvalidHostedFormValueError(payload.errors);
+        }
+    }
+
+    private _getFontUrls(): string[] {
+        const hostname = 'fonts.googleapis.com';
+        const links = document.querySelectorAll(`link[href*='${hostname}'][rel='stylesheet']`);
+
+        return Array.prototype.slice
+            .call(links)
+            .filter((link) => parseUrl(link.href).hostname === hostname)
+            .filter((link) =>
+                values(this._styles)
+                    .map((style) => style && style.fontFamily)
+                    .filter((family): family is string => typeof family === 'string')
+                    .some((family) =>
+                        family
+                            .split(/,\s/)
+                            .some((name) => link.href.indexOf(name.replace(' ', '+')) !== -1),
+                    ),
+            )
+            .map((link) => link.href);
+    }
+
+    private _isSubmitErrorEvent(event: any): event is HostedInputSubmitErrorEvent {
+        return event.type === HostedInputEventType.SubmitFailed;
+    }
+}

--- a/packages/hosted-form-v2/src/hosted-form-factory.spec.ts
+++ b/packages/hosted-form-v2/src/hosted-form-factory.spec.ts
@@ -1,0 +1,24 @@
+import HostedFieldType from './hosted-field-type';
+import HostedForm from './hosted-form';
+import HostedFormFactory from './hosted-form-factory';
+
+describe('HostedFormFactory', () => {
+    let factory: HostedFormFactory;
+
+    beforeEach(() => {
+        factory = new HostedFormFactory();
+    });
+
+    it('creates hosted form', () => {
+        const result = factory.create('https://store.foobar.com', {
+            fields: {
+                [HostedFieldType.CardCode]: { containerId: 'card-code' },
+                [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                [HostedFieldType.CardName]: { containerId: 'card-name' },
+                [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+            },
+        });
+
+        expect(result).toBeInstanceOf(HostedForm);
+    });
+});

--- a/packages/hosted-form-v2/src/hosted-form-factory.ts
+++ b/packages/hosted-form-v2/src/hosted-form-factory.ts
@@ -1,0 +1,42 @@
+import { pick } from 'lodash';
+
+import { DetachmentObserver, MutationObserverFactory } from './common/dom';
+import { IframeEventListener, IframeEventPoster } from './common/iframe';
+import HostedField from './hosted-field';
+import HostedFieldType from './hosted-field-type';
+import HostedForm from './hosted-form';
+import HostedFormOptions from './hosted-form-options';
+
+export default class HostedFormFactory {
+    create(host: string, options: HostedFormOptions): HostedForm {
+        const fieldTypes = Object.keys(options.fields) as HostedFieldType[];
+        const fields = fieldTypes.reduce<HostedField[]>((result, type) => {
+            const fields = options.fields;
+            const fieldOptions = fields[type];
+
+            if (!fieldOptions) {
+                return result;
+            }
+
+            return [
+                ...result,
+                new HostedField(
+                    type,
+                    fieldOptions.containerId,
+                    fieldOptions.placeholder || '',
+                    fieldOptions.accessibilityLabel || '',
+                    options.styles || {},
+                    new IframeEventPoster(host),
+                    new IframeEventListener(host),
+                    new DetachmentObserver(new MutationObserverFactory()),
+                ),
+            ];
+        }, []);
+
+        return new HostedForm(
+            fields,
+            new IframeEventListener(host),
+            pick(options, 'onBlur', 'onEnter', 'onFocus', 'onCardTypeChange', 'onValidate'),
+        );
+    }
+}

--- a/packages/hosted-form-v2/src/hosted-form-options.ts
+++ b/packages/hosted-form-v2/src/hosted-form-options.ts
@@ -1,0 +1,62 @@
+import HostedFieldType from './hosted-field-type';
+import {
+    HostedInputBlurEvent,
+    HostedInputCardTypeChangeEvent,
+    HostedInputEnterEvent,
+    HostedInputFocusEvent,
+    HostedInputStyles,
+    HostedInputValidateEvent,
+} from './iframe-content';
+
+export default interface HostedFormOptions {
+    fields: HostedCardFieldOptionsMap;
+    styles?: HostedFieldStylesMap;
+    onBlur?(data: HostedFieldBlurEventData): void;
+    onCardTypeChange?(data: HostedFieldCardTypeChangeEventData): void;
+    onEnter?(data: HostedFieldEnterEventData): void;
+    onFocus?(data: HostedFieldFocusEventData): void;
+    onValidate?(data: HostedFieldValidateEventData): void;
+}
+
+export type HostedFormErrorDataKeys =
+    | 'number'
+    | 'expirationDate'
+    | 'expirationMonth'
+    | 'expirationYear'
+    | 'cvv'
+    | 'postalCode';
+
+export interface HostedFormErrorData {
+    isEmpty: boolean;
+    isPotentiallyValid: boolean;
+    isValid: boolean;
+}
+
+export type HostedFormErrorsData = Partial<Record<HostedFormErrorDataKeys, HostedFormErrorData>>;
+
+export type HostedFieldBlurEventData = HostedInputBlurEvent['payload'];
+export type HostedFieldCardTypeChangeEventData = HostedInputCardTypeChangeEvent['payload'];
+export type HostedFieldEnterEventData = HostedInputEnterEvent['payload'];
+export type HostedFieldFocusEventData = HostedInputFocusEvent['payload'];
+export type HostedFieldValidateEventData = HostedInputValidateEvent['payload'];
+
+export interface HostedCardFieldOptionsMap {
+    [HostedFieldType.CardCode]?: HostedCardFieldOptions;
+    [HostedFieldType.CardExpiry]: HostedCardFieldOptions;
+    [HostedFieldType.CardName]: HostedCardFieldOptions;
+    [HostedFieldType.CardNumber]: HostedCardFieldOptions;
+}
+
+export interface HostedCardFieldOptions {
+    accessibilityLabel?: string;
+    containerId: string;
+    placeholder?: string;
+}
+
+export interface HostedFieldStylesMap {
+    default?: HostedFieldStyles;
+    error?: HostedFieldStyles;
+    focus?: HostedFieldStyles;
+}
+
+export type HostedFieldStyles = HostedInputStyles;

--- a/packages/hosted-form-v2/src/hosted-form-order-data.ts
+++ b/packages/hosted-form-v2/src/hosted-form-order-data.ts
@@ -1,0 +1,3 @@
+export default interface HostedFormOrderData {
+    authToken: string;
+}

--- a/packages/hosted-form-v2/src/hosted-form-service.ts
+++ b/packages/hosted-form-v2/src/hosted-form-service.ts
@@ -17,6 +17,7 @@ export default class HostedFormService {
     deinitialize() {
         if (this._hostedForm) {
             this._hostedForm.detach();
+            this._hostedForm = undefined;
         }
     }
 }

--- a/packages/hosted-form-v2/src/hosted-form-service.ts
+++ b/packages/hosted-form-v2/src/hosted-form-service.ts
@@ -1,0 +1,22 @@
+import HostedForm from './hosted-form';
+import HostedFormFactory from './hosted-form-factory';
+import HostedFormOptions from './hosted-form-options';
+
+export default class HostedFormService {
+    protected _hostedForm?: HostedForm;
+    constructor(protected _host: string, protected _hostedFormFactory: HostedFormFactory) {}
+
+    initialize(options: HostedFormOptions): Promise<void> {
+        const form = this._hostedFormFactory.create(this._host, options);
+
+        return form.attach().then(() => {
+            this._hostedForm = form;
+        });
+    }
+
+    deinitialize() {
+        if (this._hostedForm) {
+            this._hostedForm.detach();
+        }
+    }
+}

--- a/packages/hosted-form-v2/src/hosted-form.spec.ts
+++ b/packages/hosted-form-v2/src/hosted-form.spec.ts
@@ -1,0 +1,166 @@
+import { IframeEventListener } from './common/iframe';
+import HostedField from './hosted-field';
+import HostedFieldType from './hosted-field-type';
+import HostedForm from './hosted-form';
+import HostedFormOptions from './hosted-form-options';
+import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
+
+describe('HostedForm', () => {
+    let callbacks: Pick<
+        HostedFormOptions,
+        'onBlur' | 'onCardTypeChange' | 'onEnter' | 'onFocus' | 'onValidate'
+    >;
+    let eventListener: IframeEventListener<HostedInputEventMap>;
+    let fields: HostedField[];
+    let form: HostedForm;
+
+    const fieldPrototype: Partial<HostedField> = {
+        attach: jest.fn(),
+        detach: jest.fn(),
+        getType: jest.fn(),
+        submitForm: jest.fn(),
+        validateForm: jest.fn(),
+    };
+
+    beforeEach(() => {
+        callbacks = {
+            onBlur: jest.fn(),
+            onEnter: jest.fn(),
+            onFocus: jest.fn(),
+            onCardTypeChange: jest.fn(),
+            onValidate: jest.fn(),
+        };
+
+        fields = [
+            Object.create(fieldPrototype) as HostedField,
+            Object.create(fieldPrototype) as HostedField,
+            Object.create(fieldPrototype) as HostedField,
+            Object.create(fieldPrototype) as HostedField,
+        ];
+
+        jest.spyOn(fields[0], 'getType').mockReturnValue(HostedFieldType.CardCode);
+        jest.spyOn(fields[1], 'getType').mockReturnValue(HostedFieldType.CardExpiry);
+        jest.spyOn(fields[2], 'getType').mockReturnValue(HostedFieldType.CardName);
+        jest.spyOn(fields[3], 'getType').mockReturnValue(HostedFieldType.CardNumber);
+
+        eventListener = new IframeEventListener('https://store.foobar.com');
+        // payloadTransformer = { transform: jest.fn() };
+
+        form = new HostedForm(fields, eventListener, callbacks);
+    });
+
+    it('attaches all fields to document', async () => {
+        fields.forEach((field) => jest.spyOn(field, 'attach').mockResolvedValue(undefined));
+
+        await form.attach();
+
+        expect(fields[0].attach).toHaveBeenCalled();
+        expect(fields[1].attach).toHaveBeenCalled();
+        expect(fields[2].attach).toHaveBeenCalled();
+        expect(fields[3].attach).toHaveBeenCalled();
+    });
+
+    it('detaches all fields from document', async () => {
+        fields.forEach((field) => jest.spyOn(field, 'detach').mockReturnValue(undefined));
+
+        await form.detach();
+
+        expect(fields[0].detach).toHaveBeenCalled();
+        expect(fields[1].detach).toHaveBeenCalled();
+        expect(fields[2].detach).toHaveBeenCalled();
+        expect(fields[3].detach).toHaveBeenCalled();
+    });
+
+    it('notifies when card type changes', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.CardTypeChanged,
+            payload: { cardType: 'visa' },
+        });
+
+        expect(callbacks.onCardTypeChange).toHaveBeenCalledWith({ cardType: 'visa' });
+    });
+
+    it('notifies when validation happens', () => {
+        const payload = {
+            isValid: false,
+            errors: {
+                cardCode: [
+                    {
+                        fieldType: HostedFieldType.CardCode,
+                        type: 'required',
+                        message: 'Missing required data',
+                    },
+                ],
+                cardExpiry: [],
+                cardName: [],
+                cardNumber: [],
+            },
+        };
+
+        eventListener.trigger({ type: HostedInputEventType.Validated, payload });
+
+        expect(callbacks.onValidate).toHaveBeenCalledWith(payload);
+    });
+
+    it('notifies when input receives focus event', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.Focused,
+            payload: { fieldType: HostedFieldType.CardCode },
+        });
+
+        expect(callbacks.onFocus).toHaveBeenCalledWith({ fieldType: HostedFieldType.CardCode });
+    });
+
+    it('notifies when input receives blur event', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.Blurred,
+            payload: { fieldType: HostedFieldType.CardCode },
+        });
+
+        expect(callbacks.onBlur).toHaveBeenCalledWith({ fieldType: HostedFieldType.CardCode });
+    });
+
+    it('notifies when enter key is pressed', async () => {
+        jest.spyOn(fields[0], 'validateForm').mockResolvedValue(undefined);
+
+        eventListener.trigger({
+            type: HostedInputEventType.Entered,
+            payload: { fieldType: HostedFieldType.CardCode },
+        });
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(callbacks.onEnter).toHaveBeenCalledWith({ fieldType: HostedFieldType.CardCode });
+    });
+
+    it('validates form when enter key is pressed', async () => {
+        jest.spyOn(fields[0], 'validateForm').mockResolvedValue(undefined);
+
+        eventListener.trigger({
+            type: HostedInputEventType.Entered,
+            payload: { fieldType: HostedFieldType.CardCode },
+        });
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(fields[0].validateForm).toHaveBeenCalled();
+    });
+
+    it('returns card type', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.CardTypeChanged,
+            payload: { cardType: 'visa' },
+        });
+
+        expect(form.getCardType()).toBe('visa');
+    });
+
+    it('returns bin number', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.BinChanged,
+            payload: { bin: '411111' },
+        });
+
+        expect(form.getBin()).toBe('411111');
+    });
+});

--- a/packages/hosted-form-v2/src/hosted-form.ts
+++ b/packages/hosted-form-v2/src/hosted-form.ts
@@ -86,7 +86,7 @@ export default class HostedForm implements HostedFormInterface {
     }
 
     // TODO: CHECKOUT-8275 need to add the submit method implementation when implementing submitPayment
-    // async submit(): Promise<void> {
+    // async submitManualOrderPayment(): Promise<void> {
     // }
 
     async validate(): Promise<void> {

--- a/packages/hosted-form-v2/src/hosted-form.ts
+++ b/packages/hosted-form-v2/src/hosted-form.ts
@@ -1,0 +1,123 @@
+import { noop, without } from 'lodash';
+
+import { IframeEventListener } from './common/iframe';
+import { InvalidHostedFormConfigError } from './errors';
+import HostedField from './hosted-field';
+import HostedFormOptions from './hosted-form-options';
+import { HostedInputEnterEvent, HostedInputEventMap, HostedInputEventType } from './iframe-content';
+
+type HostedFormEventCallbacks = Pick<
+    HostedFormOptions,
+    'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onEnter' | 'onValidate'
+>;
+
+export interface HostedFormInterface {
+    attach(): Promise<void>;
+    detach(): void;
+    getBin(): string | undefined;
+    validate(): Promise<void>;
+    getCardType(): string | undefined;
+}
+
+export default class HostedForm implements HostedFormInterface {
+    private _bin?: string;
+    private _cardType?: string;
+
+    constructor(
+        private _fields: HostedField[],
+        private _eventListener: IframeEventListener<HostedInputEventMap>,
+        private _eventCallbacks: HostedFormEventCallbacks,
+    ) {
+        const {
+            onBlur = noop,
+            onCardTypeChange = noop,
+            onFocus = noop,
+            onValidate = noop,
+        } = this._eventCallbacks;
+
+        this._eventListener.addListener(HostedInputEventType.Blurred, ({ payload }) =>
+            onBlur(payload),
+        );
+        this._eventListener.addListener(HostedInputEventType.CardTypeChanged, ({ payload }) =>
+            onCardTypeChange(payload),
+        );
+        this._eventListener.addListener(HostedInputEventType.Focused, ({ payload }) =>
+            onFocus(payload),
+        );
+        this._eventListener.addListener(HostedInputEventType.Validated, ({ payload }) =>
+            onValidate(payload),
+        );
+        this._eventListener.addListener(HostedInputEventType.Entered, this._handleEnter);
+
+        this._eventListener.addListener(
+            HostedInputEventType.CardTypeChanged,
+            ({ payload }) => (this._cardType = payload.cardType),
+        );
+        this._eventListener.addListener(
+            HostedInputEventType.BinChanged,
+            ({ payload }) => (this._bin = payload.bin),
+        );
+    }
+
+    getBin(): string | undefined {
+        return this._bin;
+    }
+
+    getCardType(): string | undefined {
+        return this._cardType;
+    }
+
+    async attach(): Promise<void> {
+        this._eventListener.listen();
+
+        const field = this._getFirstField();
+        const otherFields = without(this._fields, field);
+
+        await field.attach();
+        await Promise.all(otherFields.map((otherField) => otherField.attach()));
+    }
+
+    detach(): void {
+        this._eventListener.stopListen();
+
+        this._fields.forEach((field) => {
+            field.detach();
+        });
+    }
+
+    // TODO: CHECKOUT-8275 need to add the submit method implementation when implementing submitPayment
+    // async submit(): Promise<void> {
+    // }
+
+    async validate(): Promise<void> {
+        return this._getFirstField().validateForm();
+    }
+
+    private _getFirstField(): HostedField {
+        const field = this._fields[0];
+
+        if (!field) {
+            throw new InvalidHostedFormConfigError(
+                'Unable to proceed because the payment form has no field defined.',
+            );
+        }
+
+        return field;
+    }
+
+    private _handleEnter: (event: HostedInputEnterEvent) => Promise<void> = async ({ payload }) => {
+        try {
+            await this.validate();
+        } catch (error) {
+            // Catch form validation error because we want to trigger `onEnter`
+            // irrespective of the validation result.
+            if (error.name !== 'InvalidHostedFormValueError') {
+                throw error;
+            }
+        }
+
+        const { onEnter = noop } = this._eventCallbacks;
+
+        onEnter(payload);
+    };
+}

--- a/packages/hosted-form-v2/src/iframe-content/card-expiry-date.ts
+++ b/packages/hosted-form-v2/src/iframe-content/card-expiry-date.ts
@@ -1,0 +1,4 @@
+export default interface CardExpiryDate {
+    month: string;
+    year: string;
+}

--- a/packages/hosted-form-v2/src/iframe-content/card-expiry-formatter.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/card-expiry-formatter.spec.ts
@@ -1,0 +1,49 @@
+import CardExpiryFormatter from './card-expiry-formatter';
+
+describe('CardExpiryFormatter', () => {
+    let formatter: CardExpiryFormatter;
+
+    beforeEach(() => {
+        formatter = new CardExpiryFormatter();
+    });
+
+    describe('#format', () => {
+        it('converts date into MM/YY date format', () => {
+            expect(formatter.format('10/2019')).toBe('10 / 19');
+        });
+
+        it('formats partial date value', () => {
+            expect(formatter.format('10')).toBe('10 / ');
+        });
+
+        it('returns month only if there is no year and separator has no trailing space', () => {
+            expect(formatter.format('10 /')).toBe('10');
+        });
+
+        it('surrounds separator with whitespaces', () => {
+            expect(formatter.format('10/19')).toBe('10 / 19');
+        });
+    });
+
+    describe('#toObject', () => {
+        it('converts MM / YY date format into expiry date object', () => {
+            expect(formatter.toObject('01 / 30')).toEqual({ month: '01', year: '2030' });
+
+            expect(formatter.toObject('12 / 30')).toEqual({ month: '12', year: '2030' });
+        });
+
+        it('converts MM / YYYY date format into expiry date object', () => {
+            expect(formatter.toObject('01 / 2030')).toEqual({ month: '01', year: '2030' });
+
+            expect(formatter.toObject('12 / 2030')).toEqual({ month: '12', year: '2030' });
+        });
+
+        it('converts M / YY date format into expiry date object', () => {
+            expect(formatter.toObject('1 / 30')).toEqual({ month: '01', year: '2030' });
+        });
+
+        it('returns empty expiry date object if date format is invalid', () => {
+            expect(formatter.toObject('fo / ba')).toEqual({ month: '', year: '' });
+        });
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/card-expiry-formatter.ts
+++ b/packages/hosted-form-v2/src/iframe-content/card-expiry-formatter.ts
@@ -1,0 +1,37 @@
+import CardExpiryDate from './card-expiry-date';
+
+const NUMBER_SEPARATOR = '/';
+
+export default class CardExpiryFormatter {
+    format(value: string): string {
+        const [month = '', year = ''] = value.split(new RegExp(`\\s*${NUMBER_SEPARATOR}\\s*`));
+        const trimmedMonth = month.slice(0, 2);
+        const trimmedYear =
+            year.length === 4 ? year.slice(-2) : year ? year.slice(0, 2) : month.slice(2);
+
+        // i.e.: '1'
+        if (value.length < 2) {
+            return month;
+        }
+
+        // ie.: '10 /' (without trailing space)
+        if (value.length > 3 && !trimmedYear) {
+            return trimmedMonth;
+        }
+
+        return `${trimmedMonth} ${NUMBER_SEPARATOR} ${trimmedYear}`;
+    }
+
+    toObject(value: string): CardExpiryDate {
+        const [month = '', year = ''] = value.split(new RegExp(`\\s*${NUMBER_SEPARATOR}\\s*`));
+
+        if (!/^\d+$/.test(month) || !/^\d+$/.test(year)) {
+            return { month: '', year: '' };
+        }
+
+        return {
+            month: month.length === 1 ? `0${month}` : month.slice(0, 2),
+            year: year.length === 2 ? `20${year}` : year.slice(0, 4),
+        };
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/card-number-formatter.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/card-number-formatter.spec.ts
@@ -1,0 +1,61 @@
+import CardNumberFormatter from './card-number-formatter';
+
+describe('CardNumberFormatter', () => {
+    let formatter: CardNumberFormatter;
+
+    beforeEach(() => {
+        formatter = new CardNumberFormatter();
+    });
+
+    describe('#format()', () => {
+        it('formats Visa credit card number', () => {
+            expect(formatter.format('4111111111111111')).toBe('4111 1111 1111 1111');
+
+            expect(formatter.format('4111 1111 1111 1111234')).toBe('4111 1111 1111 1111234');
+        });
+
+        it('formats Mastercard credit card number', () => {
+            expect(formatter.format('5555555555554444')).toBe('5555 5555 5555 4444');
+        });
+
+        it('formats Amex credit card number', () => {
+            expect(formatter.format('378282246310005')).toBe('3782 822463 10005');
+        });
+
+        it('formats Diners Club credit card number', () => {
+            expect(formatter.format('36259600000004')).toBe('3625 960000 0004');
+        });
+
+        it('formats Discover credit card number', () => {
+            expect(formatter.format('6011111111111117')).toBe('6011 1111 1111 1117');
+        });
+
+        it('formats potentially invalid credit card number', () => {
+            expect(formatter.format('41111')).toBe('4111 1');
+
+            expect(formatter.format('5555')).toBe('5555');
+
+            expect(formatter.format('37828224631')).toBe('3782 822463 1');
+        });
+
+        it('does not format if credit card number cannot be recognized', () => {
+            expect(formatter.format('99999999')).toBe('99999999');
+        });
+    });
+
+    describe('#unformat()', () => {
+        it('removes credit card number formatting', () => {
+            expect(formatter.unformat('4111 1111 1111 1111')).toBe('4111111111111111');
+
+            expect(formatter.unformat('3782 822463 10005')).toBe('378282246310005');
+        });
+
+        it('unformats credit card number that is partially complete', () => {
+            expect(formatter.unformat('4111 1111')).toBe('41111111');
+        });
+
+        it('does not do anything if credit card number is invalid', () => {
+            expect(formatter.unformat('xxxx xxxx 1111 1111')).toBe('xxxx xxxx 1111 1111');
+        });
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/card-number-formatter.ts
+++ b/packages/hosted-form-v2/src/iframe-content/card-number-formatter.ts
@@ -1,0 +1,37 @@
+import { creditCardType, number } from 'card-validator';
+import { max } from 'lodash';
+
+const NUMBER_SEPARATOR = ' ';
+
+export default class CardNumberFormatter {
+    format(value: string): string {
+        const { card } = number(value);
+
+        if (!card) {
+            return value;
+        }
+
+        const maxLength = max(creditCardType(value).map((info) => max(info.lengths)));
+        const unformattedValue = this.unformat(value).slice(0, maxLength);
+
+        return card.gaps
+            .filter((gapIndex) => unformattedValue.length > gapIndex)
+            .reduce(
+                (output, gapIndex, index) =>
+                    [output.slice(0, gapIndex + index), output.slice(gapIndex + index)].join(
+                        NUMBER_SEPARATOR,
+                    ),
+                unformattedValue,
+            );
+    }
+
+    unformat(value: string): string {
+        const { card } = number(value);
+
+        if (!card) {
+            return value;
+        }
+
+        return value.replace(new RegExp(NUMBER_SEPARATOR, 'g'), '');
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/get-hosted-input-storage.ts
+++ b/packages/hosted-form-v2/src/iframe-content/get-hosted-input-storage.ts
@@ -1,0 +1,9 @@
+import HostedInputStorage from './hosted-input-storage';
+
+let storage: HostedInputStorage | null;
+
+export default function getHostedInputStorage(): HostedInputStorage {
+    storage = storage || new HostedInputStorage();
+
+    return storage;
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-autocomplete-fieldset.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-autocomplete-fieldset.spec.ts
@@ -1,0 +1,93 @@
+import HostedFieldType from '../hosted-field-type';
+
+import HostedAutocompleteFieldset from './hosted-autocomplete-fieldset';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+
+describe('HostedAutocompleteFieldset', () => {
+    let container: HTMLFormElement;
+    let fieldset: HostedAutocompleteFieldset;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputs'>;
+
+    beforeEach(() => {
+        inputAggregator = { getInputs: jest.fn() };
+
+        container = document.createElement('form');
+        document.body.appendChild(container);
+
+        fieldset = new HostedAutocompleteFieldset(
+            container,
+            [HostedFieldType.CardExpiry, HostedFieldType.CardName],
+            inputAggregator as HostedInputAggregator,
+        );
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('attaches autocomplete inputs to container', () => {
+        fieldset.attach();
+
+        expect(container.querySelector('#autocomplete-card-expiry')).toBeTruthy();
+        expect(container.querySelector('#autocomplete-card-name')).toBeTruthy();
+    });
+
+    it('hides autocomplete input from user', () => {
+        fieldset.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const input = container.querySelector<HTMLInputElement>('#autocomplete-card-expiry')!;
+
+        expect(input.style.opacity).toBe('0');
+        expect(input.style.position).toBe('absolute');
+        expect(input.tabIndex).toEqual(-1);
+    });
+
+    it('configures autocomplete property based on field type', () => {
+        fieldset.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const expiryInput = container.querySelector<HTMLInputElement>('#autocomplete-card-expiry')!;
+        // tslint:disable-next-line:no-non-null-assertion
+        const nameInput = container.querySelector<HTMLInputElement>('#autocomplete-card-name')!;
+
+        expect(expiryInput.autocomplete).toBe('cc-exp');
+        expect(nameInput.autocomplete).toBe('cc-name');
+    });
+
+    it('updates corresponding hosted inputs when autocomplete inputs receive update', () => {
+        const hostedExpiryInput: Pick<HostedInput, 'getType' | 'setValue'> = {
+            getType: jest.fn(() => HostedFieldType.CardExpiry),
+            setValue: jest.fn(),
+        };
+        const hostedNameInput: Pick<HostedInput, 'getType' | 'setValue'> = {
+            getType: jest.fn(() => HostedFieldType.CardName),
+            setValue: jest.fn(),
+        };
+
+        jest.spyOn(inputAggregator, 'getInputs').mockReturnValue([
+            hostedExpiryInput,
+            hostedNameInput,
+        ]);
+
+        fieldset.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const input = container.querySelector<HTMLInputElement>('#autocomplete-card-expiry')!;
+
+        input.value = '10 / 20';
+        input.dispatchEvent(new Event('change'));
+
+        expect(hostedExpiryInput.setValue).toHaveBeenCalledWith('10 / 20');
+        expect(hostedNameInput.setValue).not.toHaveBeenCalledWith('10 / 20');
+    });
+
+    it('removes autocomplete inputs when fieldset detaches', () => {
+        fieldset.attach();
+        fieldset.detach();
+
+        expect(container.querySelector('#autocomplete-card-expiry')).toBeFalsy();
+        expect(container.querySelector('#autocomplete-card-name')).toBeFalsy();
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-autocomplete-fieldset.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-autocomplete-fieldset.ts
@@ -1,0 +1,69 @@
+import { kebabCase } from 'lodash';
+
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import mapToAutocompleteType from './map-to-autocomplete-type';
+
+export default class HostedAutocompleteFieldset {
+    private _inputs: HTMLInputElement[];
+
+    constructor(
+        private _form: HTMLFormElement,
+        private _fieldTypes: HostedFieldType[],
+        private _inputAggregator: HostedInputAggregator,
+    ) {
+        this._inputs = this._fieldTypes.map((type) => this._createInput(type));
+    }
+
+    attach(): void {
+        this._inputs.forEach((input) => this._form.appendChild(input));
+    }
+
+    detach(): void {
+        this._inputs.forEach((input) => {
+            if (!input.parentElement) {
+                return;
+            }
+
+            input.parentElement.removeChild(input);
+        });
+    }
+
+    private _createInput(type: HostedFieldType): HTMLInputElement {
+        const input = document.createElement('input');
+
+        input.autocomplete = mapToAutocompleteType(type);
+        input.id = this._getAutocompleteElementId(type);
+        input.tabIndex = -1;
+        input.style.position = 'absolute';
+        input.style.opacity = '0';
+        input.style.zIndex = '-1';
+
+        input.addEventListener('change', this._handleChange);
+
+        return input;
+    }
+
+    private _handleChange: (event: Event) => void = (event) => {
+        const targetInput = event.target as HTMLInputElement;
+
+        if (!targetInput) {
+            throw new Error('Unable to get a reference to the target of the change event.');
+        }
+
+        const targetHostedInput = this._inputAggregator
+            .getInputs()
+            .find((input) => this._getAutocompleteElementId(input.getType()) === targetInput.id);
+
+        if (!targetHostedInput) {
+            return;
+        }
+
+        targetHostedInput.setValue(targetInput.value);
+    };
+
+    private _getAutocompleteElementId(type: HostedFieldType): string {
+        return `autocomplete-${kebabCase(type)}`;
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-card-expiry-input.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-card-expiry-input.spec.ts
@@ -1,0 +1,91 @@
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import { HostedFieldEventMap } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import CardExpiryFormatter from './card-expiry-formatter';
+import HostedCardExpiryInput from './hosted-card-expiry-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent } from './hosted-input-events';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+
+describe('HostedCardExpiryInput', () => {
+    let container: HTMLFormElement;
+    let eventListener: Pick<
+        IframeEventListener<HostedFieldEventMap>,
+        'addListener' | 'listen' | 'stopListen'
+    >;
+    let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'post' | 'setTarget'>;
+    let expiryFormatter: Pick<CardExpiryFormatter, 'format'>;
+    let input: HostedCardExpiryInput;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
+    let inputValidator: Pick<HostedInputValidator, 'validate'>;
+    let paymentHandler: Pick<HostedInputPaymentHandler, 'handle'>;
+    let styles: HostedInputStylesMap;
+
+    beforeEach(() => {
+        eventListener = {
+            addListener: jest.fn(),
+            listen: jest.fn(),
+            stopListen: jest.fn(),
+        };
+        eventPoster = {
+            post: jest.fn(),
+            setTarget: jest.fn(),
+        };
+        expiryFormatter = { format: jest.fn() };
+        inputAggregator = { getInputValues: jest.fn() };
+        inputValidator = {
+            validate: jest.fn(() =>
+                Promise.resolve({
+                    isValid: true,
+                    errors: {},
+                }),
+            ),
+        };
+        paymentHandler = { handle: jest.fn() };
+        styles = { default: { color: 'rgb(255, 255, 255)' } };
+
+        container = document.createElement('form');
+        document.body.appendChild(container);
+
+        input = new HostedCardExpiryInput(
+            container,
+            'Expiration',
+            'Card expiration',
+            'cc-expiry',
+            styles,
+            [],
+            eventListener as IframeEventListener<HostedFieldEventMap>,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            paymentHandler as HostedInputPaymentHandler,
+            expiryFormatter as CardExpiryFormatter,
+        );
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('returns input type', () => {
+        expect(input.getType()).toEqual(HostedFieldType.CardExpiry);
+    });
+
+    it('formats input on change', () => {
+        jest.spyOn(expiryFormatter, 'format').mockReturnValue('10 / 20');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '1020';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(expiryFormatter.format).toHaveBeenCalledWith('1020');
+        expect(element.value).toBe('10 / 20');
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-card-expiry-input.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-card-expiry-input.ts
@@ -1,0 +1,50 @@
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import { HostedFieldEventMap } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import CardExpiryFormatter from './card-expiry-formatter';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent } from './hosted-input-events';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+
+export default class HostedCardExpiryInput extends HostedInput {
+    /**
+     * @internal
+     */
+    constructor(
+        form: HTMLFormElement,
+        placeholder: string,
+        accessibilityLabel: string,
+        autocomplete: string,
+        styles: HostedInputStylesMap,
+        fontUrls: string[],
+        eventListener: IframeEventListener<HostedFieldEventMap>,
+        eventPoster: IframeEventPoster<HostedInputEvent>,
+        inputAggregator: HostedInputAggregator,
+        inputValidator: HostedInputValidator,
+        paymentHandler: HostedInputPaymentHandler,
+        private _formatter: CardExpiryFormatter,
+    ) {
+        super(
+            HostedFieldType.CardExpiry,
+            form,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            fontUrls,
+            eventListener,
+            eventPoster,
+            inputAggregator,
+            inputValidator,
+            paymentHandler,
+        );
+    }
+
+    protected _formatValue(value: string): void {
+        this._input.value = this._formatter.format(value);
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-card-number-input.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-card-number-input.spec.ts
@@ -1,0 +1,207 @@
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import { HostedFieldEventMap } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import CardNumberFormatter from './card-number-formatter';
+import HostedAutocompleteFieldset from './hosted-autocomplete-fieldset';
+import HostedCardNumberInput from './hosted-card-number-input';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+
+describe('HostedCardNumberInput', () => {
+    let autocompleteFieldset: HostedAutocompleteFieldset;
+    let container: HTMLFormElement;
+    let eventListener: Pick<
+        IframeEventListener<HostedFieldEventMap>,
+        'addListener' | 'listen' | 'stopListen'
+    >;
+    let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'setTarget' | 'post'>;
+    let input: HostedInput;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
+    let inputValidator: Pick<HostedInputValidator, 'validate'>;
+    let numberFormatter: Pick<CardNumberFormatter, 'format' | 'unformat'>;
+    let paymentHandler: Pick<HostedInputPaymentHandler, 'handle'>;
+    let styles: HostedInputStylesMap;
+
+    beforeEach(() => {
+        container = document.createElement('form');
+        document.body.appendChild(container);
+
+        autocompleteFieldset = new HostedAutocompleteFieldset(
+            container,
+            [HostedFieldType.CardCode, HostedFieldType.CardExpiry, HostedFieldType.CardName],
+            new HostedInputAggregator(window.parent),
+        );
+        eventListener = {
+            addListener: jest.fn(),
+            listen: jest.fn(),
+            stopListen: jest.fn(),
+        };
+        eventPoster = {
+            post: jest.fn(),
+            setTarget: jest.fn(),
+        };
+        inputAggregator = { getInputValues: jest.fn() };
+        inputValidator = {
+            validate: jest.fn(() =>
+                Promise.resolve({
+                    isValid: true,
+                    errors: {},
+                }),
+            ),
+        };
+        numberFormatter = { format: jest.fn(), unformat: (value) => value.replace(/ /g, '') };
+        paymentHandler = { handle: jest.fn() };
+        styles = { default: { color: 'rgb(255, 255, 255)' } };
+
+        input = new HostedCardNumberInput(
+            HostedFieldType.CardNumber,
+            container,
+            'Full name',
+            'Cardholder name',
+            'cc-name',
+            styles,
+            [],
+            eventListener as IframeEventListener<HostedFieldEventMap>,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            paymentHandler as HostedInputPaymentHandler,
+            autocompleteFieldset,
+            numberFormatter as CardNumberFormatter,
+        );
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('returns input type', () => {
+        expect(input.getType()).toEqual(HostedFieldType.CardNumber);
+    });
+
+    it('notifies card type change', () => {
+        jest.spyOn(numberFormatter, 'format').mockReturnValue('4111');
+
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '4111';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.CardTypeChanged,
+            payload: {
+                cardType: 'visa',
+            },
+        });
+    });
+
+    it('notifies bin number change', () => {
+        jest.spyOn(numberFormatter, 'format').mockReturnValue('4111 1111 1111 1111');
+
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '4111111111111111';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.BinChanged,
+            payload: {
+                bin: '411111',
+            },
+        });
+
+        element.value = '4987 6511 1111 1111';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.BinChanged,
+            payload: {
+                bin: '498765',
+            },
+        });
+    });
+
+    it('notifies when bin number can no longer be detected', () => {
+        jest.spyOn(numberFormatter, 'format').mockImplementation((value) =>
+            value === '4111111111111111' ? '4111 1111 1111 1111' : value,
+        );
+
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '4111111111111111';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        element.value = '41';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.BinChanged,
+            payload: {
+                bin: '',
+            },
+        });
+    });
+
+    it('does not notify if bin number is invalid', () => {
+        jest.spyOn(numberFormatter, 'format').mockReturnValue('0000 0000 0000 0000');
+
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '0000000000000000';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(eventPoster.post).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: HostedInputEventType.BinChanged,
+            }),
+        );
+    });
+
+    it('formats input on change', () => {
+        jest.spyOn(numberFormatter, 'format').mockReturnValue('4111 1111 1111 1111');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '4111111111111111';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(numberFormatter.format).toHaveBeenCalledWith('4111111111111111');
+        expect(element.value).toBe('4111 1111 1111 1111');
+    });
+
+    it('attaches autocomplete fieldset', () => {
+        jest.spyOn(autocompleteFieldset, 'attach');
+
+        input.attach();
+
+        expect(autocompleteFieldset.attach).toHaveBeenCalled();
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-card-number-input.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-card-number-input.ts
@@ -1,0 +1,104 @@
+import { number } from 'card-validator';
+import { get } from 'lodash';
+
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import { HostedFieldEventMap } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import CardNumberFormatter from './card-number-formatter';
+import HostedAutocompleteFieldset from './hosted-autocomplete-fieldset';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+
+export default class HostedCardNumberInput extends HostedInput {
+    /**
+     * @internal
+     */
+    constructor(
+        type: HostedFieldType,
+        form: HTMLFormElement,
+        placeholder: string,
+        accessibilityLabel: string,
+        autocomplete: string,
+        styles: HostedInputStylesMap,
+        fontUrls: string[],
+        eventListener: IframeEventListener<HostedFieldEventMap>,
+        eventPoster: IframeEventPoster<HostedInputEvent>,
+        inputAggregator: HostedInputAggregator,
+        inputValidator: HostedInputValidator,
+        paymentHandler: HostedInputPaymentHandler,
+        private _autocompleteFieldset: HostedAutocompleteFieldset,
+        private _formatter: CardNumberFormatter,
+    ) {
+        super(
+            type,
+            form,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            fontUrls,
+            eventListener,
+            eventPoster,
+            inputAggregator,
+            inputValidator,
+            paymentHandler,
+        );
+    }
+
+    attach(): void {
+        super.attach();
+
+        this._autocompleteFieldset.attach();
+    }
+
+    protected _notifyChange(value: string): void {
+        const cardInfo = number(value).card;
+        const prevCardInfo = this._previousValue && number(this._previousValue).card;
+
+        if (get(prevCardInfo, 'type') !== get(cardInfo, 'type')) {
+            this._eventPoster.post({
+                type: HostedInputEventType.CardTypeChanged,
+                payload: {
+                    cardType: cardInfo ? cardInfo.type : undefined,
+                },
+            });
+        }
+
+        const unformattedValue = this._formatter.unformat(value);
+        const unformattedPreviousValue = this._previousValue
+            ? this._formatter.unformat(this._previousValue)
+            : '';
+
+        const bin =
+            unformattedValue.length >= 6 && number(unformattedValue).isPotentiallyValid
+                ? unformattedValue.substr(0, 6)
+                : '';
+        const prevBin =
+            unformattedPreviousValue.length >= 6 ? unformattedPreviousValue.substr(0, 6) : '';
+
+        if (bin !== prevBin) {
+            this._eventPoster.post({
+                type: HostedInputEventType.BinChanged,
+                payload: { bin },
+            });
+        }
+    }
+
+    protected _formatValue(value: string): void {
+        const selectionEnd = this._input.selectionEnd;
+        const formattedValue = this._formatter.format(value);
+
+        if (selectionEnd === value.length && value.length < formattedValue.length) {
+            this._input.setSelectionRange(formattedValue.length, formattedValue.length);
+        } else {
+            this._input.setSelectionRange(selectionEnd || 0, selectionEnd || 0);
+        }
+
+        this._input.value = formattedValue;
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-aggregator.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-aggregator.spec.ts
@@ -1,0 +1,117 @@
+import { includes } from 'lodash';
+
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import HostedInputWindow from './hosted-input-window';
+
+describe('HostedInputAggregator', () => {
+    let aggregator: HostedInputAggregator;
+    let frames: HostedInputWindow[];
+    let parentWindow: Pick<Window, 'frames'>;
+
+    beforeEach(() => {
+        parentWindow = Object.create(window);
+        aggregator = new HostedInputAggregator(parentWindow as Window);
+        frames = [
+            Object.create(window),
+            Object.create(window),
+            Object.create(window),
+            Object.create(window),
+        ];
+
+        const codeInput = {
+            getType: jest.fn(() => HostedFieldType.CardCode),
+            getValue: jest.fn(() => '123'),
+        } as Pick<HostedInput, 'getType' | 'getValue'>;
+
+        const expiryInput = {
+            getType: jest.fn(() => HostedFieldType.CardExpiry),
+            getValue: jest.fn(() => '10 / 20'),
+        } as Pick<HostedInput, 'getType' | 'getValue'>;
+
+        const nameInput = {
+            getType: jest.fn(() => HostedFieldType.CardName),
+            getValue: jest.fn(() => 'Good Shopper'),
+        } as Pick<HostedInput, 'getType' | 'getValue'>;
+
+        const numberInput = {
+            getType: jest.fn(() => HostedFieldType.CardNumber),
+            getValue: jest.fn(() => '4111 1111 1111 1111'),
+        } as Pick<HostedInput, 'getType' | 'getValue'>;
+
+        frames[0].hostedInput = codeInput as HostedInput;
+        frames[1].hostedInput = expiryInput as HostedInput;
+        frames[2].hostedInput = nameInput as HostedInput;
+        frames[3].hostedInput = numberInput as HostedInput;
+
+        (parentWindow as any).frames = frames;
+    });
+
+    it('gathers all adjacent hosted inputs', () => {
+        expect(aggregator.getInputs()).toEqual(frames.map((frame) => frame.hostedInput));
+    });
+
+    it('does not throw error if there are other iframes in parent window that belong to different origin than itself', () => {
+        frames.push({
+            get hostedInput() {
+                throw new DOMException();
+            },
+        } as unknown as HostedInputWindow);
+
+        expect(aggregator.getInputs()).toEqual(
+            frames.slice(0, -1).map((frame) => frame.hostedInput),
+        );
+    });
+
+    it('does not throw error if there are other iframes in parent window that belong to different origin than itself in IE 11', () => {
+        frames.push({
+            get hostedInput() {
+                throw new DOMException();
+            },
+        } as unknown as HostedInputWindow);
+
+        expect(aggregator.getInputs()).toEqual(
+            frames.slice(0, -1).map((frame) => frame.hostedInput),
+        );
+    });
+
+    it('does not fail silently if unable to gather adjacent hosted inputs for other reasons', () => {
+        frames.push({
+            get hostedInput() {
+                throw new TypeError();
+            },
+        } as unknown as HostedInputWindow);
+
+        expect(() => aggregator.getInputs()).toThrow(TypeError);
+    });
+
+    it('gathers all adjacent hosted inputs that satisfy filter', () => {
+        expect(
+            aggregator.getInputs((field) =>
+                includes([HostedFieldType.CardCode, HostedFieldType.CardExpiry], field.getType()),
+            ),
+        ).toEqual([frames[0].hostedInput, frames[1].hostedInput]);
+    });
+
+    it('gathers all values of adjacent hosted inputs', () => {
+        expect(aggregator.getInputValues()).toEqual({
+            [HostedFieldType.CardCode]: '123',
+            [HostedFieldType.CardExpiry]: '10 / 20',
+            [HostedFieldType.CardName]: 'Good Shopper',
+            [HostedFieldType.CardNumber]: '4111 1111 1111 1111',
+        });
+    });
+
+    it('gathers all values of adjacent hosted inputs that satisfy filter', () => {
+        expect(
+            aggregator.getInputValues((field) =>
+                includes([HostedFieldType.CardCode, HostedFieldType.CardExpiry], field.getType()),
+            ),
+        ).toEqual({
+            [HostedFieldType.CardCode]: '123',
+            [HostedFieldType.CardExpiry]: '10 / 20',
+        });
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-aggregator.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-aggregator.ts
@@ -1,0 +1,43 @@
+import HostedInput from './hosted-input';
+import HostedInputValues from './hosted-input-values';
+import HostedInputWindow from './hosted-input-window';
+
+export default class HostedInputAggregator {
+    constructor(private _parentWindow: Window) {}
+
+    getInputs(filter?: (field: HostedInput) => boolean): HostedInput[] {
+        return Array.prototype.slice
+            .call(this._parentWindow.frames)
+            .reduce((result: Window[], frame: Window) => {
+                try {
+                    const input = (frame as HostedInputWindow).hostedInput;
+
+                    if (!input || (filter && !filter(input))) {
+                        return result;
+                    }
+
+                    return [...result, input];
+                } catch (error) {
+                    if (error instanceof DOMException) {
+                        return result;
+                    }
+
+                    // IE11 doesn't throw `DOMException`
+                    if (error instanceof Error && error.message === 'Permission denied') {
+                        return result;
+                    }
+
+                    throw error;
+                }
+            }, []);
+    }
+
+    getInputValues(filter?: (field: HostedInput) => boolean): HostedInputValues {
+        return this.getInputs(filter).reduce((result, input) => {
+            return {
+                ...result,
+                [input.getType()]: input.getValue(),
+            };
+        }, {} as HostedInputValues);
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-events.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-events.ts
@@ -1,0 +1,130 @@
+import { Response } from '@bigcommerce/request-sender';
+
+import {
+    PaymentErrorData,
+    PaymentErrorResponseBody,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import HostedFieldType from '../hosted-field-type';
+import { HostedFormErrorsData } from '../hosted-form-options';
+
+import HostedInputInitializeErrorData from './hosted-input-initialize-error-data';
+import HostedInputValidateResults from './hosted-input-validate-results';
+
+// Event types
+export enum HostedInputEventType {
+    AttachSucceeded = 'HOSTED_INPUT:ATTACH_SUCCEEDED',
+    AttachFailed = 'HOSTED_INPUT:ATTACH_FAILED',
+    BinChanged = 'HOSTED_INPUT:BIN_CHANGED',
+    Blurred = 'HOSTED_INPUT:BLURRED',
+    Changed = 'HOSTED_INPUT:CHANGED',
+    CardTypeChanged = 'HOSTED_INPUT:CARD_TYPE_CHANGED',
+    Entered = 'HOSTED_INPUT:ENTERED',
+    Focused = 'HOSTED_INPUT:FOCUSED',
+    SubmitSucceeded = 'HOSTED_INPUT:SUBMIT_SUCCEEDED',
+    SubmitFailed = 'HOSTED_INPUT:SUBMIT_FAILED',
+    Validated = 'HOSTED_INPUT:VALIDATED',
+}
+
+// Event mapping
+export interface HostedInputEventMap {
+    [HostedInputEventType.AttachSucceeded]: HostedInputAttachSuccessEvent;
+    [HostedInputEventType.AttachFailed]: HostedInputAttachErrorEvent;
+    [HostedInputEventType.BinChanged]: HostedInputBinChangeEvent;
+    [HostedInputEventType.Blurred]: HostedInputBlurEvent;
+    [HostedInputEventType.Changed]: HostedInputChangeEvent;
+    [HostedInputEventType.CardTypeChanged]: HostedInputCardTypeChangeEvent;
+    [HostedInputEventType.Entered]: HostedInputEnterEvent;
+    [HostedInputEventType.Focused]: HostedInputFocusEvent;
+    [HostedInputEventType.SubmitSucceeded]: HostedInputSubmitSuccessEvent;
+    [HostedInputEventType.SubmitFailed]: HostedInputSubmitErrorEvent;
+    [HostedInputEventType.Validated]: HostedInputValidateEvent;
+}
+
+// Events
+export type HostedInputEvent =
+    | HostedInputAttachSuccessEvent
+    | HostedInputAttachErrorEvent
+    | HostedInputBinChangeEvent
+    | HostedInputBlurEvent
+    | HostedInputChangeEvent
+    | HostedInputCardTypeChangeEvent
+    | HostedInputEnterEvent
+    | HostedInputFocusEvent
+    | HostedInputSubmitSuccessEvent
+    | HostedInputSubmitErrorEvent
+    | HostedInputValidateEvent;
+
+export interface HostedInputAttachSuccessEvent {
+    type: HostedInputEventType.AttachSucceeded;
+}
+
+export interface HostedInputAttachErrorEvent {
+    type: HostedInputEventType.AttachFailed;
+    payload: {
+        error: HostedInputInitializeErrorData;
+    };
+}
+
+export interface HostedInputBinChangeEvent {
+    type: HostedInputEventType.BinChanged;
+    payload: {
+        bin?: string;
+    };
+}
+
+export interface HostedInputBlurEvent {
+    type: HostedInputEventType.Blurred;
+    payload: {
+        fieldType: HostedFieldType;
+        errors?: HostedFormErrorsData;
+    };
+}
+
+export interface HostedInputChangeEvent {
+    type: HostedInputEventType.Changed;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export interface HostedInputCardTypeChangeEvent {
+    type: HostedInputEventType.CardTypeChanged;
+    payload: {
+        cardType?: string;
+    };
+}
+
+export interface HostedInputFocusEvent {
+    type: HostedInputEventType.Focused;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export interface HostedInputEnterEvent {
+    type: HostedInputEventType.Entered;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export interface HostedInputSubmitSuccessEvent {
+    type: HostedInputEventType.SubmitSucceeded;
+    payload: {
+        response: Response<unknown>;
+    };
+}
+
+export interface HostedInputSubmitErrorEvent {
+    type: HostedInputEventType.SubmitFailed;
+    payload: {
+        error: PaymentErrorData;
+        response?: Response<PaymentErrorResponseBody>;
+    };
+}
+
+export interface HostedInputValidateEvent {
+    type: HostedInputEventType.Validated;
+    payload: HostedInputValidateResults;
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-factory.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-factory.spec.ts
@@ -1,0 +1,48 @@
+import HostedFieldType from '../hosted-field-type';
+
+import HostedCardExpiryInput from './hosted-card-expiry-input';
+import HostedCardNumberInput from './hosted-card-number-input';
+import HostedInput from './hosted-input';
+import HostedInputFactory from './hosted-input-factory';
+
+describe('HostedInputFactory', () => {
+    let factory: HostedInputFactory;
+
+    beforeEach(() => {
+        factory = new HostedInputFactory('https://store.foobar.com');
+    });
+
+    it('creates card number field', () => {
+        expect(
+            factory.create(document.createElement('form'), HostedFieldType.CardNumber),
+        ).toBeInstanceOf(HostedCardNumberInput);
+    });
+
+    it('creates card expiry field', () => {
+        expect(
+            factory.create(document.createElement('form'), HostedFieldType.CardExpiry),
+        ).toBeInstanceOf(HostedCardExpiryInput);
+    });
+
+    it('creates regular input field for other field types', () => {
+        expect(
+            factory.create(document.createElement('form'), HostedFieldType.CardCode),
+        ).toBeInstanceOf(HostedInput);
+
+        expect(
+            factory.create(document.createElement('form'), HostedFieldType.CardName),
+        ).toBeInstanceOf(HostedInput);
+    });
+
+    it('normalises parent origin if origin contains www', () => {
+        factory.normalizeParentOrigin('https://www.store.foobar.com');
+
+        expect(factory.getParentOrigin()).toBe('https://www.store.foobar.com');
+    });
+
+    it('does not normalise parent origin if origin is completely different', () => {
+        factory.normalizeParentOrigin('https://www.xyz.com');
+
+        expect(factory.getParentOrigin()).toBe('https://store.foobar.com');
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-factory.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-factory.ts
@@ -1,0 +1,178 @@
+import { createClient as createBigpayClient } from '@bigcommerce/bigpay-client';
+
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import { appendWww, parseUrl } from '../common/url';
+import HostedFieldType from '../hosted-field-type';
+import { PaymentRequestSender, PaymentRequestTransformer } from '../payment';
+
+import CardExpiryFormatter from './card-expiry-formatter';
+import CardNumberFormatter from './card-number-formatter';
+import getHostedInputStorage from './get-hosted-input-storage';
+import HostedAutocompleteFieldset from './hosted-autocomplete-fieldset';
+import HostedCardExpiryInput from './hosted-card-expiry-input';
+import HostedCardNumberInput from './hosted-card-number-input';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+import mapToAccessibilityLabel from './map-to-accessibility-label';
+import mapToAutocompleteType from './map-to-autocomplete-type';
+
+export default class HostedInputFactory {
+    constructor(private _parentOrigin: string) {}
+
+    create(
+        form: HTMLFormElement,
+        type: HostedFieldType,
+        styles: HostedInputStylesMap = {},
+        fontUrls: string[] = [],
+        placeholder = '',
+        accessibilityLabel: string = mapToAccessibilityLabel(type),
+    ): HostedInput {
+        const autocomplete = mapToAutocompleteType(type);
+
+        if (type === HostedFieldType.CardNumber) {
+            return this._createNumberInput(
+                type,
+                form,
+                styles,
+                fontUrls,
+                placeholder,
+                accessibilityLabel,
+                autocomplete,
+            );
+        }
+
+        if (type === HostedFieldType.CardExpiry) {
+            return this._createExpiryInput(
+                form,
+                styles,
+                fontUrls,
+                placeholder,
+                accessibilityLabel,
+                autocomplete,
+            );
+        }
+
+        return this._createInput(
+            type,
+            form,
+            styles,
+            fontUrls,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+        );
+    }
+
+    normalizeParentOrigin(origin: string): void {
+        if (this._parentOrigin === origin) {
+            return;
+        }
+
+        if (
+            this._parentOrigin !== appendWww(parseUrl(origin)).origin &&
+            origin !== appendWww(parseUrl(this._parentOrigin)).origin
+        ) {
+            return;
+        }
+
+        this._parentOrigin = origin;
+    }
+
+    getParentOrigin(): string {
+        return this._parentOrigin;
+    }
+
+    private _createExpiryInput(
+        form: HTMLFormElement,
+        styles: HostedInputStylesMap,
+        fontUrls: string[],
+        placeholder: string,
+        accessibilityLabel = '',
+        autocomplete = '',
+    ): HostedCardExpiryInput {
+        return new HostedCardExpiryInput(
+            form,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            fontUrls,
+            new IframeEventListener(this._parentOrigin),
+            new IframeEventPoster(this._parentOrigin, window.parent),
+            new HostedInputAggregator(window.parent),
+            new HostedInputValidator(),
+            this._createPaymentHandler(),
+            new CardExpiryFormatter(),
+        );
+    }
+
+    private _createNumberInput(
+        type: HostedFieldType,
+        form: HTMLFormElement,
+        styles: HostedInputStylesMap,
+        fontUrls: string[],
+        placeholder: string,
+        accessibilityLabel = '',
+        autocomplete = '',
+    ): HostedCardNumberInput {
+        return new HostedCardNumberInput(
+            type,
+            form,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            fontUrls,
+            new IframeEventListener(this._parentOrigin),
+            new IframeEventPoster(this._parentOrigin, window.parent),
+            new HostedInputAggregator(window.parent),
+            new HostedInputValidator(),
+            this._createPaymentHandler(),
+            new HostedAutocompleteFieldset(
+                form,
+                [HostedFieldType.CardCode, HostedFieldType.CardExpiry, HostedFieldType.CardName],
+                new HostedInputAggregator(window.parent),
+            ),
+            new CardNumberFormatter(),
+        );
+    }
+
+    private _createInput(
+        type: HostedFieldType,
+        form: HTMLFormElement,
+        styles: HostedInputStylesMap,
+        fontUrls: string[],
+        placeholder: string,
+        accessibilityLabel = '',
+        autocomplete = '',
+    ): HostedInput {
+        return new HostedInput(
+            type,
+            form,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            fontUrls,
+            new IframeEventListener(this._parentOrigin),
+            new IframeEventPoster(this._parentOrigin, window.parent),
+            new HostedInputAggregator(window.parent),
+            new HostedInputValidator(),
+            this._createPaymentHandler(),
+        );
+    }
+
+    private _createPaymentHandler(): HostedInputPaymentHandler {
+        return new HostedInputPaymentHandler(
+            new HostedInputAggregator(window.parent),
+            new HostedInputValidator(),
+            getHostedInputStorage(),
+            new IframeEventPoster(this._parentOrigin, window.parent),
+            new PaymentRequestSender(createBigpayClient()),
+            new PaymentRequestTransformer(),
+        );
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-initialize-error-data.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-initialize-error-data.ts
@@ -1,0 +1,4 @@
+export default interface HostedInputInitializeErrorData {
+    message: string;
+    redirectUrl: string;
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-initializer.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-initializer.spec.ts
@@ -1,0 +1,127 @@
+import { IframeEventListener } from '../common/iframe';
+import { InvalidHostedFormConfigError } from '../errors';
+import { HostedFieldEventMap, HostedFieldEventType } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInput from './hosted-input';
+import HostedInputFactory from './hosted-input-factory';
+import HostedInputInitializer from './hosted-input-initializer';
+import HostedInputStorage from './hosted-input-storage';
+
+describe('HostedInputInitializer', () => {
+    let container: HTMLElement;
+    let eventListener: IframeEventListener<HostedFieldEventMap>;
+    let factory: Pick<HostedInputFactory, 'create' | 'normalizeParentOrigin'>;
+    let initializer: HostedInputInitializer;
+    let input: Pick<HostedInput, 'attach'>;
+    let storage: Pick<HostedInputStorage, 'setNonce'>;
+
+    beforeEach(() => {
+        factory = { create: jest.fn(), normalizeParentOrigin: jest.fn() };
+        storage = { setNonce: jest.fn() };
+        eventListener = new IframeEventListener('https://store.foobar.com');
+        input = { attach: jest.fn() };
+
+        initializer = new HostedInputInitializer(
+            factory as HostedInputFactory,
+            storage as HostedInputStorage,
+            eventListener,
+        );
+
+        container = document.createElement('div');
+        container.id = 'input-container';
+        document.body.appendChild(container);
+
+        jest.spyOn(input, 'attach').mockImplementation();
+
+        jest.spyOn(factory, 'create').mockReturnValue(input);
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('creates new hosted input', async () => {
+        process.nextTick(() => {
+            eventListener.trigger({
+                type: HostedFieldEventType.AttachRequested,
+                payload: {
+                    type: HostedFieldType.CardNumber,
+                    accessibilityLabel: 'Name',
+                    fontUrls: [],
+                    placeholder: 'Card name',
+                    styles: { default: { color: 'rgb(0, 0, 0)' } },
+                },
+            });
+        });
+
+        await initializer.initialize('input-container');
+
+        expect(factory.create).toHaveBeenCalledWith(
+            expect.any(HTMLFormElement),
+            HostedFieldType.CardNumber,
+            { default: { color: 'rgb(0, 0, 0)' } },
+            [],
+            'Card name',
+            'Name',
+        );
+    });
+
+    it('attaches input to container', async () => {
+        process.nextTick(() => {
+            eventListener.trigger({
+                type: HostedFieldEventType.AttachRequested,
+                payload: { type: HostedFieldType.CardNumber },
+            });
+        });
+
+        await initializer.initialize('input-container');
+
+        expect(input.attach).toHaveBeenCalled();
+    });
+
+    it('stores nonce into storage', async () => {
+        process.nextTick(() => {
+            eventListener.trigger({
+                type: HostedFieldEventType.AttachRequested,
+                payload: { type: HostedFieldType.CardNumber },
+            });
+        });
+
+        await initializer.initialize('input-container', 'abc');
+
+        expect(storage.setNonce).toHaveBeenCalledWith('abc');
+    });
+
+    it('returns newly created input', async () => {
+        process.nextTick(() => {
+            eventListener.trigger({
+                type: HostedFieldEventType.AttachRequested,
+                payload: { type: HostedFieldType.CardNumber },
+            });
+        });
+
+        expect(await initializer.initialize('input-container')).toEqual(input);
+    });
+
+    it('throws error if container cannot be found', () => {
+        container.remove();
+
+        expect(() => initializer.initialize('input-container')).toThrow(
+            InvalidHostedFormConfigError,
+        );
+    });
+
+    it('normalises parent origin for input factory', async () => {
+        process.nextTick(() => {
+            eventListener.trigger({
+                type: HostedFieldEventType.AttachRequested,
+                payload: { type: HostedFieldType.CardNumber, origin: 'https://www.foobar.com' },
+            });
+        });
+
+        await initializer.initialize('input-container');
+
+        expect(factory.normalizeParentOrigin).toHaveBeenCalled();
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-initializer.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-initializer.ts
@@ -1,0 +1,109 @@
+import { fromEvent } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+
+import { IframeEventListener } from '../common/iframe';
+import { InvalidHostedFormConfigError } from '../errors';
+import {
+    HostedFieldAttachEvent,
+    HostedFieldEventMap,
+    HostedFieldEventType,
+} from '../hosted-field-events';
+
+import HostedInput from './hosted-input';
+import HostedInputFactory from './hosted-input-factory';
+import HostedInputStorage from './hosted-input-storage';
+
+interface EventTargetLike<TEvent> {
+    addListener(eventName: string, handler: (event: TEvent) => void): void;
+    removeListener(eventName: string, handler: (event: TEvent) => void): void;
+}
+
+export default class HostedInputInitializer {
+    constructor(
+        private _factory: HostedInputFactory,
+        private _storage: HostedInputStorage,
+        private _eventListener: IframeEventListener<HostedFieldEventMap>,
+    ) {}
+
+    initialize(containerId: string, nonce?: string): Promise<HostedInput> {
+        if (nonce) {
+            this._storage.setNonce(nonce);
+        }
+
+        const form = this._createFormContainer(containerId);
+
+        this._resetPageStyles(containerId);
+        this._eventListener.listen();
+
+        return fromEvent<HostedFieldAttachEvent>(
+            this._eventListener as EventTargetLike<HostedFieldAttachEvent>,
+            HostedFieldEventType.AttachRequested,
+        )
+            .pipe(
+                map(({ payload }) => {
+                    const { accessibilityLabel, fontUrls, placeholder, styles, origin, type } =
+                        payload;
+
+                    if (origin) {
+                        this._factory.normalizeParentOrigin(origin);
+                    }
+
+                    const field = this._factory.create(
+                        form,
+                        type,
+                        styles,
+                        fontUrls,
+                        placeholder,
+                        accessibilityLabel,
+                    );
+
+                    field.attach();
+
+                    return field;
+                }),
+                take(1),
+            )
+            .toPromise();
+    }
+
+    private _resetPageStyles(containerId: string) {
+        const html = document.querySelector('html');
+        const body = document.querySelector('body');
+        const container = document.getElementById(containerId);
+
+        [html, body, container].forEach((node) => {
+            if (!node) {
+                return;
+            }
+
+            node.style.height = '100%';
+            node.style.width = '100%';
+            node.style.overflow = 'hidden';
+            node.style.padding = '0';
+            node.style.margin = '0';
+        });
+    }
+
+    private _createFormContainer(containerId: string): HTMLFormElement {
+        const container = document.getElementById(containerId);
+
+        if (!container) {
+            throw new InvalidHostedFormConfigError(
+                'Unable to proceed because the provided container ID is not valid.',
+            );
+        }
+
+        const form = document.createElement('form');
+        const button = document.createElement('button');
+
+        form.noValidate = true;
+        form.style.height = '100%';
+        form.style.width = '100%';
+        button.style.display = 'none';
+
+        container.appendChild(form);
+        form.appendChild(button);
+
+        return form;
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-options.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-options.ts
@@ -1,0 +1,6 @@
+export default interface HostedInputOptions {
+    containerId: string;
+    nonce?: string;
+    origin: string;
+    parentOrigin: string;
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-payment-handler.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-payment-handler.ts
@@ -1,0 +1,79 @@
+import { Response } from '@bigcommerce/request-sender';
+import { snakeCase } from 'lodash';
+
+import { PaymentErrorResponseBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { IframeEventPoster } from '../common/iframe';
+import { InvalidHostedFormValueError } from '../errors';
+import { HostedFieldSubmitRequestEvent } from '../hosted-field-events';
+import { PaymentRequestSender, PaymentRequestTransformer } from '../payment';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputStorage from './hosted-input-storage';
+import HostedInputValidator from './hosted-input-validator';
+
+export default class HostedInputPaymentHandler {
+    constructor(
+        private _inputAggregator: HostedInputAggregator,
+        private _inputValidator: HostedInputValidator,
+        private _inputStorage: HostedInputStorage,
+        private _eventPoster: IframeEventPoster<HostedInputEvent>,
+        private _paymentRequestSender: PaymentRequestSender,
+        private _paymentRequestTransformer: PaymentRequestTransformer,
+    ) {}
+
+    handle: (event: HostedFieldSubmitRequestEvent) => Promise<void> = async ({
+        payload: { data },
+    }) => {
+        const values = this._inputAggregator.getInputValues();
+        const results = await this._inputValidator.validate(values);
+
+        this._eventPoster.post({
+            type: HostedInputEventType.Validated,
+            payload: results,
+        });
+
+        if (!results.isValid) {
+            const error = new InvalidHostedFormValueError(results.errors);
+
+            return this._eventPoster.post({
+                type: HostedInputEventType.SubmitFailed,
+                payload: {
+                    error: { code: snakeCase(error.name), message: error.message },
+                },
+            });
+        }
+
+        try {
+            const response = await this._paymentRequestSender.submitPayment(
+                this._paymentRequestTransformer.transformWithHostedFormData(
+                    values,
+                    data,
+                    this._inputStorage.getNonce() || '',
+                ),
+            );
+
+            this._eventPoster.post({
+                type: HostedInputEventType.SubmitSucceeded,
+                payload: { response },
+            });
+        } catch (error) {
+            this._eventPoster.post({
+                type: HostedInputEventType.SubmitFailed,
+                payload: this._isPaymentErrorResponse(error)
+                    ? { error: error.body.errors[0], response: error }
+                    : { error: { code: snakeCase(error.name), message: error.message } },
+            });
+        }
+    };
+
+    private _isPaymentErrorResponse(response: any): response is Response<PaymentErrorResponseBody> {
+        const { body: { errors = [] } = {} } = response || {};
+
+        return (
+            typeof (errors[0] && errors[0].code) === 'string' &&
+            typeof (errors[0] && errors[0].message) === 'string'
+        );
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-storage.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-storage.spec.ts
@@ -1,0 +1,15 @@
+import HostedInputStorage from './hosted-input-storage';
+
+describe('HostedInputStorage', () => {
+    let subject: HostedInputStorage;
+
+    beforeEach(() => {
+        subject = new HostedInputStorage();
+    });
+
+    it('sets nonce for later retrieval', () => {
+        subject.setNonce('abc');
+
+        expect(subject.getNonce()).toBe('abc');
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-storage.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-storage.ts
@@ -1,0 +1,11 @@
+export default class HostedInputStorage {
+    private _nonce?: string;
+
+    setNonce(nonce: string): void {
+        this._nonce = nonce;
+    }
+
+    getNonce(): string | undefined {
+        return this._nonce;
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-styles.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-styles.ts
@@ -1,0 +1,11 @@
+type HostedInputStyles = Partial<
+    Pick<CSSStyleDeclaration, 'color' | 'fontFamily' | 'fontSize' | 'fontWeight'>
+>;
+
+export default HostedInputStyles;
+
+export interface HostedInputStylesMap {
+    default?: HostedInputStyles;
+    error?: HostedInputStyles;
+    focus?: HostedInputStyles;
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validate-error-data.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validate-error-data.ts
@@ -1,0 +1,14 @@
+import HostedFieldType from '../hosted-field-type';
+
+export default interface HostedInputValidateErrorData {
+    fieldType: string;
+    message: string;
+    type: string;
+}
+
+export interface HostedInputValidateErrorDataMap {
+    [HostedFieldType.CardCode]?: HostedInputValidateErrorData[];
+    [HostedFieldType.CardExpiry]?: HostedInputValidateErrorData[];
+    [HostedFieldType.CardName]?: HostedInputValidateErrorData[];
+    [HostedFieldType.CardNumber]?: HostedInputValidateErrorData[];
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validate-results.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validate-results.ts
@@ -1,0 +1,6 @@
+import { HostedInputValidateErrorDataMap } from './hosted-input-validate-error-data';
+
+export default interface HostedInputValidateResults {
+    errors: HostedInputValidateErrorDataMap;
+    isValid: boolean;
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.spec.ts
@@ -1,0 +1,249 @@
+import { omit } from 'lodash';
+
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInputValidateResults from './hosted-input-validate-results';
+import HostedInputValidator from './hosted-input-validator';
+import HostedInputValues from './hosted-input-values';
+
+describe('HostedInputValidator', () => {
+    let validData: HostedInputValues;
+    let validResults: HostedInputValidateResults;
+    let validator: HostedInputValidator;
+
+    beforeEach(() => {
+        validData = {
+            cardCode: '123',
+            cardExpiry: '10 / 25',
+            cardName: 'BC',
+            cardNumber: '4111 1111 1111 1111',
+        };
+
+        validResults = {
+            isValid: true,
+            errors: {
+                cardCode: [],
+                cardExpiry: [],
+                cardName: [],
+                cardNumber: [],
+            },
+        };
+
+        validator = new HostedInputValidator();
+    });
+
+    it('does not throw error if data is valid', async () => {
+        expect(await validator.validate(validData)).toEqual(validResults);
+    });
+
+    it('does not throw error if card number is valid 13-digit visa card number', async () => {
+        expect(await validator.validate({ ...validData, cardNumber: '4929 0000 0555 9' })).toEqual(
+            validResults,
+        );
+    });
+
+    it('does not throw error if card number is valid 8-BIN discover card number', async () => {
+        expect(
+            await validator.validate({ ...validData, cardNumber: '8171 9999 2766 0000' }),
+        ).toEqual(validResults);
+    });
+
+    it('returns error if card number is missing', async () => {
+        expect(await validator.validate({ ...validData, cardNumber: '' })).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardNumber: [
+                    {
+                        fieldType: 'cardNumber',
+                        type: 'required',
+                        message: 'Credit card number is required',
+                    },
+                    {
+                        fieldType: 'cardNumber',
+                        type: 'invalid_card_number',
+                        message: 'Credit card number must be valid',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('returns error if card number is invalid', async () => {
+        expect(
+            await validator.validate({ ...validData, cardNumber: '9999 9999 9999 9999' }),
+        ).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardNumber: [
+                    {
+                        fieldType: 'cardNumber',
+                        type: 'invalid_card_number',
+                        message: 'Credit card number must be valid',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('does not return error if card number is not required', async () => {
+        expect(await validator.validate(omit(validData, HostedFieldType.CardNumber))).toEqual({
+            ...validResults,
+            errors: omit(validResults.errors, HostedFieldType.CardNumber),
+        });
+    });
+
+    it('returns error if card name is missing', async () => {
+        expect(await validator.validate({ ...validData, cardName: '' })).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardName: [
+                    { fieldType: 'cardName', type: 'required', message: 'Full name is required' },
+                ],
+            },
+        });
+    });
+
+    it('does not return error if card name is not required', async () => {
+        expect(await validator.validate(omit(validData, HostedFieldType.CardName))).toEqual({
+            ...validResults,
+            errors: omit(validResults.errors, HostedFieldType.CardName),
+        });
+    });
+
+    it('returns error if expiry date is missing', async () => {
+        expect(await validator.validate({ ...validData, cardExpiry: '' })).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardExpiry: [
+                    {
+                        fieldType: 'cardExpiry',
+                        type: 'required',
+                        message: 'Expiration date is required',
+                    },
+                    {
+                        fieldType: 'cardExpiry',
+                        type: 'invalid_card_expiry',
+                        message: 'Expiration date must be a valid future date in MM / YY format',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('returns error if expiry date is invalid', async () => {
+        expect(await validator.validate({ ...validData, cardExpiry: '2030 / 12' })).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardExpiry: [
+                    {
+                        fieldType: 'cardExpiry',
+                        type: 'invalid_card_expiry',
+                        message: 'Expiration date must be a valid future date in MM / YY format',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('returns error if expiry date is in past', async () => {
+        expect(await validator.validate({ ...validData, cardExpiry: '2030 / 12' })).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardExpiry: [
+                    {
+                        fieldType: 'cardExpiry',
+                        type: 'invalid_card_expiry',
+                        message: 'Expiration date must be a valid future date in MM / YY format',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('does not return error if expiry date is not required', async () => {
+        expect(await validator.validate(omit(validData, HostedFieldType.CardExpiry))).toEqual({
+            ...validResults,
+            errors: omit(validResults.errors, HostedFieldType.CardExpiry),
+        });
+    });
+
+    it('returns error if card code is missing when required', async () => {
+        expect(await validator.validate({ ...validData, cardCode: '' })).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardCode: [
+                    { fieldType: 'cardCode', type: 'required', message: 'CVV is required' },
+                    {
+                        fieldType: 'cardCode',
+                        type: 'invalid_card_code',
+                        message: 'CVV must be valid',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('returns error if card code is invalid when required', async () => {
+        expect(await validator.validate({ ...validData, cardCode: '99999' })).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardCode: [
+                    {
+                        fieldType: 'cardCode',
+                        type: 'invalid_card_code',
+                        message: 'CVV must be valid',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('returns error if card code is invalid for given card number', async () => {
+        // Card code for American Express should have 4 digts
+        expect(
+            await validator.validate({
+                ...validData,
+                cardCode: '123',
+                cardNumber: '378282246310005',
+            }),
+        ).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardCode: [
+                    {
+                        fieldType: 'cardCode',
+                        type: 'invalid_card_code',
+                        message: 'CVV must be valid',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('does not return error if card code is not required', async () => {
+        expect(await validator.validate(omit(validData, HostedFieldType.CardCode))).toEqual({
+            ...validResults,
+            errors: omit(validResults.errors, HostedFieldType.CardCode),
+        });
+    });
+
+    it('does not return invalid card code error if card code is provided before card number', async () => {
+        expect(await validator.validate({ ...validData, cardCode: '123', cardNumber: '' })).toEqual(
+            {
+                isValid: false,
+                errors: expect.objectContaining({
+                    cardCode: [],
+                }),
+            },
+        );
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.ts
@@ -1,0 +1,141 @@
+import { creditCardType, cvv, expirationDate, number } from 'card-validator';
+import { object, ObjectShape, string, StringSchema, ValidationError } from 'yup';
+
+import { HostedInputValidateErrorDataMap } from './hosted-input-validate-error-data';
+import HostedInputValidateResults from './hosted-input-validate-results';
+import HostedInputValues from './hosted-input-values';
+
+export default class HostedInputValidator {
+    private readonly _completeSchema: ObjectShape = {
+        cardCode: this._getCardCodeSchema(),
+        cardExpiry: this._getCardExpirySchema(),
+        cardName: this._getCardNameSchema(),
+        cardNumber: this._getCardNumberSchema(),
+    };
+
+    constructor() {
+        this._configureCardValidator();
+    }
+
+    async validate(values: HostedInputValues): Promise<HostedInputValidateResults> {
+        const schemas: ObjectShape = {};
+        const results: HostedInputValidateResults = {
+            errors: {},
+            isValid: true,
+        };
+
+        let requiredField: keyof HostedInputValues;
+
+        for (requiredField in values) {
+            if (Object.prototype.hasOwnProperty.call(values, requiredField)) {
+                schemas[requiredField] = this._completeSchema[requiredField];
+                results.errors[requiredField] = [];
+            }
+        }
+
+        try {
+            await object(schemas).validate(values, { abortEarly: false });
+
+            return results;
+        } catch (error) {
+            if (error.name !== 'ValidationError') {
+                throw error;
+            }
+
+            return {
+                errors: (
+                    Object.keys(results.errors) as Array<keyof HostedInputValidateErrorDataMap>
+                ).reduce(
+                    (result, fieldType) => ({
+                        ...result,
+                        [fieldType]: (error as ValidationError).inner
+                            .filter((innerError) => innerError.path === fieldType)
+                            .map((innerError) => ({
+                                fieldType: innerError.path,
+                                message: innerError.errors.join(' '),
+                                type: innerError.type,
+                            })),
+                    }),
+                    {} as HostedInputValidateErrorDataMap,
+                ),
+                isValid: false,
+            };
+        }
+    }
+
+    private _configureCardValidator(): void {
+        const discoverInfo = creditCardType.getTypeInfo('discover');
+        const visaInfo = creditCardType.getTypeInfo('visa');
+
+        // Need to support 13 digit PAN because some gateways only provide test credit card numbers in this format.
+        creditCardType.updateCard('visa', {
+            lengths: [13, ...(visaInfo.lengths || [])],
+        });
+
+        // Add support for 8-BIN Discover Cards.
+        creditCardType.updateCard('discover', {
+            patterns: [...(discoverInfo.patterns || []), [810, 817]],
+        });
+
+        creditCardType.addCard({
+            niceType: 'Mada',
+            type: 'mada',
+            patterns: [
+                400861, 401757, 407197, 407395, 409201, 410685, 412565, 417633, 419593, 422817,
+                422818, 422819, 428331, 428671, 428672, 428673, 431361, 432328, 434107, 439954,
+                440533, 440647, 440795, 445564, 446393, 446404, 446672, 455036, 455708, 457865,
+                458456, 462220, 468540, 468541, 468542, 468543, 483010, 483011, 483012, 484783,
+                486094, 486095, 486096, 489317, 489318, 489319, 493428, 504300, 506968, 508160,
+                513213, 520058, 521076, 524130, 524514, 529415, 529741, 530060, 530906, 531095,
+                531196, 532013, 535825, 535989, 536023, 537767, 539931, 543085, 543357, 549760,
+                554180, 557606, 558848, 585265, 588845, 588846, 588847, 588848, 588849, 588850,
+                588851, 588982, 588983, 589005, 589206, 604906, 605141, 636120, 968201, 968202,
+                968203, 968204, 968205, 968206, 968207, 968208, 968209, 968210, 968211,
+            ],
+            gaps: [4, 8, 12],
+            lengths: [16, 18, 19],
+            code: {
+                name: 'CVV',
+                size: 3,
+            },
+        });
+    }
+
+    private _getCardCodeSchema(): StringSchema {
+        return string()
+            .required('CVV is required')
+            .test({
+                message: 'CVV must be valid',
+                name: 'invalid_card_code',
+                test(value) {
+                    const { card } = number((this.parent as HostedInputValues).cardNumber || '');
+
+                    return cvv(value, card && card.code ? card.code.size : undefined).isValid;
+                },
+            });
+    }
+
+    private _getCardExpirySchema(): StringSchema {
+        return string()
+            .required('Expiration date is required')
+            .test({
+                message: 'Expiration date must be a valid future date in MM / YY format',
+                name: 'invalid_card_expiry',
+                test: (value) => expirationDate(value).isValid,
+            });
+    }
+
+    private _getCardNameSchema(): StringSchema {
+        return string().max(200).required('Full name is required');
+    }
+
+    private _getCardNumberSchema(): StringSchema {
+        return string()
+            .required('Credit card number is required')
+            .test({
+                message: 'Credit card number must be valid',
+                name: 'invalid_card_number',
+                test: (value) => number(value).isValid,
+            });
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-values.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-values.ts
@@ -1,0 +1,8 @@
+import HostedFieldType from '../hosted-field-type';
+
+export default interface HostedInputValues {
+    [HostedFieldType.CardCode]?: string;
+    [HostedFieldType.CardExpiry]?: string;
+    [HostedFieldType.CardName]?: string;
+    [HostedFieldType.CardNumber]?: string;
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-window.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-window.ts
@@ -1,0 +1,5 @@
+import HostedInput from './hosted-input';
+
+export default interface HostedInputWindow extends Window {
+    hostedInput: HostedInput;
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input.spec.ts
@@ -1,0 +1,317 @@
+import { EventEmitter } from 'events';
+
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import {
+    HostedFieldEventMap,
+    HostedFieldEventType,
+    HostedFieldSubmitRequestEvent,
+} from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+import HostedInputValues from './hosted-input-values';
+
+describe('HostedInput', () => {
+    let container: HTMLFormElement;
+    let eventEmitter: EventEmitter;
+    let eventListener: Pick<
+        IframeEventListener<HostedFieldEventMap>,
+        'addListener' | 'listen' | 'stopListen'
+    >;
+    let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'setTarget' | 'post'>;
+    let fontUrls: string[];
+    let input: HostedInput;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
+    let inputValidator: Pick<HostedInputValidator, 'validate'>;
+    let paymentHandler: Pick<HostedInputPaymentHandler, 'handle'>;
+    let styles: HostedInputStylesMap;
+    let values: HostedInputValues;
+
+    beforeEach(() => {
+        values = {
+            cardCode: '123',
+            cardExpiry: '10 / 20',
+            cardName: 'Good Shopper',
+            cardNumber: '4111 1111 1111 1111',
+        };
+
+        styles = {
+            default: {
+                color: 'rgb(255, 255, 255)',
+                fontSize: '15px',
+            },
+        };
+
+        eventEmitter = new EventEmitter();
+
+        eventListener = {
+            addListener: jest.fn((type, listener) => {
+                eventEmitter.on(type, listener);
+            }),
+            listen: jest.fn(),
+            stopListen: jest.fn(),
+        };
+
+        eventPoster = {
+            post: jest.fn(),
+            setTarget: jest.fn(),
+        };
+
+        fontUrls = ['https://fonts.googleapis.com/css?family=Open+Sans&display=swap'];
+
+        paymentHandler = { handle: jest.fn() };
+
+        inputAggregator = {
+            getInputValues: jest.fn(() => values),
+        };
+
+        inputValidator = {
+            validate: jest.fn(() =>
+                Promise.resolve({
+                    isValid: true,
+                    errors: {
+                        cardExpiry: [],
+                        cardName: [],
+                        cardNumber: [],
+                    },
+                }),
+            ),
+        };
+
+        container = document.createElement('form');
+        document.body.appendChild(container);
+
+        input = new HostedInput(
+            HostedFieldType.CardName,
+            container,
+            'Full name',
+            'Cardholder name',
+            'cc-name',
+            styles,
+            fontUrls,
+            eventListener as IframeEventListener<HostedFieldEventMap>,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            paymentHandler as HostedInputPaymentHandler,
+        );
+    });
+
+    afterEach(() => {
+        input.detach();
+        container.remove();
+    });
+
+    it('returns input type', () => {
+        expect(input.getType()).toEqual(HostedFieldType.CardName);
+    });
+
+    it('sets and returns input value', () => {
+        input.setValue('abc');
+
+        expect(input.getValue()).toBe('abc');
+    });
+
+    it('attaches input to container', () => {
+        input.attach();
+
+        expect(container.querySelector('input')).toBeDefined();
+    });
+
+    it('configures input with expected attributes', () => {
+        input.attach();
+
+        const element = container.querySelector('input')!;
+
+        expect(element.id).toBe('card-name');
+        expect(element.placeholder).toBe('Full name');
+        expect(element.autocomplete).toBe('cc-name');
+        expect(element.getAttribute('aria-label')).toBe('Cardholder name');
+        expect(element.inputMode).toBe('text');
+    });
+
+    it('configures card number input with numeric inputmode', () => {
+        const cardNumberInput = new HostedInput(
+            HostedFieldType.CardNumber,
+            container,
+            'Full name',
+            'Cardholder name',
+            'cc-name',
+            styles,
+            fontUrls,
+            eventListener as IframeEventListener<HostedFieldEventMap>,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            paymentHandler as HostedInputPaymentHandler,
+        );
+
+        cardNumberInput.attach();
+
+        expect(container.querySelector('input')!.inputMode).toBe('numeric');
+
+        cardNumberInput.detach();
+    });
+
+    it('sets target for event poster', () => {
+        input.attach();
+
+        expect(eventPoster.setTarget).toHaveBeenCalled();
+    });
+
+    it('starts listening to events', () => {
+        input.attach();
+
+        expect(eventListener.listen).toHaveBeenCalled();
+    });
+
+    it('applies default styles to input', () => {
+        input.attach();
+
+        const element = container.querySelector('input')!;
+
+        expect(element.style.color).toBe('rgb(255, 255, 255)');
+        expect(element.style.fontSize).toBe('15px');
+    });
+
+    it('notifies when input is attached', () => {
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.AttachSucceeded,
+        });
+    });
+
+    it('loads required fonts when input is attached', () => {
+        input.attach();
+
+        const links = Array.from<HTMLLinkElement>(
+            document.querySelectorAll('link[href*="fonts.googleapis.com"][rel="stylesheet"]'),
+        );
+
+        expect(links.map((link) => link.href)).toEqual(fontUrls);
+    });
+
+    it('notifies input change', () => {
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        const element = container.querySelector('input')!;
+
+        element.value = '123';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.Changed,
+            payload: {
+                fieldType: HostedFieldType.CardName,
+            },
+        });
+    });
+
+    it('notifies when input is in focus', () => {
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        const element = container.querySelector('input')!;
+
+        element.dispatchEvent(new Event('focus', { bubbles: true }));
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.Focused,
+            payload: {
+                fieldType: HostedFieldType.CardName,
+            },
+        });
+    });
+
+    it('notifies when input loses focus', () => {
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        const element = container.querySelector('input')!;
+
+        element.dispatchEvent(new Event('blur', { bubbles: true }));
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.Blurred,
+            payload: {
+                fieldType: HostedFieldType.CardName,
+            },
+        });
+    });
+
+    it('validates form when input loses focus', () => {
+        input.attach();
+
+        const element = container.querySelector('input')!;
+
+        element.dispatchEvent(new Event('blur', { bubbles: true }));
+
+        expect(inputValidator.validate).toHaveBeenCalledWith(values);
+    });
+
+    it('validates form when requested by parent frame', () => {
+        input.attach();
+
+        eventEmitter.emit(HostedFieldEventType.ValidateRequested);
+
+        expect(inputValidator.validate).toHaveBeenCalledWith(values);
+    });
+
+    it('submits form when requested by parent frame', () => {
+        const event = {} as HostedFieldSubmitRequestEvent;
+
+        input.attach();
+
+        eventEmitter.emit(HostedFieldEventType.SubmitRequested, event);
+
+        expect(paymentHandler.handle).toHaveBeenCalledWith(event);
+    });
+
+    it('emits event when enter key is pressed', () => {
+        input.attach();
+
+        container.dispatchEvent(new Event('submit'));
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.Entered,
+            payload: {
+                fieldType: HostedFieldType.CardName,
+            },
+        });
+    });
+
+    it('cleans up when it detaches', () => {
+        jest.spyOn(eventListener, 'stopListen');
+
+        input.attach();
+        input.detach();
+
+        expect(eventListener.stopListen).toHaveBeenCalled();
+        expect(container.querySelector('input')).toBeFalsy();
+        expect(
+            document.querySelector('link[href*="fonts.googleapis.com"][rel="stylesheet"]'),
+        ).toBeFalsy();
+    });
+
+    it('applies bugfix of forcing focus on input field', () => {
+        input.attach();
+
+        expect(document.activeElement).toEqual(document.body);
+
+        window.dispatchEvent(new Event('focus'));
+
+        expect(document.activeElement).toEqual(container.querySelector('input'));
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input.ts
@@ -1,0 +1,297 @@
+import { kebabCase } from 'lodash';
+
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import { parseUrl } from '../common/url';
+import {
+    HostedFieldEventMap,
+    HostedFieldEventType,
+    HostedFieldValidateRequestEvent,
+} from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import HostedInputStyles, { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+import HostedInputWindow from './hosted-input-window';
+
+export default class HostedInput {
+    protected _input: HTMLInputElement;
+    protected _previousValue?: string;
+    private _fontLinks?: HTMLLinkElement[];
+    private _isTouched = false;
+
+    /**
+     * @internal
+     */
+    constructor(
+        protected _type: HostedFieldType,
+        protected _form: HTMLFormElement,
+        protected _placeholder: string,
+        protected _accessibilityLabel: string,
+        protected _autocomplete: string,
+        protected _styles: HostedInputStylesMap,
+        protected _fontUrls: string[],
+        protected _eventListener: IframeEventListener<HostedFieldEventMap>,
+        protected _eventPoster: IframeEventPoster<HostedInputEvent>,
+        protected _inputAggregator: HostedInputAggregator,
+        protected _inputValidator: HostedInputValidator,
+        protected _paymentHandler: HostedInputPaymentHandler,
+    ) {
+        this._input = document.createElement('input');
+
+        this._input.addEventListener('input', this._handleInput);
+        this._input.addEventListener('blur', this._handleBlur);
+        this._input.addEventListener('focus', this._handleFocus);
+        this._eventListener.addListener(
+            HostedFieldEventType.ValidateRequested,
+            this._handleValidate,
+        );
+        this._eventListener.addListener(
+            HostedFieldEventType.SubmitRequested,
+            this._paymentHandler.handle,
+        );
+
+        this._configureInput();
+    }
+
+    getType(): HostedFieldType {
+        return this._type;
+    }
+
+    getValue(): string {
+        return this._input.value;
+    }
+
+    setValue(value: string): void {
+        this._processChange(value);
+    }
+
+    isTouched(): boolean {
+        return this._isTouched;
+    }
+
+    attach(): void {
+        this._form.appendChild(this._input);
+        this._form.addEventListener('submit', this._handleSubmit);
+
+        this._loadFonts();
+
+        this._eventPoster.setTarget(window.parent);
+        this._eventListener.listen();
+
+        // fixes the issue on Firefox/Safari where the input doesn't focus properly
+        window.addEventListener('focus', this._forceFocusToInput);
+
+        // Assign itself to the global so it can be accessed by its sibling frames
+        (window as unknown as HostedInputWindow).hostedInput = this;
+
+        this._eventPoster.post({ type: HostedInputEventType.AttachSucceeded });
+    }
+
+    detach(): void {
+        if (this._input.parentElement) {
+            this._input.parentElement.removeChild(this._input);
+        }
+
+        this._form.removeEventListener('submit', this._handleSubmit);
+        this._unloadFonts();
+
+        window.removeEventListener('focus', this._forceFocusToInput);
+
+        this._eventListener.stopListen();
+    }
+
+    protected _formatValue(value: string): void {
+        this._input.value = value;
+    }
+
+    protected _notifyChange(_value: string): void {
+        this._eventPoster.post({
+            type: HostedInputEventType.Changed,
+            payload: {
+                fieldType: this._type,
+            },
+        });
+    }
+
+    private _configureInput(): void {
+        this._input.style.backgroundColor = 'transparent';
+        this._input.style.border = '0';
+        this._input.style.display = 'block';
+        this._input.style.height = '100%';
+        this._input.style.margin = '0';
+        this._input.style.outline = 'none';
+        this._input.style.padding = '0';
+        this._input.style.width = '100%';
+        this._input.id = kebabCase(this._type);
+        this._input.placeholder = this._placeholder;
+        this._input.autocomplete = this._autocomplete;
+
+        this._input.setAttribute('aria-label', this._accessibilityLabel);
+
+        this._applyStyles(this._styles.default);
+
+        switch (this._input.id) {
+            case 'card-code':
+            case 'card-expiry':
+            case 'card-number':
+                this._input.type = 'text';
+                this._input.inputMode = 'numeric';
+                this._input.pattern = '[0-9]*';
+                break;
+
+            case 'card-name':
+                this._input.type = 'text';
+                this._input.inputMode = 'text';
+                break;
+        }
+    }
+
+    private _applyStyles(styles: HostedInputStyles = {}): void {
+        const allowedStyles: {
+            [key in keyof Required<HostedInputStyles>]: HostedInputStyles[key];
+        } = {
+            color: styles.color,
+            fontFamily: styles.fontFamily,
+            fontSize: styles.fontSize,
+            fontWeight: styles.fontWeight,
+        };
+        const styleKeys = Object.keys(allowedStyles) as Array<keyof HostedInputStyles>;
+
+        styleKeys.forEach((key) => {
+            if (!allowedStyles[key]) {
+                return;
+            }
+
+            this._input.style[key] = allowedStyles[key] || '';
+        });
+    }
+
+    private _loadFonts(): void {
+        if (this._fontLinks) {
+            return;
+        }
+
+        this._fontLinks = this._fontUrls
+            .filter((url) => parseUrl(url).hostname === 'fonts.googleapis.com')
+            .filter((url) => !document.querySelector(`link[href='${url}'][rel='stylesheet']`))
+            .map((url) => {
+                const link = document.createElement('link');
+
+                link.rel = 'stylesheet';
+                link.href = url;
+
+                document.head.appendChild(link);
+
+                return link;
+            });
+    }
+
+    private _unloadFonts(): void {
+        if (!this._fontLinks) {
+            return;
+        }
+
+        this._fontLinks.forEach((link) => {
+            if (!link.parentElement) {
+                return;
+            }
+
+            link.parentElement.removeChild(link);
+        });
+
+        this._fontLinks = undefined;
+    }
+
+    private async _validateForm(): Promise<void> {
+        const values = this._inputAggregator.getInputValues();
+        const results = await this._inputValidator.validate(values);
+
+        if (results.isValid) {
+            this._applyStyles(this._styles.default);
+        } else {
+            this._applyStyles(this._styles.error);
+        }
+
+        this._eventPoster.post({
+            type: HostedInputEventType.Validated,
+            payload: results,
+        });
+    }
+
+    private _processChange(value: string): void {
+        if (value === this._previousValue) {
+            return;
+        }
+
+        this._isTouched = true;
+
+        this._formatValue(value);
+        this._validateForm();
+        this._notifyChange(value);
+
+        this._previousValue = value;
+    }
+
+    private _handleInput: (event: Event) => void = (event) => {
+        const input = event.target as HTMLInputElement;
+
+        this._processChange(input.value);
+    };
+
+    private _handleBlur: (event: Event) => void = () => {
+        this._applyStyles(this._styles.default);
+        this._validateForm();
+
+        this._eventPoster.post({
+            type: HostedInputEventType.Blurred,
+            payload: {
+                fieldType: this._type,
+            },
+        });
+    };
+
+    private _handleFocus: (event: Event) => void = () => {
+        this._applyStyles(this._styles.focus);
+
+        this._eventPoster.post({
+            type: HostedInputEventType.Focused,
+            payload: {
+                fieldType: this._type,
+            },
+        });
+    };
+
+    private _handleValidate: (event: HostedFieldValidateRequestEvent) => void = () => {
+        this._validateForm();
+    };
+
+    private _handleSubmit: (event: Event) => void = (event) => {
+        event.preventDefault();
+
+        this._eventPoster.post({
+            type: HostedInputEventType.Entered,
+            payload: {
+                fieldType: this._type,
+            },
+        });
+    };
+
+    private _forceFocusToInput = (): void => {
+        if (document.activeElement === document.body) {
+            const browserName = navigator.userAgent.toLowerCase();
+
+            if (browserName.indexOf('safari') > -1) {
+                if (this._input.value === '') {
+                    this._input.setAttribute('value', ' ');
+                    this._input.setSelectionRange(0, 1);
+                    this._input.setAttribute('value', '');
+                }
+            } else {
+                this._input.focus();
+            }
+        }
+    };
+}

--- a/packages/hosted-form-v2/src/iframe-content/index.ts
+++ b/packages/hosted-form-v2/src/iframe-content/index.ts
@@ -1,0 +1,13 @@
+export * from './hosted-input-events';
+
+export { default as initializeHostedInput } from './initialize-hosted-input';
+export { default as notifyInitializeError } from './notify-initialize-error';
+export { default as CardExpiryFormatter } from './card-expiry-formatter';
+export { default as CardNumberFormatter } from './card-number-formatter';
+export { default as HostedInputStyles } from './hosted-input-styles';
+export { default as HostedInputValues } from './hosted-input-values';
+export {
+    default as HostedInputValidateErrorData,
+    HostedInputValidateErrorDataMap,
+} from './hosted-input-validate-error-data';
+export { default as HostedInputValidateResults } from './hosted-input-validate-results';

--- a/packages/hosted-form-v2/src/iframe-content/initialize-hosted-input.ts
+++ b/packages/hosted-form-v2/src/iframe-content/initialize-hosted-input.ts
@@ -1,0 +1,19 @@
+import { IframeEventListener } from '../common/iframe';
+import { HostedFieldEventMap } from '../hosted-field-events';
+
+import getHostedInputStorage from './get-hosted-input-storage';
+import HostedInput from './hosted-input';
+import HostedInputFactory from './hosted-input-factory';
+import HostedInputInitializer from './hosted-input-initializer';
+import HostedInputOptions from './hosted-input-options';
+
+export default function initializeHostedInput(options: HostedInputOptions): Promise<HostedInput> {
+    const { containerId, nonce, parentOrigin } = options;
+    const initializer = new HostedInputInitializer(
+        new HostedInputFactory(parentOrigin),
+        getHostedInputStorage(),
+        new IframeEventListener<HostedFieldEventMap>(parentOrigin),
+    );
+
+    return initializer.initialize(containerId, nonce);
+}

--- a/packages/hosted-form-v2/src/iframe-content/map-to-accessibility-label.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/map-to-accessibility-label.spec.ts
@@ -1,0 +1,21 @@
+import HostedFieldType from '../hosted-field-type';
+
+import mapToAccessibilityLabel from './map-to-accessibility-label';
+
+describe('mapToAccessibilityLabel()', () => {
+    it('returns label for card code input', () => {
+        expect(mapToAccessibilityLabel(HostedFieldType.CardCode)).toBe('CVC');
+    });
+
+    it('returns label for card expiry input', () => {
+        expect(mapToAccessibilityLabel(HostedFieldType.CardExpiry)).toBe('Expiration');
+    });
+
+    it('returns label for card name input', () => {
+        expect(mapToAccessibilityLabel(HostedFieldType.CardName)).toBe('Name on card');
+    });
+
+    it('returns label for card number input', () => {
+        expect(mapToAccessibilityLabel(HostedFieldType.CardNumber)).toBe('Credit card number');
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/map-to-accessibility-label.ts
+++ b/packages/hosted-form-v2/src/iframe-content/map-to-accessibility-label.ts
@@ -1,0 +1,17 @@
+import HostedFieldType from '../hosted-field-type';
+
+export default function mapToAccessibilityLabel(type: HostedFieldType): string {
+    switch (type) {
+        case HostedFieldType.CardCode:
+            return 'CVC';
+
+        case HostedFieldType.CardExpiry:
+            return 'Expiration';
+
+        case HostedFieldType.CardName:
+            return 'Name on card';
+
+        case HostedFieldType.CardNumber:
+            return 'Credit card number';
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/map-to-autocomplete-type.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/map-to-autocomplete-type.spec.ts
@@ -1,0 +1,21 @@
+import HostedFieldType from '../hosted-field-type';
+
+import mapToAutocompleteType from './map-to-autocomplete-type';
+
+describe('mapToAutocompleteType()', () => {
+    it('returns autocomplete type for card code input', () => {
+        expect(mapToAutocompleteType(HostedFieldType.CardCode)).toBe('cc-csc');
+    });
+
+    it('returns autocomplete type for card expiry input', () => {
+        expect(mapToAutocompleteType(HostedFieldType.CardExpiry)).toBe('cc-exp');
+    });
+
+    it('returns autocomplete type for card name input', () => {
+        expect(mapToAutocompleteType(HostedFieldType.CardName)).toBe('cc-name');
+    });
+
+    it('returns autocomplete type for card number input', () => {
+        expect(mapToAutocompleteType(HostedFieldType.CardNumber)).toBe('cc-number');
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/map-to-autocomplete-type.ts
+++ b/packages/hosted-form-v2/src/iframe-content/map-to-autocomplete-type.ts
@@ -1,0 +1,20 @@
+import HostedFieldType from '../hosted-field-type';
+
+export default function mapToAutocompleteType(type: HostedFieldType): string {
+    switch (type) {
+        case HostedFieldType.CardCode:
+            return 'cc-csc';
+
+        case HostedFieldType.CardExpiry:
+            return 'cc-exp';
+
+        case HostedFieldType.CardName:
+            return 'cc-name';
+
+        case HostedFieldType.CardNumber:
+            return 'cc-number';
+
+        default:
+            return '';
+    }
+}

--- a/packages/hosted-form-v2/src/iframe-content/notify-initialize-error.ts
+++ b/packages/hosted-form-v2/src/iframe-content/notify-initialize-error.ts
@@ -1,0 +1,13 @@
+import { IframeEventPoster } from '../common/iframe';
+
+import { HostedInputAttachErrorEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputInitializeErrorData from './hosted-input-initialize-error-data';
+
+const poster = new IframeEventPoster<HostedInputAttachErrorEvent>('*', window.parent);
+
+export default function notifyInitializeError(error: HostedInputInitializeErrorData): void {
+    poster.post({
+        type: HostedInputEventType.AttachFailed,
+        payload: { error },
+    });
+}

--- a/packages/hosted-form-v2/src/index.ts
+++ b/packages/hosted-form-v2/src/index.ts
@@ -1,0 +1,5 @@
+export { initializeHostedInput, notifyInitializeError } from './iframe-content';
+export { createHostedFormService } from './create-hosted-form-service';
+export { default as HostedFieldType } from './hosted-field-type';
+export { default as HostedFormOptions } from './hosted-form-options';
+export { default as HostedFormService } from './hosted-form-service';

--- a/packages/hosted-form-v2/src/payment/bigpay-client.d.ts
+++ b/packages/hosted-form-v2/src/payment/bigpay-client.d.ts
@@ -1,0 +1,2 @@
+// TODO: Remove this once we've added type definitions to `@bigcommerce/bigpay-client`
+declare module '@bigcommerce/bigpay-client';

--- a/packages/hosted-form-v2/src/payment/index.ts
+++ b/packages/hosted-form-v2/src/payment/index.ts
@@ -1,0 +1,3 @@
+export { PaymentRequestSender } from './payment-request-sender';
+export { PaymentRequestTransformer } from './payment-request-transformer';
+export { default as PaymentResponse } from './payment-response';

--- a/packages/hosted-form-v2/src/payment/payment-request-body.ts
+++ b/packages/hosted-form-v2/src/payment/payment-request-body.ts
@@ -1,0 +1,3 @@
+export default interface PaymentRequestBody {
+    authToken: string;
+}

--- a/packages/hosted-form-v2/src/payment/payment-request-sender.ts
+++ b/packages/hosted-form-v2/src/payment/payment-request-sender.ts
@@ -1,0 +1,38 @@
+import { Response } from '@bigcommerce/request-sender';
+
+import PaymentRequestBody from './payment-request-body';
+
+export class PaymentRequestSender {
+    /**
+     * @class
+     * @param {BigpayClient} client
+     */
+    constructor(private _client: any) {}
+
+    submitPayment(payload: PaymentRequestBody): Promise<Response<any>> {
+        return new Promise((resolve, reject) => {
+            this._client.submitPayment(payload, (error: any, response: any) => {
+                if (error) {
+                    reject(this._transformResponse(error));
+                } else {
+                    resolve(this._transformResponse(response));
+                }
+            });
+        });
+    }
+
+    initializeOffsitePayment(payload: PaymentRequestBody, target?: string): Promise<void> {
+        return new Promise(() => {
+            this._client.initializeOffsitePayment(payload, null, target);
+        });
+    }
+
+    private _transformResponse(response: any): Response<any> {
+        return {
+            headers: response.headers,
+            body: response.data,
+            status: response.status,
+            statusText: response.statusText,
+        };
+    }
+}

--- a/packages/hosted-form-v2/src/payment/payment-request-transformer.ts
+++ b/packages/hosted-form-v2/src/payment/payment-request-transformer.ts
@@ -1,0 +1,21 @@
+import HostedFormOrderData from '../hosted-form-order-data';
+import { HostedInputValues } from '../iframe-content';
+
+export class PaymentRequestTransformer {
+    transform() {
+        return {};
+    }
+
+    transformWithHostedFormData(
+        values: HostedInputValues,
+        data: HostedFormOrderData,
+        nonce: string,
+    ) {
+        // TODO: CHECKOUT-8275 need to add the actual implementation when implementing submitPayment
+        return {
+            authToken: data.authToken,
+            values,
+            nonce,
+        };
+    }
+}

--- a/packages/hosted-form-v2/src/payment/payment-response.ts
+++ b/packages/hosted-form-v2/src/payment/payment-response.ts
@@ -1,0 +1,6 @@
+export default interface PaymentResponse<T = any> {
+    data: T;
+    headers: { [key: string]: any };
+    status: number;
+    statusText: string;
+}

--- a/packages/hosted-form-v2/tsconfig.json
+++ b/packages/hosted-form-v2/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "include": [
+        "src/common/types/card-validator.d.ts",
+        "src/**/*.ts",
+    ],
+    "files": [
+        "src/common/types/card-validator.d.ts",
+        "src/common/types/webpack.d.ts"
+    ]
+}

--- a/packages/hosted-form-v2/tsconfig.spec.json
+++ b/packages/hosted-form-v2/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "**/*.spec.jsx"
+    ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -66,6 +66,7 @@
             "@bigcommerce/checkout-sdk/google-pay-integration": [
                 "packages/google-pay-integration/src/index.ts"
             ],
+            "@bigcommerce/checkout-sdk/hosted-form-v2": ["packages/hosted-form-v2/src/index.ts"],
             "@bigcommerce/checkout-sdk/humm": ["packages/humm-integration/src/index.ts"],
             "@bigcommerce/checkout-sdk/klarna-integration": [
                 "packages/klarna-integration/src/index.ts"

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -9,6 +9,7 @@ const {
 const libraryName = 'checkoutKit';
 
 const coreSrcPath = path.join(__dirname, 'packages/core/src');
+const hostedFormV2SrcPath = path.join(__dirname, 'packages/hosted-form-v2/src');
 
 const libraryEntries = {
     'checkout-sdk': path.join(coreSrcPath, 'bundles', 'checkout-sdk.ts'),
@@ -17,6 +18,16 @@ const libraryEntries = {
     extension: path.join(coreSrcPath, 'bundles', 'extension.ts'),
     'hosted-form': path.join(coreSrcPath, 'bundles', 'hosted-form.ts'),
     'internal-mappers': path.join(coreSrcPath, 'bundles', 'internal-mappers.ts'),
+    'hosted-form-v2-iframe-content': path.join(
+        hostedFormV2SrcPath,
+        'bundles',
+        'hosted-form-v2-iframe-content.ts',
+    ),
+    'hosted-form-v2-iframe-host': path.join(
+        hostedFormV2SrcPath,
+        'bundles',
+        'hosted-form-v2-iframe-host.ts',
+    ),
 };
 
 async function getBaseConfig() {

--- a/workspace.json
+++ b/workspace.json
@@ -19,6 +19,7 @@
         "cybersource-integration": "packages/cybersource-integration",
         "external-integration": "packages/external-integration",
         "google-pay-integration": "packages/google-pay-integration",
+        "hosted-form-v2": "packages/hosted-form-v2",
         "humm-integration": "packages/humm-integration",
         "klarna-integration": "packages/klarna-integration",
         "legacy-integration": "packages/legacy-integration",


### PR DESCRIPTION
## What?
Create a new hosted-form-v2 package for generating hosted form fields in manual order. 

## Why?
So that manual orders UI can import it and generate the hosted form fields (without importing the entire sdk in future). And eventually we can modify [My Account](https://github.com/bigcommerce/storefront-account-payments) and checkout to use the new implementation and remove the old one.

## Testing / Proof

- CI checks
