### PR TITLE
fix(payment): PI-2191 fixed hosted fields validation for the Worldpay…

### DIFF
--- a/packages/core/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
@@ -49,6 +49,12 @@ describe('HostedInputValidator', () => {
         ).toEqual(validResults);
     });
 
+    it('does not throw error if card number is valid JCB test card number', async () => {
+        expect(await validator.validate({ ...validData, cardNumber: '3337000000000008' })).toEqual(
+            validResults,
+        );
+    });
+
     it('returns error if card number is missing', async () => {
         expect(await validator.validate({ ...validData, cardNumber: '' })).toEqual({
             isValid: false,

--- a/packages/core/src/hosted-form/iframe-content/hosted-input-validator.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input-validator.ts
@@ -69,6 +69,7 @@ export default class HostedInputValidator {
 
     private _configureCardValidator(): void {
         const discoverInfo = creditCardType.getTypeInfo('discover');
+        const jcbInfo = creditCardType.getTypeInfo('jcb');
         const visaInfo = creditCardType.getTypeInfo('visa');
 
         // Need to support 13 digit PAN because some gateways only provide test credit card numbers in this format.
@@ -102,6 +103,11 @@ export default class HostedInputValidator {
                 name: 'CVV',
                 size: 3,
             },
+        });
+
+        // Add support WorldPayAccess and Authorize.net test cards
+        creditCardType.updateCard('jcb', {
+            patterns: [...(jcbInfo.patterns || []), 3088, 3337, 3338],
         });
     }
 


### PR DESCRIPTION
…Access and Authorize.net JCB test cards

## What?
Fixed hosted fields validation for the Worldpay Access and Authorize.net test cards

## Why?
[Worldpay Access](https://developer.worldpay.com/products/access/3ds/testing/) and [Authorize.net](https://developer.authorize.net/hello_world/testing_guide.html) have test card numbers that do not meet our default  [JCB validation rule](https://github.com/braintree/credit-card-type/blob/main/src/lib/card-types.ts#L62).
I've extended validation rule for these test cards

## Testing / Proof
Before fix [WP Access JCB test card number](https://developer.worldpay.com/products/access/3ds/testing/) fails validation 

After fix:
![Screenshot 2024-06-03 at 16 28 47](https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/3656f551-489d-4187-9b11-1b5f906e6ed3)




https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/e19e23b0-afba-4908-9d29-b9af79e963b9

@bigcommerce/team-checkout 
