### PR TITLE
refactor(checkout): PAYPAL-4527 removed almost all ts-ignore from core/src/checkout folder

### DIFF
--- a/packages/core/src/checkout/checkout-action-creator.spec.ts
+++ b/packages/core/src/checkout/checkout-action-creator.spec.ts
@@ -156,10 +156,9 @@ describe('CheckoutActionCreator', () => {
         it('does not call loadCheckout until loadConfig resolves', () => {
             const { id } = getCheckout();
 
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(configActionCreator, 'loadConfig').mockReturnValue(new Promise(() => {}));
+            jest.spyOn(configActionCreator, 'loadConfig').mockReturnValue(
+                of(createAction(ConfigActionType.LoadConfigSucceeded)),
+            );
 
             from(actionCreator.loadCheckout(id)(store)).toPromise();
 
@@ -215,10 +214,9 @@ describe('CheckoutActionCreator', () => {
         });
 
         it('does not call loadCheckout until loadConfig resolves', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(configActionCreator, 'loadConfig').mockReturnValue(new Promise(() => {}));
+            jest.spyOn(configActionCreator, 'loadConfig').mockReturnValue(
+                of(createAction(ConfigActionType.LoadConfigSucceeded)),
+            );
 
             from(actionCreator.loadDefaultCheckout()(store)).toPromise();
 

--- a/packages/core/src/checkout/checkout-store-error-selector.spec.ts
+++ b/packages/core/src/checkout/checkout-store-error-selector.spec.ts
@@ -1,8 +1,5 @@
-import { Response } from '@bigcommerce/request-sender';
-
-import { ErrorResponseBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
-import { getErrorResponse } from '../common/http-request/responses.mock';
+import { RequestError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { getErrorResponse } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import {
     CheckoutStoreErrorSelectorFactory,
@@ -14,14 +11,16 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 describe('CheckoutStoreErrorSelector', () => {
     let createCheckoutStoreErrorSelector: CheckoutStoreErrorSelectorFactory;
-    let errorResponse: Response<ErrorResponseBody>;
+    let error: Error;
+    let requestError: RequestError;
     let selectors: InternalCheckoutSelectors;
 
     beforeEach(() => {
         createCheckoutStoreErrorSelector = createCheckoutStoreErrorSelectorFactory();
         selectors = createInternalCheckoutSelectors(getCheckoutStoreStateWithOrder());
 
-        errorResponse = getErrorResponse();
+        error = new Error();
+        requestError = new RequestError(getErrorResponse());
     });
 
     describe('#getError()', () => {
@@ -33,16 +32,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
         it('returns the first error that it encounters', () => {
             jest.spyOn(selectors.checkout, 'getLoadError').mockReturnValue(undefined);
-            jest.spyOn(selectors.paymentStrategies, 'getExecuteError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.paymentStrategies, 'getExecuteError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getError()).toEqual(errorResponse);
+            expect(errors.getError()).toEqual(error);
 
             expect(selectors.checkout.getLoadError).toHaveBeenCalled();
             expect(selectors.paymentStrategies.getExecuteError).toHaveBeenCalled();
@@ -51,14 +45,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadCheckoutError()', () => {
         it('returns error if there is an error when loading checkout', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.checkout, 'getLoadError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.checkout, 'getLoadError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadCheckoutError()).toEqual(errorResponse);
+            expect(errors.getLoadCheckoutError()).toEqual(error);
             expect(selectors.checkout.getLoadError).toHaveBeenCalled();
         });
 
@@ -74,14 +65,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getCreateCustomerAccountError()', () => {
         it('returns error if there is an error when loading checkout', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.customer, 'getCreateAccountError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.customer, 'getCreateAccountError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getCreateCustomerAccountError()).toEqual(errorResponse);
+            expect(errors.getCreateCustomerAccountError()).toEqual(error);
             expect(selectors.customer.getCreateAccountError).toHaveBeenCalled();
         });
 
@@ -97,14 +85,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getSignInEmailError()', () => {
         it('returns error if theres one', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.signInEmail, 'getSendError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.signInEmail, 'getSendError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getSignInEmailError()).toEqual(errorResponse);
+            expect(errors.getSignInEmailError()).toEqual(error);
             expect(selectors.signInEmail.getSendError).toHaveBeenCalled();
         });
 
@@ -120,14 +105,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getUpdateCheckoutError()', () => {
         it('returns error if there is an error when loading checkout', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.checkout, 'getUpdateError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.checkout, 'getUpdateError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getUpdateCheckoutError()).toEqual(errorResponse);
+            expect(errors.getUpdateCheckoutError()).toEqual(error);
             expect(selectors.checkout.getUpdateError).toHaveBeenCalled();
         });
 
@@ -143,16 +125,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getSubmitOrderError()', () => {
         it('returns error if there is an error when submitting order', () => {
-            jest.spyOn(selectors.paymentStrategies, 'getExecuteError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.paymentStrategies, 'getExecuteError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getSubmitOrderError()).toEqual(errorResponse);
+            expect(errors.getSubmitOrderError()).toEqual(error);
             expect(selectors.paymentStrategies.getExecuteError).toHaveBeenCalled();
         });
 
@@ -168,16 +145,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getFinalizeOrderError()', () => {
         it('returns error if there is an error when finalizing order', () => {
-            jest.spyOn(selectors.paymentStrategies, 'getFinalizeError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.paymentStrategies, 'getFinalizeError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getFinalizeOrderError()).toEqual(errorResponse);
+            expect(errors.getFinalizeOrderError()).toEqual(error);
             expect(selectors.paymentStrategies.getFinalizeError).toHaveBeenCalled();
         });
 
@@ -193,14 +165,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadOrderError()', () => {
         it('returns error if there is an error when loading order', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.order, 'getLoadError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.order, 'getLoadError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadOrderError()).toEqual(errorResponse);
+            expect(errors.getLoadOrderError()).toEqual(error);
             expect(selectors.order.getLoadError).toHaveBeenCalled();
         });
 
@@ -216,14 +185,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadCartError()', () => {
         it('returns error if there is an error when loading cart', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.cart, 'getLoadError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.cart, 'getLoadError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadCartError()).toEqual(errorResponse);
+            expect(errors.getLoadCartError()).toEqual(error);
             expect(selectors.cart.getLoadError).toHaveBeenCalled();
         });
 
@@ -239,14 +205,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadBillingCountriesError()', () => {
         it('returns error if there is an error when loading billing countries', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.countries, 'getLoadError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.countries, 'getLoadError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadBillingCountriesError()).toEqual(errorResponse);
+            expect(errors.getLoadBillingCountriesError()).toEqual(error);
             expect(selectors.countries.getLoadError).toHaveBeenCalled();
         });
 
