### PR TITLE
feat(payment): PI-2551 make widgetInteraction action available for integration packages

### DIFF
--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -25,6 +25,7 @@ import {
     PaymentRequestTransformer,
 } from '../payment';
 import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
+import PaymentStrategyWidgetActionCreator from '../payment/payment-strategy-widget-action-creator';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 import {
     ConsignmentActionCreator,
@@ -132,6 +133,8 @@ export default function createPaymentIntegrationService(
         checkoutActionCreator,
     );
 
+    const paymentStrategyWidgetActionCreator = new PaymentStrategyWidgetActionCreator();
+
     return new DefaultPaymentIntegrationService(
         store,
         storeProjectionFactory,
@@ -151,5 +154,6 @@ export default function createPaymentIntegrationService(
         paymentProviderCustomerActionCreator,
         shippingCountryActionCreator,
         remoteCheckoutActionCreator,
+        paymentStrategyWidgetActionCreator,
     );
 }

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -31,6 +31,7 @@ import { getOrder } from '../order/orders.mock';
 import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
+import PaymentStrategyWidgetActionCreator from '../payment/payment-strategy-widget-action-creator';
 import { getPayment } from '../payment/payments.mock';
 import { RemoteCheckoutActionCreator } from '../remote-checkout';
 import { ConsignmentActionCreator, ShippingCountryActionCreator } from '../shipping';
@@ -89,6 +90,7 @@ describe('DefaultPaymentIntegrationService', () => {
         RemoteCheckoutActionCreator,
         'initializePayment' | 'forgetCheckout'
     >;
+    let paymentStrategyWidgetActionCreator: PaymentStrategyWidgetActionCreator;
 
     beforeEach(() => {
         requestSender = createRequestSender();
@@ -270,6 +272,10 @@ describe('DefaultPaymentIntegrationService', () => {
             ),
         };
 
+        paymentStrategyWidgetActionCreator = {
+            widgetInteraction: jest.fn(),
+        };
+
         subject = new DefaultPaymentIntegrationService(
             store as CheckoutStore,
             storeProjectionFactory as PaymentIntegrationStoreProjectionFactory,
@@ -289,6 +295,7 @@ describe('DefaultPaymentIntegrationService', () => {
             paymentProviderCustomerActionCreator,
             shippingCountryActionCreator as ShippingCountryActionCreator,
             remoteCheckoutActionCreator as RemoteCheckoutActionCreator,
+            paymentStrategyWidgetActionCreator,
         );
     });
 
@@ -634,6 +641,20 @@ describe('DefaultPaymentIntegrationService', () => {
             await subject.handlePaymentHumanVerification('methodId', 'key');
 
             expect(paymentHumanVerificationHandler.handle).toHaveBeenCalled();
+        });
+    });
+
+    describe('#widgetInteraction', () => {
+        it('should dispatch widgetInteraction action', async () => {
+            const callbackFn = jest.fn();
+            const output = await subject.widgetInteraction(callbackFn);
+
+            expect(paymentStrategyWidgetActionCreator.widgetInteraction).toHaveBeenCalled();
+            expect(store.dispatch).toHaveBeenCalledWith(
+                paymentStrategyWidgetActionCreator.widgetInteraction(callbackFn),
+                { queueId: 'widgetInteraction' },
+            );
+            expect(output).toEqual(paymentIntegrationSelectors);
         });
     });
 });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -27,6 +27,7 @@ import {
 } from '../payment-provider-customer';
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
+import PaymentStrategyWidgetActionCreator from '../payment/payment-strategy-widget-action-creator';
 import { RemoteCheckoutActionCreator } from '../remote-checkout';
 import { InitializePaymentOptions } from '../remote-checkout/remote-checkout-request-sender';
 import { ConsignmentActionCreator, ShippingCountryActionCreator } from '../shipping';
@@ -57,6 +58,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator,
         private _shippingCountryActionCreator: ShippingCountryActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
+        private _paymentStrategyWidgetActionCreator: PaymentStrategyWidgetActionCreator,
     ) {
         this._storeProjection = this._storeProjectionFactory.create(this._store);
     }
@@ -297,5 +299,16 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         }
 
         return this._paymentHumanVerificationHandler.handle(errorOrId);
+    }
+
+    async widgetInteraction(
+        callback: () => Promise<unknown>,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._paymentStrategyWidgetActionCreator.widgetInteraction(callback),
+            { queueId: 'widgetInteraction' },
+        );
+
+        return this._storeProjection.getState();
     }
 }

