### PR TITLE
CHECKOUT-8300: Fix config and form field cache by ensuring input parameters are correctly compared

### DIFF
--- a/packages/core/src/checkout/checkout-action-creator.ts
+++ b/packages/core/src/checkout/checkout-action-creator.ts
@@ -29,11 +29,14 @@ export default class CheckoutActionCreator {
                 of(createAction(CheckoutActionType.LoadCheckoutRequested)),
                 merge(
                     this._configActionCreator.loadConfig({
-                        ...options,
                         useCache: true,
-                        params: { ...options?.params, checkoutId: id },
+                        timeout: options?.timeout,
+                        params: { checkoutId: id },
                     }),
-                    this._formFieldsActionCreator.loadFormFields({ ...options, useCache: true }),
+                    this._formFieldsActionCreator.loadFormFields({
+                        useCache: true,
+                        timeout: options?.timeout,
+                    }),
                 ),
                 defer(() => {
                     return this._checkoutRequestSender
@@ -64,8 +67,14 @@ export default class CheckoutActionCreator {
             concat(
                 of(createAction(CheckoutActionType.LoadCheckoutRequested)),
                 merge(
-                    this._configActionCreator.loadConfig(),
-                    this._formFieldsActionCreator.loadFormFields({ ...options, useCache: true }),
+                    this._configActionCreator.loadConfig({
+                        useCache: true,
+                        timeout: options?.timeout,
+                    }),
+                    this._formFieldsActionCreator.loadFormFields({
+                        useCache: true,
+                        timeout: options?.timeout,
+                    }),
                 ),
                 defer(async () => {
                     const state = store.getState();

--- a/packages/core/src/common/data-store/cache-action.spec.ts
+++ b/packages/core/src/common/data-store/cache-action.spec.ts
@@ -26,14 +26,14 @@ describe('cacheAction()', () => {
             Promise.resolve(createAction('GET_MESSAGE', `Hello ${name}`)),
         );
         const subscriber = jest.fn();
-        const createCachedAction = cacheAction((name) =>
+        const createCachedAction = cacheAction((name, _) =>
             defer(() => getMessage(name) as Promise<Action>),
         );
 
-        createCachedAction('Foo').subscribe(subscriber);
-        createCachedAction('Foo').subscribe(subscriber);
-        createCachedAction('Bar').subscribe(subscriber);
-        createCachedAction('Bar').subscribe(subscriber);
+        createCachedAction('Foo', { params: { abc: 'abc' } }).subscribe(subscriber);
+        createCachedAction('Foo', { params: { abc: 'abc' } }).subscribe(subscriber);
+        createCachedAction('Bar', { params: { abc: 'efg' } }).subscribe(subscriber);
+        createCachedAction('Bar', { params: { abc: 'efg' } }).subscribe(subscriber);
 
         await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/core/src/common/data-store/cache-action.ts
+++ b/packages/core/src/common/data-store/cache-action.ts
@@ -1,5 +1,6 @@
 import { Action, ThunkAction } from '@bigcommerce/data-store';
 import { memoize } from '@bigcommerce/memoize';
+import { isEqual } from 'lodash';
 import { from, Observable } from 'rxjs';
 import { shareReplay } from 'rxjs/operators';
 
@@ -12,13 +13,13 @@ export default function cacheAction<TFunction extends CreateActionFn>(fn: TFunct
         }
 
         if (typeof action === 'function') {
-            return memoize((store) => from(action(store)).pipe(shareReplay()));
+            return memoize((store) => from(action(store)).pipe(shareReplay()), { isEqual });
         }
 
         return action;
     }
 
-    return memoize(decoratedFn as TFunction);
+    return memoize(decoratedFn as TFunction, { isEqual });
 }
 
 type CreateActionFn = (...args: any[]) => Observable<Action> | ThunkAction<Action> | Action;

--- a/packages/core/src/config/config-action-creator.spec.ts
+++ b/packages/core/src/config/config-action-creator.spec.ts
@@ -58,8 +58,14 @@ describe('ConfigActionCreator', () => {
 
         it('dispatches actions using cached responses if available', async () => {
             const actions = await merge(
-                configActionCreator.loadConfig({ useCache: true }),
-                configActionCreator.loadConfig({ useCache: true }),
+                configActionCreator.loadConfig({
+                    useCache: true,
+                    params: { checkoutId: '6554a0a0-527f-4d51-9197-58ab22eb1dab' },
+                }),
+                configActionCreator.loadConfig({
+                    useCache: true,
+                    params: { checkoutId: '6554a0a0-527f-4d51-9197-58ab22eb1dab' },
+                }),
             )
                 .pipe(toArray())
                 .toPromise();


### PR DESCRIPTION
## What?
Fix the client-side cache for the `/api/storefront/checkout-settings` and `/api/storefront/form-fields` endpoints so that the cache is used when the CheckoutService#loadCheckout or CheckoutService#loadDefaultCheckout method is called multiple times.

## Why?
The client-side cache isn't working properly because the input parameter for `ConfigActionCreator` and `FormFieldActionCreator` includes the `params` field, which may contain a nested object (i.e.: `{ params: { checkoutId: id } }` and `{ params: { include: ['categoryNames'] } })`. The nested object breaks the caching as `@cacheableAction` decorator only works on shallow objects. As a result, when `ExtensionCommandType.ReloadCheckout` command is issued by an extension, we end up making repeated calls to these endpoints instead of re-using the local cache.

## Testing / Proof
### Before

This video shows that local cache is not used when `ReloadCheckout` is called repeatedly.

https://github.com/user-attachments/assets/a12f7ea9-a474-4a76-9942-1a5e6b244698

### After

This video shows that local cache is used as expected when `ReloadCheckout` is called repeatedly.

https://github.com/user-attachments/assets/b9d716d8-9cc6-4275-adca-9d62f253dcba
