### PR TITLE
feat(payment): PAYPAL-4284 reverted PPCP onShippingAddressChange and onShippingOptionChange callbacks

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -243,12 +243,20 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                     }
                 });
 
-                eventEmitter.on('onShippingChange', () => {
-                    if (options.onShippingChange) {
-                        options.onShippingChange({
-                            orderID: paypalOrderId,
-                            shipping_address: paypalShippingAddressPayloadMock,
-                            selected_shipping_option: paypalSelectedShippingOptionPayloadMock,
+                eventEmitter.on('onShippingAddressChange', () => {
+                    if (options.onShippingAddressChange) {
+                        options.onShippingAddressChange({
+                            orderId: paypalOrderId,
+                            shippingAddress: paypalShippingAddressPayloadMock,
+                        });
+                    }
+                });
+
+                eventEmitter.on('onShippingOptionsChange', () => {
+                    if (options.onShippingOptionsChange) {
+                        options.onShippingOptionsChange({
+                            orderId: paypalOrderId,
+                            selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
                         });
                     }
                 });
@@ -448,7 +456,8 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                 fundingSource: paypalSdk.FUNDING.PAYLATER,
                 style: paypalCommerceCreditOptions.style,
                 createOrder: expect.any(Function),
-                onShippingChange: expect.any(Function),
+                onShippingAddressChange: expect.any(Function),
+                onShippingOptionsChange: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });
@@ -685,7 +694,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         });
     });
 
-    describe('#onShippingChange button callback', () => {
+    describe('#onShippingAddressChange button callback', () => {
         beforeEach(() => {
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
@@ -722,7 +731,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingChange');
+            eventEmitter.emit('onShippingAddressChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -733,7 +742,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         it('selects shipping option after address update', async () => {
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingChange');
+            eventEmitter.emit('onShippingAddressChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -754,7 +763,47 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingChange');
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.updateOrder).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onShippingOptionsChange button callback', () => {
+        beforeEach(() => {
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+        });
+
+        it('selects shipping option', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.getShippingOptionOrThrow).toHaveBeenCalled();
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                getShippingOption().id,
+            );
+        });
+
+        it('updates PayPal order', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -96,6 +96,13 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
 
     const paypalShippingAddressPayloadMock = {
         city: 'New York',
+        countryCode: 'US',
+        postalCode: '07564',
+        state: 'New York',
+    };
+
+    const paypalShippingCallbackAddressMock = {
+        city: 'New York',
         country_code: 'US',
         postal_code: '07564',
         state: 'New York',
@@ -183,6 +190,13 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         jest.spyOn(payPalMessagesSdk, 'Messages').mockImplementation(() => ({
             render: paypalCommerceSdkRenderMock,
         }));
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
+            checkoutSettings: {
+                features: {
+                    'PAYPAL-4387.paypal_shipping_callbacks': true,
+                },
+            },
+        });
 
         jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
             (options: PayPalCommerceButtonsOptions) => {
@@ -257,6 +271,16 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                         options.onShippingOptionsChange({
                             orderId: paypalOrderId,
                             selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
+                        });
+                    }
+                });
+
+                eventEmitter.on('onShippingChange', () => {
+                    if (options.onShippingChange) {
+                        options.onShippingChange({
+                            orderID: paypalOrderId,
+                            shipping_address: paypalShippingCallbackAddressMock,
+                            selected_shipping_option: paypalSelectedShippingOptionPayloadMock,
                         });
                     }
                 });
@@ -458,6 +482,39 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('initializes PayPal button to render (with shipping options feature enabled and shipping experiment is off)', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
+                checkoutSettings: {
+                    features: {
+                        'PAYPAL-4387.paypal_shipping_callbacks': false,
+                    },
+                },
+            });
+
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYLATER,
+                style: paypalCommerceCreditOptions.style,
+                createOrder: expect.any(Function),
+                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });
@@ -720,8 +777,8 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                 address1: '',
                 address2: '',
                 city: paypalShippingAddressPayloadMock.city,
