### PR TITLE
refactor(payment): PAYPAL-4578 updated ApplePay strategies with BraintreeSdk

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
@@ -1,6 +1,6 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 
-import { BraintreeIntegrationService } from '@bigcommerce/checkout-sdk/braintree-utils';
+import { BraintreeSdk } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     InvalidArgumentError,
     NotInitializedError,
@@ -45,7 +45,7 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
         private _requestSender: RequestSender,
         private _paymentIntegrationService: PaymentIntegrationService,
         private _sessionFactory: ApplePaySessionFactory,
-        private _braintreeIntegrationService: BraintreeIntegrationService,
+        private _braintreeSdk: BraintreeSdk,
     ) {}
 
     async initialize(
@@ -68,7 +68,7 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
         const paymentMethod: PaymentMethod = state.getPaymentMethodOrThrow(methodId);
 
         if (paymentMethod.initializationData?.gateway === ApplePayGatewayType.BRAINTREE) {
-            await this._initializeBraintreeIntegrationService();
+            await this._initializeBraintreeSdk();
         }
     }
 
@@ -266,40 +266,32 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
         }
     }
 
-    private async _getBraintreeDeviceData() {
-        const braintreePaymentMethod = this._paymentIntegrationService
-            .getState()
-            .getPaymentMethod(ApplePayGatewayType.BRAINTREE);
+    private async _getBraintreeDeviceData(): Promise<string | undefined> {
+        try {
+            const { deviceData } = await this._braintreeSdk.getDataCollectorOrThrow();
 
-        if (braintreePaymentMethod?.clientToken) {
-            const data = await this._braintreeIntegrationService.getDataCollector();
-
-            return data.deviceData;
+            return deviceData;
+        } catch (_) {
+            // Don't throw an error to avoid breaking checkout flow
         }
     }
 
-    private async _initializeBraintreeIntegrationService() {
-        try {
-            await this._paymentIntegrationService.loadPaymentMethod(ApplePayGatewayType.BRAINTREE);
+    private async _initializeBraintreeSdk(): Promise<void> {
+        // TODO: This is a temporary solution when we load braintree to get client token (should be fixed after PAYPAL-4122)
+        await this._paymentIntegrationService.loadPaymentMethod(ApplePayGatewayType.BRAINTREE);
 
-            const state = this._paymentIntegrationService.getState();
+        const state = this._paymentIntegrationService.getState();
+        const storeConfig = state.getStoreConfigOrThrow();
+        const braintreePaymentMethod = state.getPaymentMethod(ApplePayGatewayType.BRAINTREE);
 
-            const storeConfig = state.getStoreConfigOrThrow();
-
-            const braintreePaymentMethod: PaymentMethod = state.getPaymentMethodOrThrow(
-                ApplePayGatewayType.BRAINTREE,
-            );
-
-            if (!braintreePaymentMethod.clientToken || !braintreePaymentMethod.initializationData) {
-                return;
-            }
-
-            this._braintreeIntegrationService.initialize(
-                braintreePaymentMethod.clientToken,
-                storeConfig,
-            );
-        } catch (_) {
-            // we don't need to do anything in this block
+        if (
+            !braintreePaymentMethod ||
+            !braintreePaymentMethod.clientToken ||
+            !braintreePaymentMethod.initializationData
+        ) {
+            return;
         }
+
+        this._braintreeSdk.initialize(braintreePaymentMethod.clientToken, storeConfig);
     }
 }

--- a/packages/apple-pay-integration/src/create-apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/create-apple-pay-button-strategy.ts
@@ -1,10 +1,7 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
-import {
-    BraintreeIntegrationService,
-    BraintreeScriptLoader,
-} from '@bigcommerce/checkout-sdk/braintree-utils';
+import { BraintreeScriptLoader, BraintreeSdk } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     CheckoutButtonStrategyFactory,
     toResolvableModule,
@@ -17,16 +14,12 @@ const createApplePayButtonStrategy: CheckoutButtonStrategyFactory<ApplePayButton
     paymentIntegrationService,
 ) => {
     const { getHost } = paymentIntegrationService.getState();
-    const hostWindow = window;
 
     return new ApplePayButtonStrategy(
         createRequestSender({ host: getHost() }),
         paymentIntegrationService,
         new ApplePaySessionFactory(),
-        new BraintreeIntegrationService(
-            new BraintreeScriptLoader(getScriptLoader(), hostWindow),
-            hostWindow,
-        ),
+        new BraintreeSdk(new BraintreeScriptLoader(getScriptLoader(), window)),
     );
 };
 

--- a/packages/apple-pay-integration/src/create-apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/create-apple-pay-customer-strategy.ts
@@ -1,10 +1,7 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
-import {
-    BraintreeIntegrationService,
-    BraintreeScriptLoader,
-} from '@bigcommerce/checkout-sdk/braintree-utils';
+import { BraintreeScriptLoader, BraintreeSdk } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     CustomerStrategyFactory,
     toResolvableModule,
@@ -17,16 +14,12 @@ const createApplePayCustomerStrategy: CustomerStrategyFactory<ApplePayCustomerSt
     paymentIntegrationService,
 ) => {
     const { getHost } = paymentIntegrationService.getState();
-    const hostWindow = window;
 
     return new ApplePayCustomerStrategy(
         createRequestSender({ host: getHost() }),
         paymentIntegrationService,
         new ApplePaySessionFactory(),
-        new BraintreeIntegrationService(
-            new BraintreeScriptLoader(getScriptLoader(), hostWindow),
-            hostWindow,
-        ),
+        new BraintreeSdk(new BraintreeScriptLoader(getScriptLoader(), window)),
     );
 };
 

--- a/packages/apple-pay-integration/src/create-apple-pay-payment-strategy.ts
+++ b/packages/apple-pay-integration/src/create-apple-pay-payment-strategy.ts
@@ -1,10 +1,7 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
-import {
-    BraintreeIntegrationService,
-    BraintreeScriptLoader,
-} from '@bigcommerce/checkout-sdk/braintree-utils';
+import { BraintreeScriptLoader, BraintreeSdk } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     PaymentStrategyFactory,
     toResolvableModule,
@@ -17,16 +14,12 @@ const createApplePayPaymentStrategy: PaymentStrategyFactory<ApplePayPaymentStrat
     paymentIntegrationService,
 ) => {
     const { getHost } = paymentIntegrationService.getState();
-    const hostWindow = window;
 
     return new ApplePayPaymentStrategy(
         createRequestSender({ host: getHost() }),
         paymentIntegrationService,
         new ApplePaySessionFactory(),
-        new BraintreeIntegrationService(
-            new BraintreeScriptLoader(getScriptLoader(), hostWindow),
-            hostWindow,
-        ),
+        new BraintreeSdk(new BraintreeScriptLoader(getScriptLoader(), window)),
     );
 };
 


### PR DESCRIPTION
## What?
Updated apple pay strategies with `BraintreeSdk` class instead of `BraintreeIntegrationService`

## Why?
`BraintreeIntegrationService` is deprecated, so to be able to remove it in the future apple pay strategies should be updated

## Testing / Proof
Manual tests:
- successfully payed with apple pay on PDP page;
- successfully payed with apple pay on mini cart;
- successfully payed with apple pay on cart page;
- successfully payed with apple pay using button on top of checkout page;
- successfully payed with apple pay on payment step of checkout page;
(can't share videos, because macOs doesn't give an ability to pay with Apple Pay when screen recording is on)

Unit tests
CI

