### PR TITLE
Revert "Revert "feat(shipping): SHIPPING-3183 Add support for channel_ids to the load shipping countries action""

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -432,7 +432,7 @@ describe('CheckoutService', () => {
             paymentMethodActionCreator,
             paymentStrategyActionCreator,
             new PickupOptionActionCreator(new PickupOptionRequestSender(requestSender)),
-            new ShippingCountryActionCreator(shippingCountryRequestSender),
+            new ShippingCountryActionCreator(shippingCountryRequestSender, store),
             shippingStrategyActionCreator,
             signInEmailActionCreator,
             spamProtectionActionCreator,

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -528,7 +528,7 @@ export default class CheckoutService {
      * ```
      *
      * @alpha
-     * @param options - Options for loading the available shipping countries.
+     * @param query - Options for loading the available shipping countries.
      * @returns A promise that resolves to the current state.
      */
     loadPickupOptions(query: PickupOptionRequestBody): Promise<CheckoutSelectors> {

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -193,6 +193,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new PickupOptionActionCreator(new PickupOptionRequestSender(requestSender)),
         new ShippingCountryActionCreator(
             new ShippingCountryRequestSender(requestSender, { locale }),
+            store,
         ),
         new ShippingStrategyActionCreator(createShippingStrategyRegistry(store, requestSender)),
         new SignInEmailActionCreator(new SignInEmailRequestSender(requestSender)),

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -124,6 +124,7 @@ export default function createPaymentIntegrationService(
 
     const shippingCountryActionCreator = new ShippingCountryActionCreator(
         new ShippingCountryRequestSender(requestSender, { locale: getLocale() }),
+        store,
     );
 
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
@@ -483,7 +483,6 @@ describe('AmazonPayV2PaymentStrategy', () => {
             );
 
             const { publicKeyId, createCheckoutSessionConfig } =
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                 getAmazonPayV2Ph4ButtonParamsMock() as AmazonPayV2NewButtonParams;
             const expectedConfig = {
                 publicKeyId,

--- a/packages/core/src/shipping/shipping-country-action-creator.spec.ts
+++ b/packages/core/src/shipping/shipping-country-action-creator.spec.ts
@@ -4,6 +4,9 @@ import { catchError, toArray } from 'rxjs/operators';
 
 import { ErrorResponseBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
+import { CheckoutStore } from '../checkout';
+import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import createCheckoutStore from '../checkout/create-checkout-store';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 import { getCountries } from '../geography/countries.mock';
 
@@ -16,8 +19,10 @@ describe('ShippingCountryActionCreator', () => {
     let shippingCountryActionCreator: ShippingCountryActionCreator;
     let errorResponse: Response<ErrorResponseBody>;
     let response: Response<any>;
+    let store: CheckoutStore;
 
     beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
         response = getResponse({ data: getCountries() });
         errorResponse = getErrorResponse();
 
@@ -25,7 +30,7 @@ describe('ShippingCountryActionCreator', () => {
 
         jest.spyOn(requestSender, 'loadCountries').mockReturnValue(Promise.resolve(response));
 
-        shippingCountryActionCreator = new ShippingCountryActionCreator(requestSender);
+        shippingCountryActionCreator = new ShippingCountryActionCreator(requestSender, store);
     });
 
     describe('#loadCountries()', () => {

--- a/packages/core/src/shipping/shipping-country-action-creator.ts
+++ b/packages/core/src/shipping/shipping-country-action-creator.ts
@@ -1,20 +1,27 @@
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { Observable, Observer } from 'rxjs';
 
+import CheckoutStore from '../checkout/checkout-store';
 import { RequestOptions } from '../common/http-request';
 
 import { LoadShippingCountriesAction, ShippingCountryActionType } from './shipping-country-actions';
 import ShippingCountryRequestSender from './shipping-country-request-sender';
 
 export default class ShippingCountryActionCreator {
-    constructor(private _shippingCountryRequestSender: ShippingCountryRequestSender) {}
+    constructor(
+        private _shippingCountryRequestSender: ShippingCountryRequestSender,
+        private _store: CheckoutStore,
+    ) {}
 
     loadCountries(options?: RequestOptions): Observable<LoadShippingCountriesAction> {
+        const { checkout } = this._store.getState();
+        const { channelId } = checkout.getCheckoutOrThrow();
+
         return Observable.create((observer: Observer<LoadShippingCountriesAction>) => {
             observer.next(createAction(ShippingCountryActionType.LoadShippingCountriesRequested));
 
             this._shippingCountryRequestSender
-                .loadCountries(options)
+                .loadCountries(channelId, options)
                 .then((response) => {
                     observer.next(
                         createAction(

--- a/packages/core/src/shipping/shipping-country-request-sender.spec.ts
+++ b/packages/core/src/shipping/shipping-country-request-sender.spec.ts
@@ -33,29 +33,35 @@ describe('ShippingCountryRequestSender', () => {
         });
 
         it('loads shipping countries', async () => {
-            const output = await shippingCountryRequestSender.loadCountries();
+            const output = await shippingCountryRequestSender.loadCountries(1);
 
             expect(output).toEqual(response);
-            expect(requestSender.get).toHaveBeenCalledWith('/internalapi/v1/shipping/countries', {
-                headers: {
-                    'Accept-Language': 'en',
-                    ...SDK_VERSION_HEADERS,
+            expect(requestSender.get).toHaveBeenCalledWith(
+                '/internalapi/v1/shipping/countries?channel_id=1',
+                {
+                    headers: {
+                        'Accept-Language': 'en',
+                        ...SDK_VERSION_HEADERS,
+                    },
                 },
-            });
+            );
         });
 
         it('loads shipping countries with timeout', async () => {
             const options = { timeout: createTimeout() };
-            const output = await shippingCountryRequestSender.loadCountries(options);
+            const output = await shippingCountryRequestSender.loadCountries(2, options);
 
             expect(output).toEqual(response);
-            expect(requestSender.get).toHaveBeenCalledWith('/internalapi/v1/shipping/countries', {
-                ...options,
-                headers: {
-                    'Accept-Language': 'en',
-                    ...SDK_VERSION_HEADERS,
+            expect(requestSender.get).toHaveBeenCalledWith(
+                '/internalapi/v1/shipping/countries?channel_id=2',
+                {
+                    ...options,
+                    headers: {
+                        'Accept-Language': 'en',
+                        ...SDK_VERSION_HEADERS,
+                    },
                 },
-            });
+            );
         });
     });
 });

--- a/packages/core/src/shipping/shipping-country-request-sender.ts
+++ b/packages/core/src/shipping/shipping-country-request-sender.ts
@@ -6,8 +6,12 @@ import { CountryResponseBody } from '../geography';
 export default class ShippingCountryRequestSender {
     constructor(private _requestSender: RequestSender, private _config: { locale?: string }) {}
 
-    loadCountries({ timeout }: RequestOptions = {}): Promise<Response<CountryResponseBody>> {
-        const url = '/internalapi/v1/shipping/countries';
+    loadCountries(
+        channelId: number,
+        { timeout }: RequestOptions = {},
+    ): Promise<Response<CountryResponseBody>> {
+        const url = `/internalapi/v1/shipping/countries?channel_id=${channelId}`;
+
         const headers = {
             'Accept-Language': this._config.locale,
             ...SDK_VERSION_HEADERS,


### PR DESCRIPTION
## What?

This is a revert of the revert. i.e. we are re-raising this [PR](https://github.com/bigcommerce/checkout-sdk-js/pull/2579) 

This adds support for displaying available shipping countries based on shipping method channel associations.

## Why? 

To support this we need checkout to query the shipping/countries endpoint with a channel_id through as a query parameter.

## Testing/Proof


With the checkout-sdk-js and checkout-js running locally, the channel_id is piped through from checkout-sdk to checkout. The following video shows that the shipping/countries endpoint now has the query parameter channel_id passed through to it.

https://github.com/user-attachments/assets/39db2078-e888-4479-95fd-15107d74f6e2

ping @bigcommerce/team-checkout 