### PR TITLE
feat(payment): PAYPAL-4550 added force reload of paypal client to avoid initializaing with wrong intent value

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-payment-strategy.ts
@@ -2,6 +2,7 @@ import {
     PaymentStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { createPayPalCommerceSdk } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import createPayPalCommerceIntegrationService from '../create-paypal-commerce-integration-service';
@@ -15,6 +16,7 @@ const createPayPalCommerceAlternativeMethodsPaymentStrategy: PaymentStrategyFact
     new PayPalCommerceAlternativeMethodsPaymentStrategy(
         paymentIntegrationService,
         createPayPalCommerceIntegrationService(paymentIntegrationService),
+        createPayPalCommerceSdk(),
         new LoadingIndicator({
             containerStyles: LOADING_INDICATOR_STYLES,
         }),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
@@ -14,6 +14,10 @@ import {
     getBillingAddress,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    createPayPalCommerceSdk,
+    PayPalCommerceSdk,
+} from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import {
@@ -43,6 +47,7 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
     let paypalCommerceIntegrationService: PayPalCommerceIntegrationService;
     let paypalSdk: PayPalSDK;
     let strategy: PayPalCommerceAlternativeMethodsPaymentStrategy;
+    let paypalCommerceSdk: PayPalCommerceSdk;
 
     const paypalOrderId = 'paypal123';
 
@@ -78,10 +83,12 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
         loadingIndicator = new LoadingIndicator();
         paypalCommerceIntegrationService = getPayPalCommerceIntegrationServiceMock();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
+        paypalCommerceSdk = createPayPalCommerceSdk();
 
         strategy = new PayPalCommerceAlternativeMethodsPaymentStrategy(
             paymentIntegrationService,
             paypalCommerceIntegrationService,
+            paypalCommerceSdk,
             loadingIndicator,
         );
 
@@ -93,10 +100,7 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
             'getBillingAddressOrThrow',
         ).mockReturnValue(billingAddress);
 
-        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(paypalSdk);
-        jest.spyOn(paypalCommerceIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
-            paypalSdk,
-        );
+        jest.spyOn(paypalCommerceSdk, 'getPayPalApmsSdk').mockReturnValue(paypalSdk);
         jest.spyOn(paypalCommerceIntegrationService, 'createOrder').mockReturnValue(paypalOrderId);
         jest.spyOn(paypalCommerceIntegrationService, 'submitPayment').mockReturnValue(undefined);
         jest.spyOn(paypalCommerceIntegrationService, 'getOrderStatus').mockReturnValue(
@@ -223,15 +227,13 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            expect(paypalCommerceIntegrationService.loadPayPalSdk).not.toHaveBeenCalled();
+            expect(paypalCommerceSdk.getPayPalApmsSdk).not.toHaveBeenCalled();
         });
 
         it('loads paypal sdk', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(
-                defaultMethodId,
-            );
+            expect(paypalCommerceSdk.getPayPalApmsSdk).toHaveBeenCalledWith(paymentMethod, 'USD');
         });
     });
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -134,12 +134,6 @@ export interface PayPalCommerceButtonsOptions {
     onCancel?(): void;
 }
 
-export interface ShippingChangeCallbackPayload {
-    orderID: string;
-    shipping_address: PaypalAddressCallbackData;
-    selected_shipping_option: PayPalSelectedShippingOption;
-}
-
 export interface PayPalButtonClickCallbackPayload {
     fundingSource: string;
 }
