### PR TITLE
feat(payment): PI-2549 Move AmazonPay button strategy

### DIFF
--- a/packages/amazon-pay-integration/src/amazon-pay-v2-button-options.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-button-options.ts
@@ -1,0 +1,23 @@
+import {
+    AmazonPayV2ButtonConfig,
+    AmazonPayV2ButtonParameters,
+} from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import { BuyNowCartRequestBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export interface WithBuyNowFeature extends AmazonPayV2ButtonConfig {
+    /**
+     * The options that are required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    };
+}
+
+/**
+ * The required config to render the AmazonPayV2 button.
+ */
+export type AmazonPayV2ButtonInitializeOptions = AmazonPayV2ButtonParameters | WithBuyNowFeature;
+
+export interface WithAmazonPayV2ButtonInitializeOptions {
+    amazonpay?: AmazonPayV2ButtonInitializeOptions;
+}

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-button-strategy.spec.ts
@@ -1,0 +1,196 @@
+import {
+    AmazonPayV2ButtonColor,
+    AmazonPayV2PaymentProcessor,
+    AmazonPayV2Placement,
+    getAmazonPayV2,
+    getAmazonPayV2PaymentProcessorMock,
+} from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import {
+    CartSource,
+    CheckoutButtonInitializeOptions,
+    InvalidArgumentError,
+    PaymentArgumentInvalidError,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getCart,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import AmazonPayV2ButtonStrategy from './amazon-pay-v2-button-strategy';
+import AmazonPayV2RequestSender from './amazon-pay-v2-request-sender';
+import { getAmazonPayV2CheckoutButtonOptions, Mode } from './mock/amazon-pay-v2-button.mock';
+import { getAmazonPayV2RequestSenderMock } from './mock/amazon-pay-v2-config-request-sender.mock';
+import AmazonPayV2ConfigCreationError from './errors/amazon-pay-v2-config-creation-error';
+
+describe('AmazonPayV2ButtonStrategy', () => {
+    let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+    let amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let strategy: AmazonPayV2ButtonStrategy;
+    let amazonPayV2RequestSender: AmazonPayV2RequestSender;
+
+    beforeEach(() => {
+        const cart = getCart();
+
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        amazonPayV2PaymentProcessor =
+            getAmazonPayV2PaymentProcessorMock() as unknown as AmazonPayV2PaymentProcessor;
+        amazonPayV2RequestSender =
+            getAmazonPayV2RequestSenderMock() as unknown as AmazonPayV2RequestSender;
+        checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions();
+
+        const buyNowCartMock = {
+            ...cart,
+            id: '999',
+            source: CartSource.BuyNow,
+        };
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            getAmazonPayV2(),
+        );
+        jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(
+            Promise.resolve(buyNowCartMock),
+        );
+        jest.spyOn(
+            amazonPayV2PaymentProcessor,
+            'prepareCheckoutWithCreationRequestConfig',
+        ).mockImplementation((callback) => {
+            void callback();
+        });
+
+        strategy = new AmazonPayV2ButtonStrategy(
+            paymentIntegrationService,
+            amazonPayV2PaymentProcessor,
+            amazonPayV2RequestSender,
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('#initialize', () => {
+        it('should initialize the processor', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(amazonPayV2PaymentProcessor.initialize).toHaveBeenCalledWith(getAmazonPayV2());
+        });
+
+        it('should initialize with Buy Now Flow', async () => {
+            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.BuyNowFlow);
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(amazonPayV2PaymentProcessor.initialize).toHaveBeenCalledWith(getAmazonPayV2());
+            expect(paymentIntegrationService.loadDefaultCheckout).not.toHaveBeenCalled();
+            expect(
+                amazonPayV2PaymentProcessor.prepareCheckoutWithCreationRequestConfig,
+            ).toHaveBeenCalled();
+        });
+
+        it('loads the checkout if AmazonPayV2ButtonInitializeOptions is not provided', async () => {
+            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentIntegrationService.loadDefaultCheckout).toHaveBeenCalled();
+        });
+
+        it('does not load the checkout if AmazonPayV2ButtonInitializeOptions is provided', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentIntegrationService.loadDefaultCheckout).not.toHaveBeenCalled();
+        });
+
+        it('should render the button', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(amazonPayV2PaymentProcessor.renderAmazonPayButton).toHaveBeenCalledWith({
+                buttonColor: AmazonPayV2ButtonColor.Gold,
+                checkoutState: paymentIntegrationService.getState(),
+                containerId: 'amazonpayCheckoutButton',
+                methodId: 'amazonpay',
+                options: checkoutButtonOptions.amazonpay,
+                placement: AmazonPayV2Placement.Cart,
+            });
+        });
+
+        describe('should fail...', () => {
+            test('if methodId is not provided', async () => {
+                checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedMethodId);
+
+                const initialize = strategy.initialize(checkoutButtonOptions);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+
+            test('if containerId is not provided', async () => {
+                checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(
+                    Mode.UndefinedContainer,
+                );
+
+                const initialize = strategy.initialize(checkoutButtonOptions);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+
+            test('if there is no payment method data', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockImplementation(() => {
+                    throw new PaymentArgumentInvalidError();
+                });
+
+                const initialize = strategy.initialize(checkoutButtonOptions);
+
+                await expect(initialize).rejects.toThrow(PaymentArgumentInvalidError);
+            });
+
+            it('if initialize with Buy Now Flow but createBuyNowCart throw error', async () => {
+                checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.BuyNowFlow);
+
+                jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockRejectedValue(
+                    undefined,
+                );
+
+                await strategy.initialize(checkoutButtonOptions);
+
+                expect(amazonPayV2RequestSender.createCheckoutConfig).not.toHaveBeenCalled();
+            });
+
+            it('if initialize with Buy Now Flow but createCheckoutConfig throw error', async () => {
+                let callbackResult;
+
+                checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.BuyNowFlow);
+
+                jest.spyOn(
+                    amazonPayV2PaymentProcessor,
+                    'prepareCheckoutWithCreationRequestConfig',
+                ).mockImplementation((callback) => {
+                    callbackResult = callback();
+                });
+                jest.spyOn(amazonPayV2RequestSender, 'createCheckoutConfig').mockRejectedValue(
+                    undefined,
+                );
+
+                try {
+                    await strategy.initialize(checkoutButtonOptions);
+                    await new Promise((resolve) => process.nextTick(resolve));
+                } catch (err) {
+                    callbackResult = err;
+                } finally {
+                    await expect(callbackResult).rejects.toThrow(AmazonPayV2ConfigCreationError);
+                }
+            });
+        });
+    });
+
+    describe('#deinitialize', () => {
+        it('succesfully deinitializes the strategy', async () => {
+            await strategy.deinitialize();
+
+            expect(amazonPayV2PaymentProcessor.deinitialize).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-button-strategy.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-button-strategy.ts
@@ -1,0 +1,145 @@
+import {
+    AmazonPayV2CheckoutSessionConfig,
+    AmazonPayV2InitializeOptions,
+    AmazonPayV2PaymentProcessor,
+    AmazonPayV2PayOptions,
+    AmazonPayV2Placement,
+} from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import {
+    BuyNowCartCreationError,
+    CheckoutButtonInitializeOptions,
+    CheckoutButtonStrategy,
+    getShippableItemsCount,
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import {
+    WithAmazonPayV2ButtonInitializeOptions,
+    WithBuyNowFeature,
+} from './amazon-pay-v2-button-options';
+import AmazonPayV2RequestSender from './amazon-pay-v2-request-sender';
+import AmazonPayV2ConfigCreationError from './errors/amazon-pay-v2-config-creation-error';
+import { isWithBuyNowFeatures } from './isWithBuyNowFeatures';
+
+export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy {
+    private _buyNowInitializeOptions: WithBuyNowFeature['buyNowInitializeOptions'];
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor,
+        private amazonPayV2ConfigRequestSender: AmazonPayV2RequestSender,
+    ) {}
+
+    async initialize(
+        options: CheckoutButtonInitializeOptions & WithAmazonPayV2ButtonInitializeOptions,
+    ): Promise<void> {
+        const { methodId, containerId, amazonpay } = options;
+        const { buttonColor } = amazonpay || {};
+
+        if (!methodId || !containerId) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "methodId" or "containerId" argument is not provided.',
+            );
+        }
+
+        const { getPaymentMethodOrThrow } = this.paymentIntegrationService.getState();
+
+        const paymentMethod = getPaymentMethodOrThrow<AmazonPayV2InitializeOptions>(methodId);
+        const { initializationData } = paymentMethod;
+
+        await this.amazonPayV2PaymentProcessor.initialize(paymentMethod);
+
+        if (!amazonpay) {
+            await this.paymentIntegrationService.loadDefaultCheckout();
+        }
+
+        const initializeAmazonButtonOptions = isWithBuyNowFeatures(amazonpay)
+            ? undefined
+            : amazonpay;
+
+        if (
+            isWithBuyNowFeatures(amazonpay) &&
+            typeof amazonpay.buyNowInitializeOptions?.getBuyNowCartRequestBody === 'function'
+        ) {
+            this._buyNowInitializeOptions = amazonpay.buyNowInitializeOptions;
+            this.amazonPayV2PaymentProcessor.updateBuyNowFlowFlag(true);
+        }
+
+        this.amazonPayV2PaymentProcessor.renderAmazonPayButton({
+            checkoutState: this.paymentIntegrationService.getState(),
+            containerId,
+            methodId,
+            options: initializeAmazonButtonOptions,
+            placement: AmazonPayV2Placement.Cart,
+            buttonColor,
+            isButtonMicroTextDisabled: initializationData?.isButtonMicroTextDisabled,
+        });
+
+        if (this._buyNowInitializeOptions) {
+            this.amazonPayV2PaymentProcessor.prepareCheckoutWithCreationRequestConfig(
+                this._getCheckoutCreationRequestConfig.bind(this),
+            );
+        }
+    }
+
+    deinitialize(): Promise<void> {
+        return this.amazonPayV2PaymentProcessor.deinitialize();
+    }
+
+    private async _createBuyNowCartOrThrow() {
+        const buyNowCartRequestBody = this._buyNowInitializeOptions?.getBuyNowCartRequestBody?.();
+
+        if (!buyNowCartRequestBody) {
+            throw new MissingDataError(MissingDataErrorType.MissingCart);
+        }
+
+        try {
+            const buyNowCart = await this.paymentIntegrationService.createBuyNowCart(
+                buyNowCartRequestBody,
+            );
+
+            return buyNowCart;
+        } catch (error) {
+            throw new BuyNowCartCreationError();
+        }
+    }
+
+    private async _createCheckoutConfig(
+        id: string,
+    ): Promise<Required<AmazonPayV2CheckoutSessionConfig>> {
+        try {
+            const {
+                body: { payload, public_key, ...rest },
+            } = await this.amazonPayV2ConfigRequestSender.createCheckoutConfig(id);
+
+            return {
+                payloadJSON: payload,
+                publicKeyId: public_key,
+                ...rest,
+            };
+        } catch (error) {
+            throw new AmazonPayV2ConfigCreationError();
+        }
+    }
+
+    private async _getCheckoutCreationRequestConfig() {
+        const buyNowCart = await this._createBuyNowCartOrThrow();
+        const estimatedOrderAmount = {
+            amount: String(buyNowCart.baseAmount),
+            currencyCode: buyNowCart.currency.code,
+        };
+        const createCheckoutSessionConfig = await this._createCheckoutConfig(buyNowCart.id);
+
+        return {
+            createCheckoutSessionConfig,
+            estimatedOrderAmount,
+            productType:
+                getShippableItemsCount(buyNowCart) === 0
+                    ? AmazonPayV2PayOptions.PayOnly
+                    : AmazonPayV2PayOptions.PayAndShip,
+        };
+    }
+}

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-request-sender.spec.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-request-sender.spec.ts
@@ -1,0 +1,39 @@
+import { RequestSender } from '@bigcommerce/request-sender';
+
+import {
+    ContentType,
+    INTERNAL_USE_ONLY,
+    SDK_VERSION_HEADERS,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import AmazonPayV2RequestSender from './amazon-pay-v2-request-sender';
+
+describe('AmazonPayV2RequestSender', () => {
+    let requestSenderMock: RequestSender;
+    let amazonPayV2RequestSender: AmazonPayV2RequestSender;
+
+    beforeEach(() => {
+        requestSenderMock = {
+            post: jest.fn(),
+        } as unknown as RequestSender;
+
+        amazonPayV2RequestSender = new AmazonPayV2RequestSender(requestSenderMock);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('createCheckoutConfig', async () => {
+        await amazonPayV2RequestSender.createCheckoutConfig('cartId');
+
+        expect(requestSenderMock.post).toHaveBeenCalledWith('/api/storefront/payment/amazonpay', {
+            body: { cartId: 'cartId' },
+            headers: {
+                'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                'Content-Type': ContentType.Json,
+                ...SDK_VERSION_HEADERS,
+            },
+        });
+    });
+});

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-request-sender.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-request-sender.ts
@@ -1,0 +1,28 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import {
+    ContentType,
+    INTERNAL_USE_ONLY,
+    SDK_VERSION_HEADERS,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export interface CheckoutConfig {
+    payload: string;
+    signature: string;
+    public_key: string;
+}
+
+export default class AmazonPayV2RequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    createCheckoutConfig(cartId: string): Promise<Response<CheckoutConfig>> {
+        const body = { cartId };
+        const headers = {
+            'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            'Content-Type': ContentType.Json,
+            ...SDK_VERSION_HEADERS,
+        };
+
+        return this._requestSender.post('/api/storefront/payment/amazonpay', { headers, body });
+    }
+}

--- a/packages/amazon-pay-integration/src/create-amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/amazon-pay-integration/src/create-amazon-pay-v2-button-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import AmazonPayV2ButtonStrategy from './amazon-pay-v2-button-strategy';
+import createAmazonPayV2ButtonStrategy from './create-amazon-pay-v2-button-strategy';
+
+describe('createAmazonPayV2PaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates AmazonPayV2 payment strategy', () => {
+        const strategy = createAmazonPayV2ButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(AmazonPayV2ButtonStrategy);
+    });
+});

--- a/packages/amazon-pay-integration/src/create-amazon-pay-v2-button-strategy.ts
+++ b/packages/amazon-pay-integration/src/create-amazon-pay-v2-button-strategy.ts
@@ -1,0 +1,26 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import { createAmazonPayV2PaymentProcessor } from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import AmazonPayV2ButtonStrategy from './amazon-pay-v2-button-strategy';
+import AmazonPayV2RequestSender from './amazon-pay-v2-request-sender';
+
+const createAmazonPayV2ButtonStrategy: CheckoutButtonStrategyFactory<AmazonPayV2ButtonStrategy> = (
+    paymentIntegrationService,
+) => {
+    const requestSender = createRequestSender();
+    const amazonPayV2RequestSender = new AmazonPayV2RequestSender(requestSender);
+    const amazonPayV2PaymentProcessor = createAmazonPayV2PaymentProcessor();
+
+    return new AmazonPayV2ButtonStrategy(
+        paymentIntegrationService,
+        amazonPayV2PaymentProcessor,
+        amazonPayV2RequestSender,
+    );
+};
+
+export default toResolvableModule(createAmazonPayV2ButtonStrategy, [{ id: 'amazonpay' }]);

--- a/packages/amazon-pay-integration/src/errors/amazon-pay-v2-config-creation-error.spec.ts
+++ b/packages/amazon-pay-integration/src/errors/amazon-pay-v2-config-creation-error.spec.ts
@@ -1,0 +1,26 @@
+import { StandardError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import AmazonPayV2ConfigCreationError from './amazon-pay-v2-config-creation-error';
+
+describe('AmazonPayV2ConfigCreationError', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should throw default error message', () => {
+        const error = new AmazonPayV2ConfigCreationError();
+
+        expect(error).toBeInstanceOf(StandardError);
+        expect(error.message).toBe(
+            'An unexpected error has occurred during config creation process. Please try again later.',
+        );
+        expect(error.name).toBe('AmazonPayV2ConfigCreationError');
+        expect(error.type).toBe('amazon_pay_v2_config_creation_error');
+    });
+
+    it('should throw custom error message', () => {
+        const error = new AmazonPayV2ConfigCreationError('Custom error message');
+
+        expect(error.message).toBe('Custom error message');
+    });
+});

--- a/packages/amazon-pay-integration/src/errors/amazon-pay-v2-config-creation-error.ts
+++ b/packages/amazon-pay-integration/src/errors/amazon-pay-v2-config-creation-error.ts
@@ -1,0 +1,13 @@
+import { StandardError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default class AmazonPayV2ConfigCreationError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message ||
+                'An unexpected error has occurred during config creation process. Please try again later.',
+        );
+
+        this.name = 'AmazonPayV2ConfigCreationError';
+        this.type = 'amazon_pay_v2_config_creation_error';
+    }
+}

