### PR TITLE
feat(checkout): CHECKOUT-8587 Throw error when payment endpoint returns error/failure

### DIFF
--- a/packages/hosted-form-v2/src/hosted-field.ts
+++ b/packages/hosted-form-v2/src/hosted-field.ts
@@ -169,7 +169,11 @@ export default class HostedField {
                     throw new InvalidHostedFormError(event.payload.error.message);
                 }
 
-                throw new Error(event.payload.error.message);
+                if (event.payload.error.message) {
+                    throw new Error(event.payload.error.message);
+                }
+
+                throw new Error(event.payload.error.code);
             }
 
             throw event;

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
@@ -62,18 +62,14 @@ export default class HostedInputManualOrderPaymentHandler {
                         error: { code: get(response.body, 'code') },
                     },
                 });
-            }
-
-            if (isError) {
+            } else if (isError) {
                 this._eventPoster.post({
                     type: HostedInputEventType.SubmitManualOrderFailed,
                     payload: {
                         error: { code: get(response.body, 'type') },
                     },
                 });
-            }
-
-            if (isSuccess) {
+            } else if (isSuccess) {
                 this._eventPoster.post({
                     type: HostedInputEventType.SubmitManualOrderSucceeded,
                 });

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.ts
@@ -1,4 +1,4 @@
-import { RequestSender } from '@bigcommerce/request-sender';
+import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import ContentType from '../common/http-request/content-type';
 import HostedFormManualOrderData from '../hosted-form-manual-order-data';
@@ -11,7 +11,7 @@ export class ManualOrderPaymentRequestSender {
         requestInitializationData: HostedFormManualOrderData,
         instrumentFormData: HostedInputValues,
         nonce?: string,
-    ): Promise<void> {
+    ): Promise<Response<unknown>> {
         const { paymentMethodId, paymentSessionToken } = requestInitializationData;
 
         const [expiryMonth, expiryYear] = instrumentFormData.cardExpiry
@@ -42,6 +42,6 @@ export class ManualOrderPaymentRequestSender {
             },
         };
 
-        await this._requestSender.post<void>(`${this._paymentOrigin}/payments`, options);
+        return this._requestSender.post<unknown>(`${this._paymentOrigin}/payments`, options);
     }
 }


### PR DESCRIPTION
## What?
Throw error when the payments endpoint returns `type: error/failure` with status 200.

## Why?
So that error can be better handled on manual order UI and appropriate message could be displayed.

## Testing / Proof

- CI checks