@@ -156,24 +150,6 @@ export interface PayPalButtonInitCallbackPayload {
 export interface PayPalButtonInitCallbackActions {
     disable(): void;
     enable(): void;
-}
-
-export interface PaypalAddressCallbackData {
-    city: string;
-    country_code: string;
-    postal_code: string;
-    state: string;
-}
-
-export interface PayPalSelectedShippingOption {
-    amount: {
-        currency_code: string;
-        value: string;
-    };
-    id: string;
-    label: string;
-    selected: boolean;
-    type: string;
 }
 
 export interface PayPalButtonApproveCallbackPayload {

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -6,6 +6,7 @@ import { CardInstrument, CustomerAddress } from '@bigcommerce/checkout-sdk/payme
  *
  */
 export type FundingType = string[];
+export type EnableFundingType = FundingType | string;
 
 /**
  *
@@ -48,6 +49,7 @@ export interface PayPalCommerceHostWindow extends Window {
     paypalFastlane?: PayPalFastlane;
     paypalFastlaneSdk?: PayPalFastlaneSdk;
     paypalMessages?: PayPalMessagesSdk;
+    paypalApms?: PayPalApmSdk;
 }
 
 /**
@@ -60,6 +62,8 @@ export interface PayPalSdkConfig {
         'client-id'?: string;
         'merchant-id'?: string;
         'buyer-country'?: string;
+        'enable-funding'?: EnableFundingType;
+        'disable-funding'?: FundingType;
         currency?: string;
         commit?: boolean;
         intent?: PayPalCommerceIntent;
@@ -70,6 +74,7 @@ export interface PayPalSdkConfig {
         'data-partner-attribution-id'?: string;
         'data-user-id-token'?: string;
         'data-namespace'?: string;
+        'data-client-token'?: string;
     };
 }
 
@@ -78,7 +83,7 @@ export enum PayPalCommerceIntent {
     CAPTURE = 'capture',
 }
 
-export type PayPalSdkComponents = Array<'fastlane' | 'messages'>;
+export type PayPalSdkComponents = Array<'fastlane' | 'messages' | 'buttons' | 'payment-fields'>;
 
 /**
  *
@@ -91,6 +96,191 @@ export interface PayPalFastlaneSdk {
 
 export interface PayPalMessagesSdk {
     Messages(options: MessagingOptions): MessagingRender;
+}
+
+export interface PayPalApmSdk {
+    Buttons(options: PayPalCommerceButtonsOptions): PayPalCommerceButtons;
+    PaymentFields(options: PayPalCommercePaymentFieldsOptions): PayPalCommercePaymentFields;
+}
+
+/**
+ *
+ * PayPal Commerce Buttons
+ *
+ */
+export interface PayPalCommerceButtons {
+    render(id: string): void;
+    close(): void;
+    isEligible(): boolean;
+}
+
+export interface PayPalCommerceButtonsOptions {
+    style?: PayPalButtonStyleOptions;
+    fundingSource: string;
+    createOrder(): Promise<string>;
+    onApprove(
+        data: PayPalButtonApproveCallbackPayload,
+        actions: PayPalButtonApproveCallbackActions,
+    ): Promise<boolean | void> | void;
+    onInit?(
+        data: PayPalButtonInitCallbackPayload,
+        actions: PayPalButtonInitCallbackActions,
+    ): Promise<void>;
+    onClick?(
+        data: PayPalButtonClickCallbackPayload,
+        actions: PayPalButtonClickCallbackActions,
+    ): Promise<void> | void;
+    onError?(error: Error): void;
+    onCancel?(): void;
+}
+
+export interface ShippingChangeCallbackPayload {
+    orderID: string;
+    shipping_address: PaypalAddressCallbackData;
+    selected_shipping_option: PayPalSelectedShippingOption;
+}
+
+export interface PayPalButtonClickCallbackPayload {
+    fundingSource: string;
+}
+
+export interface PayPalButtonClickCallbackActions {
+    reject(): void;
+    resolve(): void;
+}
+
+export interface PayPalButtonInitCallbackPayload {
+    correlationID: string;
+}
+
+export interface PayPalButtonInitCallbackActions {
+    disable(): void;
+    enable(): void;
+}
+
+export interface PaypalAddressCallbackData {
+    city: string;
+    country_code: string;
+    postal_code: string;
+    state: string;
+}
+
+export interface PayPalSelectedShippingOption {
+    amount: {
+        currency_code: string;
+        value: string;
+    };
+    id: string;
+    label: string;
+    selected: boolean;
+    type: string;
+}
+
+export interface PayPalButtonApproveCallbackPayload {
+    orderID?: string;
+}
+
+export interface PayPalButtonApproveCallbackActions {
+    order: {
+        get: () => Promise<PayPalOrderDetails>;
+    };
+}
+
+export interface PayPalOrderDetails {
+    payer: {
+        name: {
+            given_name: string;
+            surname: string;
+        };
+        email_address: string;
+        address: PayPalOrderAddress;
+    };
+    purchase_units: Array<{
+        shipping: {
+            address: PayPalOrderAddress;
+        };
+    }>;
+}
+
+export interface PayPalOrderAddress {
+    address_line_1: string;
+    admin_area_2: string;
+    admin_area_1?: string;
+    postal_code: string;
+    country_code: string;
+}
+
+export enum StyleButtonLabel {
+    paypal = 'paypal',
+    checkout = 'checkout',
+    buynow = 'buynow',
+    pay = 'pay',
+    installment = 'installment',
+}
+
+export enum StyleButtonColor {
+    gold = 'gold',
+    blue = 'blue',
+    silver = 'silver',
+    black = 'black',
+    white = 'white',
+}
+
+export enum StyleButtonShape {
+    pill = 'pill',
+    rect = 'rect',
+}
+
+export interface PayPalButtonStyleOptions {
+    color?: StyleButtonColor;
+    shape?: StyleButtonShape;
+    height?: number;
+    label?: StyleButtonLabel;
+}
+
+/**
+ *
+ * PayPal Commerce Payment fields
+ *
+ */
+export interface PayPalCommercePaymentFields {
+    render(id: string): void;
+}
+
+export interface PayPalCommercePaymentFieldsOptions {
+    style?: PayPalCommerceFieldsStyleOptions;
+    fundingSource: string;
+    fields: {
+        name?: {
+            value?: string;
+        };
+        email?: {
+            value?: string;
+        };
+    };
+}
+
+export interface PayPalCommerceFieldsStyleOptions {
+    variables?: {
+        fontFamily?: string;
+        fontSizeBase?: string;
+        fontSizeSm?: string;
+        fontSizeM?: string;
+        fontSizeLg?: string;
+        textColor?: string;
+        colorTextPlaceholder?: string;
+        colorBackground?: string;
+        colorInfo?: string;
+        colorDanger?: string;
+        borderRadius?: string;
+        borderColor?: string;
+        borderWidth?: string;
+        borderFocusColor?: string;
+        spacingUnit?: string;
+    };
+    rules?: {
+        [key: string]: any;
+    };
 }
 
 /**


### PR DESCRIPTION
## What?

Added a new configuration for loading APMs related functionality

## Why?

To avoid initializaing with wrong intent value

## Testing / Proof

https://github.com/user-attachments/assets/2bef14e0-af8b-468e-935e-cb9710a4c9de

@bigcommerce/team-checkout @bigcommerce/team-payments
