### PR TITLE
feat(payment): PI-2284 Add Google Pay on TD Online Mart - checkout customer step

### DIFF
--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-tdonlinemart-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-tdonlinemart-customer-strategy.spec.ts
@@ -1,0 +1,29 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getConfig,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+
+import createGooglePayTdOnlineMartCustomerStrategy from './create-google-pay-tdonlinemart-customer-strategy';
+
+describe('createGooglePayTdOnlineMartCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay TD Online Mart customer strategy', () => {
+        const storeConfigMock = getConfig().storeConfig;
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValueOnce(
+            storeConfigMock,
+        );
+
+        const strategy = createGooglePayTdOnlineMartCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-tdonlinemart-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-tdonlinemart-customer-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayTdOnlineMartGateway from '../../gateways/google-pay-tdonlinemart-gateway';
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayTdOnlineMartCustomerStrategy: CustomerStrategyFactory<
+    GooglePayCustomerStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayCustomerStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayTdOnlineMartGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayTdOnlineMartCustomerStrategy, [
+    { id: 'googlepaytdonlinemart' },
+]);

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -26,6 +26,7 @@ export { default as createGooglePayStripeUpeCustomerStrategy } from './factories
 export { default as createGooglePayWorldpayAccessCustomerStrategy } from './factories/customer/create-google-pay-worldpayaccess-customer-strategy';
 export { default as createGooglePayBraintreeCustomerStrategy } from './factories/customer/create-google-pay-braintree-customer-strategy';
 export { default as createGooglePayPayPalCommerceCustomerStrategy } from './google-pay-paypal-commerce/create-google-pay-paypal-commerce-customer-strategy';
+export { default as createGooglePayTdOnlineMartCustomerStrategy } from './factories/customer/create-google-pay-tdonlinemart-customer-strategy';
 
 export { default as createGooglePayBraintreeButtonStrategy } from './factories/button/create-google-pay-braintree-button-strategy';
 export { default as createGooglePayPayPalCommerceButtonStrategy } from './google-pay-paypal-commerce/create-google-pay-paypal-commerce-button-strategy';


### PR DESCRIPTION
checkout-js part: https://github.com/bigcommerce/checkout-js/pull/1910

## What?
Add Google Pay on TD Online Mart in button payment step

## Why?
As a merchant I want to be able to offer my shoppers Google Pay wallet through TD Online Mart

## Testing / Proof
Tested manually
Work on backend part of this project is not started yet. Therefore added part of the code will not execute before BE part will be ready.
@bigcommerce/team-checkout @bigcommerce/team-payments
