### PR TITLE
feat(payment): PI-1617 Move AmazonPay payments strategy

### DIFF
--- a/packages/amazon-pay-integration/.eslintrc.json
+++ b/packages/amazon-pay-integration/.eslintrc.json
@@ -4,11 +4,16 @@
     "overrides": [
         {
             "files": ["*.ts"],
-            "rules": {}
+            "rules": {
+                "@typescript-eslint/naming-convention": "off"
+            }
         },
         {
             "files": ["*.spec.ts"],
-            "rules": {}
+            "rules": {
+                "@typescript-eslint/consistent-type-assertions": "off",
+                "@typescript-eslint/no-unsafe-member-access": "off"
+            }
         }
     ]
 }

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-payment-initialize-options.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-payment-initialize-options.ts
@@ -1,0 +1,34 @@
+/**
+ * A set of options that are required to initialize the payment step of
+ * checkout in order to support AmazonPayV2.
+ *
+ * When AmazonPayV2 is initialized, a change payment button will be bound.
+ * When the customer clicks on it, they will be redirected to Amazon to
+ * select a different payment method.
+ *
+ * ```html
+ * <!-- This is the change payment button that will be bound -->
+ * <button id="edit-button">Change card</button>
+ * ```
+ *
+ * ```js
+ * service.initializePayment({
+ *     methodId: 'amazonpay',
+ *     amazonpay: {
+ *         editButtonId: 'edit-button',
+ *     },
+ * });
+ * ```
+ */
+export default interface AmazonPayV2PaymentInitializeOptions {
+    /**
+     * This editButtonId is used to set an event listener, provide an element ID
+     * if you want users to be able to select a different payment method by
+     * clicking on a button. It should be an HTML element.
+     */
+    editButtonId?: string;
+}
+
+export interface WithAmazonPayV2PaymentInitializeOptions {
+    amazonpay?: AmazonPayV2PaymentInitializeOptions;
+}

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.ts
@@ -1,0 +1,231 @@
+import { noop } from 'lodash';
+
+import {
+    AmazonPayV2ChangeActionType,
+    AmazonPayV2CheckoutSessionConfig,
+    AmazonPayV2InitializeOptions,
+    AmazonPayV2PaymentProcessor,
+    AmazonPayV2Placement,
+    isAmazonPayAdditionalActionErrorBody,
+} from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import {
+    CheckoutSettings,
+    guard,
+    InvalidArgumentError,
+    isRequestError,
+    NotInitializedError,
+    NotInitializedErrorType,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethodCancelledError,
+    PaymentRequestOptions,
+    PaymentStrategy,
+    StoreProfile,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { WithAmazonPayV2PaymentInitializeOptions } from './amazon-pay-v2-payment-initialize-options';
+
+export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
+    private _amazonPayButton?: HTMLDivElement;
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor,
+    ) {}
+
+    async initialize(
+        options: PaymentInitializeOptions & WithAmazonPayV2PaymentInitializeOptions,
+    ): Promise<void> {
+        const { methodId, amazonpay } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "methodId" argument is not provided.',
+            );
+        }
+
+        const state = this.paymentIntegrationService.getState();
+        const { features } = state.getStoreConfigOrThrow().checkoutSettings;
+        const paymentMethod = state.getPaymentMethodOrThrow<AmazonPayV2InitializeOptions>(methodId);
+        const initializationData = paymentMethod.initializationData || {};
+        const { paymentToken = '', region = '', isButtonMicroTextDisabled } = initializationData;
+
+        await this.amazonPayV2PaymentProcessor.initialize(paymentMethod);
+
+        if (this._isReadyToPay(paymentToken)) {
+            if (amazonpay?.editButtonId) {
+                this._bindEditButton(
+                    amazonpay.editButtonId,
+                    paymentToken,
+                    'changePayment',
+                    this._isModalFlow(region),
+                );
+            }
+        } else {
+            const { id: containerId } = this._createContainer();
+
+            this._amazonPayButton = this.amazonPayV2PaymentProcessor.renderAmazonPayButton({
+                checkoutState: state,
+                containerId,
+                decoupleCheckoutInitiation: this._isOneTimeTransaction(
+                    features,
+                    region.toUpperCase(),
+                ),
+                methodId,
+                placement: AmazonPayV2Placement.Checkout,
+                isButtonMicroTextDisabled,
+            });
+        }
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
+        const { payment } = payload;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        const { methodId } = payment;
+        const state = this.paymentIntegrationService.getState();
+        const { features } = state.getStoreConfigOrThrow().checkoutSettings;
+        const paymentMethod = state.getPaymentMethodOrThrow<AmazonPayV2InitializeOptions>(methodId);
+        const initializationData = paymentMethod.initializationData || {};
+        const { paymentToken = '', region = '' } = initializationData;
+
+        if (
+            this._isReadyToPay(paymentToken) ||
+            this._isOneTimeTransaction(features, region.toUpperCase())
+        ) {
+            const paymentPayload = {
+                methodId,
+                paymentData: { nonce: paymentToken || 'apb' },
+            };
+
+            await this.paymentIntegrationService.submitOrder(payload, options);
+
+            try {
+                await this.paymentIntegrationService.submitPayment(paymentPayload);
+
+                return;
+            } catch (error) {
+                if (!isRequestError(error) || !isAmazonPayAdditionalActionErrorBody(error.body)) {
+                    throw error;
+                }
+
+                const { additional_action_required: additionalAction } = error.body;
+                const { redirect_url } = additionalAction.data;
+
+                if (paymentToken) {
+                    return new Promise(() => window.location.assign(redirect_url));
+                }
+
+                this.amazonPayV2PaymentProcessor.prepareCheckout(
+                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                    JSON.parse(redirect_url) as Required<AmazonPayV2CheckoutSessionConfig>,
+                );
+            }
+        }
+
+        this._getAmazonPayButton().click();
+
+        // Focus of parent window used to try and detect the user cancelling the Amazon log in modal
+        // Should be refactored if/when Amazon add a modal close hook to their SDK
+        if (this._isModalFlow(region)) {
+            return new Promise((_, reject) => {
+                const onFocus = () => {
+                    window.removeEventListener('focus', onFocus);
+                    reject(
+                        new PaymentMethodCancelledError(
+                            'Shopper needs to login to Amazonpay to continue',
+                        ),
+                    );
+                };
+
+                window.addEventListener('focus', onFocus);
+            });
+        }
+
+        return new Promise<never>(noop);
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    async deinitialize(): Promise<void> {
+        await this.amazonPayV2PaymentProcessor.deinitialize();
+
+        this._amazonPayButton = undefined;
+    }
+
+    private _bindEditButton(
+        buttonId: string,
+        sessionId: string,
+        changeAction: AmazonPayV2ChangeActionType,
+        isModalFlow: boolean,
+    ): void {
+        const button = document.getElementById(buttonId);
+
+        if (!button || !button.parentNode) {
+            return;
+        }
+
+        if (!isModalFlow) {
+            const clone = button.cloneNode(true);
+
+            button.parentNode.replaceChild(clone, button);
+
+            clone.addEventListener('click', () => {
+                void this._showLoadingSpinner();
+            });
+        }
+
+        this.amazonPayV2PaymentProcessor.bindButton(buttonId, sessionId, changeAction);
+    }
+
+    private _isModalFlow(region: string) {
+        return region === 'us';
+    }
+
+    private async _showLoadingSpinner(): Promise<void> {
+        await this.paymentIntegrationService.widgetInteraction(() => new Promise(noop));
+    }
+
+    private _createContainer(): HTMLElement {
+        let container = document.getElementById('AmazonPayButton');
+
+        if (container) {
+            return container;
+        }
+
+        container = document.createElement('div');
+        container.id = 'AmazonPayButton';
+        container.style.display = 'none';
+
+        return document.body.appendChild(container);
+    }
+
+    private _getAmazonPayButton() {
+        return guard(
+            this._amazonPayButton,
+            () => new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized),
+        );
+    }
+
+    private _isOneTimeTransaction(
+        features: CheckoutSettings['features'],
+        storeCountryCode: StoreProfile['storeCountryCode'],
+    ): boolean {
+        return (
+            this.amazonPayV2PaymentProcessor.isPh4Enabled(features, storeCountryCode) &&
+            features['INT-6399.amazon_pay_apb']
+        );
+    }
+
+    private _isReadyToPay(paymentToken?: string): boolean {
+        return !!paymentToken;
+    }
+}

