### PR TITLE
refactor(payment): PAYPAL-3598 updated PPCP Fastlane strategies to trigger the flow only for Guests

### DIFF
--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
@@ -99,7 +99,7 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
     beforeEach(() => {
         billingAddress = getBillingAddress();
         cart = getCart();
-        customer = getCustomer();
+        customer = { ...getCustomer(), isGuest: true };
         storeConfig = getConfig().storeConfig;
         paymentMethod = getPayPalCommerceAcceleratedCheckoutPaymentMethod();
         paypalAxoSdk = getPayPalAxoSdk();
@@ -259,26 +259,12 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
             }
         });
 
-        it('does not continue with Fastlane flow if feature is disabled for store members', async () => {
+        it('does not trigger with Fastlane flow for store members', async () => {
             const guestCustomer = {
                 ...customer,
                 isGuest: false,
             };
 
-            const storeConfigWithAFeature = {
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        ...storeConfig.checkoutSettings.features,
-                        'PAYPAL-4001.paypal_commerce_fastlane_stored_member_flow_removal': true,
-                    },
-                },
-            };
-
-            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
-                storeConfigWithAFeature,
-            );
             jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue(
                 guestCustomer,
             );
@@ -306,6 +292,8 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
         });
 
         it('initializes paypal sdk and authenticates user with paypal connect', async () => {
+            paymentMethod.initializationData.isFastlaneEnabled = false;
+
             await strategy.initialize(initializationOptions);
 
             expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(methodId);

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
@@ -60,7 +60,10 @@ export default class PayPalCommerceFastlaneShippingStrategy implements ShippingS
             );
         }
 
-        if (this._shouldSkipFastlaneForStoredMembers()) {
+        const state = this._store.getState();
+        const customer = state.customer.getCustomerOrThrow();
+
+        if (!customer?.isGuest) {
             return Promise.resolve(this._store.getState());
         }
 
@@ -113,19 +116,6 @@ export default class PayPalCommerceFastlaneShippingStrategy implements ShippingS
             : {};
 
         return paypalCommercePaymentProviderCustomer.authenticationState;
-    }
-
-    // TODO: remove this method when PAYPAL-4001.paypal_commerce_fastlane_stored_member_flow_removal will be rolled out to 100%
-    private _shouldSkipFastlaneForStoredMembers(): boolean {
-        const state = this._store.getState();
-        const customer = state.customer.getCustomerOrThrow();
-        const features = state.config.getStoreConfigOrThrow().checkoutSettings.features;
-
-        return (
-            features &&
-            features['PAYPAL-4001.paypal_commerce_fastlane_stored_member_flow_removal'] &&
-            !customer.isGuest
-        );
     }
 
     private _shouldAuthenticateUserWithFastlane(): boolean {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -122,13 +122,8 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
 
         const state = this.paymentIntegrationService.getState();
         const customer = state.getCustomerOrThrow();
-        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
-        const shouldSkipFastlaneForStoredMembers =
-            features &&
-            features['PAYPAL-4001.paypal_commerce_fastlane_stored_member_flow_removal'] &&
-            !customer.isGuest;
 
-        if (this.isAcceleratedCheckoutFeatureEnabled && !shouldSkipFastlaneForStoredMembers) {
+        if (this.isAcceleratedCheckoutFeatureEnabled && customer.isGuest) {
             const shouldRunAuthenticationFlow = await this.shouldRunAuthenticationFlow();
 
             if (

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -13,6 +13,7 @@ import {
     getCart,
     getConfig,
     getCustomer,
+    getGuestCustomer,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 import {
@@ -50,7 +51,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
 
     const address = getBillingAddress();
     const cart = getCart();
-    const customer = getCustomer();
+    const customer = getGuestCustomer();
     const storeConfig = getConfig().storeConfig;
 
     const authenticationResultMock = getPayPalConnectAuthenticationResultMock();
@@ -400,33 +401,15 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                 expect(paypalCommerceFastlaneUtils.lookupCustomerOrThrow).not.toHaveBeenCalled();
             });
 
-            it('does not trigger lookup method for store members when experiment is on', async () => {
+            it('does not trigger lookup method for store members', async () => {
                 paymentMethod.initializationData.isFastlaneEnabled = true;
 
-                const guestCustomer = {
-                    ...getCustomer(),
-                    isGuest: false,
-                };
-
-                const storeConfigWithAFeature = {
-                    ...storeConfig,
-                    checkoutSettings: {
-                        ...storeConfig.checkoutSettings,
-                        features: {
-                            ...storeConfig.checkoutSettings.features,
-                            'PAYPAL-4001.paypal_commerce_fastlane_stored_member_flow_removal': true,
-                        },
-                    },
-                };
+                const storeMember = getCustomer();
 
                 jest.spyOn(
                     paymentIntegrationService.getState(),
                     'getCustomerOrThrow',
-                ).mockReturnValue(guestCustomer);
-                jest.spyOn(
-                    paymentIntegrationService.getState(),
-                    'getStoreConfigOrThrow',
-                ).mockReturnValue(storeConfigWithAFeature);
+                ).mockReturnValue(storeMember);
 
                 await strategy.initialize(initializationOptions);
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -185,21 +185,15 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
         const customer = state.getCustomerOrThrow();
-        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
         const paymentProviderCustomer = state.getPaymentProviderCustomer();
         const paypalFastlaneCustomer = isPayPalFastlaneCustomer(paymentProviderCustomer)
             ? paymentProviderCustomer
             : {};
 
-        const shouldSkipFastlaneForStoredMembers =
-            features &&
-            features['PAYPAL-4001.paypal_commerce_fastlane_stored_member_flow_removal'] &&
-            !customer.isGuest;
-
         const paypalFastlaneSessionId = this.paypalCommerceFastlaneUtils.getStorageSessionId();
 
         if (
-            shouldSkipFastlaneForStoredMembers ||
+            !customer.isGuest ||
             paypalFastlaneCustomer?.authenticationState ===
                 PayPalFastlaneAuthenticationState.CANCELED
         ) {


### PR DESCRIPTION
## What?
Updated PPCP Fastlane strategies to trigger the flow only for Guests

## Why?
PayPal Fastlane does not support store member experience

## Testing / Proof
Unit tests
Manual tests
CI

The result of the work:
On sign up and sign in customer does not get Fastlane experience

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/2f182853-f98d-4d0a-b0fa-cbc54a689ccf


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/bcaf0e59-29b0-4752-b86f-503e22f41b8e

