### PR TITLE
Revert "Revert "CHECKOUT-8300: Fix config and form field cache by ensuring input parameters are correctly compared""

### DIFF
--- a/packages/core/src/checkout/checkout-action-creator.ts
+++ b/packages/core/src/checkout/checkout-action-creator.ts
@@ -29,11 +29,14 @@ export default class CheckoutActionCreator {
                 of(createAction(CheckoutActionType.LoadCheckoutRequested)),
                 merge(
                     this._configActionCreator.loadConfig({
-                        ...options,
                         useCache: true,
-                        params: { ...options?.params, checkoutId: id },
+                        timeout: options?.timeout,
+                        params: { checkoutId: id },
                     }),
-                    this._formFieldsActionCreator.loadFormFields({ ...options, useCache: true }),
+                    this._formFieldsActionCreator.loadFormFields({
+                        useCache: true,
+                        timeout: options?.timeout,
+                    }),
                 ),
                 defer(() => {
                     return this._checkoutRequestSender
@@ -64,8 +67,14 @@ export default class CheckoutActionCreator {
             concat(
                 of(createAction(CheckoutActionType.LoadCheckoutRequested)),
                 merge(
-                    this._configActionCreator.loadConfig(),
-                    this._formFieldsActionCreator.loadFormFields({ ...options, useCache: true }),
+                    this._configActionCreator.loadConfig({
+                        useCache: true,
+                        timeout: options?.timeout,
+                    }),
+                    this._formFieldsActionCreator.loadFormFields({
+                        useCache: true,
+                        timeout: options?.timeout,
+                    }),
                 ),
                 defer(async () => {
                     const state = store.getState();

--- a/packages/core/src/common/data-store/cache-action.spec.ts
+++ b/packages/core/src/common/data-store/cache-action.spec.ts
@@ -26,14 +26,14 @@ describe('cacheAction()', () => {
             Promise.resolve(createAction('GET_MESSAGE', `Hello ${name}`)),
         );
         const subscriber = jest.fn();
-        const createCachedAction = cacheAction((name) =>
+        const createCachedAction = cacheAction((name, _) =>
             defer(() => getMessage(name) as Promise<Action>),
         );
 
-        createCachedAction('Foo').subscribe(subscriber);
-        createCachedAction('Foo').subscribe(subscriber);
-        createCachedAction('Bar').subscribe(subscriber);
-        createCachedAction('Bar').subscribe(subscriber);
+        createCachedAction('Foo', { params: { abc: 'abc' } }).subscribe(subscriber);
+        createCachedAction('Foo', { params: { abc: 'abc' } }).subscribe(subscriber);
+        createCachedAction('Bar', { params: { abc: 'efg' } }).subscribe(subscriber);
+        createCachedAction('Bar', { params: { abc: 'efg' } }).subscribe(subscriber);
 
         await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/core/src/common/data-store/cache-action.ts
+++ b/packages/core/src/common/data-store/cache-action.ts
@@ -1,5 +1,6 @@
 import { Action, ThunkAction } from '@bigcommerce/data-store';
 import { memoize } from '@bigcommerce/memoize';
+import { isEqual } from 'lodash';
 import { from, Observable } from 'rxjs';
 import { shareReplay } from 'rxjs/operators';
 
@@ -12,13 +13,13 @@ export default function cacheAction<TFunction extends CreateActionFn>(fn: TFunct
         }
 
         if (typeof action === 'function') {
-            return memoize((store) => from(action(store)).pipe(shareReplay()));
+            return memoize((store) => from(action(store)).pipe(shareReplay()), { isEqual });
         }
 
         return action;
     }
 
-    return memoize(decoratedFn as TFunction);
+    return memoize(decoratedFn as TFunction, { isEqual });
 }
 
 type CreateActionFn = (...args: any[]) => Observable<Action> | ThunkAction<Action> | Action;

--- a/packages/core/src/config/config-action-creator.spec.ts
+++ b/packages/core/src/config/config-action-creator.spec.ts
@@ -58,8 +58,14 @@ describe('ConfigActionCreator', () => {
 
         it('dispatches actions using cached responses if available', async () => {
             const actions = await merge(
-                configActionCreator.loadConfig({ useCache: true }),
-                configActionCreator.loadConfig({ useCache: true }),
+                configActionCreator.loadConfig({
+                    useCache: true,
+                    params: { checkoutId: '6554a0a0-527f-4d51-9197-58ab22eb1dab' },
+                }),
+                configActionCreator.loadConfig({
+                    useCache: true,
+                    params: { checkoutId: '6554a0a0-527f-4d51-9197-58ab22eb1dab' },
+                }),
             )
                 .pipe(toArray())
                 .toPromise();


### PR DESCRIPTION
## What?
Restore https://github.com/bigcommerce/checkout-sdk-js/pull/2615

## Why?
It was reverted due to unexpected test failures. I couldn't resolve the failures at the end of the day so I reverted the PR to avoid blocking teams working in other timezones.

## Testing / Proof
See the original PR