--- a/packages/amazon-pay-integration/src/index.ts
+++ b/packages/amazon-pay-integration/src/index.ts
@@ -1,2 +1,3 @@
-export { default as createAmazonPayV2PaymentStrategy } from './create-amazon-pay-v2-payment-strategy';
+export { default as createAmazonPayV2ButtonStrategy } from './create-amazon-pay-v2-button-strategy';
 export { default as createAmazonPayV2CustomerStrategy } from './create-amazon-pay-v2-customer-strategy';
+export { default as createAmazonPayV2PaymentStrategy } from './create-amazon-pay-v2-payment-strategy';

--- a/packages/amazon-pay-integration/src/isWithBuyNowFeatures.spec.ts
+++ b/packages/amazon-pay-integration/src/isWithBuyNowFeatures.spec.ts
@@ -1,0 +1,25 @@
+import { isWithBuyNowFeatures } from './isWithBuyNowFeatures';
+
+describe('isWithBuyNowFeatures', () => {
+    it('should return true if options is WithBuyNowFeature', () => {
+        const options = {
+            buyNowInitializeOptions: {
+                currencyCode: 'USD',
+            },
+        };
+
+        expect(isWithBuyNowFeatures(options)).toBe(true);
+    });
+
+    it('should return false if options is not WithBuyNowFeature', () => {
+        const options = {};
+
+        expect(isWithBuyNowFeatures(options)).toBe(false);
+    });
+
+    it('should return false if options is not an object', () => {
+        const options = 'string';
+
+        expect(isWithBuyNowFeatures(options)).toBe(false);
+    });
+});

