### PR TITLE
fix(payment): STRIPE-421 payment method issue after PI change

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-script-loader.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-script-loader.ts
@@ -55,8 +55,8 @@ export default class StripeUPEScriptLoader {
 
             Object.assign(this.stripeWindow, { bcStripeElements: stripeElements });
         } else {
-            await stripeElements.fetchUpdates();
             stripeElements.update(options);
+            await stripeElements.fetchUpdates();
         }
 
         return stripeElements;


### PR DESCRIPTION
## What?
Fix issue with display payment methods after Stripe PI change

## Why?
After Stripe PI changed this changes also should be applied on FE side before fetching updates form new PI

## Testing / Proof
Before:

https://github.com/user-attachments/assets/a5d06038-6433-4c2c-95fe-c6a204ba0b30

After:

https://github.com/user-attachments/assets/74dbf49b-cd2e-4317-b1b8-565fa1bd458b



@bigcommerce/team-checkout @bigcommerce/team-payments
