### PR TITLE
refactor(payment): PAYPAL-4167 removed PAYPAL-4142.disable_paypal_fastlane_one_click_experience experiment usage from ppcp fastlane customer strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
@@ -540,31 +540,6 @@ describe('PayPalCommerceFastlaneCustomerStrategy', () => {
             );
         });
 
-        it('does not select shipping option for paypal fastlane authentication flow', async () => {
-            paymentMethod.initializationData.isFastlaneEnabled = true;
-
-            const storeConfigWithAFeature = {
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        ...storeConfig.checkoutSettings.features,
-                        'PAYPAL-4142.disable_paypal_fastlane_one_click_experience': true,
-                    },
-                },
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getStoreConfigOrThrow',
-            ).mockReturnValue(storeConfigWithAFeature);
-
-            await strategy.initialize(initializationOptions);
-            await strategy.executePaymentMethodCheckout(executionOptions);
-
-            expect(paymentIntegrationService.selectShippingOption).not.toHaveBeenCalled();
-        });
-
         it('calls continueWithCheckoutCallback callback in the end of execution flow', async () => {
             await strategy.initialize(initializationOptions);
             await strategy.executePaymentMethodCheckout(executionOptions);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -211,24 +211,14 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
         }
 
         if (shippingAddress && cart.lineItems.physicalItems.length > 0) {
-            await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
-        }
-
-        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
-        const shouldDisableFastlaneOneClickExperience =
-            features && features['PAYPAL-4142.disable_paypal_fastlane_one_click_experience'];
-
-        if (
-            shippingAddress &&
-            cart.lineItems.physicalItems.length > 0 &&
-            !shouldDisableFastlaneOneClickExperience
-        ) {
             const consignments = state.getConsignments() || [];
             const availableShippingOptions = consignments[0]?.availableShippingOptions || [];
             const firstShippingOption = availableShippingOptions[0];
             const recommendedShippingOption = availableShippingOptions.find(
                 (option) => option.isRecommended,
             );
+
+            await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
 
             if (recommendedShippingOption || firstShippingOption) {
                 const shippingOptionId = recommendedShippingOption?.id || firstShippingOption.id;


### PR DESCRIPTION
## What?
Removed `PAYPAL-4142.disable_paypal_fastlane_one_click_experience` experiment usage from ppcp fastlane customer strategy

## Why?
As part of experiments cleanup after Fastlane rollout

## Testing / Proof
Unit tests
CI