--- a/packages/amazon-pay-integration/src/isWithBuyNowFeatures.ts
+++ b/packages/amazon-pay-integration/src/isWithBuyNowFeatures.ts
@@ -1,0 +1,9 @@
+import { WithBuyNowFeature } from './amazon-pay-v2-button-options';
+
+export function isWithBuyNowFeatures(options: unknown): options is WithBuyNowFeature {
+    if (!(options instanceof Object)) {
+        return false;
+    }
+
+    return 'buyNowInitializeOptions' in options;
+}

--- a/packages/amazon-pay-integration/src/mock/amazon-pay-v2-button.mock.ts
+++ b/packages/amazon-pay-integration/src/mock/amazon-pay-v2-button.mock.ts
@@ -1,0 +1,82 @@
+import {
+    AmazonPayV2LedgerCurrency,
+    AmazonPayV2Placement,
+    getAmazonPayV2ButtonParamsMock,
+} from '@bigcommerce/checkout-sdk/amazon-pay-utils';
+import {
+    BuyNowCartRequestBody,
+    CartSource,
+    CheckoutButtonInitializeOptions,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export enum Mode {
+    Full,
+    BuyNowFlow,
+    UndefinedContainer,
+    InvalidContainer,
+    UndefinedMethodId,
+    UndefinedAmazonPay,
+}
+
+const buyNowCartRequestBody: BuyNowCartRequestBody = {
+    source: CartSource.BuyNow,
+    lineItems: [
+        {
+            productId: 1,
+            quantity: 2,
+            optionSelections: {
+                optionId: 11,
+                optionValue: 11,
+            },
+        },
+    ],
+};
+
+export function getAmazonPayV2CheckoutButtonOptions(
+    mode: Mode = Mode.Full,
+): CheckoutButtonInitializeOptions {
+    const methodId = { methodId: 'amazonpay' };
+    const containerId = 'amazonpayCheckoutButton';
+    const undefinedContainerId = { containerId: '' };
+    const invalidContainerId = { containerId: 'invalid_container' };
+    const amazonPayV2Options = { containerId, amazonpay: getAmazonPayV2ButtonParamsMock() };
+
+    const amazonPayV2BuyNowOptions = {
+        buyNowInitializeOptions: {
+            getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
+        },
+    };
+
+    switch (mode) {
+        case Mode.UndefinedContainer:
+            return { ...methodId, ...undefinedContainerId };
+
+        case Mode.InvalidContainer:
+            return { ...methodId, ...invalidContainerId };
+
+        case Mode.Full:
+            return { ...methodId, ...amazonPayV2Options };
+
+        case Mode.UndefinedMethodId:
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            return { ...amazonPayV2Options } as unknown as CheckoutButtonInitializeOptions;
+
+        case Mode.UndefinedAmazonPay:
+            return { ...getAmazonPayV2CheckoutButtonOptions(Mode.Full), amazonpay: undefined };
+
+        case Mode.BuyNowFlow:
+            return {
+                ...methodId,
+                containerId,
+                amazonpay: {
+                    ...amazonPayV2BuyNowOptions,
+                    merchantId: '',
+                    placement: AmazonPayV2Placement.Checkout,
+                    ledgerCurrency: AmazonPayV2LedgerCurrency.USD,
+                },
+            };
+
+        default:
+            return { ...methodId, containerId };
+    }
+}

--- a/packages/amazon-pay-integration/src/mock/amazon-pay-v2-config-request-sender.mock.ts
+++ b/packages/amazon-pay-integration/src/mock/amazon-pay-v2-config-request-sender.mock.ts
@@ -1,0 +1,15 @@
+import { CheckoutConfig } from '../amazon-pay-v2-request-sender';
+
+export function getAmazonPayV2RequestSenderMock() {
+    return {
+        createCheckoutConfig: jest.fn(() => Promise.resolve({ body: getCheckoutRequestConfig() })),
+    };
+}
+
+export function getCheckoutRequestConfig(): CheckoutConfig {
+    return {
+        payload: 'payload',
+        signature: 'signature',
+        public_key: 'public_key',
+    };
+}


### PR DESCRIPTION
## What?
Migrate Amazon Pay button strategy to integration package

## Why?
To keep payment integration strategies in integration packages

## Testing / Proof
Unit tests and manually tested

https://github.com/user-attachments/assets/efdf1877-b56a-4114-b468-a805c1c0ed15


https://github.com/user-attachments/assets/28c392cc-832d-4685-9a2e-5f69400db308

<img width="2556" alt="Screenshot 2024-09-11 at 20 06 38" src="https://github.com/user-attachments/assets/de000397-20c1-4f66-9e16-bb4c926fc6cb">


@bigcommerce/team-checkout @bigcommerce/team-payments
