### PR TITLE
feat(payment): PAYPAL-4698 added onEligibilityFailure callback for Braintree PayPal and PayLater button strategies

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
@@ -52,6 +52,13 @@ export interface BraintreePaypalButtonInitializeOptions {
     onError?(error: BraintreeError | StandardError): void;
 
     /**
+     *
+     *  A callback that gets called when Braintree SDK restricts to render PayPal component.
+     *
+     */
+    onEligibilityFailure?(): void;
+
+    /**
      * The option that used to initialize a PayPal script with provided currency code.
      */
     currencyCode?: string;

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -153,8 +153,8 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         methodId: string,
         testMode: boolean,
     ): void {
-        const { style, shouldProcessPayment, onAuthorizeError } = braintreepaypal;
-
+        const { style, shouldProcessPayment, onAuthorizeError, onEligibilityFailure } =
+            braintreepaypal;
         const { paypal } = this._window;
         const fundingSource = paypal?.FUNDING.PAYPAL;
 
@@ -179,6 +179,8 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
 
             if (paypalButtonRender.isEligible()) {
                 paypalButtonRender.render(`#${containerId}`);
+            } else if (onEligibilityFailure && typeof onEligibilityFailure === 'function') {
+                onEligibilityFailure();
             }
         } else {
             this._removeElement(containerId);

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
@@ -47,6 +47,13 @@ export interface BraintreePaypalCreditButtonInitializeOptions {
     onError?(error: BraintreeError | StandardError): void;
 
     /**
+     *
+     *  A callback that gets called when Braintree SDK restricts to render PayPal component.
+     *
+     */
+    onEligibilityFailure?(): void;
+
+    /**
      * The option that used to initialize a PayPal script with provided currency code.
      */
     currencyCode?: string;

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -134,7 +134,8 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         methodId: string,
         testMode: boolean,
     ): void {
-        const { style, shouldProcessPayment, onAuthorizeError } = braintreepaypalcredit;
+        const { style, shouldProcessPayment, onAuthorizeError, onEligibilityFailure } =
+            braintreepaypalcredit;
         const { paypal } = this._window;
 
         let hasRenderedSmartButton = false;
@@ -173,6 +174,15 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
                     if (paypalButtonRender.isEligible()) {
                         paypalButtonRender.render(`#${containerId}`);
                         hasRenderedSmartButton = true;
+                    } else if (
+                        paypal.FUNDING.CREDIT &&
+                        onEligibilityFailure &&
+                        typeof onEligibilityFailure === 'function'
+                    ) {
+                        // the condition is related to paypal.FUNDING.CREDIT because when paypal.FUNDING.PAYLATER is not eligible then
+                        // CREDIT button should be configured and triggered to render with eligibility check
+                        // and if it is not eligible, then onEligibilityFailure callback should be called
+                        onEligibilityFailure();
                     }
                 }
             });


### PR DESCRIPTION
## What?
Added `onEligibilityFailure` callback for Braintree PayPal and PayLater button strategies

## Why?
To be able to run related code on UI (for example: to remove html block created to contain PayPal button or console log anything and so on)

## Testing / Proof
Manual tests (no errors in console related to current changes)
Unit tests
CI

<img width="1233" alt="Screenshot 2024-10-21 at 12 44 04" src="https://github.com/user-attachments/assets/70bc0788-58c2-42a9-99a5-43beaf2a6d76">
<img width="360" alt="Screenshot 2024-10-21 at 13 20 05" src="https://github.com/user-attachments/assets/41fb0481-6997-4aad-9325-1e9c98fea606">
<img width="622" alt="Screenshot 2024-10-21 at 13 20 16" src="https://github.com/user-attachments/assets/4c919934-2e78-4ba9-b60b-9c39d3908289">
<img width="509" alt="Screenshot 2024-10-21 at 13 20 35" src="https://github.com/user-attachments/assets/521d1748-6129-49c3-8e12-ce82dac432cb">


