### PR TITLE
feat(payment): PAYPAL-4441 updated Braintree Fastlane strategies with isFastlaneStylingEnabled flag

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
@@ -143,6 +143,7 @@ describe('BraintreeFastlaneCustomerStrategy', () => {
                     isAcceleratedCheckoutEnabled: true,
                     shouldRunAcceleratedCheckout: true,
                     isFastlaneEnabled: true,
+                    isFastlaneStylingEnabled: true,
                     fastlaneStyles: {
                         fastlaneRootSettingsBackgroundColor: 'red',
                         fastlaneBrandingSettings: 'branding',

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -36,13 +36,19 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
 
         const paymentMethod = await this.getValidPaymentMethodOrThrow(methodId);
 
-        this.isAcceleratedCheckoutEnabled =
-            !!paymentMethod.initializationData?.isAcceleratedCheckoutEnabled;
+        const { isAcceleratedCheckoutEnabled, isFastlaneStylingEnabled } =
+            paymentMethod.initializationData || {};
+
+        const paypalFastlaneStylesSettings = isFastlaneStylingEnabled
+            ? paymentMethod.initializationData?.fastlaneStyles
+            : undefined;
+
+        this.isAcceleratedCheckoutEnabled = !!isAcceleratedCheckoutEnabled;
 
         try {
             if (this.isAcceleratedCheckoutEnabled) {
                 const fastlaneStyles = getFastlaneStyles(
-                    paymentMethod.initializationData?.fastlaneStyles,
+                    paypalFastlaneStylesSettings,
                     braintreefastlane?.styles,
                 );
 

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.spec.ts
@@ -389,6 +389,7 @@ describe('BraintreeFastlanePaymentStrategy', () => {
                     isAcceleratedCheckoutEnabled: true,
                     shouldRunAcceleratedCheckout: true,
                     isFastlaneEnabled: true,
+                    isFastlaneStylingEnabled: true,
                     fastlaneStyles: {
                         fastlaneRootSettingsBackgroundColor: 'red',
                         fastlaneBrandingSettings: 'branding',

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.ts
@@ -71,13 +71,18 @@ export default class BraintreeFastlanePaymentStrategy implements PaymentStrategy
 
         const state = this.paymentIntegrationService.getState();
         const paymentMethod = state.getPaymentMethodOrThrow<BraintreeInitializationData>(methodId);
+        const { clientToken, isFastlaneStylingEnabled } = paymentMethod.initializationData || {};
 
-        if (!paymentMethod.initializationData?.clientToken) {
+        const paypalFastlaneStyleSettings = isFastlaneStylingEnabled
+            ? paymentMethod.initializationData?.fastlaneStyles
+            : undefined;
+
+        if (!clientToken) {
             await this.paymentIntegrationService.loadPaymentMethod(methodId);
         }
 
         const fastlaneStyles = getFastlaneStyles(
-            paymentMethod.initializationData?.fastlaneStyles,
+            paypalFastlaneStyleSettings,
             braintreefastlane.styles,
         );
 

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -110,6 +110,7 @@ export interface BraintreeInitializationData {
     intent?: 'authorize' | 'order' | 'sale';
     isCreditEnabled?: boolean;
     isAcceleratedCheckoutEnabled?: boolean;
+    isFastlaneStylingEnabled?: boolean;
     isFastlaneEnabled?: boolean;
     fastlaneStyles?: FastlaneStylesSettings;
     isBraintreeAnalyticsV2Enabled?: boolean;

--- a/packages/braintree-utils/src/utils/get-fastlane-styles.ts
+++ b/packages/braintree-utils/src/utils/get-fastlane-styles.ts
@@ -8,7 +8,7 @@ function isInvalidStyleOption(styleOption: unknown) {
 export default function getFastlaneStyles(
     styleSettings?: FastlaneStylesSettings,
     uiStyles?: BraintreeFastlaneStylesOption,
-) {
+): BraintreeFastlaneStylesOption | undefined {
     if (!uiStyles && !styleSettings) {
         return undefined;
     }

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -507,4 +507,5 @@ export interface BraintreeInitializationData {
     isCreditEnabled?: boolean;
     isAcceleratedCheckoutEnabled?: boolean;
     isFastlaneEnabled?: boolean; // TODO: remove this line when fastlane experiment will be rolled out to 100%
+    isFastlaneStylingEnabled?: boolean;
 }

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
@@ -287,8 +287,9 @@ describe('BraintreeFastlaneShippingStrategy', () => {
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue({
                 clientToken: '123',
                 initializationData: {
-                    isFastlaneEnabled: true,
                     isAcceleratedCheckoutEnabled: true,
+                    isFastlaneEnabled: true,
+                    isFastlaneStylingEnabled: true,
                     fastlaneStyles: {
                         fastlaneRootSettingsBackgroundColor: 'orange',
                         fastlaneTextCaptionSettingsColor: 'blue',

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
@@ -85,15 +85,21 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
         try {
             if (this._shouldRunAuthenticationFlow()) {
                 const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+                const { clientToken, isFastlaneStylingEnabled } =
+                    paymentMethod?.initializationData || {};
 
-                if (!paymentMethod?.initializationData?.clientToken) {
+                if (!clientToken) {
                     await this._store.dispatch(
                         this._paymentMethodActionCreator.loadPaymentMethod(methodId),
                     );
                 }
 
+                const paypalFastlaneStylesSettings = isFastlaneStylingEnabled
+                    ? paymentMethod?.initializationData?.fastlaneStyles
+                    : undefined;
+
                 const fastlaneStyles = getFastlaneStyles(
-                    paymentMethod?.initializationData?.fastlaneStyles,
+                    paypalFastlaneStylesSettings,
                     braintreefastlane?.styles,
                 );
 


### PR DESCRIPTION
## What?
Updated Braintree Fastlane strategies with isFastlaneStylingEnabled flag

## Why?
To be able to turn on/off Fastlane styling settings provided by merchant through configuration from CP

## Testing / Proof
Unit tests
Manual tests
CI
