### PR TITLE
feat(payment): PAYPAL-4697 added onEligibilityFailure callback to paypal commerce buttons strategies

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-initialize-options.ts
@@ -20,6 +20,13 @@ export default interface PayPalCommerceAlternativeMethodsButtonOptions {
      * A set of styling options for the checkout button.
      */
     style?: PayPalButtonStyleOptions;
+
+    /**
+     *
+     *  A callback that gets called when PayPal SDK restricts to render PayPal component.
+     *
+     */
+    onEligibilityFailure?(): void;
 }
 
 export interface WithPayPalCommerceAlternativeMethodsButtonInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.spec.ts
@@ -70,6 +70,7 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
         style: {
             height: 45,
         },
+        onEligibilityFailure: jest.fn(),
     };
 
     const initializationOptions: CheckoutButtonInitializeOptions = {
@@ -104,14 +105,16 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
             paymentMethod,
         );
 
-        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(
+            Promise.resolve(paypalSdk),
+        );
         jest.spyOn(paypalCommerceIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
             paypalSdk,
         );
         jest.spyOn(paypalCommerceIntegrationService, 'createBuyNowCartOrThrow').mockReturnValue(
-            buyNowCart,
+            Promise.resolve(buyNowCart),
         );
-        jest.spyOn(paypalCommerceIntegrationService, 'createOrder').mockReturnValue(undefined);
+        jest.spyOn(paypalCommerceIntegrationService, 'createOrder');
         jest.spyOn(paypalCommerceIntegrationService, 'tokenizePayment').mockImplementation(
             jest.fn(),
         );
@@ -179,6 +182,7 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
                 return {
                     isEligible: jest.fn(() => true),
                     render: jest.fn(),
+                    close: jest.fn(),
                 };
             },
         );
@@ -372,6 +376,7 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 isEligible: jest.fn(() => true),
                 render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
             }));
 
             await strategy.initialize(initializationOptions);
@@ -379,16 +384,18 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
             expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
         });
 
-        it('does not render PayPal APM button if it is not eligible', async () => {
+        it('calls onEligibilityFailure callback when PayPal APM button is not eligible', async () => {
             const paypalCommerceSdkRenderMock = jest.fn();
 
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 isEligible: jest.fn(() => false),
                 render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
             }));
 
             await strategy.initialize(initializationOptions);
 
+            expect(paypalCommerceAlternativeMethodsOptions.onEligibilityFailure).toHaveBeenCalled();
             expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
         });
 
@@ -398,9 +405,16 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 isEligible: jest.fn(() => false),
                 render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
             }));
 
