### PR TITLE
feat(payment): PAYPAL-2518 Add challengeRequested property to 3D Secure

### DIFF
--- a/docs/interfaces/BraintreeThreeDSecureOptions.md
+++ b/docs/interfaces/BraintreeThreeDSecureOptions.md
@@ -12,6 +12,7 @@ through a web page via an iframe provided by the card issuer.
 
 ### Properties
 
+- [challengeRequested](BraintreeThreeDSecureOptions.md#challengerequested)
 - [additionalInformation](BraintreeThreeDSecureOptions.md#additionalinformation)
 
 ### Methods
@@ -20,6 +21,10 @@ through a web page via an iframe provided by the card issuer.
 - [removeFrame](BraintreeThreeDSecureOptions.md#removeframe)
 
 ## Properties
+
+### challengeRequested
+
+• `Optional` **challengeRequested**: `boolean`
 
 ### additionalInformation
 

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
@@ -123,6 +123,7 @@ export interface BraintreeThreeDSecureOptions {
      * the current page.
      */
     removeFrame(): void;
+    challengeRequested?: boolean;
     additionalInformation?: {
         acsWindowSize?: '01' | '02' | '03' | '04' | '05';
     };

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -433,7 +433,7 @@ describe('BraintreePaymentProcessor', () => {
             expect(threeDSecureMock.verifyCard).toHaveBeenCalledWith({
                 addFrame: expect.any(Function),
                 removeFrame: expect.any(Function),
-                challengeRequested: true,
+                challengeRequested: expect.any(Boolean),
                 amount: 122,
                 bin: '123456',
                 nonce: 'tokenization_nonce',

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -206,7 +206,12 @@ export default class BraintreePaymentProcessor {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        const { addFrame, removeFrame, additionalInformation } = this._threeDSecureOptions;
+        const {
+            addFrame,
+            removeFrame,
+            challengeRequested = true,
+            additionalInformation,
+        } = this._threeDSecureOptions;
         const cancelVerifyCard = async () => {
             const response = await threeDSecure.cancelVerifyCard();
 
@@ -224,7 +229,7 @@ export default class BraintreePaymentProcessor {
                 },
                 amount: Number(roundedAmount),
                 bin,
-                challengeRequested: true,
+                challengeRequested,
                 nonce,
                 removeFrame,
                 onLookupComplete: (_data, next) => {


### PR DESCRIPTION
## What?
Add challengeRequested property to pass to Braintree sdk

## Why?
Give the choice as to whether to force a 3D Secure challenge where possible. See issue here - #2518 

## Testing / Proof
See in Braintree with challengeRequested set to true
![image](https://github.com/bigcommerce/checkout-sdk-js/assets/126817242/aeac245a-cfa8-4736-b170-cf45c26ab6c4)

And when challengeRequested is set to false
![image](https://github.com/bigcommerce/checkout-sdk-js/assets/126817242/535b0886-b1e8-412b-ad09-a497581f652f)

@bigcommerce/team-checkout @bigcommerce/team-payments

