### PR TITLE
refactor(checkout): PI-2349 moved Worldpay Access payment strategy to…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,7 +44,6 @@
 /packages/core/src/payment/strategies/stripe-upe @bigcommerce/team-integrations
 /packages/core/src/payment/strategies/stripev3 @bigcommerce/team-integrations
 /packages/core/src/payment/strategies/wepay @bigcommerce/team-integrations
-/packages/core/src/payment/strategies/worldpayaccess @bigcommerce/team-integrations
 /packages/adyen-integration @bigcommerce/team-integrations
 /packages/adyen-utils @bigcommerce/team-integrations
 /packages/affirm-integration @bigcommerce/team-integrations
@@ -64,6 +63,7 @@
 /packages/klarna-integration @bigcommerce/team-integrations
 /packages/humm-integration @bigcommerce/team-integrations
 /packages/zip-integration @bigcommerce/team-integrations
+/packages/worldpayaccess-integration @bigcommerce/team-integrations
 
 ## PayPal team
 

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -79,7 +79,6 @@ import {
 import { QuadpayPaymentStrategy } from './strategies/quadpay';
 import { SquarePaymentStrategy, SquareScriptLoader } from './strategies/square';
 import { WepayPaymentStrategy, WepayRiskClient } from './strategies/wepay';
-import { WorldpayaccessPaymetStrategy } from './strategies/worldpayaccess';
 
 export default function createPaymentStrategyRegistry(
     store: CheckoutStore,
@@ -407,17 +406,6 @@ export default function createPaymentStrategyRegistry(
                 paymentActionCreator,
                 hostedFormFactory,
                 new WepayRiskClient(scriptLoader),
-            ),
-    );
-
-    registry.register(
-        PaymentStrategyType.WORLDPAYACCESS,
-        () =>
-            new WorldpayaccessPaymetStrategy(
-                store,
-                orderActionCreator,
-                paymentActionCreator,
-                hostedFormFactory,
             ),
     );
 

--- a/packages/core/src/payment/payment-request-options.ts
+++ b/packages/core/src/payment/payment-request-options.ts
@@ -15,7 +15,6 @@ import { MonerisPaymentInitializeOptions } from './strategies/moneris';
 import { OpyPaymentInitializeOptions } from './strategies/opy';
 import { PaypalExpressPaymentInitializeOptions } from './strategies/paypal';
 import { SquarePaymentInitializeOptions } from './strategies/square';
-import { WorldpayAccessPaymentInitializeOptions } from './strategies/worldpayaccess';
 
 export { PaymentInitializeOptions } from '../generated/payment-initialize-options';
 
@@ -116,10 +115,4 @@ export interface BasePaymentInitializeOptions extends PaymentRequestOptions {
      * They can be omitted unless you need to support Chasepay.
      */
     chasepay?: ChasePayInitializeOptions;
-
-    /**
-     * The options that are required to initialize the Worldpay payment method.
-     * They can be omitted unless you need to support Worldpay.
-     */
-    worldpay?: WorldpayAccessPaymentInitializeOptions;
 }

--- a/packages/core/src/payment/strategies/worldpayaccess/index.ts
+++ b/packages/core/src/payment/strategies/worldpayaccess/index.ts
@@ -1,2 +1,0 @@
-export { WorldpayAccessPaymentInitializeOptions } from './worldpayaccess-payment-options';
-export { default as WorldpayaccessPaymetStrategy } from './worldpayaccess-payment-strategy';

--- a/packages/worldpayaccess-integration/.eslintrc.json
+++ b/packages/worldpayaccess-integration/.eslintrc.json
@@ -1,0 +1,39 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {
+                "@typescript-eslint/naming-convention": "off",
+                "@typescript-eslint/consistent-type-assertions": "off",
+                "@typescript-eslint/no-misused-promises": "off",
+                "@typescript-eslint/no-unsafe-assignment": "off",
+                "@typescript-eslint/no-unsafe-argument": "off",
+                "@typescript-eslint/no-floating-promises": "off",
+                "@typescript-eslint/no-unsafe-call": "off",
+                "@typescript-eslint/no-explicit-any": "off",
+                "@typescript-eslint/no-unsafe-member-access": "off",
+                "@typescript-eslint/no-unsafe-return": "off"
+            }
+        },
+        {
+            "files": ["*.spec.ts"],
+            "rules": {
+                "jest/valid-expect": "off",
+                "jest/no-if": "off",
+                "@typescript-eslint/await-thenable": "off",
+                "@typescript-eslint/no-unsafe-assignment": "off",
+                "jest/no-conditional-expect": "off",
+                "jest/no-test-return-statement": "off",
+                "@typescript-eslint/no-shadow": "off"
+            }
+        },
+        {
+            "files": ["*.mock.ts"],
+            "rules": {
+                "@typescript-eslint/no-explicit-any": "off"
+            }
+        }
+    ]
+}