-            await strategy.initialize(initializationOptions);
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    onEligibilityFailure: undefined,
+                },
+            });
 
             expect(paypalCommerceIntegrationService.removeElement).toHaveBeenCalledWith(
                 defaultButtonContainerId,
@@ -424,8 +438,10 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
 
     describe('#handleClick', () => {
         beforeEach(() => {
-            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(buyNowCart);
-            jest.spyOn(paymentIntegrationService, 'loadCheckout').mockReturnValue(true);
+            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(
+                Promise.resolve(buyNowCart),
+            );
+            jest.spyOn(paymentIntegrationService, 'loadCheckout');
         });
 
         it('creates buy now cart on button click', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.ts
@@ -103,7 +103,8 @@ export default class PayPalCommerceAlternativeMethodsButtonStrategy
         methodId: string,
         paypalcommercealternativemethods: PayPalCommerceAlternativeMethodsButtonOptions,
     ): void {
-        const { apm, buyNowInitializeOptions, style } = paypalcommercealternativemethods;
+        const { apm, buyNowInitializeOptions, style, onEligibilityFailure } =
+            paypalcommercealternativemethods;
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const isAvailableFundingSource = Object.values(paypalSdk.FUNDING).includes(apm);
@@ -139,6 +140,8 @@ export default class PayPalCommerceAlternativeMethodsButtonStrategy
 
         if (paypalButtonRender.isEligible()) {
             paypalButtonRender.render(`#${containerId}`);
+        } else if (onEligibilityFailure && typeof onEligibilityFailure === 'function') {
+            onEligibilityFailure();
         } else {
             this.paypalCommerceIntegrationService.removeElement(containerId);
         }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-initialize-options.ts
@@ -25,6 +25,13 @@ export default interface PayPalCommerceCreditButtonInitializeOptions {
      * A callback that gets called when payment complete on paypal side.
      */
     onComplete?(): void;
+
+    /**
+     *
+     *  A callback that gets called when PayPal SDK restricts to render PayPal component.
+     *
+     */
+    onEligibilityFailure?(): void;
 }
 
 export interface WithPayPalCommerceCreditButtonInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -121,7 +121,8 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         methodId: string,
         paypalcommercecredit: PayPalCommerceCreditButtonInitializeOptions,
     ): void {
-        const { buyNowInitializeOptions, style, onComplete } = paypalcommercecredit;
+        const { buyNowInitializeOptions, style, onComplete, onEligibilityFailure } =
+            paypalcommercecredit;
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
@@ -182,6 +183,8 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
                 if (paypalButton.isEligible()) {
                     paypalButton.render(`#${containerId}`);
                     hasRenderedSmartButton = true;
+                } else if (onEligibilityFailure && typeof onEligibilityFailure === 'function') {
+                    onEligibilityFailure();
                 }
             }
         });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-initialize-options.ts
@@ -15,6 +15,13 @@ export default interface PayPalCommerceVenmoButtonInitializeOptions {
      * The options that required to initialize Buy Now functionality.
      */
     buyNowInitializeOptions?: PayPalBuyNowInitializeOptions;
+
+    /**
+     *
+     *  A callback that gets called when PayPal SDK restricts to render PayPal component.
+     *
+     */
+    onEligibilityFailure?(): void;
 }
 
 export interface WithPayPalCommerceVenmoButtonInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
@@ -67,6 +67,7 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
         style: {
             height: 45,
         },
+        onEligibilityFailure: jest.fn(),
     };
 
     const initializationOptions: CheckoutButtonInitializeOptions = {
@@ -100,14 +101,16 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
             paymentMethod,
         );
 
-        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(
+            Promise.resolve(paypalSdk),
+        );
         jest.spyOn(paypalCommerceIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
             paypalSdk,
         );
         jest.spyOn(paypalCommerceIntegrationService, 'createBuyNowCartOrThrow').mockReturnValue(
-            buyNowCart,
+            Promise.resolve(buyNowCart),
         );
-        jest.spyOn(paypalCommerceIntegrationService, 'createOrder').mockReturnValue(undefined);
+        jest.spyOn(paypalCommerceIntegrationService, 'createOrder');
         jest.spyOn(paypalCommerceIntegrationService, 'tokenizePayment').mockImplementation(
             jest.fn(),
         );
@@ -175,6 +178,7 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
                 return {
                     isEligible: jest.fn(() => true),
                     render: jest.fn(),
+                    close: jest.fn(),
                 };
             },
         );
@@ -357,6 +361,7 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 isEligible: jest.fn(() => true),
                 render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
             }));
 
             await strategy.initialize(initializationOptions);
@@ -364,16 +369,18 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
             expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
         });
 
-        it('does not render PayPal Venmo button if it is not eligible', async () => {
+        it('calls onEligibilityFailure when PayPal Venmo button if it is not eligible', async () => {
             const paypalCommerceSdkRenderMock = jest.fn();
 
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 isEligible: jest.fn(() => false),
                 render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
             }));
 
             await strategy.initialize(initializationOptions);
 
+            expect(paypalCommerceVenmoOptions.onEligibilityFailure).toHaveBeenCalled();
             expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
         });
 
@@ -383,9 +390,16 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 isEligible: jest.fn(() => false),
                 render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
             }));
 
