### PR TITLE
fix(payment): STRIPE-422 Fix saving Stripe Link instrument

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -30,6 +30,7 @@ import {
     StripeElementsOptions,
     StripeElementType,
     StripeElementUpdateOptions,
+    StripeEventType,
     StripePaymentMethodType,
     StripeStringConstants,
     StripeUPEClient,
@@ -123,6 +124,47 @@ describe('StripeUPEPaymentStrategy', () => {
             fieldBackground: testColor,
             fieldInnerShadow: testColor,
             fieldBorder: testColor,
+        };
+
+        const getPaymentElementActionsMock = (
+            isElementCreated = true,
+            onCallbackPayload = {} as StripeEventType,
+        ) => {
+            const updateMock = jest.fn();
+            const stripePaymentElementMock = {
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: (_: string, callback: (event: StripeEventType) => void) =>
+                    callback(onCallbackPayload),
+                update: updateMock,
+            };
+            const createElementMock = jest.fn(() => stripePaymentElementMock);
+            const getElementMock = jest.fn(() =>
+                isElementCreated ? stripePaymentElementMock : null,
+            );
+            const stripeElementsMock = {
+                create: createElementMock,
+                getElement: getElementMock,
+                update: jest.fn(),
+                fetchUpdates: jest.fn(),
+            };
+
+            stripeUPEJsMock = {
+                ...getStripeUPEJsMock(),
+                elements: jest.fn(() => stripeElementsMock),
+            };
+
+            jest.spyOn(stripeScriptLoader, 'getStripeClient').mockReturnValue(
+                Promise.resolve(stripeUPEJsMock),
+            );
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve(stripeElementsMock),
+            );
+
+            return {
+                updateMock,
+                createElementMock,
+            };
         };
 
         beforeEach(() => {
@@ -281,6 +323,82 @@ describe('StripeUPEPaymentStrategy', () => {
             });
         });
 
+        describe('Stripe element events', () => {
+            it('Should not update Stripe Link auth state if Link already has been authenticated', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentProviderCustomerOrThrow',
+                ).mockReturnValue({ stripeLinkAuthenticationState: true });
+
+                const updatePaymentProviderCustomerMock = jest.spyOn(
+                    paymentIntegrationService,
+                    'updatePaymentProviderCustomer',
+                );
+                const callbackPayload = {
+                    value: {
+                        type: StripePaymentMethodType.Link,
+                    },
+                } as StripeEventType;
+
+                getPaymentElementActionsMock(true, callbackPayload);
+
+                await strategy.initialize(options);
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(updatePaymentProviderCustomerMock).not.toHaveBeenCalled();
+            });
+
+            it('Should not update Stripe Link auth state if not Link element was rendered', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentProviderCustomerOrThrow',
+                ).mockReturnValue({});
+
+                const updatePaymentProviderCustomerMock = jest.spyOn(
+                    paymentIntegrationService,
+                    'updatePaymentProviderCustomer',
+                );
+                const callbackPayload = {
+                    value: {
+                        type: StripePaymentMethodType.CreditCard,
+                    },
+                } as StripeEventType;
+
+                getPaymentElementActionsMock(true, callbackPayload);
+
+                await strategy.initialize(options);
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(updatePaymentProviderCustomerMock).not.toHaveBeenCalled();
+            });
+
+            it('Should update Stripe Link auth state if Link element was rendered', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentProviderCustomerOrThrow',
+                ).mockReturnValue({});
+
+                const updatePaymentProviderCustomerMock = jest.spyOn(
+                    paymentIntegrationService,
+                    'updatePaymentProviderCustomer',
+                );
+                const callbackPayload = {
+                    value: {
+                        type: StripePaymentMethodType.Link,
+                    },
+                } as StripeEventType;
+
+                getPaymentElementActionsMock(true, callbackPayload);
+
+                await strategy.initialize(options);
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(updatePaymentProviderCustomerMock).toHaveBeenCalledWith({
+                    stripeLinkAuthenticationState: true,
+                });
+            });
+        });
+
         describe('Update stripe payment element', () => {
             let updateTriggerFn: (payload: StripeElementUpdateOptions) => void = jest.fn();
 
@@ -297,43 +415,6 @@ describe('StripeUPEPaymentStrategy', () => {
                     paymentIntegrationService.getState(),
                     'getStoreConfigOrThrow',
                 ).mockReturnValue(storeConfig);
-            };
-
-            const getPaymentElementActionsMock = (isElementCreated = true) => {
-                const updateMock = jest.fn();
-                const stripePaymentElementMock = {
-                    mount: jest.fn(),
-                    unmount: jest.fn(),
-                    on: jest.fn((_, callback) => callback()),
-                    update: updateMock,
-                };
-                const createElementMock = jest.fn(() => stripePaymentElementMock);
-                const getElementMock = jest.fn(() =>
-                    isElementCreated ? stripePaymentElementMock : null,
-                );
-                const stripeElementsMock = {
-                    create: createElementMock,
-                    getElement: getElementMock,
-                    update: jest.fn(),
-                    fetchUpdates: jest.fn(),
-                };
-
-                stripeUPEJsMock = {
-                    ...getStripeUPEJsMock(),
-                    elements: jest.fn(() => stripeElementsMock),
-                };
-
-                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockReturnValue(
-                    Promise.resolve(stripeUPEJsMock),
-                );
-                jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
-                    Promise.resolve(stripeElementsMock),
-                );
-
-                return {
-                    updateMock,
-                    createElementMock,
-                };
             };
 
             beforeEach(() => {

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
@@ -88,6 +88,12 @@ export interface StripeShippingEvent extends StripeEvent {
     };
 }
 
+export interface StripePaymentEvent extends StripeEvent {
+    value: {
+        type: StripePaymentMethodType;
+    };
+}
+
 interface Address {
     city: string;
     country: string;
@@ -97,7 +103,7 @@ interface Address {
     state: string;
 }
 
-export type StripeEventType = StripeShippingEvent | StripeCustomerEvent;
+export type StripeEventType = StripeShippingEvent | StripeCustomerEvent | StripePaymentEvent;
 
 /**
  * Object definition for part of the data sent to confirm the PaymentIntent.
@@ -392,6 +398,7 @@ export interface StripeHostWindow extends Window {
 
 export enum StripePaymentMethodType {
     CreditCard = 'card',
+    Link = 'link',
     SOFORT = 'sofort',
     EPS = 'eps',
     GRABPAY = 'grabpay',


### PR DESCRIPTION
## What?
- Remove saving instrument checkbox for Stripe Link stored cards.
- Remove other payment methods for Stripe Link authorised shopper.

## Why?
- We can't save instrument that was already saved for Stripe Link shopper account.
- For Stripe Link authorised shopper we should show only Stripe Link payment method

## Testing / Proof
Before:

https://github.com/user-attachments/assets/0030845a-418d-4cf1-bc9a-eb8edbc6ec77


After:

https://github.com/user-attachments/assets/fbfa9f4b-bf2e-435d-bf05-0d7ba4d87b9e


Regression:
Basic Stripe Link for store visitor

https://github.com/user-attachments/assets/54d2ff75-96cd-4e8e-abcb-0735fa0b2d6f


Store authorised shopper without Stripe Link

https://github.com/user-attachments/assets/17b57f83-da88-4566-940a-acbcef59b10b




@bigcommerce/team-checkout @bigcommerce/team-payments
