### PR TITLE
fix(payment): PI-2161 [TDOnlineMart] fix issue with vaulted card payment when mixed products in the cart

### DIFF
--- a/packages/td-bank-integration/src/td-online-mart-payment-strategy.ts
+++ b/packages/td-bank-integration/src/td-online-mart-payment-strategy.ts
@@ -118,9 +118,11 @@ export default class TDOnlineMartPaymentStrategy implements PaymentStrategy {
             isVaultedInstrument(paymentData) &&
             paymentData.instrumentId
         ) {
-            const shouldAddVerificationToken = !this.isTrustedVaultingInstrument(
-                paymentData.instrumentId,
-            );
+            const cart = this.paymentIntegrationService.getState().getCartOrThrow();
+            const digitalItemsInCart = !!cart.lineItems.digitalItems.length;
+
+            const shouldAddVerificationToken =
+                !this.isTrustedVaultingInstrument(paymentData.instrumentId) || digitalItemsInCart;
 
             return {
                 methodId,


### PR DESCRIPTION
## What?
Added additional check for digital items in the cart to decide whether or not to add verification nonce to `submitPayment` payload in TD Bank.

## Why?
With both digital and physical items in the cart, the `trustedShippingAddress` value is set to true, so the verification nonce wasn't added to the `submitPayment` payload. However, verification nonce seems to be required for payments when there are digital items in the cart.

## Testing / Proof
Unit + manual testing

Before:

<img width="1512" alt="Screenshot 2024-06-12 at 09 51 13" src="https://github.com/bigcommerce/checkout-sdk-js/assets/138816572/f35e0ce5-5941-4b13-99a5-d9a2472b47b1">

After:

<img width="1512" alt="Screenshot 2024-06-12 at 09 49 37" src="https://github.com/bigcommerce/checkout-sdk-js/assets/138816572/34827511-1c9d-49fc-99f3-17ee8cd63dc7">
