### PR TITLE
CHECKOUT-8284: Fix build issue affecting `hosted-form-v2` package

### DIFF
--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -63,7 +63,8 @@
                 "commands": [
                     "tsc --outDir ../../temp --declaration --emitDeclarationOnly",
                     "api-extractor run --config api-extractor/checkout-sdk.json & api-extractor run --config api-extractor/checkout-button.json & api-extractor run --config api-extractor/embedded-checkout.json & api-extractor run --config api-extractor/internal-mappers.json",
-                    "rm -rf ../../temp"
+                    "rm -rf ../../temp",
+                    "nx run hosted-form-v2:build-dts"
                 ]
             }
         },

--- a/packages/core/src/bundles/checkout-sdk.ts
+++ b/packages/core/src/bundles/checkout-sdk.ts
@@ -1,5 +1,4 @@
 export { createTimeout } from '@bigcommerce/request-sender';
-
 export { createCheckoutService } from '../checkout';
 export { createCheckoutButtonInitializer } from '../checkout-buttons';
 export { embedCheckout } from '../embedded-checkout';
@@ -14,4 +13,3 @@ export {
 export { createStoredCardHostedFormService } from '../hosted-form';
 export { createBodlService } from '../bodl';
 export { ExtensionCommandType } from '../extension';
-export { createHostedFormService } from './hosted-form-v2';

--- a/packages/hosted-form-v2/api-extractor/hosted-form-v2-iframe-content.json
+++ b/packages/hosted-form-v2/api-extractor/hosted-form-v2-iframe-content.json
@@ -1,0 +1,22 @@
+{
+    "compiler": {
+        "configType": "tsconfig",
+        "rootFolder": "."
+    },
+    "project": {
+        "entryPointSourceFile": "../../temp/hosted-form-v2/src/bundles/hosted-form-v2-iframe-content.d.ts"
+    },
+    "validationRules": {
+        "missingReleaseTags": "allow"
+    },
+    "apiReviewFile": {
+        "enabled": false
+    },
+    "apiJsonFile": {
+        "enabled": false
+    },
+    "dtsRollup": {
+        "enabled": true,
+        "mainDtsRollupPath": "hosted-form-v2-iframe-content.d.ts"
+    }
+}

--- a/packages/hosted-form-v2/api-extractor/hosted-form-v2-iframe-host.json
+++ b/packages/hosted-form-v2/api-extractor/hosted-form-v2-iframe-host.json
@@ -1,0 +1,22 @@
+{
+    "compiler": {
+        "configType": "tsconfig",
+        "rootFolder": "."
+    },
+    "project": {
+        "entryPointSourceFile": "../../temp/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.d.ts"
+    },
+    "validationRules": {
+        "missingReleaseTags": "allow"
+    },
+    "apiReviewFile": {
+        "enabled": false
+    },
+    "apiJsonFile": {
+        "enabled": false
+    },
+    "dtsRollup": {
+        "enabled": true,
+        "mainDtsRollupPath": "hosted-form-v2-iframe-host.d.ts"
+    }
+}

--- a/packages/hosted-form-v2/project.json
+++ b/packages/hosted-form-v2/project.json
@@ -17,6 +17,18 @@
                 "jestConfig": "packages/hosted-form-v2/jest.config.js",
                 "passWithNoTests": true
             }
+        },
+        "build-dts": {
+            "executor": "@nrwl/workspace:run-commands",
+            "options": {
+                "cwd": "packages/hosted-form-v2",
+                "parallel": false,
+                "commands": [
+                    "tsc --outDir ../../temp --declaration --emitDeclarationOnly",
+                    "api-extractor run --config api-extractor/hosted-form-v2-iframe-content.json & api-extractor run --config api-extractor/hosted-form-v2-iframe-host.json",
+                    "rm -rf ../../temp"
+                ]
+            }
         }
     },
     "tags": ["scope:shared"]

--- a/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-content.ts
+++ b/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-content.ts
@@ -1,0 +1,1 @@
+export { initializeHostedInput, notifyInitializeError } from '../iframe-content';

--- a/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.ts
+++ b/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.ts
@@ -1,0 +1,1 @@
+export { createHostedFormService } from '../create-hosted-form-service';

--- a/packages/hosted-form-v2/src/common/types/card-validator.d.ts
+++ b/packages/hosted-form-v2/src/common/types/card-validator.d.ts
@@ -1,0 +1,40 @@
+import 'card-validator';
+
+// Merge @types/card-validator with missing methods. We probably don't need this
+// once the official package is updated with the latest type definitions.
+declare module 'card-validator' {
+    type CardBrand =
+        | 'american-express'
+        | 'diners-club'
+        | 'discover'
+        | 'jcb'
+        | 'maestro'
+        | 'mastercard'
+        | 'unionpay'
+        | 'visa'
+        | 'mada';
+
+    interface CreditCardTypeInfo {
+        patterns?: Array<number | [number, number]>;
+        niceType?: string;
+        type?: CardBrand;
+        prefixPattern?: RegExp;
+        exactPattern?: RegExp;
+        gaps?: number[];
+        lengths?: number[];
+        code?: {
+            name?: string;
+            size?: number;
+        };
+    }
+
+    interface CreditCardType {
+        types: { [type: string]: string };
+        (cardNumber: string): CreditCardTypeInfo[];
+        getTypeInfo(type: string): CreditCardTypeInfo;
+        updateCard(type: string, updates: Partial<CreditCardTypeInfo>): void;
+        addCard(config: Partial<CreditCardTypeInfo>): void;
+    }
+
+    export const creditCardType: CreditCardType;
+}

