### PR TITLE
feat(payment): PAYPAL-4611 Update Braintree LPMs strategy by adding functionality for Trustly

### DIFF
--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
@@ -256,6 +256,7 @@ describe('BraintreeLocalMethodsPaymentStrategy', () => {
                         paymentData: expect.objectContaining({
                             formattedPayload: expect.objectContaining({
                                 device_info: 'token',
+                                method_id: 'trustly',
                                 set_as_default_stored_instrument: null,
                                 trustly_account: expect.objectContaining({
                                     phone: '380112223344',
@@ -284,7 +285,7 @@ describe('BraintreeLocalMethodsPaymentStrategy', () => {
 
                 try {
                     await strategy.execute(payload);
-                } catch (e) {
+                } catch (_) {
                     expect(window.location.replace).toHaveBeenCalledWith('redirect_url');
                 }
             });

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
@@ -135,6 +135,7 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
             formattedPayload: {
                 vault_payment_instrument: null,
                 set_as_default_stored_instrument: null,
+                method_id: methodId,
                 device_info: sessionId || null,
                 [`${methodId}_account`]: {
                     phone: phoneNumber,
@@ -153,7 +154,13 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
             if (this.isBraintreeRedirectError(error)) {
                 const redirectUrl = error.body.additional_action_required.data.redirect_url;
 
-                window.location.replace(redirectUrl);
+                return new Promise((_, reject) => {
+                    window.location.replace(redirectUrl);
+
+                    this.toggleLoadingIndicator(false);
+
+                    reject();
+                });
             }
 
             this.toggleLoadingIndicator(false);

--- a/packages/braintree-integration/src/is-phone-number-instrument-like.ts
+++ b/packages/braintree-integration/src/is-phone-number-instrument-like.ts
@@ -1,0 +1,14 @@
+import {
+    PaymentInstrumentPayload,
+    WithPhoneNumberInstrument,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default function isPhoneNumberInstrumentLike(
+    paymentData?: PaymentInstrumentPayload,
+): paymentData is WithPhoneNumberInstrument {
+    if (!paymentData) {
+        return false;
+    }
+
+    return 'phoneNumber' in paymentData;
+}

--- a/packages/braintree-utils/src/types.ts
+++ b/packages/braintree-utils/src/types.ts
@@ -641,3 +641,24 @@ export interface BraintreeError extends Error {
     code: string | BraintreeErrorCode.KountNotEnabled;
     details?: unknown;
 }
+
+/**
+ *
+ * Braintree non-instant payment methods
+ *
+ */
+
+export enum NonInstantLocalPaymentMethods {
+    TRUSTLY = 'trustly',
+}
+
+export interface BraintreeLocalPaymentMethodRedirectAction {
+    body: {
+        additional_action_required: {
+            type: 'offsite_redirect';
+            data: {
+                redirect_url: string;
+            };
+        };
+    };
+}

--- a/packages/core/src/order/order-request-body.ts
+++ b/packages/core/src/order/order-request-body.ts
@@ -2,6 +2,7 @@ import {
     WithAccountCreation,
     WithBankAccountInstrument,
     WithEcpInstrument,
+    WithPhoneNumberInstrument,
     WithSepaInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
@@ -55,7 +56,8 @@ export type OrderPaymentInstrument =
     | (CreditCardInstrument & WithCheckoutcomSEPAInstrument)
     | (CreditCardInstrument & WithIdealInstrument)
     | (HostedInstrument & WithMollieIssuerInstrument)
-    | WithAccountCreation;
+    | WithAccountCreation
+    | WithPhoneNumberInstrument;
 
 /**
  * An object that contains the payment information required for submitting an

--- a/packages/core/src/payment/payment.ts
+++ b/packages/core/src/payment/payment.ts
@@ -5,6 +5,7 @@ import {
     WithAccountCreation,
     WithBankAccountInstrument,
     WithEcpInstrument,
+    WithPhoneNumberInstrument,
     WithSepaInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
@@ -56,7 +57,8 @@ export type PaymentInstrument =
     | VaultedInstrument
     | (VaultedInstrument & WithHostedFormNonce)
     | WithAccountCreation
-    | WithBankAccountInstrument;
+    | WithBankAccountInstrument
+    | WithPhoneNumberInstrument;
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -162,6 +162,7 @@ export {
     PaymentStrategyResolveId,
     VaultedInstrument,
     WithAccountCreation,
+    WithPhoneNumberInstrument,
     StripeUPEIntent,
     StripeV3FormattedPayload,
     PaypalInstrument,

--- a/packages/payment-integration-api/src/order/order-request-body.ts
+++ b/packages/payment-integration-api/src/order/order-request-body.ts
@@ -13,6 +13,7 @@ import {
     WithEcpInstrument,
     WithIdealInstrument,
     WithMollieIssuerInstrument,
+    WithPhoneNumberInstrument,
     WithSepaInstrument,
 } from '../payment';
 
@@ -71,5 +72,6 @@ export interface OrderPaymentRequestBody {
         | (CreditCardInstrument & WithCheckoutcomSEPAInstrument)
         | (CreditCardInstrument & WithIdealInstrument)
         | (HostedInstrument & WithMollieIssuerInstrument)
-        | WithAccountCreation;
+        | WithAccountCreation
+        | WithPhoneNumberInstrument;
 }

--- a/packages/payment-integration-api/src/payment/index.ts
+++ b/packages/payment-integration-api/src/payment/index.ts
@@ -39,6 +39,7 @@ export {
     FormattedPayload,
     StripeUPEIntent,
     StripeV3FormattedPayload,
+    WithPhoneNumberInstrument,
 } from './payment';
 
 export { default as isCreditCardInstrument } from './is-credit-card-instrument';

--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -49,7 +49,8 @@ export type PaymentInstrumentPayload<T = unknown> =
     | VaultedInstrument
     | (VaultedInstrument & WithHostedFormNonce)
     | WithAccountCreation
-    | WithBankAccountInstrument;
+    | WithBankAccountInstrument
+    | WithPhoneNumberInstrument;
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;
@@ -57,6 +58,10 @@ export interface PaymentInstrumentMeta {
 
 export interface WithAccountCreation {
     shouldCreateAccount?: boolean;
+}
+
+export interface WithPhoneNumberInstrument {
+    phoneNumber: string;
 }
 
 export interface CreditCardInstrument {


### PR DESCRIPTION
## What?

Update Braintree LPMs strategy by adding functionality for Trustly

## Why?

To be able place an order via Braintree Trustly payment method

## Testing / Proof

All tests passed

@bigcommerce/team-checkout @bigcommerce/team-payments
