### PR TITLE
fix(checkout): CHECKOUT-8653 Move tslib back to production dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "reselect": "^4.1.8",
         "rxjs": "^6.6.7",
         "shallowequal": "^1.1.0",
+        "tslib": "^2.4.0",
         "yup": "^1.2.0"
       },
       "devDependencies": {
@@ -74,7 +75,6 @@
         "standard-version": "^9.5.0",
         "ts-jest": "^26.5.6",
         "ts-loader": "^9.2.9",
-        "tslib": "^2.4.0",
         "typedoc": "^0.22.0",
         "typedoc-plugin-markdown": "^3.11.0",
         "typescript": "^4.7.2",
@@ -24475,8 +24475,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -44487,8 +44486,7 @@
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tslint": {
       "version": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "reselect": "^4.1.8",
     "rxjs": "^6.6.7",
     "shallowequal": "^1.1.0",
+    "tslib": "^2.4.0",
     "yup": "^1.2.0"
   },
   "devDependencies": {
@@ -117,7 +118,6 @@
     "standard-version": "^9.5.0",
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.2.9",
-    "tslib": "^2.4.0",
     "typedoc": "^0.22.0",
     "typedoc-plugin-markdown": "^3.11.0",
     "typescript": "^4.7.2",


### PR DESCRIPTION
## What?
Move `tslib` back to production dep

## Why?
FIx `checout-js` test issue.
```
TypeError: (0 , u.__spreadArray) is not a function
```

## Testing / Proof
CI.

@bigcommerce/team-checkout @bigcommerce/team-payments