--- a/packages/amazon-pay-integration/src/create-amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/amazon-pay-integration/src/create-amazon-pay-v2-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import AmazonPayV2PaymentStrategy from './amazon-pay-v2-payment-strategy';
+import createAmazonPayV2PaymentStrategy from './create-amazon-pay-v2-payment-strategy';
+
+describe('createAmazonPayV2PaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates AmazonPayV2 payment strategy', () => {
+        const strategy = createAmazonPayV2PaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(AmazonPayV2PaymentStrategy);
+    });
+});

--- a/packages/amazon-pay-integration/src/create-amazon-pay-v2-payment-strategy.ts
+++ b/packages/amazon-pay-integration/src/create-amazon-pay-v2-payment-strategy.ts
@@ -1,0 +1,18 @@
+import { createAmazonPayV2PaymentProcessor } from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import AmazonPayV2PaymentStrategy from './amazon-pay-v2-payment-strategy';
+
+const createAmazonPayV2PaymentStrategy: PaymentStrategyFactory<AmazonPayV2PaymentStrategy> = (
+    paymentIntegrationService,
+) => {
+    return new AmazonPayV2PaymentStrategy(
+        paymentIntegrationService,
+        createAmazonPayV2PaymentProcessor(),
+    );
+};
+
+export default toResolvableModule(createAmazonPayV2PaymentStrategy, [{ id: 'amazonpay' }]);

