### PR TITLE
chore(common): CHECKOUT-8523 Remove experiment code for CHECKOUT-4936_enable_custom_item_shipping

### DIFF
--- a/packages/google-pay-integration/src/utils/items-require-shipping.ts
+++ b/packages/google-pay-integration/src/utils/items-require-shipping.ts
@@ -9,11 +9,7 @@ const itemsRequireShipping = (cart?: Cart, config?: StoreConfig) => {
         return true;
     }
 
-    if (
-        config &&
-        config.checkoutSettings.features['CHECKOUT-4936.enable_custom_item_shipping'] &&
-        cart.lineItems.customItems
-    ) {
+    if (config && cart.lineItems.customItems) {
         return cart.lineItems.customItems.length > 0;
     }
 


### PR DESCRIPTION
## What?
Remove experiment code for CHECKOUT-4936_enable_custom_item_shipping

## Why?
This codepath has been ramped up for a few years now, so good idea to remove it.

## Testing / Proof
- CI

@bigcommerce/team-checkout @bigcommerce/team-payments