--- a/packages/core/src/payment/payment-strategy-widget-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-strategy-widget-action-creator.spec.ts
@@ -1,0 +1,76 @@
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { PaymentStrategyActionType } from './payment-strategy-actions';
+import PaymentStrategyWidgetActionCreator from './payment-strategy-widget-action-creator';
+
+describe('PaymentStrategyWidgetActionCreator', () => {
+    let actionCreator: PaymentStrategyWidgetActionCreator;
+
+    beforeEach(() => {
+        actionCreator = new PaymentStrategyWidgetActionCreator();
+    });
+
+    describe('#widgetInteraction()', () => {
+        it('executes widget interaction callback', async () => {
+            const options = { methodId: 'default' };
+            const fakeMethod = jest.fn(() => Promise.resolve());
+
+            await from(actionCreator.widgetInteraction(fakeMethod, options))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(fakeMethod).toHaveBeenCalled();
+        });
+
+        it('emits action to notify widget interaction in progress', async () => {
+            const actions = await from(
+                actionCreator.widgetInteraction(
+                    jest.fn(() => Promise.resolve()),
+                    { methodId: 'default' },
+                ),
+            )
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                {
+                    type: PaymentStrategyActionType.WidgetInteractionStarted,
+                    meta: { methodId: 'default' },
+                },
+                {
+                    type: PaymentStrategyActionType.WidgetInteractionFinished,
+                    meta: { methodId: 'default' },
+                },
+            ]);
+        });
+
+        it('emits error action if widget interaction fails', async () => {
+            const signInError = new Error();
+            const errorHandler = jest.fn((action) => of(action));
+
+            const actions = await from(
+                actionCreator.widgetInteraction(
+                    jest.fn(() => Promise.reject(signInError)),
+                    { methodId: 'default' },
+                ),
+            )
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                {
+                    type: PaymentStrategyActionType.WidgetInteractionStarted,
+                    meta: { methodId: 'default' },
+                },
+                {
+                    type: PaymentStrategyActionType.WidgetInteractionFailed,
+                    error: true,
+                    payload: signInError,
+                    meta: { methodId: 'default' },
+                },
+            ]);
+        });
+    });
+});

--- a/packages/core/src/payment/payment-strategy-widget-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-widget-action-creator.ts
@@ -1,0 +1,35 @@
+import { createAction } from '@bigcommerce/data-store';
+import { concat, defer, Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { throwErrorAction } from '../common/error';
+
+import { PaymentRequestOptions } from './payment-request-options';
+import { PaymentStrategyActionType, PaymentStrategyWidgetAction } from './payment-strategy-actions';
+
+export default class PaymentStrategyWidgetActionCreator {
+    widgetInteraction(
+        method: () => Promise<unknown>,
+        options?: PaymentRequestOptions,
+    ): Observable<PaymentStrategyWidgetAction> {
+        const methodId = options && options.methodId;
+        const meta = { methodId };
+
+        return concat(
+            of(createAction(PaymentStrategyActionType.WidgetInteractionStarted, undefined, meta)),
+            defer(() =>
+                method().then(() =>
+                    createAction(
+                        PaymentStrategyActionType.WidgetInteractionFinished,
+                        undefined,
+                        meta,
+                    ),
+                ),
+            ),
+        ).pipe(
+            catchError((error) =>
+                throwErrorAction(PaymentStrategyActionType.WidgetInteractionFailed, error, meta),
+            ),
+        );
+    }
+}

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -102,4 +102,6 @@ export default interface PaymentIntegrationService {
         errorOrId: Error | string,
         key?: string,
     ): Promise<PaymentAdditionalAction>;
+
+    widgetInteraction(method: () => Promise<unknown>): Promise<PaymentIntegrationSelectors>;
 }


### PR DESCRIPTION
## What?
Make `widgetInteraction` action from `PaymentStrategyActionCreator` available for payment integration packages

## Why?
Need this action for migration [AmazonPay payment strategy](https://github.com/bigcommerce/checkout-sdk-js/blob/master/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts#L203) to integration package

## Testing / Proof

https://github.com/user-attachments/assets/18497b06-fbe9-480c-b369-b32b20f817ae

<img width="2543" alt="Screenshot 2024-09-03 at 18 31 06" src="https://github.com/user-attachments/assets/10ac7a73-3742-4b53-ad2e-b597e769431e">
<img width="2541" alt="Screenshot 2024-09-03 at 18 31 32" src="https://github.com/user-attachments/assets/64e78f5a-c007-4f43-bd1c-aed4a745290e">
<img width="2543" alt="Screenshot 2024-09-03 at 18 32 20" src="https://github.com/user-attachments/assets/92059212-33a1-432b-861d-14830751cf12">


@bigcommerce/team-checkout @bigcommerce/team-payments