### PR TITLE
feat(checkout): PAYPAL-4200 provided initial state config for store creation on createCheckoutButtonInitializer

### DIFF
--- a/packages/core/src/checkout-buttons/create-checkout-button-initializer.spec.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-initializer.spec.ts
@@ -1,11 +1,21 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 
+import { createCheckoutStore } from '../checkout';
+
 import CheckoutButtonInitializer from './checkout-button-initializer';
 import createCheckoutButtonInitializer from './create-checkout-button-initializer';
 
 jest.mock('@bigcommerce/form-poster');
 jest.mock('@bigcommerce/request-sender');
+jest.mock('../checkout', () => ({
+    createCheckoutStore: jest.fn(() => ({
+        getState: jest.fn().mockReturnValue({}),
+        subscribe: jest.fn(),
+    })),
+}));
+jest.mock('../payment-integration');
+jest.mock('./create-checkout-button-registry');
 
 describe('createCheckoutButtonInitializer()', () => {
     afterEach(() => {
@@ -21,8 +31,18 @@ describe('createCheckoutButtonInitializer()', () => {
     it('configures instance with host URL', () => {
         const host = 'https://foobar.com';
 
-        createCheckoutButtonInitializer({ host });
+        createCheckoutButtonInitializer({ host, locale: 'en' });
 
+        expect(createCheckoutStore).toHaveBeenCalledWith({
+            config: {
+                meta: {
+                    host,
+                    locale: 'en',
+                },
+                errors: {},
+                statuses: {},
+            },
+        });
         expect(createFormPoster).toHaveBeenCalledWith({ host });
         expect(createRequestSender).toHaveBeenCalledWith({ host });
     });

--- a/packages/core/src/checkout-buttons/create-checkout-button-initializer.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-initializer.ts
@@ -2,6 +2,7 @@ import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 
 import { createCheckoutStore } from '../checkout';
+import { ConfigState } from '../config';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
 import { createPaymentIntegrationService } from '../payment-integration';
 
@@ -38,7 +39,17 @@ export default function createCheckoutButtonInitializer(
     options?: CheckoutButtonInitializerOptions,
 ): CheckoutButtonInitializer {
     const { host, locale = 'en' } = options ?? {};
-    const store = createCheckoutStore();
+
+    const config: ConfigState = {
+        meta: {
+            host: options?.host,
+            locale: options?.locale,
+        },
+        errors: {},
+        statuses: {},
+    };
+
+    const store = createCheckoutStore({ config });
     const requestSender = createRequestSender({ host });
     const formPoster = createFormPoster({ host });
     const paymentIntegrationService = createPaymentIntegrationService(store);


### PR DESCRIPTION
## What?
Updated `createCheckoutButtonInitializer` with default initialization config param for `createCheckoutStore` function

## Why?
There was an issue that host option provided to `createCheckoutButtonInitializer` did not use in checkout api requests. Default request sender uses window.location.origin param as default when getHost method from store state returns empty string. The main problem is Headless stores do not have a chance to change default host, so checkout api calls fails due to the wrong domain origin, however payment api requests work as expected.

## Testing / Proof
Unit tests
Manual tests

Before this fix paypal commerce request used host option provided into createCheckoutButtonInitializer, while checkout-settings request used `window.location.origin`:
<img width="1154" alt="Screenshot 2024-06-05 at 10 34 22" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/ce77010b-e2fa-4d07-a23e-ba91f1ee5e80">
<img width="1152" alt="Screenshot 2024-06-05 at 10 34 41" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/2b20e633-80de-41cf-b686-d021d479d760">

After the fix, all requests uses the same host and api calls do not fail:
<img width="1529" alt="Screenshot 2024-06-05 at 10 35 30" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/d9a70083-3d1b-44df-bc74-584029d749c1">


P.s.: This is a part of Headless eWallet Buttons initialitive

