### PR TITLE
feat(payment): PAYPAL-3273 added patch method on paypal order creation for non instant payment methods PPCP

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
@@ -53,6 +53,7 @@ describe('PayPalCommerceIntegrationService', () => {
     let paypalSdk: PayPalSDK;
 
     const defaultMethodId = 'paypalcommerce';
+    const defaultGatewayId = 'paypalcommercealternativemethods';
     const mockedOrderId = 'order123';
 
     beforeEach(() => {
@@ -339,6 +340,30 @@ describe('PayPalCommerceIntegrationService', () => {
             expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
                 methodId: defaultMethodId,
                 paymentData: paymentDataMock,
+            });
+        });
+
+        it('successfully submits payment with provided gateway', async () => {
+            jest.spyOn(paymentIntegrationService, 'submitPayment').mockImplementation(jest.fn());
+
+            const paymentDataMock = {
+                formattedPayload: {
+                    vault_payment_instrument: null,
+                    set_as_default_stored_instrument: null,
+                    device_info: null,
+                    method_id: defaultMethodId,
+                    paypal_account: {
+                        order_id: mockedOrderId,
+                    },
+                },
+            };
+
+            await subject.submitPayment(defaultMethodId, mockedOrderId, defaultGatewayId);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: defaultMethodId,
+                paymentData: paymentDataMock,
+                gatewayId: defaultGatewayId,
             });
         });
     });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -182,7 +182,7 @@ export default class PayPalCommerceIntegrationService {
         });
     }
 
-    async submitPayment(methodId: string, orderId: string): Promise<void> {
+    async submitPayment(methodId: string, orderId: string, gatewayId?: string): Promise<void> {
         const paymentData = {
             formattedPayload: {
                 vault_payment_instrument: null,
@@ -195,7 +195,11 @@ export default class PayPalCommerceIntegrationService {
             },
         };
 
-        await this.paymentIntegrationService.submitPayment({ methodId, paymentData });
+        await this.paymentIntegrationService.submitPayment({
+            methodId,
+            paymentData,
+            ...(gatewayId ? { gatewayId } : {}),
+        });
     }
 
     /**


### PR DESCRIPTION
## What?
Added patch method on PayPal order creation for non instant payment methods for PPCP APMs

## Why?
Non instant payment methods has a bit different flow of submitting an order, so we should firstly patch the order to send request to the bank and then submit it after approval.

## Testing / Proof
Unit tests
Manual tests
CI