@@ -262,14 +225,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadShippingCountriesError()', () => {
         it('returns error if there is an error when loading shipping countries', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.shippingCountries, 'getLoadError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.shippingCountries, 'getLoadError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadShippingCountriesError()).toEqual(errorResponse);
+            expect(errors.getLoadShippingCountriesError()).toEqual(error);
             expect(selectors.shippingCountries.getLoadError).toHaveBeenCalled();
         });
 
@@ -285,14 +245,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadPaymentMethodsError()', () => {
         it('returns error if there is an error when loading payment methods', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.paymentMethods, 'getLoadError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.paymentMethods, 'getLoadError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadPaymentMethodsError()).toEqual(errorResponse);
+            expect(errors.getLoadPaymentMethodsError()).toEqual(error);
             expect(selectors.paymentMethods.getLoadError).toHaveBeenCalled();
         });
 
@@ -308,16 +265,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadPaymentMethodError()', () => {
         it('returns error if there is an error when loading payment method', () => {
-            jest.spyOn(selectors.paymentMethods, 'getLoadMethodError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.paymentMethods, 'getLoadMethodError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadPaymentMethodError('braintree')).toEqual(errorResponse);
+            expect(errors.getLoadPaymentMethodError('braintree')).toEqual(error);
             expect(selectors.paymentMethods.getLoadMethodError).toHaveBeenCalledWith('braintree');
         });
 
