### PR TITLE
feat(payment): PI-2285 Add Google Pay on TD Online Mart - all other p…

### DIFF
--- a/packages/google-pay-integration/src/factories/button/create-google-pay-tdonlinemart-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-tdonlinemart-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayTdOnlineMartButtonStrategy from './create-google-pay-tdonlinemart-button-strategy';
+
+describe('createGooglePayTdOnlineMartButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay TD Online Mart button strategy', () => {
+        const strategy = createGooglePayTdOnlineMartButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-tdonlinemart-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-tdonlinemart-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayTdOnlineMartGateway from '../../gateways/google-pay-tdonlinemart-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayTdOnlineMartButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayTdOnlineMartGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayTdOnlineMartButtonStrategy, [
+    { id: 'googlepaytdonlinemart' },
+]);

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -39,3 +39,4 @@ export { default as createGooglePayCybersourceButtonStrategy } from './factories
 export { default as createGooglePayOrbitalButtonStrategy } from './factories/button/create-google-pay-orbital-button-strategy';
 export { default as createGooglePayStripeButtonStrategy } from './factories/button/create-google-pay-stripe-button-strategy';
 export { default as createGooglePayWorldpayAccessButtonStrategy } from './factories/button/create-google-pay-worldpayaccess-button-strategy';
+export { default as createGooglePayTdOnlineMartButtonStrategy } from './factories/button/create-google-pay-tdonlinemart-button-strategy';


### PR DESCRIPTION
…laces

## What?
Add Google Pay on TD Online Mart in:
- PDP
- Cart page
- Quick cart modal
- Mini cart dropdown

## Why?
As a merchant I want to be able to offer my shoppers Google Pay wallet through TD Online Mart



## Testing / Proof
Tested manually
Work on backend part of this project is not started yet. Therefore added part of the code will not execute before BE part will be ready.

@bigcommerce/team-checkout @bigcommerce/team-payments
