### PR TITLE
refactor(payment): PAYPAL-4251 updated Braintree Fastlane strategies to run the flow only for guests

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -78,13 +78,8 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
 
         const state = this.paymentIntegrationService.getState();
         const customer = state.getCustomerOrThrow();
-        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
-        const shouldSkipFastlaneForStoredMembers =
-            features &&
-            features['PAYPAL-4001.braintree_fastlane_stored_member_flow_removal'] &&
-            !customer.isGuest;
 
-        if (this.isAcceleratedCheckoutEnabled && !shouldSkipFastlaneForStoredMembers) {
+        if (this.isAcceleratedCheckoutEnabled && customer.isGuest) {
             const shouldRunAuthenticationFlow = await this.shouldRunAuthenticationFlow();
 
             if (

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.spec.ts
@@ -24,6 +24,7 @@ import {
     getCart,
     getConfig,
     getCustomer,
+    getGuestCustomer,
     getShippingAddress,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
@@ -47,7 +48,7 @@ describe('BraintreeFastlanePaymentStrategy', () => {
     const instrumentId = 'asd123';
 
     const cart = getCart();
-    const customer = getCustomer();
+    const customer = getGuestCustomer();
     const billingAddress = getBillingAddress();
     const shippingAddress = getShippingAddress();
     const storeConfig = getConfig().storeConfig;
@@ -368,30 +369,12 @@ describe('BraintreeFastlanePaymentStrategy', () => {
             ).toHaveBeenCalled();
         });
 
-        it('does not trigger lookup method for store members when experiment is on', async () => {
-            const guestCustomer = {
-                ...getCustomer(),
-                isGuest: false,
-            };
-
-            const storeConfigWithAFeature = {
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        ...storeConfig.checkoutSettings.features,
-                        'PAYPAL-4001.braintree_fastlane_stored_member_flow_removal': true,
-                    },
-                },
-            };
+        it('does not trigger lookup method for store members', async () => {
+            const storeMember = getCustomer();
 
             jest.spyOn(paymentIntegrationService.getState(), 'getCustomerOrThrow').mockReturnValue(
-                guestCustomer,
+                storeMember,
             );
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getStoreConfigOrThrow',
-            ).mockReturnValue(storeConfigWithAFeature);
 
             await strategy.initialize(defaultInitializationOptions);
 

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.ts
@@ -319,7 +319,6 @@ export default class BraintreeFastlanePaymentStrategy implements PaymentStrategy
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
         const customer = state.getCustomerOrThrow();
-        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
         const paymentProviderCustomer = state.getPaymentProviderCustomer();
         const braintreePaymentProviderCustomer = isBraintreeAcceleratedCheckoutCustomer(
             paymentProviderCustomer,
@@ -329,13 +328,8 @@ export default class BraintreeFastlanePaymentStrategy implements PaymentStrategy
 
         const paypalFastlaneSessionId = this.browserStorage.getItem('sessionId');
 
-        const shouldSkipFastlaneForStoredMembers =
-            features &&
-            features['PAYPAL-4001.braintree_fastlane_stored_member_flow_removal'] &&
-            !customer.isGuest;
-
         if (
-            shouldSkipFastlaneForStoredMembers ||
+            !customer.isGuest ||
             braintreePaymentProviderCustomer?.authenticationState ===
                 BraintreeFastlaneAuthenticationState.CANCELED
         ) {

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
@@ -137,7 +137,10 @@ describe('BraintreeFastlaneShippingStrategy', () => {
         jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
             getConfig().storeConfig,
         );
-        jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue(getCustomer());
+        jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue({
+            ...getCustomer(),
+            isGuest: true,
+        });
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
             clientToken: 'clientToken',
             initializationData: {},
@@ -318,34 +321,16 @@ describe('BraintreeFastlaneShippingStrategy', () => {
             expect(loadPaymentMethodMock).toHaveBeenCalledWith(BRAINTREE_AXO_METHOD_ID);
         });
 
-        it('skip authentication flow for store members when experiment is on', async () => {
+        it('skip authentication flow for store members', async () => {
             const getBraintreeFastlaneMock = jest.fn();
-            const storeConfig = getConfig().storeConfig;
 
-            const guestCustomer = {
-                ...getCustomer(),
-                isGuest: false,
-            };
-
-            const storeConfigWithAFeature = {
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        ...storeConfig.checkoutSettings.features,
-                        'PAYPAL-4001.braintree_fastlane_stored_member_flow_removal': true,
-                    },
-                },
-            };
+            const storeMember = getCustomer();
 
             jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeFastlane').mockImplementation(
                 getBraintreeFastlaneMock,
             );
-            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
-                storeConfigWithAFeature,
-            );
             jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue(
-                guestCustomer,
+                storeMember,
             );
 
             const strategy = createStrategy();
@@ -702,13 +687,6 @@ describe('BraintreeFastlaneShippingStrategy', () => {
     describe('#handleBraintreeFastlaneShippingAddressChange', () => {
         beforeEach(() => {
             const storeConfig = getConfig().storeConfig;
-            const guestCustomer = {
-                ...getCustomer(),
-                isGuest: false,
-            };
-            jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue(
-                guestCustomer,
-            );
 
             const storeConfigWithAFeature = {
                 ...storeConfig,
@@ -716,11 +694,11 @@ describe('BraintreeFastlaneShippingStrategy', () => {
                     ...storeConfig.checkoutSettings,
                     features: {
                         ...storeConfig.checkoutSettings.features,
-                        'PAYPAL-4001.braintree_fastlane_stored_member_flow_removal': false,
                         'PAYPAL-3996.paypal_fastlane_shipping_update': true,
                     },
                 },
             };
+
             jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeFastlane').mockImplementation(
                 () => braintreeFastlane,
             );
@@ -753,6 +731,7 @@ describe('BraintreeFastlaneShippingStrategy', () => {
             const onPayPalFastlaneAddressChange = jest.fn((showPaypalAddressSelector) => {
                 showPaypalAddressSelector();
             });
+
             jest.spyOn(braintreeFastlane.profile, 'showShippingAddressSelector').mockImplementation(
                 () => ({
                     selectionChanged: true,
@@ -825,6 +804,7 @@ describe('BraintreeFastlaneShippingStrategy', () => {
             const onPayPalFastlaneAddressChange = jest.fn((showPaypalAddressSelector) => {
                 showPaypalAddressSelector();
             });
+
             jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeFastlane').mockImplementation(
                 () => braintreeFastlane,
             );


### PR DESCRIPTION
## What?
Updated Braintree Fastlane strategies to run the flow only for guest users

## Why?
PayPal Fastlane does not support store member experience

## Testing / Proof
Unit tests
Manual tests
CI

The result of the work:
On sign up and sign in customer does not get Fastlane experience

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/2f182853-f98d-4d0a-b0fa-cbc54a689ccf


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/bcaf0e59-29b0-4752-b86f-503e22f41b8e


