### PR TITLE
fix(billing): CHECKOUT-8392 Fix issue with billing address creation

### DIFF
--- a/packages/core/src/billing/billing-address-action-creator.ts
+++ b/packages/core/src/billing/billing-address-action-creator.ts
@@ -36,7 +36,7 @@ export default class BillingAddressActionCreator {
             const isBillingFixExperimentEnabled =
                 state.config.getConfig()?.storeConfig.checkoutSettings.features[
                     'CHECKOUT-8392.fix_billing_creation_in_checkout'
-                ] ?? false;
+                ] ?? true;
 
             if (!checkout) {
                 throw new MissingDataError(MissingDataErrorType.MissingCheckout);
@@ -101,7 +101,7 @@ export default class BillingAddressActionCreator {
                 const isBillingFixExperimentEnabled =
                     state.config.getConfig()?.storeConfig.checkoutSettings.features[
                         'CHECKOUT-8392.fix_billing_creation_in_checkout'
-                    ] ?? false;
+                    ] ?? true;
 
                 if (!checkout) {
                     throw new MissingDataError(MissingDataErrorType.MissingCheckout);

--- a/packages/core/src/billing/billing-address-action-creator.ts
+++ b/packages/core/src/billing/billing-address-action-creator.ts
@@ -1,5 +1,6 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { Response } from '@bigcommerce/request-sender';
+import { isEmpty } from 'lodash';
 import { concat, defer, empty, merge, Observable, Observer, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -63,6 +64,8 @@ export default class BillingAddressActionCreator {
                 };
             }
 
+            const hasBillingAddress = !isEmpty(billingAddress);
+
             return merge(
                 concat(
                     of(createAction(BillingAddressActionType.ContinueAsGuestRequested)),
@@ -71,7 +74,7 @@ export default class BillingAddressActionCreator {
                             checkout.id,
                             billingAddressRequestBody,
                             isBillingFixExperimentEnabled,
-                            undefined,
+                            hasBillingAddress,
                             options,
                         );
 
@@ -111,7 +114,7 @@ export default class BillingAddressActionCreator {
 
                 const billingAddress = state.billingAddress.getBillingAddress();
 
-                const billingAddressId = billingAddress ? billingAddress.id : undefined;
+                const hasBillingAddress = !isEmpty(billingAddress);
 
                 // If email is not present in the address provided by the client, then
                 // fall back to the stored email as it could have been set separately
@@ -134,7 +137,7 @@ export default class BillingAddressActionCreator {
                     checkout.id,
                     billingAddressRequestBody,
                     isBillingFixExperimentEnabled,
-                    billingAddressId,
+                    hasBillingAddress,
                     options,
                 )
                     .then(({ body }) => {
@@ -182,11 +185,11 @@ export default class BillingAddressActionCreator {
         checkoutId: string,
         address: Partial<BillingAddressUpdateRequestBody>,
         isBillingFixExperimentEnabled: boolean,
-        billingAddressId?: string,
+        hasBillingAddress: boolean,
         options?: RequestOptions,
     ): Promise<Response<Checkout>> {
         if (isBillingFixExperimentEnabled) {
-            if (!billingAddressId) {
+            if (!hasBillingAddress) {
                 return this._requestSender.createAddress(checkoutId, address, options);
             }
 

--- a/packages/core/src/billing/billing-address-action-creator.ts
+++ b/packages/core/src/billing/billing-address-action-creator.ts
@@ -66,6 +66,7 @@ export default class BillingAddressActionCreator {
                         const { body } = await this._createOrUpdateBillingAddress(
                             checkout.id,
                             billingAddressRequestBody,
+                            undefined,
                             options,
                         );
 
@@ -101,6 +102,8 @@ export default class BillingAddressActionCreator {
 
                 const billingAddress = state.billingAddress.getBillingAddress();
 
+                const billingAddressId = billingAddress ? billingAddress.id : undefined;
+
                 // If email is not present in the address provided by the client, then
                 // fall back to the stored email as it could have been set separately
                 // using a convenience method. We can't rely on billingAddress having
@@ -118,7 +121,12 @@ export default class BillingAddressActionCreator {
                     billingAddressRequestBody.id = billingAddress.id;
                 }
 
-                this._createOrUpdateBillingAddress(checkout.id, billingAddressRequestBody, options)
+                this._createOrUpdateBillingAddress(
+                    checkout.id,
+                    billingAddressRequestBody,
+                    billingAddressId,
+                    options,
+                )
                     .then(({ body }) => {
                         observer.next(
                             createAction(
@@ -163,9 +171,10 @@ export default class BillingAddressActionCreator {
     private _createOrUpdateBillingAddress(
         checkoutId: string,
         address: Partial<BillingAddressUpdateRequestBody>,
+        billingAddressId?: string,
         options?: RequestOptions,
     ): Promise<Response<Checkout>> {
-        if (!address.id) {
+        if (!billingAddressId) {
             return this._requestSender.createAddress(checkoutId, address, options);
         }
 


### PR DESCRIPTION
## What?
Fix issue with billing address creation, when a user logs in from control panel.

## Why?
We have an issue if a login happens from control panel we assign the guest cart to shopper but billing address object is not created, when the checkbox `billing address is same as shipping is unchecked`.

Which leads to an issue in billing step of checkout, since we try and use customer address id as billing address id for update. Hence add a check and for billing address.

## Testing / Proof
- CI
- Screencast

https://github.com/bigcommerce/checkout-sdk-js/assets/7134802/0a262b9c-9b49-46d1-b00e-66f67340d922



@bigcommerce/team-checkout @bigcommerce/team-payments
