### PR TITLE
feat(payment): PAYPAL-4292 Pay Later messaging at payment step of Checkout is based off of Order subtotal instead of grand total

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -194,11 +194,11 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         const { paypal } = this._window;
 
         if (paypal && isMessageContainerAvailable) {
-            const state = this._store.getState();
-            const cart = state.cart.getCartOrThrow();
+            const { checkout } = this._store.getState();
+            const grandTotal = checkout.getCheckoutOrThrow().outstandingBalance;
 
             const paypalMessagesRender = paypal.Messages({
-                amount: cart.cartAmount,
+                amount: grandTotal,
                 placement: 'cart',
             });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -257,10 +257,12 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         messagingContainerId: string,
     ): void {
         if (messagingContainerId && document.getElementById(messagingContainerId)) {
-            const cart = this.paymentIntegrationService.getState().getCartOrThrow();
+            const checkout = this.paymentIntegrationService.getState().getCheckoutOrThrow();
+
+            const grandTotal = checkout.outstandingBalance;
 
             const paypalMessagesOptions: MessagingOptions = {
-                amount: cart.cartAmount,
+                amount: grandTotal,
                 placement: 'cart',
                 style: {
                     layout: 'text',

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
@@ -249,10 +249,12 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
      *
      * */
     private renderMessages(paypalMessages: PayPalMessagesSdk, bannerContainerId: string): void {
-        const cart = this.paymentIntegrationService.getState().getCartOrThrow();
+        const checkout = this.paymentIntegrationService.getState().getCheckoutOrThrow();
+
+        const grandTotal = checkout.outstandingBalance;
 
         const paypalMessagesOptions: MessagingOptions = {
-            amount: cart.cartAmount,
+            amount: grandTotal,
             placement: 'payment',
             style: {
                 layout: 'text',


### PR DESCRIPTION
## What?

Corrected amount parameter

## Why?

For the right calculation of PayLater Messaging amount

## Testing / Proof

Manual

@bigcommerce/team-checkout @bigcommerce/team-payments
