### PR TITLE
feat(payment): PI-2592 Make remoteCheckoutActionCreator.signOut available for integration packages

### DIFF
--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -88,7 +88,7 @@ describe('DefaultPaymentIntegrationService', () => {
     let shippingCountryActionCreator: Pick<ShippingCountryActionCreator, 'loadCountries'>;
     let remoteCheckoutActionCreator: Pick<
         RemoteCheckoutActionCreator,
-        'initializePayment' | 'forgetCheckout'
+        'initializePayment' | 'forgetCheckout' | 'signOut'
     >;
     let paymentStrategyWidgetActionCreator: PaymentStrategyWidgetActionCreator;
 
@@ -270,6 +270,10 @@ describe('DefaultPaymentIntegrationService', () => {
             initializePayment: jest.fn(
                 async () => () => createAction('INITIALIZE_REMOTE_PAYMENT_REQUESTED'),
             ),
+            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            signOut: jest.fn(async () => () => createAction('SIGN_OUT_REMOTE_CUSTOMER_REQUESTED')),
         };
 
         paymentStrategyWidgetActionCreator = {
@@ -623,6 +627,18 @@ describe('DefaultPaymentIntegrationService', () => {
             expect(remoteCheckoutActionCreator.forgetCheckout).toHaveBeenCalled();
             expect(store.dispatch).toHaveBeenCalledWith(
                 remoteCheckoutActionCreator.forgetCheckout('methodId'),
+            );
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#remoteCheckoutSignOut', () => {
+        it('remote checkout sign out', async () => {
+            const output = await subject.remoteCheckoutSignOut('methodId');
+
+            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalled();
+            expect(store.dispatch).toHaveBeenCalledWith(
+                remoteCheckoutActionCreator.signOut('methodId'),
             );
             expect(output).toEqual(paymentIntegrationSelectors);
         });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -286,6 +286,15 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         return this._storeProjection.getState();
     }
 
+    async remoteCheckoutSignOut(
+        methodId: string,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(this._remoteCheckoutActionCreator.signOut(methodId, options));
+
+        return this._storeProjection.getState();
+    }
+
     async validateCheckout(checkout?: Checkout, options?: RequestOptions): Promise<void> {
         await this._checkoutValidator.validate(checkout, options);
     }

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -96,6 +96,11 @@ export default interface PaymentIntegrationService {
         options?: RequestOptions,
     ): Promise<PaymentIntegrationSelectors>;
 
+    remoteCheckoutSignOut(
+        methodId: string,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors>;
+
     validateCheckout(checkout?: Checkout, options?: RequestOptions): Promise<void>;
 
     handlePaymentHumanVerification(

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -55,6 +55,7 @@ const state = {
 const createBuyNowCart = jest.fn();
 const createHostedForm = jest.fn();
 const forgetCheckout = jest.fn();
+const remoteCheckoutSignOut = jest.fn();
 const getConsignments = jest.fn();
 const getState = jest.fn(() => state);
 const handlePaymentHumanVerification = jest.fn();
@@ -94,6 +95,7 @@ const PaymentIntegrationServiceMock = jest
             deleteConsignment,
             subscribe,
             forgetCheckout,
+            remoteCheckoutSignOut,
             getConsignments,
             getPaymentProviderCustomerOrThrow,
             getState,


### PR DESCRIPTION
## What?
 Make remoteCheckoutActionCreator.signOut available for integration packages

## Why?
Will use this action for migration AmazonPay customer strategy to integration package.

## Testing / Proof
Unit test
<img width="2545" alt="Screenshot 2024-09-09 at 14 59 08" src="https://github.com/user-attachments/assets/8696adce-6db0-4535-9651-5a0bae3f2b38">


@bigcommerce/team-checkout @bigcommerce/team-payments