-                countryCode: paypalShippingAddressPayloadMock.country_code,
-                postalCode: paypalShippingAddressPayloadMock.postal_code,
+                countryCode: paypalShippingAddressPayloadMock.countryCode,
+                postalCode: paypalShippingAddressPayloadMock.postalCode,
                 stateOrProvince: '',
                 stateOrProvinceCode: paypalShippingAddressPayloadMock.state,
                 customFields: [],

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -20,6 +20,7 @@ import {
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
+    ShippingChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
@@ -140,11 +141,25 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
             onCancel: () => this.paymentIntegrationService.loadDefaultCheckout(),
         };
 
+        const isPaypalShippingCallbacksExperimentIsOn =
+            state.getStoreConfig()?.checkoutSettings.features[
+                'PAYPAL-4387.paypal_shipping_callbacks'
+            ];
+
+        const onShippingChangeCallbacks = isPaypalShippingCallbacksExperimentIsOn
+            ? {
+                  onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                      this.onShippingAddressChange(data),
+                  onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                      this.onShippingOptionsChange(data),
+              }
+            : {
+                  onShippingChange: (data: ShippingChangeCallbackPayload) =>
+                      this.onShippingChange(data),
+              };
+
         const hostedCheckoutCallbacks = {
-            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                this.onShippingAddressChange(data),
-            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                this.onShippingOptionsChange(data),
+            ...onShippingChangeCallbacks,
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -238,8 +253,8 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
     ): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
             city: data.shippingAddress.city,
-            countryCode: data.shippingAddress.country_code,
-            postalCode: data.shippingAddress.postal_code,
+            countryCode: data.shippingAddress.countryCode,
+            postalCode: data.shippingAddress.postalCode,
             stateOrProvinceCode: data.shippingAddress.state,
         });
 
@@ -266,6 +281,29 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         );
 
         try {
+            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+            await this.paypalCommerceIntegrationService.updateOrder();
+        } catch (error) {
+            throw new Error(error);
+        }
+    }
+
+    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
+        const address = this.paypalCommerceIntegrationService.getAddress({
+            city: data.shipping_address.city,
+            countryCode: data.shipping_address.country_code,
+            postalCode: data.shipping_address.postal_code,
+            stateOrProvinceCode: data.shipping_address.state,
+        });
+
+        try {
+            await this.paymentIntegrationService.updateBillingAddress(address);
+            await this.paymentIntegrationService.updateShippingAddress(address);
+
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+                data.selected_shipping_option?.id,
+            );
+
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -19,7 +19,8 @@ import {
     PayPalBuyNowInitializeOptions,
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
-    ShippingChangeCallbackPayload,
+    ShippingAddressChangeCallbackPayload,
+    ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCreditButtonInitializeOptions, {
@@ -140,7 +141,10 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         };
 
         const hostedCheckoutCallbacks = {
-            onShippingChange: (data: ShippingChangeCallbackPayload) => this.onShippingChange(data),
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                this.onShippingAddressChange(data),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                this.onShippingOptionsChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -229,22 +233,39 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         }
     }
 
-    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
+    private async onShippingAddressChange(
+        data: ShippingAddressChangeCallbackPayload,
+    ): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shipping_address.city,
-            countryCode: data.shipping_address.country_code,
-            postalCode: data.shipping_address.postal_code,
-            stateOrProvinceCode: data.shipping_address.state,
+            city: data.shippingAddress.city,
+            countryCode: data.shippingAddress.country_code,
+            postalCode: data.shippingAddress.postal_code,
+            stateOrProvinceCode: data.shippingAddress.state,
         });
 
         try {
+            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
+            // on this stage we don't have access to valid customer's address accept shipping data
             await this.paymentIntegrationService.updateBillingAddress(address);
             await this.paymentIntegrationService.updateShippingAddress(address);
 
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-                data.selected_shipping_option?.id,
-            );
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow();
 
