### PR TITLE
feat(payment): PI-2403 Pay by Bank integration

### DIFF
--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.ts
@@ -12,6 +12,7 @@ import { BlueSnapDirectRedirectResponse } from '../types';
 import {
     isEcpInstrument,
     isIdealInstrument,
+    isPayByBankInstrument,
     isSepaInstrument,
 } from '../utils/is-bluesnap-direct-instrument';
 import isBlueSnapDirectRedirectResponseProviderData from '../utils/is-bluesnap-direct-provider-data';
@@ -123,6 +124,19 @@ export default class BlueSnapDirectAPMPaymentStrategy implements PaymentStrategy
                     formattedPayload: {
                         ideal: {
                             bic: payment.paymentData.bic,
+                        },
+                    },
+                },
+            };
+        }
+
+        if (isPayByBankInstrument(payment.paymentData)) {
+            return {
+                ...payment,
+                paymentData: {
+                    formattedPayload: {
+                        pay_by_bank: {
+                            iban: payment.paymentData.iban,
                         },
                     },
                 },

--- a/packages/bluesnap-direct-integration/src/utils/is-bluesnap-direct-instrument.ts
+++ b/packages/bluesnap-direct-integration/src/utils/is-bluesnap-direct-instrument.ts
@@ -1,6 +1,7 @@
 import {
     WithEcpInstrument,
     WithIdealInstrument,
+    WithPayByBankInstrument,
     WithSepaInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
@@ -27,5 +28,18 @@ export function isSepaInstrument(paymentData: unknown): paymentData is WithSepaI
             'firstName' in paymentData &&
             'lastName' in paymentData &&
             'shopperPermission' in paymentData,
+    );
+}
+
+export function isPayByBankInstrument(
+    paymentData: unknown,
+): paymentData is WithPayByBankInstrument {
+    return Boolean(
+        typeof paymentData === 'object' &&
+            paymentData !== null &&
+            'iban' in paymentData &&
+            !('firstName' in paymentData) &&
+            !('lastName' in paymentData) &&
+            !('shopperPermission' in paymentData),
     );
 }

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -123,6 +123,7 @@ export {
     WithEcpInstrument,
     WithSepaInstrument,
     WithIdealInstrument,
+    WithPayByBankInstrument,
     BlueSnapDirectEcpPayload,
     BlueSnapDirectSepaPayload,
     IdealPayload,

--- a/packages/payment-integration-api/src/payment/index.ts
+++ b/packages/payment-integration-api/src/payment/index.ts
@@ -18,6 +18,7 @@ export {
     FormattedHostedInstrument,
     WithBankAccountInstrument,
     WithIdealInstrument,
+    WithPayByBankInstrument,
     WithCheckoutcomFawryInstrument,
     WithCheckoutcomSEPAInstrument,
     HostedCreditCardInstrument,

--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -107,6 +107,9 @@ export interface IdealPayload {
     ideal: WithIdealInstrument;
 }
 
+export interface WithPayByBankInstrument {
+    iban: string;
+}
 export interface WithCheckoutcomSEPAInstrument {
     iban: string;
     bic: string;


### PR DESCRIPTION
## What?
Pay By Bank is a supported payment method - [Pay by Bank (Open Banking)](https://developers.bluesnap.com/reference/pay-by-bank)

Allow shoppers to input IBAN in the Pay By Bank payment step

## Why?
To allow shoppers to use Pay by Bank method

## Testing / Proof
<img width="1056" alt="Screenshot 2024-08-26 at 10 29 14" src="https://github.com/user-attachments/assets/d697a423-ea62-4e8d-a3a6-eae279add8b7">

<img width="1502" alt="Screenshot 2024-08-26 at 12 10 28" src="https://github.com/user-attachments/assets/5219a5a1-56ab-4230-b373-2f8db5b21918">
...