-            await strategy.initialize(initializationOptions);
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercevenmo: {
+                    ...paypalCommerceVenmoOptions,
+                    onEligibilityFailure: undefined,
+                },
+            });
 
             expect(paypalCommerceIntegrationService.removeElement).toHaveBeenCalledWith(
                 defaultButtonContainerId,
@@ -409,8 +423,10 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
 
     describe('#handleClick', () => {
         beforeEach(() => {
-            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(buyNowCart);
-            jest.spyOn(paymentIntegrationService, 'loadCheckout').mockReturnValue(true);
+            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(
+                Promise.resolve(buyNowCart),
+            );
+            jest.spyOn(paymentIntegrationService, 'loadCheckout');
         });
 
         it('creates buy now cart on button click', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
@@ -93,7 +93,7 @@ export default class PayPalCommerceVenmoButtonStrategy implements CheckoutButton
         methodId: string,
         paypalcommercevenmo: PayPalCommerceVenmoButtonInitializeOptions,
     ): void {
-        const { buyNowInitializeOptions, style } = paypalcommercevenmo;
+        const { buyNowInitializeOptions, style, onEligibilityFailure } = paypalcommercevenmo;
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const fundingSource = paypalSdk.FUNDING.VENMO;
@@ -121,6 +121,8 @@ export default class PayPalCommerceVenmoButtonStrategy implements CheckoutButton
 
         if (paypalButtonRender.isEligible()) {
             paypalButtonRender.render(`#${containerId}`);
+        } else if (onEligibilityFailure && typeof onEligibilityFailure === 'function') {
+            onEligibilityFailure();
         } else {
             this.paypalCommerceIntegrationService.removeElement(containerId);
         }

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-initialize-options.ts
@@ -26,6 +26,13 @@ export default interface PayPalCommerceButtonInitializeOptions {
      * A callback that gets called when payment complete on paypal side.
      */
     onComplete?(): void;
+
+    /**
+     *
+     *  A callback that gets called when PayPal SDK restricts to render PayPal component.
+     *
+     */
+    onEligibilityFailure?(): void;
 }
 
 export interface WithPayPalCommerceButtonInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -60,6 +60,7 @@ describe('PayPalCommerceButtonStrategy', () => {
             height: 45,
         },
         onComplete: jest.fn(),
+        onEligibilityFailure: jest.fn(),
     };
 
     const buyNowInitializationOptions: CheckoutButtonInitializeOptions = {
@@ -73,6 +74,7 @@ describe('PayPalCommerceButtonStrategy', () => {
             height: 45,
         },
         onComplete: jest.fn(),
+        onEligibilityFailure: jest.fn(),
     };
 
     const initializationOptions: CheckoutButtonInitializeOptions = {
@@ -137,12 +139,14 @@ describe('PayPalCommerceButtonStrategy', () => {
         );
         jest.spyOn(paymentIntegrationService, 'selectShippingOption').mockImplementation(jest.fn());
 
-        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(
+            Promise.resolve(paypalSdk),
+        );
         jest.spyOn(paypalCommerceIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
             paypalSdk,
         );
         jest.spyOn(paypalCommerceIntegrationService, 'createBuyNowCartOrThrow').mockReturnValue(
-            buyNowCart,
+            Promise.resolve(buyNowCart),
         );
         jest.spyOn(paypalCommerceIntegrationService, 'createOrder').mockImplementation(jest.fn());
         jest.spyOn(paypalCommerceIntegrationService, 'updateOrder').mockImplementation(jest.fn());
@@ -165,6 +169,7 @@ describe('PayPalCommerceButtonStrategy', () => {
         jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
             checkoutSettings: {
                 features: {
+                    // TODO: remove this experiment
                     'PAYPAL-4387.paypal_shipping_callbacks': true,
                 },
             },
@@ -260,6 +265,7 @@ describe('PayPalCommerceButtonStrategy', () => {
                 return {
                     isEligible: jest.fn(() => true),
                     render: jest.fn(),
+                    close: jest.fn(),
                 };
             },
         );
@@ -475,6 +481,7 @@ describe('PayPalCommerceButtonStrategy', () => {
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 isEligible: jest.fn(() => true),
                 render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
             }));
 
             await strategy.initialize(initializationOptions);
@@ -488,6 +495,7 @@ describe('PayPalCommerceButtonStrategy', () => {
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 isEligible: jest.fn(() => false),
                 render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
             }));
 
             await strategy.initialize(initializationOptions);
@@ -495,15 +503,36 @@ describe('PayPalCommerceButtonStrategy', () => {
             expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
         });
 
-        it('removes PayPal button container if the button is not eligible', async () => {
+        it('calls onEligibilityFailure callback when the PayPal button is not eligible', async () => {
             const paypalCommerceSdkRenderMock = jest.fn();
 
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 isEligible: jest.fn(() => false),
                 render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
             }));
 
             await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceOptions.onEligibilityFailure).toHaveBeenCalled();
+        });
+
+        it('removes PayPal button container if the button is not eligible and onEligibilityFailure callback is not provided', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+                close: jest.fn(),
+            }));
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommerce: {
+                    ...paypalCommerceOptions,
+                    onEligibilityFailure: undefined,
+                },
+            });
 
             expect(paypalCommerceIntegrationService.removeElement).toHaveBeenCalledWith(
                 defaultButtonContainerId,
@@ -527,8 +556,10 @@ describe('PayPalCommerceButtonStrategy', () => {
 
     describe('#handleClick', () => {
         beforeEach(() => {
-            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(buyNowCart);
-            jest.spyOn(paymentIntegrationService, 'loadCheckout').mockReturnValue(true);
+            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(
+                Promise.resolve(buyNowCart),
+            );
+            jest.spyOn(paymentIntegrationService, 'loadCheckout');
         });
 
         it('creates buy now cart on button click', async () => {
@@ -576,7 +607,7 @@ describe('PayPalCommerceButtonStrategy', () => {
                                     { orderID: paypalOrderId },
                                     {
                                         order: {
-                                            get: jest.fn(() => paypalOrderDetails),
+                                            get: () => Promise.resolve(paypalOrderDetails),
                                         },
                                     },
                                 );
@@ -586,6 +617,7 @@ describe('PayPalCommerceButtonStrategy', () => {
                         return {
                             render: jest.fn(),
                             isEligible: jest.fn(() => true),
+                            close: jest.fn(),
                         };
                     },
                 );
@@ -605,7 +637,7 @@ describe('PayPalCommerceButtonStrategy', () => {
             });
 
             it('takes order details data from paypal', async () => {
-                const getOrderActionMock = jest.fn(() => paypalOrderDetails);
+                const getOrderActionMock = jest.fn();
 
                 jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
                     (options: PayPalCommerceButtonsOptions) => {
@@ -625,6 +657,7 @@ describe('PayPalCommerceButtonStrategy', () => {
                         return {
                             render: jest.fn(),
                             isEligible: jest.fn(() => true),
+                            close: jest.fn(),
                         };
                     },
                 );
@@ -636,7 +669,6 @@ describe('PayPalCommerceButtonStrategy', () => {
                 await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(getOrderActionMock).toHaveBeenCalled();
-                expect(getOrderActionMock).toHaveReturnedWith(paypalOrderDetails);
             });
 
             it('updates billing address with valid customers data', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -96,7 +96,7 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
         methodId: string,
         paypalcommerce: PayPalCommerceButtonInitializeOptions,
     ): void {
-        const { buyNowInitializeOptions, style, onComplete } = paypalcommerce;
+        const { buyNowInitializeOptions, style, onComplete, onEligibilityFailure } = paypalcommerce;
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
@@ -150,6 +150,8 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
 
         if (paypalButton.isEligible()) {
             paypalButton.render(`#${containerId}`);
+        } else if (onEligibilityFailure && typeof onEligibilityFailure === 'function') {
+            onEligibilityFailure();
         } else {
             this.paypalCommerceIntegrationService.removeElement(containerId);
         }


### PR DESCRIPTION
## What?
Added `onEligibilityFailure` callback to paypal commerce buttons strategies

## Why?
To be able to run related code on UI (for example: to remove html block created to contain PayPal button or console log anything and so on)

## Testing / Proof
Manual tests (no errors in console related to current changes)
Unit tests
CI

<img width="1233" alt="Screenshot 2024-10-21 at 12 44 04" src="https://github.com/user-attachments/assets/70bc0788-58c2-42a9-99a5-43beaf2a6d76">
<img width="360" alt="Screenshot 2024-10-21 at 13 20 05" src="https://github.com/user-attachments/assets/41fb0481-6997-4aad-9325-1e9c98fea606">
<img width="622" alt="Screenshot 2024-10-21 at 13 20 16" src="https://github.com/user-attachments/assets/4c919934-2e78-4ba9-b60b-9c39d3908289">
<img width="509" alt="Screenshot 2024-10-21 at 13 20 35" src="https://github.com/user-attachments/assets/521d1748-6129-49c3-8e12-ce82dac432cb">