### PR TITLE
Revert "fix(payment): PAYPAL-4610 Avoiding redundant order creation requests (#2632)"

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -479,23 +479,6 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
             });
             expect(paypalCommerceFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(true);
         });
-
-        it('do not create an order if there is an error  while receiving a payment order', async () => {
-            await strategy.initialize(initializationOptions);
-
-            const paypalFastlaneComponent = await paypalFastlane.FastlaneCardComponent({});
-
-            jest.spyOn(paypalFastlaneComponent, 'getPaymentToken').mockRejectedValue(
-                new Error('input data error'),
-            );
-
-            try {
-                await strategy.execute(executeOptions);
-            } catch (error) {
-                expect(error).toBeInstanceOf(Error);
-                expect(paypalCommerceRequestSender.createOrder).not.toHaveBeenCalled();
-            }
-        });
     });
 
     describe('#onInit option callback', () => {


### PR DESCRIPTION
This reverts commit 1336b4c4ad89c666a4171d82c8c72b9607ec735d.

## What?
Revert https://github.com/bigcommerce/checkout-sdk-js/pull/2632 PR

## Why?
Because it brakes PayPal Commerce Fastlane flow for fastlane users with vaulted instruments

## Testing / Proof
Manual tests
