### PR TITLE
fix(common): PAYPAL-000 fixed apple pay package name in codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,5 +91,5 @@
 /packages/core/src/customer/strategies/googlepay @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
 /packages/core/src/payment/strategies/googlepay @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
 
-/packages/apple-pay @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
+/packages/apple-pay-integration @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
 /packages/google-pay-integration @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal


### PR DESCRIPTION
## What?
Fixed apple pay package name in codeowners file

## Why?
To be able to set right owner rules for apple-pay-integration package

## Testing / Proof
There is nothing to test