@@ -333,16 +285,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getInitializePaymentError()', () => {
         it('returns error if unable to initialize payment', () => {
-            jest.spyOn(selectors.paymentStrategies, 'getInitializeError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.paymentStrategies, 'getInitializeError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getInitializePaymentError('braintree')).toEqual(errorResponse);
+            expect(errors.getInitializePaymentError('braintree')).toEqual(error);
             expect(selectors.paymentStrategies.getInitializeError).toHaveBeenCalledWith(
                 'braintree',
             );
@@ -364,16 +311,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getSignInError()', () => {
         it('returns error if there is an error when signing in', () => {
-            jest.spyOn(selectors.customerStrategies, 'getSignInError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.customerStrategies, 'getSignInError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getSignInError()).toEqual(errorResponse);
+            expect(errors.getSignInError()).toEqual(error);
             expect(selectors.customerStrategies.getSignInError).toHaveBeenCalled();
         });
 
@@ -389,16 +331,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getSignOutError()', () => {
         it('returns error if there is an error when signing out', () => {
-            jest.spyOn(selectors.customerStrategies, 'getSignOutError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.customerStrategies, 'getSignOutError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getSignOutError()).toEqual(errorResponse);
+            expect(errors.getSignOutError()).toEqual(error);
             expect(selectors.customerStrategies.getSignOutError).toHaveBeenCalled();
         });
 
@@ -414,16 +351,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getInitializeCustomerError()', () => {
         it('returns error if unable to initialize customer', () => {
-            jest.spyOn(selectors.customerStrategies, 'getInitializeError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.customerStrategies, 'getInitializeError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getInitializeCustomerError()).toEqual(errorResponse);
+            expect(errors.getInitializeCustomerError()).toEqual(error);
             expect(selectors.customerStrategies.getInitializeError).toHaveBeenCalled();
         });
 
@@ -442,15 +374,12 @@ describe('CheckoutStoreErrorSelector', () => {
     describe('#getLoadShippingOptionsError()', () => {
         it('returns error if there is an error when loading the shipping options', () => {
             jest.spyOn(selectors.consignments, 'getLoadShippingOptionsError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
+                error,
             );
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadShippingOptionsError()).toEqual(errorResponse);
+            expect(errors.getLoadShippingOptionsError()).toEqual(error);
             expect(selectors.consignments.getLoadShippingOptionsError).toHaveBeenCalled();
         });
 
@@ -468,16 +397,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getSelectShippingOptionError()', () => {
         it('returns error if there is an error when selecting the shipping options', () => {
-            jest.spyOn(selectors.shippingStrategies, 'getSelectOptionError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.shippingStrategies, 'getSelectOptionError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getSelectShippingOptionError()).toEqual(errorResponse);
+            expect(errors.getSelectShippingOptionError()).toEqual(error);
             expect(selectors.shippingStrategies.getSelectOptionError).toHaveBeenCalled();
         });
 
@@ -495,14 +419,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getUpdateBillingAddressError()', () => {
         it('returns error if there is an error when updating the billing address', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.billingAddress, 'getUpdateError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.billingAddress, 'getUpdateError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getUpdateBillingAddressError()).toEqual(errorResponse);
+            expect(errors.getUpdateBillingAddressError()).toEqual(error);
             expect(selectors.billingAddress.getUpdateError).toHaveBeenCalled();
         });
 
@@ -518,14 +439,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getUpdateSubscriptionsError()', () => {
         it('returns error if there is an error when updating subscriptions', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.subscriptions, 'getUpdateError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.subscriptions, 'getUpdateError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getUpdateSubscriptionsError()).toEqual(errorResponse);
+            expect(errors.getUpdateSubscriptionsError()).toEqual(error);
             expect(selectors.subscriptions.getUpdateError).toHaveBeenCalled();
         });
 
@@ -541,16 +459,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getContinueAsGuestError()', () => {
         it('returns error if there is an error', () => {
-            jest.spyOn(selectors.billingAddress, 'getContinueAsGuestError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.billingAddress, 'getContinueAsGuestError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getContinueAsGuestError()).toEqual(errorResponse);
+            expect(errors.getContinueAsGuestError()).toEqual(error);
             expect(selectors.billingAddress.getContinueAsGuestError).toHaveBeenCalled();
         });
 
@@ -568,14 +481,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getUpdateConsignmentError()', () => {
         it('returns error if there is an error when updating consignments', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.consignments, 'getUpdateError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.consignments, 'getUpdateError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getUpdateConsignmentError('foo')).toEqual(errorResponse);
+            expect(errors.getUpdateConsignmentError('foo')).toEqual(error);
             expect(selectors.consignments.getUpdateError).toHaveBeenCalledWith('foo');
         });
 
@@ -591,14 +501,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getDeleteConsignmentError()', () => {
         it('returns error if there is an error when deleting consignments', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.consignments, 'getDeleteError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.consignments, 'getDeleteError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getDeleteConsignmentError('foo')).toEqual(errorResponse);
+            expect(errors.getDeleteConsignmentError('foo')).toEqual(error);
             expect(selectors.consignments.getDeleteError).toHaveBeenCalledWith('foo');
         });
 
