### PR TITLE
feat(payment): PI-2548 Move AmazonPay customer strategy

### DIFF
--- a/packages/amazon-pay-integration/src/amazon-pay-v2-customer-initialize-options.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-customer-initialize-options.ts
@@ -1,0 +1,32 @@
+/**
+ * A set of options that are required to initialize the customer step of
+ * checkout in order to support AmazonPayV2.
+ *
+ * When AmazonPayV2 is initialized, a sign-in button will be inserted into the
+ * DOM. When the customer clicks on it, they will be redirected to Amazon to
+ * sign in.
+ *
+ * ```html
+ * <!-- This is where the Amazon Pay button will be inserted -->
+ * <div id="signInButton"></div>
+ * ```
+ *
+ * ```js
+ * service.initializeCustomer({
+ *     methodId: 'amazonpay',
+ *     amazonpay: {
+ *         container: 'signInButton',
+ *     },
+ * });
+ * ```
+ */
+export default interface AmazonPayV2CustomerInitializeOptions {
+    /**
+     * The ID of a container which the sign-in button should insert into.
+     */
+    container: string;
+}
+
+export interface WithAmazonPayV2CustomerInitializeOptions {
+    amazonpay?: AmazonPayV2CustomerInitializeOptions;
+}

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-customer-strategy.spec.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-customer-strategy.spec.ts
@@ -1,0 +1,183 @@
+import {
+    AmazonPayV2PaymentProcessor,
+    AmazonPayV2Placement,
+    getAmazonPayV2,
+    getAmazonPayV2PaymentProcessorMock,
+} from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import {
+    CustomerInitializeOptions,
+    InvalidArgumentError,
+    NotImplementedError,
+    PaymentArgumentInvalidError,
+    PaymentIntegrationService,
+    PaymentMethod,
+    RequestOptions,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { WithAmazonPayV2CustomerInitializeOptions } from './amazon-pay-v2-customer-initialize-options';
+import AmazonPayV2CustomerStrategy from './amazon-pay-v2-customer-strategy';
+import { getAmazonPayV2CustomerInitializeOptions, Mode } from './mock/amazon-pay-v2-customer.mock';
+
+describe('AmazonPayV2CustomerStrategy', () => {
+    let customerInitializeOptions: CustomerInitializeOptions &
+        WithAmazonPayV2CustomerInitializeOptions;
+    let amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor;
+    let strategy: AmazonPayV2CustomerStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let paymentMethodMock: PaymentMethod;
+
+    beforeEach(() => {
+        customerInitializeOptions = getAmazonPayV2CustomerInitializeOptions();
+        amazonPayV2PaymentProcessor =
+            getAmazonPayV2PaymentProcessorMock() as unknown as AmazonPayV2PaymentProcessor;
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        paymentMethodMock = getAmazonPayV2();
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethodMock,
+        );
+
+        strategy = new AmazonPayV2CustomerStrategy(
+            paymentIntegrationService,
+            amazonPayV2PaymentProcessor,
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('#initialize', () => {
+        it('should initialize the processor', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            expect(amazonPayV2PaymentProcessor.initialize).toHaveBeenCalledWith(getAmazonPayV2());
+        });
+
+        it('should render the button', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            expect(amazonPayV2PaymentProcessor.renderAmazonPayButton).toHaveBeenCalledWith({
+                checkoutState: paymentIntegrationService.getState(),
+                containerId: 'amazonpayCheckoutButton',
+                methodId: 'amazonpay',
+                placement: AmazonPayV2Placement.Checkout,
+            });
+        });
+
+        describe('should fail...', () => {
+            test('if methodId is not provided', async () => {
+                customerInitializeOptions = getAmazonPayV2CustomerInitializeOptions(
+                    Mode.UndefinedMethodId,
+                );
+
+                const initialize = strategy.initialize(customerInitializeOptions);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+
+            test('if containerId is not provided', async () => {
+                customerInitializeOptions = getAmazonPayV2CustomerInitializeOptions(
+                    Mode.Incomplete,
+                );
+
+                const initialize = strategy.initialize(customerInitializeOptions);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+
+            test('if there is no payment method data', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockImplementation(() => {
+                    throw new PaymentArgumentInvalidError();
+                });
+
+                strategy = new AmazonPayV2CustomerStrategy(
+                    paymentIntegrationService,
+                    amazonPayV2PaymentProcessor,
+                );
+
+                const initialize = strategy.initialize(customerInitializeOptions);
+
+                await expect(initialize).rejects.toThrow(PaymentArgumentInvalidError);
+            });
+        });
+    });
+
+    describe('#deinitialize', () => {
+        it('succesfully deinitializes the strategy', async () => {
+            await strategy.deinitialize();
+
+            expect(amazonPayV2PaymentProcessor.deinitialize).toHaveBeenCalled();
+        });
+    });
+
+    describe('#signIn', () => {
+        it('throws error if trying to sign in programmatically', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            expect(strategy.signIn).toThrow(NotImplementedError);
+        });
+    });
+
+    describe('#signOut', () => {
+        beforeEach(async () => {
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('signs out from Amazon and remote checkout provider', async () => {
+            const signOutMock = jest.spyOn(amazonPayV2PaymentProcessor, 'signout');
+            const remoteCheckoutSignOutMock = jest.spyOn(
+                paymentIntegrationService,
+                'remoteCheckoutSignOut',
+            );
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentId').mockReturnValueOnce({
+                providerId: 'amazonpay',
+            });
+            remoteCheckoutSignOutMock.mockImplementation(jest.fn());
+
+            await strategy.signOut({
+                methodId: 'amazonpay',
+            } as RequestOptions);
+
+            expect(signOutMock).toHaveBeenCalledTimes(1);
+            expect(remoteCheckoutSignOutMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('does nothing if already signed out from remote checkout provider', async () => {
+            const signOutMock = jest.spyOn(amazonPayV2PaymentProcessor, 'signout');
+            const remoteCheckoutSignOutMock = jest.spyOn(
+                paymentIntegrationService,
+                'remoteCheckoutSignOut',
+            );
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentId').mockReturnValueOnce(
+                undefined,
+            );
+            remoteCheckoutSignOutMock.mockImplementation(jest.fn());
+
+            await strategy.signOut({
+                methodId: 'amazonpay',
+            } as RequestOptions);
+
+            expect(signOutMock).not.toHaveBeenCalled();
+            expect(remoteCheckoutSignOutMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('#executePaymentMethodCheckout', () => {
+        it('runs continue callback automatically on execute payment method checkout', async () => {
+            const mockCallback = jest.fn();
+
+            await strategy.executePaymentMethodCheckout({
+                continueWithCheckoutCallback: mockCallback,
+            });
+
+            expect(mockCallback.mock.calls).toHaveLength(1);
+        });
+    });
+});

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-customer-strategy.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-customer-strategy.ts
@@ -1,0 +1,83 @@
+import {
+    AmazonPayV2InitializeOptions,
+    AmazonPayV2PaymentProcessor,
+    AmazonPayV2Placement,
+} from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import {
+    CustomerInitializeOptions,
+    CustomerStrategy,
+    ExecutePaymentMethodCheckoutOptions,
+    InvalidArgumentError,
+    NotImplementedError,
+    PaymentIntegrationService,
+    PaymentMethod,
+    RequestOptions,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { WithAmazonPayV2CustomerInitializeOptions } from './amazon-pay-v2-customer-initialize-options';
+
+export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor,
+    ) {}
+
+    async initialize(
+        options: CustomerInitializeOptions & WithAmazonPayV2CustomerInitializeOptions,
+    ): Promise<void> {
+        const { methodId, amazonpay } = options;
+
+        if (!methodId || !amazonpay?.container) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "methodId" or "containerId" argument is not provided.',
+            );
+        }
+
+        const state = this.paymentIntegrationService.getState();
+        let paymentMethod: PaymentMethod<AmazonPayV2InitializeOptions>;
+
+        try {
+            paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        } catch (_e) {
+            await this.paymentIntegrationService.loadPaymentMethod(methodId);
+            paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        }
+
+        await this.amazonPayV2PaymentProcessor.initialize(paymentMethod);
+
+        this.amazonPayV2PaymentProcessor.renderAmazonPayButton({
+            checkoutState: this.paymentIntegrationService.getState(),
+            containerId: amazonpay.container,
+            methodId,
+            placement: AmazonPayV2Placement.Checkout,
+        });
+    }
+
+    async deinitialize(): Promise<void> {
+        await this.amazonPayV2PaymentProcessor.deinitialize();
+    }
+
+    signIn(): Promise<void> {
+        throw new NotImplementedError(
+            'In order to sign in via Amazon, the shopper must click on "Amazon Pay" button.',
+        );
+    }
+
+    async signOut(options?: RequestOptions): Promise<void> {
+        const state = this.paymentIntegrationService.getState();
+        const payment = state.getPaymentId();
+
+        if (!payment) {
+            return;
+        }
+
+        await this.amazonPayV2PaymentProcessor.signout();
+        await this.paymentIntegrationService.remoteCheckoutSignOut(payment.providerId, options);
+    }
+
+    executePaymentMethodCheckout(options?: ExecutePaymentMethodCheckoutOptions): Promise<void> {
+        options?.continueWithCheckoutCallback?.();
+
+        return Promise.resolve();
+    }
+}

--- a/packages/amazon-pay-integration/src/create-amazon-pay-v2-customer-strategy.spec.ts
+++ b/packages/amazon-pay-integration/src/create-amazon-pay-v2-customer-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import AmazonPayV2CustomerStrategy from './amazon-pay-v2-customer-strategy';
+import createAmazonPayV2CustomerStrategy from './create-amazon-pay-v2-customer-strategy';
+
+describe('createAmazonPayV2PaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates AmazonPayV2 payment strategy', () => {
+        const strategy = createAmazonPayV2CustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(AmazonPayV2CustomerStrategy);
+    });
+});

--- a/packages/amazon-pay-integration/src/create-amazon-pay-v2-customer-strategy.ts
+++ b/packages/amazon-pay-integration/src/create-amazon-pay-v2-customer-strategy.ts
@@ -1,0 +1,18 @@
+import { createAmazonPayV2PaymentProcessor } from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import AmazonPayV2CustomerStrategy from './amazon-pay-v2-customer-strategy';
+
+const createAmazonPayV2CustomerStrategy: CustomerStrategyFactory<AmazonPayV2CustomerStrategy> = (
+    paymentIntegrationService,
+) => {
+    return new AmazonPayV2CustomerStrategy(
+        paymentIntegrationService,
+        createAmazonPayV2PaymentProcessor(),
+    );
+};
+
+export default toResolvableModule(createAmazonPayV2CustomerStrategy, [{ id: 'amazonpay' }]);

--- a/packages/amazon-pay-integration/src/index.ts
+++ b/packages/amazon-pay-integration/src/index.ts
@@ -1,1 +1,2 @@
 export { default as createAmazonPayV2PaymentStrategy } from './create-amazon-pay-v2-payment-strategy';
+export { default as createAmazonPayV2CustomerStrategy } from './create-amazon-pay-v2-customer-strategy';

--- a/packages/amazon-pay-integration/src/mock/amazon-pay-v2-customer.mock.ts
+++ b/packages/amazon-pay-integration/src/mock/amazon-pay-v2-customer.mock.ts
@@ -1,0 +1,33 @@
+import { CustomerInitializeOptions } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export enum Mode {
+    Full,
+    UndefinedMethodId,
+    InvalidContainer,
+    Incomplete,
+}
+
+export function getAmazonPayV2CustomerInitializeOptions(
+    mode: Mode = Mode.Full,
+): CustomerInitializeOptions {
+    const optionsWithMethodId = { methodId: 'amazonpay' };
+    const optionsWithUndefinedMethodId = { methodId: undefined };
+    const optionsWithContainer = { container: 'amazonpayCheckoutButton' };
+    const optionsWithInvalidContainer = { container: 'invalid_container' };
+    const amazonPayV2 = { amazonpay: optionsWithContainer };
+    const amazonPayV2WithInvalidContainer = { amazonpay: optionsWithInvalidContainer };
+
+    switch (mode) {
+        case Mode.Incomplete:
+            return { ...optionsWithMethodId };
+
+        case Mode.UndefinedMethodId:
+            return { ...optionsWithUndefinedMethodId, ...amazonPayV2 };
+
+        case Mode.InvalidContainer:
+            return { ...optionsWithMethodId, ...amazonPayV2WithInvalidContainer };
+
+        default:
+            return { ...optionsWithMethodId, ...amazonPayV2 };
+    }
+}


### PR DESCRIPTION
## What?
Migrate AmazonPay to package

## Why?
To keep payment integration strategies in separate package

## Testing / Proof

https://github.com/user-attachments/assets/135198d1-34f9-4901-9e30-cdda223bbb9c

<img width="2555" alt="Screenshot 2024-09-11 at 16 21 55" src="https://github.com/user-attachments/assets/ad2b3024-17b5-4bbf-ab49-7dda20bec1fb">

@bigcommerce/team-checkout @bigcommerce/team-payments