+            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+            await this.paypalCommerceIntegrationService.updateOrder();
+        } catch (error) {
+            throw new Error(error);
+        }
+    }
+
+    private async onShippingOptionsChange(
+        data: ShippingOptionChangeCallbackPayload,
+    ): Promise<void> {
+        const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+            data.selectedShippingOption.id,
+        );
+
+        try {
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -103,6 +103,13 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
         jest.spyOn(paypalCommerceIntegrationService, 'getShippingOptionOrThrow').mockReturnValue(
             getShippingOption(),
         );
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
+            checkoutSettings: {
+                features: {
+                    'PAYPAL-4387.paypal_shipping_callbacks': true,
+                },
+            },
+        });
 
         jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
             (options: PayPalCommerceButtonsOptions) => {
@@ -143,8 +150,8 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                             orderId: approveDataOrderId,
                             shippingAddress: {
                                 city: 'New York',
-                                country_code: 'US',
-                                postal_code: '07564',
+                                countryCode: 'US',
+                                postalCode: '07564',
                                 state: 'New York',
                             },
                         });
@@ -156,6 +163,30 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                         options.onShippingOptionsChange({
                             orderId: approveDataOrderId,
                             selectedShippingOption: {
+                                amount: {
+                                    currency_code: 'USD',
+                                    value: '100',
+                                },
+                                id: '1',
+                                label: 'Free shipping',
+                                selected: true,
+                                type: 'type_shipping',
+                            },
+                        });
+                    }
+                });
+
+                eventEmitter.on('onShippingChange', () => {
+                    if (options.onShippingChange) {
+                        options.onShippingChange({
+                            orderID: paypalOrderId,
+                            shipping_address: {
+                                city: 'New York',
+                                country_code: 'US',
+                                postal_code: '07564',
+                                state: 'New York',
+                            },
+                            selected_shipping_option: {
                                 amount: {
                                     currency_code: 'USD',
                                     value: '100',
@@ -304,6 +335,41 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+                onClick: expect.any(Function),
+            });
+        });
+
+        it('initializes paypal buttons with config related to hosted checkout feature and shipping callbacks experiment is off', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
+                checkoutSettings: {
+                    features: {
+                        'PAYPAL-4387.paypal_shipping_callbacks': false,
+                    },
+                },
+            });
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYLATER,
+                style: {
+                    height: DefaultCheckoutButtonHeight,
+                    color: StyleButtonColor.silver,
+                    label: 'checkout',
+                },
+                createOrder: expect.any(Function),
+                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
             });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -59,24 +59,6 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
         paypalcommercecredit: paypalCommerceCreditOptions,
     };
 
-    const paypalShippingAddressPayloadMock = {
-        city: 'New York',
-        country_code: 'US',
-        postal_code: '07564',
-        state: 'New York',
-    };
-
-    const paypalSelectedShippingOptionPayloadMock = {
-        amount: {
-            currency_code: 'USD',
-            value: '100',
-        },
-        id: '1',
-        label: 'Free shipping',
-        selected: true,
-        type: 'type_shipping',
-    };
-
     beforeEach(() => {
         eventEmitter = new EventEmitter();
 
@@ -155,12 +137,34 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                     }
                 });
 
