### PR TITLE
fix(payment): STRIPE-378 Spike GooglePay shipping options

### DIFF
--- a/packages/google-pay-integration/jest.config.js
+++ b/packages/google-pay-integration/jest.config.js
@@ -9,4 +9,5 @@ module.exports = {
     },
     setupFilesAfterEnv: ['../../jest-setup.js'],
     coverageDirectory: '../../coverage/packages/google-pay-integration',
+    coveragePathIgnorePatterns: ['<rootDir>/src/index.ts'],
 };

--- a/packages/google-pay-integration/src/google-pay-payment-processor.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.ts
@@ -17,17 +17,18 @@ import GooglePayGateway from './gateways/google-pay-gateway';
 import GooglePayScriptLoader from './google-pay-script-loader';
 import isGooglePayAdditionalActionProcessable from './guards/is-google-pay-additional-action-processable';
 import {
-    CallbackIntentsType,
     GooglePayBaseCardPaymentMethod,
     GooglePayButtonOptions,
     GooglePayCardDataResponse,
     GooglePayCardPaymentMethod,
+    GooglePayFullBillingAddress,
     GooglePayGatewayBaseRequest,
     GooglePayInitializationData,
     GooglePayIsReadyToPayRequest,
     GooglePaymentsClient,
     GooglePayPaymentDataRequest,
     GooglePayPaymentOptions,
+    ShippingOptionParameters,
 } from './types';
 
 export default class GooglePayPaymentProcessor {
@@ -136,6 +137,24 @@ export default class GooglePayPaymentProcessor {
         await this._requestSender.get(`/remote-checkout/${providerId}/signout`);
     }
 
+    getCallbackTriggers() {
+        return this._gateway.getCallbackTriggers();
+    }
+
+    async handleShippingAddressChange(
+        shippingAddress: GooglePayFullBillingAddress,
+    ): Promise<ShippingOptionParameters> {
+        return this._gateway.handleShippingAddressChange(shippingAddress);
+    }
+
+    async handleShippingOptionChange(optionId: string): Promise<void> {
+        await this._gateway.handleShippingOptionChange(optionId);
+    }
+
+    getTotalPrice(): string {
+        return this._gateway.getTotalPrice();
+    }
+
     async _setExternalCheckout(
         provider: string,
         response: GooglePayCardDataResponse,
@@ -218,7 +237,7 @@ export default class GooglePayPaymentProcessor {
             transactionInfo: this._gateway.getTransactionInfo(),
             merchantInfo: this._gateway.getMerchantInfo(),
             ...(await this._gateway.getRequiredData()),
-            callbackIntents: [CallbackIntentsType.OFFER],
+            callbackIntents: this._gateway.getCallbackIntents(),
         };
         this._isReadyToPayRequest = {
             ...this._baseRequest,

--- a/packages/google-pay-integration/src/types.ts
+++ b/packages/google-pay-integration/src/types.ts
@@ -151,6 +151,7 @@ export interface GooglePayPaymentDataRequest extends GooglePayGatewayBaseRequest
         allowedCountryCodes?: string[];
         phoneNumberRequired?: boolean;
     };
+    shippingOptionRequired?: boolean;
     callbackIntents?: CallbackIntentsType[];
 }
 
@@ -162,6 +163,20 @@ export interface NewTransactionInfo {
     };
 }
 
+export interface ShippingOptionParameters {
+    defaultSelectedOptionId?: string;
+    shippingOptions?: GoogleShippingOption[];
+}
+
+export interface NewShippingOptionParameters {
+    newShippingOptionParameters?: ShippingOptionParameters;
+}
+
+export interface GoogleShippingOption {
+    id: string;
+    label?: string;
+}
+
 export enum CallbackTriggerType {
     INITIALIZE = 'INITIALIZE',
     SHIPPING_OPTION = 'SHIPPING_OPTION',
@@ -171,19 +186,24 @@ export enum CallbackTriggerType {
 
 export interface IntermediatePaymentData {
     callbackTrigger: CallbackTriggerType;
+    shippingAddress: GooglePayFullBillingAddress;
+    shippingOptionData: GoogleShippingOption;
 }
 
 export interface GooglePayPaymentOptions {
     paymentDataCallbacks?: {
         onPaymentDataChanged(
             intermediatePaymentData: IntermediatePaymentData,
-        ): Promise<NewTransactionInfo | void>;
+        ): Promise<(NewTransactionInfo & NewShippingOptionParameters) | void>;
     };
 }
 
 export type GooglePayRequiredPaymentData = Pick<
     GooglePayPaymentDataRequest,
-    'emailRequired' | 'shippingAddressRequired' | 'shippingAddressParameters'
+    | 'emailRequired'
+    | 'shippingAddressRequired'
+    | 'shippingAddressParameters'
+    | 'shippingOptionRequired'
 >;
 
 interface GooglePayMinBillingAddress {
@@ -273,6 +293,7 @@ interface GooglePayBaseInitializationData {
     googleMerchantId: string;
     googleMerchantName: string;
     isThreeDSecureEnabled: boolean;
+    isShippingOptionsEnabled?: boolean;
     nonce?: string;
     platformToken: string;
     storeCountry?: string;

--- a/packages/payment-integration-api/src/currency/index.ts
+++ b/packages/payment-integration-api/src/currency/index.ts
@@ -1,2 +1,4 @@
 export { default as Currency, CurrencyConfig } from './currency';
 export { default as CurrencyFormatter } from './currency-formatter';
+export { default as CurrencyService } from './currency-service';
+export { default as createCurrencyService } from './create-currency-service';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -26,7 +26,13 @@ export { Omit, PartialDeep } from './common/types';
 export { objectWithKebabCaseKeys, AmountTransformer } from './common/utility';
 export { Config, StoreConfig, CheckoutSettings, StoreProfile } from './config';
 export { Coupon } from './coupon';
-export { Currency, CurrencyFormatter, CurrencyConfig } from './currency';
+export {
+    Currency,
+    CurrencyFormatter,
+    CurrencyConfig,
+    CurrencyService,
+    createCurrencyService,
+} from './currency';
 export {
     CheckoutPaymentMethodExecutedOptions,
     CustomerCredentials,


### PR DESCRIPTION
## What?
Add shipping options selector to Google Pay modal window

## Why?
To give ability for shopper select sipping address and shipping options inside GPay modal, and then show in the modal relevant total cost

BCApp PR: [https://github.com/bigcommerce/bigcommerce/pull/58506](https://github.com/bigcommerce/bigcommerce/pull/58506)

## Testing / Proof
When experiment disabled:

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/a9f2bcb5-142d-4ff7-9952-c5d7dfc5242a


https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/25f3cb3c-5efa-4c28-b399-c9a48687ecf1

When experiment enabled:

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/a8a4946a-97cd-45f0-b649-ab6f410acd79


https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/2f3ae34a-2e54-4303-b64e-6992007a96e2


Experiment enabled but shipping available only to US:


https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/6a9d3ed9-985e-46d4-89b2-1a033ffcbc7c

Also test for PayPal

https://github.com/user-attachments/assets/bb6e3a57-a0da-4200-8f77-88480bc3be10



https://github.com/user-attachments/assets/b68d5ab7-ee02-4efe-88fc-e73e17f49dd2


https://github.com/user-attachments/assets/a08b3f69-c701-4047-9fde-332859a93725

Package test coverage:
<img width="2560" alt="Screenshot 2024-07-24 at 15 21 20" src="https://github.com/user-attachments/assets/9030ae30-620e-4808-92b7-ed45a46cb82a">



@bigcommerce/team-checkout @bigcommerce/team-payments
