### PR TITLE
feat(payment): PAYPAL-4524 Google Pay payments fail with error "Order is missing an email address"

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -72,12 +72,12 @@ export default class GooglePayGateway {
         const {
             company = '',
             phone = '',
-            email = response.email,
+            email,
         } = this._paymentIntegrationService.getState().getBillingAddress() || {};
 
         return {
             ...this._mapToAddressRequestBody(billingAddress, company, phone),
-            email,
+            email: email || response.email,
         };
     }
 


### PR DESCRIPTION
## What?

Fix of email passing

## Why?

Because destructurization of the object will return an wrong email value in case `getBillingAddress` returns an empty string for email, but `response.email` has a non-empty value

## Testing / Proof

Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
