### PR TITLE
chore(common): CHECKOUT-8410 Update to use node20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ aliases:
   - &node_executor
       executor:
         name: node/node
-        node-version: "18.17"
+        node-version: "20.6.0"
 
 version: 2.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "18",
+        "node": "20",
         "npm": "9"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "url": "https://github.com/bigcommerce/checkout-sdk-js/issues"
   },
   "engines": {
-    "node": "18",
+    "node": "20",
     "npm": "9"
   },
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-sdk-js",
   "scripts": {
-    "prepare": "check-node-version --node '>=18' --npm '>=9'",
+    "prepare": "check-node-version --node '>=20' --npm '>=9'",
     "build": "npm run bundle && npm run bundle-dts",
     "build:link": "rm -rf dist && npx nx run core:build --skip-nx-cache && npm run bundle-dts",
     "prebuild-cdn": "rm -rf dist-cdn",


### PR DESCRIPTION
## What?
Update to use node 20.

## Why?
Node 18 is already in maintenance mode, so it makes sense to move to next active version.

## Testing / Proof
- CI

@bigcommerce/team-checkout @bigcommerce/team-payments