@@ -614,14 +521,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getCreateConsignmentsError()', () => {
         it('returns error if there is an error when creating consignments', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.consignments, 'getCreateError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.consignments, 'getCreateError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getCreateConsignmentsError()).toEqual(errorResponse);
+            expect(errors.getCreateConsignmentsError()).toEqual(error);
             expect(selectors.consignments.getCreateError).toHaveBeenCalledWith();
         });
 
@@ -638,15 +542,12 @@ describe('CheckoutStoreErrorSelector', () => {
     describe('#getUpdateShippingAddressError()', () => {
         it('returns error if there is an error when updating the shipping address', () => {
             jest.spyOn(selectors.shippingStrategies, 'getUpdateAddressError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
+                error,
             );
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getUpdateShippingAddressError()).toEqual(errorResponse);
+            expect(errors.getUpdateShippingAddressError()).toEqual(error);
             expect(selectors.shippingStrategies.getUpdateAddressError).toHaveBeenCalled();
         });
 
@@ -664,16 +565,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getInitializePaymentError()', () => {
         it('returns error if unable to initialize shipping', () => {
-            jest.spyOn(selectors.shippingStrategies, 'getInitializeError').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                errorResponse,
-            );
+            jest.spyOn(selectors.shippingStrategies, 'getInitializeError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getInitializeShippingError('foobar')).toEqual(errorResponse);
+            expect(errors.getInitializeShippingError('foobar')).toEqual(error);
             expect(selectors.shippingStrategies.getInitializeError).toHaveBeenCalledWith('foobar');
         });
 
@@ -691,14 +587,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getApplyCouponError()', () => {
         it('returns error if there is an error when updating the a coupon', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.coupons, 'getApplyError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.coupons, 'getApplyError').mockReturnValue(requestError);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getApplyCouponError()).toEqual(errorResponse);
+            expect(errors.getApplyCouponError()).toEqual(requestError);
             expect(selectors.coupons.getApplyError).toHaveBeenCalled();
         });
 
@@ -714,14 +607,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getRemoveCouponError()', () => {
         it('returns error if there is an error when updating the a coupon', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.coupons, 'getRemoveError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.coupons, 'getRemoveError').mockReturnValue(requestError);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getRemoveCouponError()).toEqual(errorResponse);
+            expect(errors.getRemoveCouponError()).toEqual(requestError);
             expect(selectors.coupons.getRemoveError).toHaveBeenCalled();
         });
 
@@ -737,14 +627,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getApplyGiftCertificateError()', () => {
         it('returns error if there is an error when applying gift certificate', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.giftCertificates, 'getApplyError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.giftCertificates, 'getApplyError').mockReturnValue(requestError);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getApplyGiftCertificateError()).toEqual(errorResponse);
+            expect(errors.getApplyGiftCertificateError()).toEqual(requestError);
             expect(selectors.giftCertificates.getApplyError).toHaveBeenCalled();
         });
 
@@ -760,14 +647,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getRemoveGiftCertificateError()', () => {
         it('returns error if there is an error when removing gift certificate', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.giftCertificates, 'getRemoveError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.giftCertificates, 'getRemoveError').mockReturnValue(requestError);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getRemoveGiftCertificateError()).toEqual(errorResponse);
+            expect(errors.getRemoveGiftCertificateError()).toEqual(requestError);
             expect(selectors.giftCertificates.getRemoveError).toHaveBeenCalled();
         });
 
@@ -783,14 +667,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadInstrumentsError()', () => {
         it('returns error if there is an error when loading instruments', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.instruments, 'getLoadError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.instruments, 'getLoadError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadInstrumentsError()).toEqual(errorResponse);
+            expect(errors.getLoadInstrumentsError()).toEqual(error);
             expect(selectors.instruments.getLoadError).toHaveBeenCalled();
         });
 
@@ -806,14 +687,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getDeleteInstrumentError()', () => {
         it('returns error if there is an error when deleting instruments', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.instruments, 'getDeleteError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.instruments, 'getDeleteError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getDeleteInstrumentError('123')).toEqual(errorResponse);
+            expect(errors.getDeleteInstrumentError('123')).toEqual(error);
             expect(selectors.instruments.getDeleteError).toHaveBeenCalledWith('123');
         });
 
@@ -829,14 +707,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadConfigError()', () => {
         it('returns error if there is an error when loading config', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.config, 'getLoadError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.config, 'getLoadError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadConfigError()).toEqual(errorResponse);
