### PR TITLE
feat(payment): PAYPAL-4231 added onCreditCardFieldsRenderingError callback to ppcp cc payment strategy to let handle an error on UI side

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-initialize-options.ts
@@ -24,6 +24,7 @@ import { HostedFormOptions } from '@bigcommerce/checkout-sdk/payment-integration
  *                 cardCode: { containerId: 'card-code' },
  *             },
  *         },
+ *         onCreditCardFieldsRenderingError: (error) => handleError(error),
  *     },
  * });
  * ```
@@ -70,6 +71,7 @@ import { HostedFormOptions } from '@bigcommerce/checkout-sdk/payment-integration
  *                 console.log(isValid);
  *             },
  *         },
+ *         onCreditCardFieldsRenderingError: (error) => handleError(error),
  *     },
  * });
  * ```
@@ -79,6 +81,11 @@ export default interface PayPalCommerceCreditCardsPaymentInitializeOptions {
      * The form is data for Credit Card Form
      */
     form: HostedFormOptions;
+
+    /**
+     * The callback that gets called when there is an issue with rendering credit card fields
+     */
+    onCreditCardFieldsRenderingError?: (error: unknown) => void;
 }
 
 // TODO: this interface should be removed
@@ -90,6 +97,11 @@ export interface DeprecatedPayPalCommerceCreditCardsPaymentInitializeOptions {
      * The form is data for Credit Card Form
      */
     form?: HostedFormOptions;
+
+    /**
+     * The callback that gets called when there is an issue with rendering credit card fields
+     */
+    onCreditCardFieldsRenderingError?: (error: unknown) => void;
 }
 
 export interface WithPayPalCommerceCreditCardsPaymentInitializeOptions {


### PR DESCRIPTION
## What?
Added onCreditCardFieldsRenderingError callback to ppcp cc payment strategy to let handle an error on UI side

## Why?
Sometimes, when customer quickly switches between different checkout steps, the async credit card initialization process can occur an error related to missing container for PayPal field. Therefore, it shows developer's related error for a customer who should not see it. Hence, the error can be handled on UI side in the way how it should be in merchant's dev perspective.

## Testing / Proof
Unit tests
CI

Before:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/b10777ca-8031-4101-85c6-ca1aea641a0f


After:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/c32b6fc3-8ec9-4d46-a52b-d91240fbbec1