-                eventEmitter.on('onShippingChange', () => {
-                    if (options.onShippingChange) {
-                        options.onShippingChange({
-                            orderID: paypalOrderId,
-                            shipping_address: paypalShippingAddressPayloadMock,
-                            selected_shipping_option: paypalSelectedShippingOptionPayloadMock,
+                eventEmitter.on('onShippingAddressChange', () => {
+                    if (options.onShippingAddressChange) {
+                        options.onShippingAddressChange({
+                            orderId: approveDataOrderId,
+                            shippingAddress: {
+                                city: 'New York',
+                                country_code: 'US',
+                                postal_code: '07564',
+                                state: 'New York',
+                            },
+                        });
+                    }
+                });
+
+                eventEmitter.on('onShippingOptionsChange', () => {
+                    if (options.onShippingOptionsChange) {
+                        options.onShippingOptionsChange({
+                            orderId: approveDataOrderId,
+                            selectedShippingOption: {
+                                amount: {
+                                    currency_code: 'USD',
+                                    value: '100',
+                                },
+                                id: '1',
+                                label: 'Free shipping',
+                                selected: true,
+                                type: 'type_shipping',
+                            },
                         });
                     }
                 });
@@ -298,7 +302,8 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                     label: 'checkout',
                 },
                 createOrder: expect.any(Function),
-                onShippingChange: expect.any(Function),
+                onShippingAddressChange: expect.any(Function),
+                onShippingOptionsChange: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
             });
@@ -530,7 +535,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
         });
     });
 