--- a/packages/amazon-pay-integration/src/index.ts
+++ b/packages/amazon-pay-integration/src/index.ts
@@ -1,0 +1,1 @@
+export { default as createAmazonPayV2PaymentStrategy } from './create-amazon-pay-v2-payment-strategy';

--- a/packages/amazon-pay-utils/jest.config.js
+++ b/packages/amazon-pay-utils/jest.config.js
@@ -13,4 +13,5 @@ module.exports = {
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
     setupFilesAfterEnv: ['../../jest-setup.js'],
     coverageDirectory: '../../coverage/packages/amazon-pay-utils',
+    coveragePathIgnorePatterns: ['<rootDir>/src/index.ts'],
 };

--- a/packages/amazon-pay-utils/src/amazon-pay-v2-script-loader.spec.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-script-loader.spec.ts
@@ -32,8 +32,29 @@ describe('AmazonPayV2ScriptLoader', () => {
             });
         });
 
+        it('loads the USA SDK if no initialization data is passed on Payment Method', async () => {
+            const paymentMethodMock = {
+                ...getPaymentMethodMock(),
+                initializationData: undefined,
+            };
+
+            await amazonPayV2ScriptLoader.load(paymentMethodMock);
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                'https://static-na.payments-amazon.com/checkout.js',
+            );
+        });
+
+        it('loads the USA SDK if no region is passed on Payment Method', async () => {
+            await amazonPayV2ScriptLoader.load(getPaymentMethodMock('us'));
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                'https://static-na.payments-amazon.com/checkout.js',
+            );
+        });
+
         it('loads the USA SDK if US region is passed on Payment Method', async () => {
-            await amazonPayV2ScriptLoader.load(getPaymentMethodMock());
+            await amazonPayV2ScriptLoader.load(getPaymentMethodMock('us'));
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
                 'https://static-na.payments-amazon.com/checkout.js',

--- a/packages/amazon-pay-utils/src/amazon-pay-v2.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2.ts
@@ -1,6 +1,7 @@
 import {
     Cart,
     Checkout,
+    PaymentIntegrationSelectors,
     PaymentMethod,
     StoreConfig,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -272,7 +273,7 @@ export interface InternalCheckoutSelectors {
         getStoreConfigOrThrow: () => StoreConfig;
     };
     paymentMethods: {
-        getPaymentMethodOrThrow: (methodId: string) => PaymentMethod<AmazonPayV2InitializeOptions>;
+        getPaymentMethodOrThrow: <T>(methodId: string) => PaymentMethod<T>;
     };
 }
 
@@ -286,10 +287,11 @@ export interface AmazonPayV2InitializeOptions {
     publicKeyId?: string;
     region?: string;
     isButtonMicroTextDisabled?: boolean;
+    paymentToken?: string;
 }
 
 export interface AmazonPayV2ButtonRenderingOptions {
-    checkoutState: InternalCheckoutSelectors;
+    checkoutState: InternalCheckoutSelectors | PaymentIntegrationSelectors;
     containerId: string;
     decoupleCheckoutInitiation?: boolean;
     methodId: string;
@@ -298,3 +300,14 @@ export interface AmazonPayV2ButtonRenderingOptions {
     placement: AmazonPayV2Placement;
     isButtonMicroTextDisabled?: boolean;
 }
+
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface AmazonPayAdditionalActionErrorBody {
+    status: string;
+    additional_action_required: {
+        data: {
+            redirect_url: string;
+        };
+    };
+}
+/* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/amazon-pay-utils/src/index.ts
+++ b/packages/amazon-pay-utils/src/index.ts
@@ -3,3 +3,4 @@ export * from './mocks/amazon-pay-v2.mock';
 export { default as AmazonPayV2ScriptLoader } from './amazon-pay-v2-script-loader';
 export { default as AmazonPayV2PaymentProcessor } from './amazon-pay-v2-payment-processor';
 export { default as createAmazonPayV2PaymentProcessor } from './create-amazon-pay-v2-payment-processor';
+export { isAmazonPayAdditionalActionErrorBody } from './isAmazonPayAdditionalActionError';

--- a/packages/amazon-pay-utils/src/isAmazonPayAdditionalActionError.spec.ts
+++ b/packages/amazon-pay-utils/src/isAmazonPayAdditionalActionError.spec.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { isAmazonPayAdditionalActionErrorBody } from './isAmazonPayAdditionalActionError';
+
+describe('isAmazonPayAdditionalActionErrorBody', () => {
+    it('Should return false if error not an object', () => {
+        expect(isAmazonPayAdditionalActionErrorBody(undefined)).toBe(false);
+    });
+
+    it('Should return false if error is equal null', () => {
+        expect(isAmazonPayAdditionalActionErrorBody(null)).toBe(false);
+    });
+
+    it('Should return false if no status option in error', () => {
+        const errorBody = {
+            additional_action_required: {},
+        };
+
+        expect(isAmazonPayAdditionalActionErrorBody(errorBody)).toBe(false);
+    });
+
+    it('Should return false if no additional_action_required option in error', () => {
+        const errorBody = {
+            status: 'additional_action_required',
+        };
+
+        expect(isAmazonPayAdditionalActionErrorBody(errorBody)).toBe(false);
+    });
+
+    it('Should return false if error status different from additional_action_required', () => {
+        const errorBody = {
+            status: 'some other status',
+            additional_action_required: {},
+        };
+
+        expect(isAmazonPayAdditionalActionErrorBody(errorBody)).toBe(false);
+    });
+
+    it('Should return false if no data object in additional_action_required', () => {
+        const errorBody = {
+            status: 'additional_action_required',
+            additional_action_required: {},
+        };
+
+        expect(isAmazonPayAdditionalActionErrorBody(errorBody)).toBe(false);
+    });
+
+    it('Should return false if no redirect_url in error', () => {
+        const errorBody = {
+            status: 'additional_action_required',
+            additional_action_required: {
+                data: {},
+            },
+        };
+
+        expect(isAmazonPayAdditionalActionErrorBody(errorBody)).toBe(false);
+    });
+
+    it('Should return false if no redirect_url not a string', () => {
+        const errorBody = {
+            status: 'additional_action_required',
+            additional_action_required: {
+                data: {
+                    redirect_url: {},
+                },
+            },
+        };
+
+        expect(isAmazonPayAdditionalActionErrorBody(errorBody)).toBe(false);
+    });
+
+    it('Should return true if error is additional action required', () => {
+        const errorBody = {
+            status: 'additional_action_required',
+            additional_action_required: {
+                data: {
+                    redirect_url: 'redirect_url',
+                },
+            },
+        };
+
+        expect(isAmazonPayAdditionalActionErrorBody(errorBody)).toBe(true);
+    });
+});

--- a/packages/amazon-pay-utils/src/isAmazonPayAdditionalActionError.ts
+++ b/packages/amazon-pay-utils/src/isAmazonPayAdditionalActionError.ts
@@ -1,0 +1,20 @@
+import { AmazonPayAdditionalActionErrorBody } from './amazon-pay-v2';
+
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+export function isAmazonPayAdditionalActionErrorBody(
+    errorBody: unknown,
+): errorBody is AmazonPayAdditionalActionErrorBody {
+    return (
+        typeof errorBody === 'object' &&
+        errorBody !== null &&
+        'status' in errorBody &&
+        'additional_action_required' in errorBody &&
+        (errorBody as AmazonPayAdditionalActionErrorBody).status === 'additional_action_required' &&
+        'data' in (errorBody as AmazonPayAdditionalActionErrorBody).additional_action_required &&
+        'redirect_url' in
+            (errorBody as AmazonPayAdditionalActionErrorBody).additional_action_required.data &&
+        typeof (errorBody as AmazonPayAdditionalActionErrorBody).additional_action_required.data
+            .redirect_url === 'string'
+    );
+}
+/* eslint-enable @typescript-eslint/consistent-type-assertions */

--- a/packages/amazon-pay-utils/src/isInternalCheckoutSelectors.spec.ts
+++ b/packages/amazon-pay-utils/src/isInternalCheckoutSelectors.spec.ts
@@ -1,0 +1,59 @@
+import { isInternalCheckoutSelectors } from './isInternalCheckoutSelectors';
+
+describe('isInternalCheckoutSelectors', () => {
+    const checkoutSelectorsMock: {
+        cart?: unknown;
+        checkout?: unknown;
+        config?: unknown;
+        paymentMethods?: unknown;
+    } = {
+        cart: {},
+        checkout: {},
+        config: {},
+        paymentMethods: {},
+    };
+
+    it('should return false if checkoutSelectors not an object', () => {
+        expect(isInternalCheckoutSelectors(undefined)).toBe(false);
+    });
+
+    it('should return false if checkoutSelectors is null', () => {
+        expect(isInternalCheckoutSelectors(null)).toBe(false);
+    });
+
+    it('should return false if checkoutSelectors not contain cart', () => {
+        const checkoutSelectors = { ...checkoutSelectorsMock };
+
+        delete checkoutSelectors.cart;
+
+        expect(isInternalCheckoutSelectors(checkoutSelectors)).toBe(false);
+    });
+
+    it('should return false if checkoutSelectors not contain checkout', () => {
+        const checkoutSelectors = { ...checkoutSelectorsMock };
+
+        delete checkoutSelectors.checkout;
+
+        expect(isInternalCheckoutSelectors(checkoutSelectors)).toBe(false);
+    });
+
+    it('should return false if checkoutSelectors not contain config', () => {
+        const checkoutSelectors = { ...checkoutSelectorsMock };
+
+        delete checkoutSelectors.config;
+
+        expect(isInternalCheckoutSelectors(checkoutSelectors)).toBe(false);
+    });
+
+    it('should return false if checkoutSelectors not contain paymentMethods', () => {
+        const checkoutSelectors = { ...checkoutSelectorsMock };
+
+        delete checkoutSelectors.paymentMethods;
+
+        expect(isInternalCheckoutSelectors(checkoutSelectors)).toBe(false);
+    });
+
+    it('should return true if checkoutSelectors is InternalCheckoutSelectors', () => {
+        expect(isInternalCheckoutSelectors(checkoutSelectorsMock)).toBe(true);
+    });
+});

--- a/packages/amazon-pay-utils/src/isInternalCheckoutSelectors.ts
+++ b/packages/amazon-pay-utils/src/isInternalCheckoutSelectors.ts
@@ -1,0 +1,14 @@
+import { InternalCheckoutSelectors } from './amazon-pay-v2';
+
+export function isInternalCheckoutSelectors(
+    checkoutSelectors: unknown,
+): checkoutSelectors is InternalCheckoutSelectors {
+    return (
+        typeof checkoutSelectors === 'object' &&
+        checkoutSelectors !== null &&
+        'cart' in checkoutSelectors &&
+        'checkout' in checkoutSelectors &&
+        'config' in checkoutSelectors &&
+        'paymentMethods' in checkoutSelectors
+    );
+}

--- a/packages/amazon-pay-utils/src/mocks/amazon-pay-v2.mock.ts
+++ b/packages/amazon-pay-utils/src/mocks/amazon-pay-v2.mock.ts
@@ -95,7 +95,7 @@ export function getAmazonPayV2ButtonParamsMock(
     };
 }
 
-export function getAmazonPayV2(region = 'us'): PaymentMethod<AmazonPayV2InitializeOptions> {
+export function getAmazonPayV2(region?: string): PaymentMethod<AmazonPayV2InitializeOptions> {
     return {
         config: {
             displayName: 'AMAZON PAY',
@@ -123,5 +123,20 @@ export function getAmazonPayV2(region = 'us'): PaymentMethod<AmazonPayV2Initiali
         method: 'credit-card',
         supportedCards: ['VISA', 'AMEX', 'MC'],
         type: 'PAYMENT_TYPE_API',
+    };
+}
+
+export function getAmazonPayV2PaymentProcessorMock() {
+    return {
+        initialize: jest.fn(() => Promise.resolve()),
+        deinitialize: jest.fn(() => Promise.resolve()),
+        bindButton: jest.fn(),
+        createButton: jest.fn(),
+        prepareCheckout: jest.fn(),
+        prepareCheckoutWithCreationRequestConfig: jest.fn(),
+        signout: jest.fn(() => Promise.resolve()),
+        renderAmazonPayButton: jest.fn(),
+        updateBuyNowFlowFlag: jest.fn(),
+        isPh4Enabled: jest.fn(() => true),
     };
 }

--- a/packages/core/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.spec.ts
@@ -65,7 +65,7 @@ describe('AmazonPayV2ShippingStrategy', () => {
             new PaymentMethodRequestSender(requestSender);
 
         paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
-        paymentMethodMock = getAmazonPayV2();
+        paymentMethodMock = getAmazonPayV2('us');
 
         container = document.createElement('div');
         container.setAttribute('id', 'container');
@@ -178,6 +178,7 @@ describe('AmazonPayV2ShippingStrategy', () => {
         });
 
         it('does not binds edit address button if no paymentToken is present on initializationData', async () => {
+            paymentMethodMock = getAmazonPayV2();
             await strategy.initialize(initializeOptions);
 
             expect(amazonPayV2PaymentProcessor.bindButton).not.toHaveBeenCalled();


### PR DESCRIPTION
## What?
Migrate Amazon Pay payment strategy to package

## Why?
To update payment integration package logic for Amazon pay.

## Testing / Proof

https://github.com/user-attachments/assets/3de8e861-bc82-4b2e-a2b0-532a03cc4456


https://github.com/user-attachments/assets/b18e9f2c-2050-461f-8af5-7df4334beb1d

<img width="1800" alt="Screenshot 2024-09-06 at 16 13 03" src="https://github.com/user-attachments/assets/0ec12fef-5ca7-4c97-90fb-1e647e3e46c8">
<img width="1800" alt="Screenshot 2024-09-06 at 16 13 34" src="https://github.com/user-attachments/assets/0e6f2cb2-bed1-45d4-bd8a-5bd2d7f4462e">


@bigcommerce/team-checkout @bigcommerce/team-payments
