### PR TITLE
fix(payment): PAYPAL-4610 Avoiding redundant order creation requests

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -479,6 +479,23 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
             });
             expect(paypalCommerceFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(true);
         });
+
+        it('do not create an order if there is an error  while receiving a payment order', async () => {
+            await strategy.initialize(initializationOptions);
+
+            const paypalFastlaneComponent = await paypalFastlane.FastlaneCardComponent({});
+
+            jest.spyOn(paypalFastlaneComponent, 'getPaymentToken').mockRejectedValue(
+                new Error('input data error'),
+            );
+
+            try {
+                await strategy.execute(executeOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+                expect(paypalCommerceRequestSender.createOrder).not.toHaveBeenCalled();
+            }
+        });
     });
 
     describe('#onInit option callback', () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -157,7 +157,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
                 throw error;
             }
 
-            return new Promise((_resolve, reject) => reject());
+            return Promise.reject();
         }
     }
 


### PR DESCRIPTION
## What?

Avoiding redundant order creation requests

## Why?

To avoid order request when card fields are invalid

## Testing / Proof

https://github.com/user-attachments/assets/d034f65f-5324-449c-bebb-18a5a0a8bb98


@bigcommerce/team-checkout @bigcommerce/team-payments