-    describe('#onShippingChange button callback', () => {
+    describe('#onShippingAddressChange button callback', () => {
         beforeEach(() => {
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
@@ -567,7 +572,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingChange');
+            eventEmitter.emit('onShippingAddressChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -578,7 +583,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
         it('selects shipping option after address update', async () => {
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingChange');
+            eventEmitter.emit('onShippingAddressChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -599,7 +604,47 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingChange');
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.updateOrder).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onShippingOptionsChange button callback', () => {
+        beforeEach(() => {
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+        });
+
+        it('selects shipping option', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.getShippingOptionOrThrow).toHaveBeenCalled();
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                getShippingOption().id,
+            );
+        });
+
+        it('updates PayPal order', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -19,7 +19,8 @@ import {
     ApproveCallbackPayload,
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
-    ShippingChangeCallbackPayload,
+    ShippingAddressChangeCallbackPayload,
+    ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCreditCustomerInitializeOptions, {
@@ -118,7 +119,10 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         };
 
         const hostedCheckoutCallbacks = {
-            onShippingChange: (data: ShippingChangeCallbackPayload) => this.onShippingChange(data),
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                this.onShippingAddressChange(data),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                this.onShippingOptionsChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -194,22 +198,39 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         }
     }
 
-    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
+    private async onShippingAddressChange(
+        data: ShippingAddressChangeCallbackPayload,
+    ): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shipping_address.city,
-            countryCode: data.shipping_address.country_code,
-            postalCode: data.shipping_address.postal_code,
-            stateOrProvinceCode: data.shipping_address.state,
+            city: data.shippingAddress.city,
+            countryCode: data.shippingAddress.country_code,
+            postalCode: data.shippingAddress.postal_code,
+            stateOrProvinceCode: data.shippingAddress.state,
         });
 
         try {
+            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
+            // on this stage we don't have access to valid customer's address except shipping data
             await this.paymentIntegrationService.updateBillingAddress(address);
             await this.paymentIntegrationService.updateShippingAddress(address);
 
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-                data.selected_shipping_option?.id,
-            );
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow();
 
+            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+            await this.paypalCommerceIntegrationService.updateOrder();
+        } catch (error) {
+            throw new Error(error);
+        }
+    }
+
+    private async onShippingOptionsChange(
+        data: ShippingOptionChangeCallbackPayload,
+    ): Promise<void> {
+        const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+            data.selectedShippingOption.id,
+        );
+
+        try {
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -20,6 +20,7 @@ import {
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
+    ShippingChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
@@ -118,11 +119,25 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
             ...(onClick && { onClick: () => onClick() }),
         };
 
+        const isPaypalShippingCallbacksExperimentIsOn =
+            state.getStoreConfig()?.checkoutSettings.features[
+                'PAYPAL-4387.paypal_shipping_callbacks'
+            ];
+
+        const onShippingChangeCallbacks = isPaypalShippingCallbacksExperimentIsOn
+            ? {
+                  onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                      this.onShippingAddressChange(data),
+                  onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                      this.onShippingOptionsChange(data),
+              }
+            : {
+                  onShippingChange: (data: ShippingChangeCallbackPayload) =>
+                      this.onShippingChange(data),
+              };
+
         const hostedCheckoutCallbacks = {
-            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                this.onShippingAddressChange(data),
-            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                this.onShippingOptionsChange(data),
+            ...onShippingChangeCallbacks,
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -203,8 +218,8 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
     ): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
             city: data.shippingAddress.city,
-            countryCode: data.shippingAddress.country_code,
-            postalCode: data.shippingAddress.postal_code,
+            countryCode: data.shippingAddress.countryCode,
+            postalCode: data.shippingAddress.postalCode,
             stateOrProvinceCode: data.shippingAddress.state,
         });
 
@@ -231,6 +246,29 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         );
 
         try {
+            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+            await this.paypalCommerceIntegrationService.updateOrder();
+        } catch (error) {
+            throw new Error(error);
+        }
+    }
+
+    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
+        const address = this.paypalCommerceIntegrationService.getAddress({
+            city: data.shipping_address.city,
+            countryCode: data.shipping_address.country_code,
+            postalCode: data.shipping_address.postal_code,
+            stateOrProvinceCode: data.shipping_address.state,
+        });
+
+        try {
+            await this.paymentIntegrationService.updateBillingAddress(address);
+            await this.paymentIntegrationService.updateShippingAddress(address);
+
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+                data.selected_shipping_option?.id,
+            );
+
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -361,7 +361,18 @@ export interface PayPalCommerceButtonsOptions {
     onClick?(data: ClickCallbackPayload, actions: ClickCallbackActions): Promise<void> | void;
     onError?(error: Error): void;
     onCancel?(): void;
-    onShippingChange?(data: ShippingChangeCallbackPayload): Promise<void>;
+    onShippingAddressChange?(data: ShippingAddressChangeCallbackPayload): Promise<void>;
+    onShippingOptionsChange?(data: ShippingOptionChangeCallbackPayload): Promise<void>;
+}
+
+export interface ShippingOptionChangeCallbackPayload {
+    orderId: string;
+    selectedShippingOption: PayPalSelectedShippingOption;
+}
+
+export interface ShippingAddressChangeCallbackPayload {
+    orderId: string;
+    shippingAddress: PayPalAddress;
 }
 
 export interface ClickCallbackPayload {
@@ -380,12 +391,6 @@ export interface InitCallbackPayload {
 export interface InitCallbackActions {
     disable(): void;
     enable(): void;
-}
-
-export interface ShippingChangeCallbackPayload {
-    orderID: string;
-    shipping_address: PayPalAddress;
-    selected_shipping_option: PayPalSelectedShippingOption;
 }
 
 export interface PayPalAddress {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -361,6 +361,7 @@ export interface PayPalCommerceButtonsOptions {
     onClick?(data: ClickCallbackPayload, actions: ClickCallbackActions): Promise<void> | void;
     onError?(error: Error): void;
     onCancel?(): void;
+    onShippingChange?(data: ShippingChangeCallbackPayload): Promise<void>;
     onShippingAddressChange?(data: ShippingAddressChangeCallbackPayload): Promise<void>;
     onShippingOptionsChange?(data: ShippingOptionChangeCallbackPayload): Promise<void>;
 }
@@ -373,6 +374,12 @@ export interface ShippingOptionChangeCallbackPayload {
 export interface ShippingAddressChangeCallbackPayload {
     orderId: string;
     shippingAddress: PayPalAddress;
+}
+
+export interface ShippingChangeCallbackPayload {
+    orderID: string;
+    shipping_address: PaypalAddressCallbackData;
+    selected_shipping_option: PayPalSelectedShippingOption;
 }
 
 export interface ClickCallbackPayload {
@@ -394,6 +401,13 @@ export interface InitCallbackActions {
 }
 
 export interface PayPalAddress {
+    city: string;
+    countryCode: string;
+    postalCode: string;
+    state: string;
+}
+
+export interface PaypalAddressCallbackData {
     city: string;
     country_code: string;
     postal_code: string;

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -215,12 +215,20 @@ describe('PayPalCommerceButtonStrategy', () => {
                     }
                 });
 
-                eventEmitter.on('onShippingChange', () => {
-                    if (options.onShippingChange) {
-                        options.onShippingChange({
-                            orderID: paypalOrderId,
-                            shipping_address: paypalShippingAddressPayloadMock,
-                            selected_shipping_option: paypalSelectedShippingOptionPayloadMock,
+                eventEmitter.on('onShippingAddressChange', () => {
+                    if (options.onShippingAddressChange) {
+                        options.onShippingAddressChange({
+                            orderId: paypalOrderId,
+                            shippingAddress: paypalShippingAddressPayloadMock,
+                        });
+                    }
+                });
+
+                eventEmitter.on('onShippingOptionsChange', () => {
+                    if (options.onShippingOptionsChange) {
+                        options.onShippingOptionsChange({
+                            orderId: paypalOrderId,
+                            selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
                         });
                     }
                 });
@@ -398,7 +406,8 @@ describe('PayPalCommerceButtonStrategy', () => {
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
                 style: paypalCommerceOptions.style,
                 createOrder: expect.any(Function),
-                onShippingChange: expect.any(Function),
+                onShippingAddressChange: expect.any(Function),
+                onShippingOptionsChange: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });
@@ -635,7 +644,7 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
     });
 
-    describe('#onShippingChange button callback', () => {
+    describe('#onShippingAddressChange button callback', () => {
         beforeEach(() => {
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
@@ -672,7 +681,7 @@ describe('PayPalCommerceButtonStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingChange');
+            eventEmitter.emit('onShippingAddressChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -683,7 +692,7 @@ describe('PayPalCommerceButtonStrategy', () => {
         it('selects shipping option after address update', async () => {
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingChange');
+            eventEmitter.emit('onShippingAddressChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -704,7 +713,47 @@ describe('PayPalCommerceButtonStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingChange');
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.updateOrder).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onShippingOptionsChange button callback', () => {
+        beforeEach(() => {
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+        });
+
+        it('selects shipping option', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.getShippingOptionOrThrow).toHaveBeenCalled();
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                getShippingOption().id,
+            );
+        });
+
+        it('updates PayPal order', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -83,6 +83,13 @@ describe('PayPalCommerceButtonStrategy', () => {
 
     const paypalShippingAddressPayloadMock = {
         city: 'New York',
+        countryCode: 'US',
+        postalCode: '07564',
+        state: 'New York',
+    };
+
+    const paypalShippingCallbackAddressMock = {
+        city: 'New York',
         country_code: 'US',
         postal_code: '07564',
         state: 'New York',
@@ -155,6 +162,13 @@ describe('PayPalCommerceButtonStrategy', () => {
         jest.spyOn(paypalCommerceIntegrationService, 'getShippingOptionOrThrow').mockReturnValue(
             getShippingOption(),
         );
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
+            checkoutSettings: {
+                features: {
+                    'PAYPAL-4387.paypal_shipping_callbacks': true,
+                },
+            },
+        });
 
         jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
             (options: PayPalCommerceButtonsOptions) => {
@@ -229,6 +243,16 @@ describe('PayPalCommerceButtonStrategy', () => {
                         options.onShippingOptionsChange({
                             orderId: paypalOrderId,
                             selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
+                        });
+                    }
+                });
+
+                eventEmitter.on('onShippingChange', () => {
+                    if (options.onShippingChange) {
+                        options.onShippingChange({
+                            orderID: paypalOrderId,
+                            shipping_address: paypalShippingCallbackAddressMock,
+                            selected_shipping_option: paypalSelectedShippingOptionPayloadMock,
                         });
                     }
                 });
@@ -408,6 +432,39 @@ describe('PayPalCommerceButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('initializes PayPal button to render (with shipping options feature enabled and shipping callback experiment is off)', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
+                checkoutSettings: {
+                    features: {
+                        'PAYPAL-4387.paypal_shipping_callbacks': false,
+                    },
+                },
+            });
+
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYPAL,
+                style: paypalCommerceOptions.style,
+                createOrder: expect.any(Function),
+                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });
@@ -670,8 +727,8 @@ describe('PayPalCommerceButtonStrategy', () => {
                 address1: '',
                 address2: '',
                 city: paypalShippingAddressPayloadMock.city,
-                countryCode: paypalShippingAddressPayloadMock.country_code,
-                postalCode: paypalShippingAddressPayloadMock.postal_code,
+                countryCode: paypalShippingAddressPayloadMock.countryCode,
+                postalCode: paypalShippingAddressPayloadMock.postalCode,
                 stateOrProvince: '',
                 stateOrProvinceCode: paypalShippingAddressPayloadMock.state,
                 customFields: [],

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -99,6 +99,13 @@ describe('PayPalCommerceCustomerStrategy', () => {
         jest.spyOn(paypalCommerceIntegrationService, 'getShippingOptionOrThrow').mockReturnValue(
             getShippingOption(),
         );
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
+            checkoutSettings: {
+                features: {
+                    'PAYPAL-4387.paypal_shipping_callbacks': true,
+                },
+            },
+        });
 
         jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
             (options: PayPalCommerceButtonsOptions) => {
@@ -139,8 +146,8 @@ describe('PayPalCommerceCustomerStrategy', () => {
                             orderId: approveDataOrderId,
                             shippingAddress: {
                                 city: 'New York',
-                                country_code: 'US',
-                                postal_code: '07564',
+                                countryCode: 'US',
+                                postalCode: '07564',
                                 state: 'New York',
                             },
                         });
@@ -152,6 +159,30 @@ describe('PayPalCommerceCustomerStrategy', () => {
                         options.onShippingOptionsChange({
                             orderId: approveDataOrderId,
                             selectedShippingOption: {
+                                amount: {
+                                    currency_code: 'USD',
+                                    value: '100',
+                                },
+                                id: '1',
+                                label: 'Free shipping',
+                                selected: true,
+                                type: 'type_shipping',
+                            },
+                        });
+                    }
+                });
+
+                eventEmitter.on('onShippingChange', () => {
+                    if (options.onShippingChange) {
+                        options.onShippingChange({
+                            orderID: paypalOrderId,
+                            shipping_address: {
+                                city: 'New York',
+                                country_code: 'US',
+                                postal_code: '07564',
+                                state: 'New York',
+                            },
+                            selected_shipping_option: {
                                 amount: {
                                     currency_code: 'USD',
                                     value: '100',
@@ -301,6 +332,41 @@ describe('PayPalCommerceCustomerStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+                onClick: expect.any(Function),
+            });
+        });
+
+        it('initializes paypal buttons with config related to hosted checkout feature and sipping callbacks experiment is off', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
+                checkoutSettings: {
+                    features: {
+                        'PAYPAL-4387.paypal_shipping_callbacks': false,
+                    },
+                },
+            });
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYPAL,
+                style: {
+                    height: DefaultCheckoutButtonHeight,
+                    color: StyleButtonColor.silver,
+                    label: 'checkout',
+                },
+                createOrder: expect.any(Function),
+                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
             });

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -19,7 +19,8 @@ import {
     ApproveCallbackPayload,
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
-    ShippingChangeCallbackPayload,
+    ShippingAddressChangeCallbackPayload,
+    ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCustomerInitializeOptions, {
@@ -121,7 +122,10 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         };
 
         const hostedCheckoutCallbacks = {
-            onShippingChange: (data: ShippingChangeCallbackPayload) => this.onShippingChange(data),
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                this.onShippingAddressChange(data),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                this.onShippingOptionsChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -187,22 +191,39 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         }
     }
 
-    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
+    private async onShippingAddressChange(
+        data: ShippingAddressChangeCallbackPayload,
+    ): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shipping_address.city,
-            countryCode: data.shipping_address.country_code,
-            postalCode: data.shipping_address.postal_code,
-            stateOrProvinceCode: data.shipping_address.state,
+            city: data.shippingAddress.city,
+            countryCode: data.shippingAddress.country_code,
+            postalCode: data.shippingAddress.postal_code,
+            stateOrProvinceCode: data.shippingAddress.state,
         });
 
         try {
+            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
+            // on this stage we don't have access to valid customer's address except shipping data
             await this.paymentIntegrationService.updateBillingAddress(address);
             await this.paymentIntegrationService.updateShippingAddress(address);
 
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-                data.selected_shipping_option?.id,
-            );
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow();
 
+            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+            await this.paypalCommerceIntegrationService.updateOrder();
+        } catch (error) {
+            this.handleError(error);
+        }
+    }
+
+    private async onShippingOptionsChange(
+        data: ShippingOptionChangeCallbackPayload,
+    ): Promise<void> {
+        const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+            data.selectedShippingOption.id,
+        );
+
+        try {
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -20,6 +20,7 @@ import {
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
+    ShippingChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
@@ -121,11 +122,25 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
             ...(onClick && { onClick: () => onClick() }),
         };
 
+        const isPaypalShippingCallbacksExperimentIsOn =
+            state.getStoreConfig()?.checkoutSettings.features[
+                'PAYPAL-4387.paypal_shipping_callbacks'
+            ];
+
+        const onShippingChangeCallbacks = isPaypalShippingCallbacksExperimentIsOn
+            ? {
+                  onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                      this.onShippingAddressChange(data),
+                  onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                      this.onShippingOptionsChange(data),
+              }
+            : {
+                  onShippingChange: (data: ShippingChangeCallbackPayload) =>
+                      this.onShippingChange(data),
+              };
+
         const hostedCheckoutCallbacks = {
-            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                this.onShippingAddressChange(data),
-            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                this.onShippingOptionsChange(data),
+            ...onShippingChangeCallbacks,
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -196,8 +211,8 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
     ): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
             city: data.shippingAddress.city,
-            countryCode: data.shippingAddress.country_code,
-            postalCode: data.shippingAddress.postal_code,
+            countryCode: data.shippingAddress.countryCode,
+            postalCode: data.shippingAddress.postalCode,
             stateOrProvinceCode: data.shippingAddress.state,
         });
 
@@ -224,6 +239,29 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         );
 
         try {
+            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+            await this.paypalCommerceIntegrationService.updateOrder();
+        } catch (error) {
+            throw new Error(error);
+        }
+    }
+
+    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
+        const address = this.paypalCommerceIntegrationService.getAddress({
+            city: data.shipping_address.city,
+            countryCode: data.shipping_address.country_code,
+            postalCode: data.shipping_address.postal_code,
+            stateOrProvinceCode: data.shipping_address.state,
+        });
+
+        try {
+            await this.paymentIntegrationService.updateBillingAddress(address);
+            await this.paymentIntegrationService.updateShippingAddress(address);
+
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+                data.selected_shipping_option?.id,
+            );
+
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {


### PR DESCRIPTION
## What?
Reverted PPCP onShippingAddressChange and onShippingOptionChange callbacks

## Why?
To support Pay Now With Venmo Button

## Testing / Proof
Unit tests

https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/ef892de3-a481-4f27-97e6-6c7d47e31d88


https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/79ccca7b-f8bf-4787-a9c0-bd26227b9a70


https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/47041435-b7fb-4271-9ee0-8258a3efc8ce


https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/c6d3f0d9-0b74-4fd4-a194-784e353e558a

@bigcommerce/team-checkout @bigcommerce/team-payments
