### PR TITLE
fix(payment): PI-831 fixed mollie ApplePay redirect

### DIFF
--- a/packages/mollie-integration/src/create-mollie-payment-strategy.ts
+++ b/packages/mollie-integration/src/create-mollie-payment-strategy.ts
@@ -17,4 +17,7 @@ const createMolliePaymentStrategy: PaymentStrategyFactory<MolliePaymentStrategy>
     );
 };
 
-export default toResolvableModule(createMolliePaymentStrategy, [{ gateway: 'mollie' }]);
+export default toResolvableModule(createMolliePaymentStrategy, [
+    { gateway: 'mollie' },
+    { gateway: 'mollie', id: 'applepay' },
+]);


### PR DESCRIPTION
## What?
Mollie ApplePay fix

## Why?
Mollie ApplePay works via Mollie Redirect, so our ApplePay implementation is not working with Mollie.
I've changed Mollie payment strategy resolver to fix this problem

## Testing / Proof
Before fix:

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/88e7c41a-6853-4283-8870-bdf3498d73cb

After fix:

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/d865b987-307a-4457-8afd-2adcbd3781f6




@bigcommerce/team-checkout @bigcommerce/team-payments