+            expect(errors.getLoadConfigError()).toEqual(error);
             expect(selectors.config.getLoadError).toHaveBeenCalled();
         });
 
@@ -852,14 +727,11 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getLoadExtensionsError()', () => {
         it('returns error if there is an error when loading extensions', () => {
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(selectors.extensions, 'getLoadError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.extensions, 'getLoadError').mockReturnValue(error);
 
             const errors = createCheckoutStoreErrorSelector(selectors);
 
-            expect(errors.getLoadExtensionsError()).toEqual(errorResponse);
+            expect(errors.getLoadExtensionsError()).toEqual(error);
             expect(selectors.extensions.getLoadError).toHaveBeenCalled();
         });
 

--- a/packages/core/src/checkout/checkout-store-selector.spec.ts
+++ b/packages/core/src/checkout/checkout-store-selector.spec.ts
@@ -98,6 +98,24 @@ describe('CheckoutStoreSelector', () => {
     });
 
     describe('#getBillingAddress()', () => {
+        const emptyBillingAddress = {
+            email: '',
+            id: '',
+            address1: '',
+            customFields: [],
+            address2: '',
+            city: '',
+            company: '',
+            country: '',
+            firstName: '',
+            lastName: '',
+            phone: '',
+            postalCode: '',
+            stateOrProvince: '',
+            stateOrProvinceCode: '',
+            countryCode: '',
+        };
+
         it('returns billing address', () => {
             expect(selector.getBillingAddress()).toEqual(
                 internalSelectors.billingAddress.getBillingAddress(),
@@ -114,20 +132,7 @@ describe('CheckoutStoreSelector', () => {
             selector = createCheckoutStoreSelector(internalSelectors);
 
             expect(selector.getBillingAddress()).toEqual({
-                id: '',
-                address1: '',
-                address2: '',
-                city: '',
-                company: '',
-                country: '',
-                customFields: [],
-                email: '',
-                firstName: '',
-                lastName: '',
-                phone: '',
-                postalCode: '',
-                stateOrProvince: '',
-                stateOrProvinceCode: '',
+                ...emptyBillingAddress,
                 countryCode: 'AU',
             });
         });
@@ -135,33 +140,18 @@ describe('CheckoutStoreSelector', () => {
         it('returns geo-ip dummy billing address when only email is defined in billing address', () => {
             internalSelectors = createInternalCheckoutSelectors(state);
 
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
             jest.spyOn(internalSelectors.billingAddress, 'getBillingAddress').mockReturnValue({
+                ...emptyBillingAddress,
                 email: 'foo@bar.com',
                 id: '2',
-                address1: '',
-                customFields: [],
             });
 
             selector = createCheckoutStoreSelector(internalSelectors);
 
             expect(selector.getBillingAddress()).toEqual({
+                ...emptyBillingAddress,
                 id: '2',
-                address1: '',
-                address2: '',
-                city: '',
-                company: '',
-                country: '',
-                customFields: [],
                 email: 'foo@bar.com',
-                firstName: '',
-                lastName: '',
-                phone: '',
-                postalCode: '',
-                stateOrProvince: '',
-                stateOrProvinceCode: '',
                 countryCode: 'AU',
             });
         });
@@ -182,17 +172,18 @@ describe('CheckoutStoreSelector', () => {
         it('returns address if address is partially defined but geo IP is not defined', () => {
             internalSelectors = createInternalCheckoutSelectors(state);
 
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
             jest.spyOn(internalSelectors.billingAddress, 'getBillingAddress').mockReturnValue({
+                ...emptyBillingAddress,
                 email: 'foo@bar.com',
             });
             jest.spyOn(internalSelectors.config, 'getContextConfig').mockReturnValue(undefined);
 
             selector = createCheckoutStoreSelector(internalSelectors);
 
-            expect(selector.getBillingAddress()).toEqual({ email: 'foo@bar.com' });
+            expect(selector.getBillingAddress()).toEqual({
+                ...emptyBillingAddress,
+                email: 'foo@bar.com',
+            });
         });
     });
 


### PR DESCRIPTION
## What?
Removed almost all ts-ignore from core/src/checkout folder

## Why?
This tech dept was created during jest dependency update. So to keep checkout sdk as clean as possible, we should do some work in this area.

## Testing / Proof
Lint & Test & Build commands passed locally
CI
