### PR TITLE
feat(payment): PAYPAL-4440 updated ppcp fastlane strategies with fastlane flag to be able to turn on/off fastlane custom styling

### DIFF
--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
@@ -298,6 +298,7 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
                 clientToken: '123',
                 initializationData: {
                     isFastlaneEnabled: true,
+                    isFastlaneStylingEnabled: true,
                     isAcceleratedCheckoutEnabled: true,
                     fastlaneStyles: {
                         fastlaneRootSettingsBackgroundColor: 'orange',
@@ -373,7 +374,7 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
             expect(paypalCommerceFastlaneUtils.initializePayPalFastlane).toHaveBeenCalledWith(
                 paypalFastlaneSdk,
                 paymentMethod.initializationData.isDeveloperModeApplicable,
-                undefined,
+                {},
             );
             expect(paypalCommerceFastlaneUtils.lookupCustomerOrThrow).toHaveBeenCalledWith(
                 customer.email,

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
@@ -151,10 +151,12 @@ export default class PayPalCommerceFastlaneShippingStrategy implements ShippingS
         const cart = state.cart.getCartOrThrow();
 
         const paymentMethod = await this._getPayPalPaymentMethodOrThrow(methodId);
-        const isTestModeEnabled = !!paymentMethod?.initializationData?.isDeveloperModeApplicable;
+        const { isDeveloperModeApplicable, isFastlaneStylingEnabled } =
+            paymentMethod?.initializationData || {};
+        const isTestModeEnabled = !!isDeveloperModeApplicable;
 
         const fastlaneStyles = getFastlaneStyles(
-            paymentMethod?.initializationData?.fastlaneStyles,
+            isFastlaneStylingEnabled ? paymentMethod?.initializationData?.fastlaneStyles : {},
             styles,
         );
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
@@ -244,6 +244,7 @@ describe('PayPalCommerceFastlaneCustomerStrategy', () => {
                     isAcceleratedCheckoutEnabled: true,
                     shouldRunAcceleratedCheckout: true,
                     isFastlaneEnabled: true,
+                    isFastlaneStylingEnabled: true,
                     fastlaneStyles: {
                         fastlaneRootSettingsBackgroundColor: 'red',
                         fastlaneBrandingSettings: 'branding',

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -42,8 +42,11 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
         }
 
         const paymentMethod = await this.getValidPaymentMethodOrThrow(methodId);
-        const { isAcceleratedCheckoutEnabled, isDeveloperModeApplicable } =
-            paymentMethod.initializationData || {};
+        const {
+            isAcceleratedCheckoutEnabled,
+            isFastlaneStylingEnabled,
+            isDeveloperModeApplicable,
+        } = paymentMethod.initializationData || {};
 
         this.isAcceleratedCheckoutFeatureEnabled = !!isAcceleratedCheckoutEnabled;
 
@@ -60,8 +63,12 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
                     cart.id,
                 );
 
+                const paypalFastlaneStyles = isFastlaneStylingEnabled
+                    ? paymentMethod?.initializationData?.fastlaneStyles
+                    : {};
+
                 const fastlaneStyles = getFastlaneStyles(
-                    paymentMethod?.initializationData?.fastlaneStyles,
+                    paypalFastlaneStyles,
                     paypalcommercefastlane?.styles,
                 );
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -237,6 +237,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                     isAcceleratedCheckoutEnabled: true,
                     shouldRunAcceleratedCheckout: true,
                     isFastlaneEnabled: true,
+                    isFastlaneStylingEnabled: true,
                     fastlaneStyles: {
                         fastlaneRootSettingsBackgroundColor: 'red',
                         fastlaneBrandingSettings: 'branding',
@@ -289,7 +290,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
             expect(paypalCommerceFastlaneUtils.initializePayPalFastlane).toHaveBeenCalledWith(
                 paypalFastlaneSdk,
                 false,
-                undefined,
+                {},
             );
         });
 
@@ -306,7 +307,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
             expect(paypalCommerceFastlaneUtils.initializePayPalFastlane).toHaveBeenCalledWith(
                 paypalFastlaneSdk,
                 true,
-                undefined,
+                {},
             );
         });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -85,7 +85,8 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
         const cart = state.getCartOrThrow();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
-        const { isDeveloperModeApplicable } = paymentMethod.initializationData || {};
+        const { isDeveloperModeApplicable, isFastlaneStylingEnabled } =
+            paymentMethod.initializationData || {};
 
         const paypalFastlaneSdk = await this.paypalCommerceSdk.getPayPalFastlaneSdk(
             paymentMethod,
@@ -93,8 +94,12 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
             cart.id,
         );
 
+        const paypalFastlaneStyling = isFastlaneStylingEnabled
+            ? paymentMethod?.initializationData?.fastlaneStyles
+            : {};
+
         const fastlaneStyles = getFastlaneStyles(
-            paymentMethod?.initializationData?.fastlaneStyles,
+            paypalFastlaneStyling,
             paypalcommercefastlane?.styles,
         );
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -25,6 +25,7 @@ export interface PayPalCommerceInitializationData {
     isDeveloperModeApplicable?: boolean;
     intent?: PayPalCommerceIntent;
     isAcceleratedCheckoutEnabled?: boolean; // PayPal Fastlane related
+    isFastlaneStylingEnabled?: boolean;
     isHostedCheckoutEnabled?: boolean;
     isPayPalCommerceAnalyticsV2Enabled?: boolean; // PayPal Fastlane related
     isPayPalCreditAvailable?: boolean;


### PR DESCRIPTION
## What?
Updated PayPalCommerce Fastlane strategies with Fastlane flag to be able to turn on/off Fastlane custom styling

## Why?
To set Fastlane styling provided from CP only if merchant turned on the feature in settings

## Testing / Proof
Manual tests
Unit tests
CI