--- a/packages/worldpayaccess-integration/README.md
+++ b/packages/worldpayaccess-integration/README.md
@@ -1,0 +1,13 @@
+# worldpayaccess-integration
+
+This package contains the integration layer for the [Worldpay Access](https://worldpay.com/) provider.
+
+For additional information on Worldpay Access, please refer to [Worldpay Access documentation](https://developer.worldpay.com/).
+
+## Running unit tests
+
+Run `nx test worldpayaccess-integration` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint worldpayaccess-integration` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/worldpayaccess-integration/jest.config.js
+++ b/packages/worldpayaccess-integration/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+    displayName: 'worldpayaccess-integration',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+            diagnostics: false,
+        },
+    },
+    transform: {
+        '^.+\\.[tj]sx?$': 'ts-jest',
+    },
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    coverageDirectory: '../../coverage/packages/worldpayaccess-integration',
+    setupFilesAfterEnv: ['../../jest-setup.js'],
+};

--- a/packages/worldpayaccess-integration/project.json
+++ b/packages/worldpayaccess-integration/project.json
@@ -1,0 +1,22 @@
+{
+    "root": "packages/worldpayaccess-integration",
+    "sourceRoot": "packages/worldpayaccess-integration/src",
+    "projectType": "library",
+    "targets": {
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/worldpayaccess-integration/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["coverage/packages/worldpayaccess-integration"],
+            "options": {
+                "jestConfig": "packages/worldpayaccess-integration/jest.config.js"
+            }
+        }
+    },
+    "tags": ["scope:integration"]
+}

--- a/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.spec.ts
+++ b/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createWorldpayAccessPaymentStrategy from './create-worldpayaccess-payment-strategy';
+import WorldpayAccessPaymetStrategy from './worldpayaccess-payment-strategy';
+
+describe('createWorldpayAccessPaymetStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates Worldpay Access payment strategy', () => {
+        const strategy = createWorldpayAccessPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(WorldpayAccessPaymetStrategy);
+    });
+});

--- a/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.ts
@@ -1,0 +1,14 @@
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import WorldpayAccessPaymetStrategy from './worldpayaccess-payment-strategy';
+
+const createWorldpayAccessPaymentStrategy: PaymentStrategyFactory<WorldpayAccessPaymetStrategy> = (
+    paymentIntegrationService,
+) => {
+    return new WorldpayAccessPaymetStrategy(paymentIntegrationService);
+};
+
+export default toResolvableModule(createWorldpayAccessPaymentStrategy, [{ id: 'worldpayaccess' }]);

--- a/packages/worldpayaccess-integration/src/index.ts
+++ b/packages/worldpayaccess-integration/src/index.ts
@@ -1,0 +1,2 @@
+export { default as createWorldpayAccessPaymentStrategy } from './create-worldpayaccess-payment-strategy';
+export { WithWorldpayAccessPaymentInitializeOptions } from './worldpayaccess-payment-options';

--- a/packages/worldpayaccess-integration/src/worldpayaccess-payment-options.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-payment-options.ts
@@ -29,3 +29,11 @@ export interface WorldpayAccessPaymentInitializeOptions {
      */
     onLoad(iframe: HTMLIFrameElement, cancel: () => void): void;
 }
+
+export interface WithWorldpayAccessPaymentInitializeOptions {
+    /**
+     * The options that are required to initialize the Apple Pay payment
+     * method. They can be omitted unless you need to support Apple Pay.
+     */
+    worldpay?: WorldpayAccessPaymentInitializeOptions;
+}

--- a/packages/worldpayaccess-integration/tsconfig.json
+++ b/packages/worldpayaccess-integration/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ],
+    "compilerOptions": {
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    }
+}

--- a/packages/worldpayaccess-integration/tsconfig.lib.json
+++ b/packages/worldpayaccess-integration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": []
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.spec.ts"]
+}

--- a/packages/worldpayaccess-integration/tsconfig.spec.json
+++ b/packages/worldpayaccess-integration/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.test.js",
+        "**/*.spec.js",
+        "**/*.test.jsx",
+        "**/*.spec.jsx",
+        "**/*.d.ts"
+    ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -124,6 +124,9 @@
             "@bigcommerce/checkout-sdk/ui": ["packages/ui/src/index.ts"],
             "@bigcommerce/checkout-sdk/utility": ["packages/utility/src/index.ts"],
             "@bigcommerce/checkout-sdk/workspace-tools": ["packages/workspace-tools/src/index.ts"],
+            "@bigcommerce/checkout-sdk/worldpayaccess-integration": [
+                "packages/worldpayaccess-integration/src/index.ts"
+            ],
             "@bigcommerce/checkout-sdk/zip-integration": ["packages/zip-integration/src/index.ts"]
         }
     }

--- a/workspace.json
+++ b/workspace.json
@@ -43,6 +43,7 @@
         "ui": "packages/ui",
         "utility": "packages/utility",
         "workspace-tools": "packages/workspace-tools",
+        "worldpayaccess-integration": "packages/worldpayaccess-integration",
         "zip-integration": "packages/zip-integration"
     }
 }


### PR DESCRIPTION
… separate package

## What?
Moved Worldpay Access payment strategy

## Why?
Due to the monorepo refactoring

## Testing / Proof
Units/manually

3ds challange

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/da041d20-f0ac-4b65-a241-e3823fcda390

Successful Authentication (Frictionless)

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/22866ebb-e606-4150-866d-9a2b4ab91cb3


@bigcommerce/team-checkout @bigcommerce/team-payments
