### PR TITLE
fix(payment): PAYPAL-4379 fixed the issue with Braintree Fastlane initialization process

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -47,7 +47,7 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
                 );
 
                 await this.braintreeFastlaneUtils.initializeBraintreeFastlaneOrThrow(
-                    methodId,
+                    paymentMethod.id,
                     fastlaneStyles,
                 );
             }


### PR DESCRIPTION
## What?
Fixed the issue with Braintree Fastlane initialization process by changing provided initial method id with valid payment id for current flow

## Why?
The main problem was due to A/B testing process where braintreeacceleratedcheckout payment method does not load on the page, so we should use braintree payment method for such purposes. There was a mistake in one of the prev PRs.

## Testing / Proof
Unit tests
Manual tests
CI