### PR TITLE
feat(payment): PI-2283 Add Google Pay on TD Online Mart - checkout pa…

### DIFF
--- a/packages/google-pay-integration/src/factories/payment/create-google-pay-tdonlinemart-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/payment/create-google-pay-tdonlinemart-payment-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayPaymentStrategy from '../../google-pay-payment-strategy';
+
+import createGooglePayTdOnlineMartPaymentStrategy from './create-google-pay-tdonlinemart-payment-strategy';
+
+describe('createGooglePayTdOnlineMartPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay TD Online Mart payment strategy', () => {
+        const strategy = createGooglePayTdOnlineMartPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayPaymentStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/payment/create-google-pay-tdonlinemart-payment-strategy.ts
+++ b/packages/google-pay-integration/src/factories/payment/create-google-pay-tdonlinemart-payment-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayTdOnlineMartGateway from '../../gateways/google-pay-tdonlinemart-gateway';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import GooglePayPaymentStrategy from '../../google-pay-payment-strategy';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayTdOnlineMartPaymentStrategy: PaymentStrategyFactory<
+    GooglePayPaymentStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayPaymentStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayTdOnlineMartGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayTdOnlineMartPaymentStrategy, [
+    { id: 'googlepaytdonlinemart' },
+]);

--- a/packages/google-pay-integration/src/gateways/google-pay-tdonlinemart-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-tdonlinemart-gateway.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayGateway from './google-pay-gateway';
+import GooglePayTdOnlineMartGateway from './google-pay-tdonlinemart-gateway';
+
+describe('GooglePayTdOnlineMartGateway', () => {
+    let gateway: GooglePayTdOnlineMartGateway;
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        gateway = new GooglePayTdOnlineMartGateway(paymentIntegrationService);
+    });
+
+    it('is a special type of GooglePayGateway', () => {
+        expect(gateway).toBeInstanceOf(GooglePayGateway);
+    });
+});

--- a/packages/google-pay-integration/src/gateways/google-pay-tdonlinemart-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-tdonlinemart-gateway.ts
@@ -1,0 +1,9 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayGateway from './google-pay-gateway';
+
+export default class GooglePayTdOnlineMartGateway extends GooglePayGateway {
+    constructor(service: PaymentIntegrationService) {
+        super('worldlinena', service);
+    }
+}

--- a/packages/google-pay-integration/src/google-pay-payment-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-initialize-options.ts
@@ -75,6 +75,7 @@ export enum GooglePayKey {
     STRIPE = 'googlepaystripe',
     STRIPE_UPE = 'googlepaystripeupe',
     WORLDPAY_ACCESS = 'googlepayworldpayaccess',
+    TD_ONLINE_MART = 'googlepaytdonlinemart',
 }
 
 /**

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -12,6 +12,7 @@ export { default as createGooglePayStripePaymentStrategy } from './factories/pay
 export { default as createGooglePayWorldpayAccessPaymentStrategy } from './factories/payment/create-google-pay-worldpayaccess-payment-strategy';
 export { default as createGooglePayBraintreePaymentStrategy } from './factories/payment/create-google-pay-braintree-payment-strategy';
 export { default as createGooglePayPPCPPaymentStrategy } from './google-pay-paypal-commerce/create-google-pay-paypal-commerce-payment-strategy';
+export { default as createGooglePayTdOnlineMartPaymentStrategy } from './factories/payment/create-google-pay-tdonlinemart-payment-strategy';
 
 export { default as createGooglePayAdyenV2CustomerStrategy } from './factories/customer/create-google-pay-adyenv2-customer-strategy';
 export { default as createGooglePayAdyenV3CustomerStrategy } from './factories/customer/create-google-pay-adyenv3-customer-strategy';


### PR DESCRIPTION
…yment step
checkout-js part: https://github.com/bigcommerce/checkout-js/pull/1906

## What?
Add Google Pay on TD Online Mart in checkout payment step

## Why?
As a merchant I want to be able to offer my shoppers Google Pay wallet through TD Online Mart

## Testing / Proof
Tested manually
Work on backend part of this project is not started yet. Therefore added part of the code will not execute before BE part will be ready.
@bigcommerce/team-checkout @bigcommerce/team-payments
