### PR TITLE
Revert "fix(checkout): CHECKOUT-8653 Move tslib back to production dep"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "reselect": "^4.1.8",
         "rxjs": "^6.6.7",
         "shallowequal": "^1.1.0",
-        "tslib": "^2.4.0",
         "yup": "^1.2.0"
       },
       "devDependencies": {
@@ -75,6 +74,7 @@
         "standard-version": "^9.5.0",
         "ts-jest": "^26.5.6",
         "ts-loader": "^9.2.9",
+        "tslib": "^2.4.0",
         "typedoc": "^0.22.0",
         "typedoc-plugin-markdown": "^3.11.0",
         "typescript": "^4.7.2",
@@ -24475,7 +24475,8 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -44486,7 +44487,8 @@
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "tslint": {
       "version": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "reselect": "^4.1.8",
     "rxjs": "^6.6.7",
     "shallowequal": "^1.1.0",
-    "tslib": "^2.4.0",
     "yup": "^1.2.0"
   },
   "devDependencies": {
@@ -118,6 +117,7 @@
     "standard-version": "^9.5.0",
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.2.9",
+    "tslib": "^2.4.0",
     "typedoc": "^0.22.0",
     "typedoc-plugin-markdown": "^3.11.0",
     "typescript": "^4.7.2",


### PR DESCRIPTION
Reverts bigcommerce/checkout-sdk-js#2664

Due to ` TypeError: (0 , u.__spreadArray) is not a function` issue in `checkout-js`.