--- a/packages/hosted-form-v2/src/common/types/webpack.d.ts
+++ b/packages/hosted-form-v2/src/common/types/webpack.d.ts
@@ -1,0 +1,8 @@
+declare const LIBRARY_NAME: string;
+declare const LIBRARY_VERSION: string;
+declare const MANIFEST_JSON: AssetManifest;
+
+interface AssetManifest {
+    version: string;
+    js: string[];
+}

--- a/packages/hosted-form-v2/src/create-hosted-form-service.ts
+++ b/packages/hosted-form-v2/src/create-hosted-form-service.ts
@@ -1,4 +1,5 @@
-import { HostedFormFactory, HostedFormService } from '@bigcommerce/checkout-sdk/hosted-form-v2';
+import HostedFormFactory from './hosted-form-factory';
+import HostedFormService from './hosted-form-service';
 
 /**
  * Creates an instance of `HostedFormService`.
@@ -10,8 +11,3 @@ import { HostedFormFactory, HostedFormService } from '@bigcommerce/checkout-sdk/
 export function createHostedFormService(host: string) {
     return new HostedFormService(host, new HostedFormFactory());
 }
-
-export {
-    initializeHostedInput,
-    notifyInitializeError,
-} from '@bigcommerce/checkout-sdk/hosted-form-v2';

--- a/packages/hosted-form-v2/src/hosted-form.spec.ts
+++ b/packages/hosted-form-v2/src/hosted-form.spec.ts
@@ -1,5 +1,3 @@
-import { createScriptLoader } from '@bigcommerce/script-loader';
-
 import { IframeEventListener } from './common/iframe';
 import HostedField from './hosted-field';
 import HostedFieldType from './hosted-field-type';

--- a/packages/hosted-form-v2/src/index.ts
+++ b/packages/hosted-form-v2/src/index.ts
@@ -1,7 +1,5 @@
 export { initializeHostedInput, notifyInitializeError } from './iframe-content';
+export { createHostedFormService } from './create-hosted-form-service';
 export { default as HostedFieldType } from './hosted-field-type';
-export { default as HostedForm } from './hosted-form';
-export { default as HostedFormFactory } from './hosted-form-factory';
 export { default as HostedFormOptions } from './hosted-form-options';
-export { default as HostedFormOrderData } from './hosted-form-order-data';
 export { default as HostedFormService } from './hosted-form-service';

--- a/packages/hosted-form-v2/src/payment/bigpay-client.d.ts
+++ b/packages/hosted-form-v2/src/payment/bigpay-client.d.ts
@@ -1,0 +1,2 @@
+// TODO: Remove this once we've added type definitions to `@bigcommerce/bigpay-client`
+declare module '@bigcommerce/bigpay-client';

--- a/packages/hosted-form-v2/tsconfig.json
+++ b/packages/hosted-form-v2/tsconfig.json
@@ -1,8 +1,11 @@
 {
     "extends": "../../tsconfig.base.json",
-    "references": [
-        {
-          "path": "./tsconfig.spec.json"
-        }
-      ]
+    "include": [
+        "src/common/types/card-validator.d.ts",
+        "src/**/*.ts",
+    ],
+    "files": [
+        "src/common/types/card-validator.d.ts",
+        "src/common/types/webpack.d.ts"
+    ]
 }

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -9,6 +9,7 @@ const {
 const libraryName = 'checkoutKit';
 
 const coreSrcPath = path.join(__dirname, 'packages/core/src');
+const hostedFormV2SrcPath = path.join(__dirname, 'packages/hosted-form-v2/src');
 
 const libraryEntries = {
     'checkout-sdk': path.join(coreSrcPath, 'bundles', 'checkout-sdk.ts'),
@@ -17,7 +18,16 @@ const libraryEntries = {
     extension: path.join(coreSrcPath, 'bundles', 'extension.ts'),
     'hosted-form': path.join(coreSrcPath, 'bundles', 'hosted-form.ts'),
     'internal-mappers': path.join(coreSrcPath, 'bundles', 'internal-mappers.ts'),
-    'hosted-form-v2': path.join(coreSrcPath, 'bundles', 'hosted-form-v2.ts'),
+    'hosted-form-v2-iframe-content': path.join(
+        hostedFormV2SrcPath,
+        'bundles',
+        'hosted-form-v2-iframe-content.ts',
+    ),
+    'hosted-form-v2-iframe-host': path.join(
+        hostedFormV2SrcPath,
+        'bundles',
+        'hosted-form-v2-iframe-host.ts',
+    ),
 };
 
 async function getBaseConfig() {


### PR DESCRIPTION
## What?
Fix the build issue that is preventing `api-extractor` from compiling types defined in `hosted-form-v2` package. The problem is due to `api-extractor` not able to reference monorepo packages, such as `@bigcommerce/hosted-form-v2`. To fix this, I've created a new `build-dts` task within `hosted-form-v2` so that it can call `api-extractor` without referencing the monorepo package from `core`.

## Why?
This is an incremental step towards making `hosted-form-v2` a standalone package that can be used for Checkout, Manual Orders, and My Account.

## Testing / Proof
CircleCI

@bigcommerce/team-checkout
