### PR TITLE
feat(payment): STRIPE-329 added name to Stripe billing_details object

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.ts
@@ -595,13 +595,13 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         const billingAddress = this.paymentIntegrationService.getState().getBillingAddress();
         const address = this._mapStripeAddress(billingAddress);
 
-        const email = billingAddress?.email;
+        const { firstName, lastName, email } = billingAddress || {};
 
         if (!this._stripeElements) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        if (!email || !address || !address.city || !address.country) {
+        if (!email || !address || !address.city || !address.country || !firstName || !lastName) {
             throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
         }
 
@@ -613,6 +613,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                     billing_details: {
                         email,
                         address,
+                        name: `${firstName} ${lastName}`,
                     },
                 },
                 ...(returnUrl && { return_url: returnUrl }),


### PR DESCRIPTION
## What?
Added `name` field to the Stripe `billing_details` object

## Testing / Proof
Before:
<img width="1238" alt="Screenshot 2024-07-19 at 12 44 49" src="https://github.com/user-attachments/assets/ac9ab3a6-deeb-47fd-bb10-723fbbd7d42d">
<img width="637" alt="Screenshot 2024-07-19 at 12 45 28" src="https://github.com/user-attachments/assets/78134cb7-0412-4d6a-9a72-b3db0d21c14f">

After:
<img width="1227" alt="Screenshot 2024-07-19 at 12 49 24" src="https://github.com/user-attachments/assets/7b1ededb-e214-4aa9-b57c-7bdd3f7bbc80">
<img width="601" alt="Screenshot 2024-07-19 at 12 48 30" src="https://github.com/user-attachments/assets/3fa5f7e9-c6f7-4bce-a95d-861be71064e1">

@bigcommerce/team-checkout @bigcommerce/team-payments
