### PR TITLE
fix(payment): PAYPAL-4649 fixed the issue with Braintree Google Pay button for Buy Now flow

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -206,7 +206,9 @@ export default class GooglePayGateway {
         };
     }
 
-    getPaymentGatewayParameters(): GooglePayGatewayParameters {
+    getPaymentGatewayParameters():
+        | Promise<GooglePayGatewayParameters>
+        | GooglePayGatewayParameters {
         const gatewayMerchantId = this.getGooglePayInitializationData().gatewayMerchantId;
 
         if (!gatewayMerchantId) {

--- a/packages/google-pay-integration/src/google-pay-payment-processor.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.ts
@@ -237,7 +237,7 @@ export default class GooglePayPaymentProcessor {
             ...baseCardPaymentMethod,
             tokenizationSpecification: {
                 type: 'PAYMENT_GATEWAY',
-                parameters: this._gateway.getPaymentGatewayParameters(),
+                parameters: await this._gateway.getPaymentGatewayParameters(),
             },
         };
         this._paymentDataRequest = {


### PR DESCRIPTION
## What?
Moved Braintree Google Pay request data params preparation from initialize to getPaymentGatewayParameters method.

## Why?
The issue with Braintree Google Pay button for BuyNow flow occurs due to the issues with getting data from state cart object, since it was not created yet.

## Testing / Proof
Unit tests
Manual tests
CI

Proof for order with digital item:

https://github.com/user-attachments/assets/fca6986e-13a1-4c87-825a-3ece4b9f7f5c



Proof for order with physical item:

https://github.com/user-attachments/assets/527bd95d-9237-44ee-a56d-2cb112e73293

