### PR TITLE
chore(payment): PAYPAL-4580 added an ability to pass custom button height for Braintree Venmo button

### DIFF
--- a/packages/braintree-integration/src/braintree-venmo/braintree-venmo-button-strategy.ts
+++ b/packages/braintree-integration/src/braintree-venmo/braintree-venmo-button-strategy.ts
@@ -29,7 +29,7 @@ import {
 import { WithBraintreeVenmoInitializeOptions } from './braintree-venmo-initialize-options';
 
 const getVenmoButtonStyle = (styles: PaypalStyleOptions): Record<string, string> => {
-    const { color } = styles;
+    const { color, height } = styles;
 
     const colorParser = (c: string) => {
         if (c === PaypalButtonStyleColorOption.WHITE) {
@@ -52,7 +52,7 @@ const getVenmoButtonStyle = (styles: PaypalStyleOptions): Record<string, string>
         borderRadius: '4px',
         cursor: 'pointer',
         transition: '0.2s ease',
-        minHeight: `${DefaultCheckoutButtonHeight}px`,
+        minHeight: `${height || DefaultCheckoutButtonHeight}px`,
         minWidth: '150px',
         height: '100%',
         width: '100%',


### PR DESCRIPTION
## What?
Added an ability to pass custom button height for Braintree Venmo button

## Why?
To be able to make Braintree Venmo button style height the same as other buttons on product details page.

## Testing / Proof
Unit tests
