### PR TITLE
fix(payment): STRIPE-384 added Klarna id to the Stripe gateway

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/create-stripe-upe-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/create-stripe-upe-payment-strategy.ts
@@ -17,4 +17,7 @@ const createStripeUPEPaymentStrategy: PaymentStrategyFactory<StripeUPEPaymentStr
     );
 };
 
-export default toResolvableModule(createStripeUPEPaymentStrategy, [{ gateway: 'stripeupe' }]);
+export default toResolvableModule(createStripeUPEPaymentStrategy, [
+    { gateway: 'stripeupe' },
+    { gateway: 'stripeupe', id: 'klarna' },
+]);


### PR DESCRIPTION
## What?
Added Klarna id to the Stripe gateway. 
Related PR: https://github.com/bigcommerce/checkout-js/pull/1956

## Why?
Because we cannot open Klarna tab without this fix.

## Testing / Proof
Before:

https://github.com/user-attachments/assets/d09e87c1-d413-461b-b583-516177ab2680


After:

https://github.com/user-attachments/assets/c5159738-c8f3-4f5b-b103-c2d4dd936e92

@bigcommerce/team-checkout @bigcommerce/team-payments
