### PR TITLE
feat(payment): PAYPAL-4681 Cannot read properties of undefined (reading 'provider__error")

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -480,9 +480,9 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
 
     private isProviderError(error: unknown): boolean {
         if (isBraintreePaypalProviderError(error)) {
-            const paypalProviderError = error?.errors?.filter((e: any) => e.provider_error) || [];
+            const paypalProviderError = error?.errors?.filter((e) => e.provider_error) || [];
 
-            return paypalProviderError[0].provider_error?.code === '2046';
+            return paypalProviderError[0]?.provider_error?.code === '2046';
         }
 
         return false;

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -361,9 +361,9 @@ export default class PayPalCommercePaymentStrategy implements PaymentStrategy {
 
     private isProviderError(error: unknown): boolean {
         if (isPaypalCommerceProviderError(error)) {
-            const paypalProviderError = error?.errors?.filter((e: any) => e.provider_error) || [];
+            const paypalProviderError = error?.errors?.filter((e) => e.provider_error) || [];
 
-            return paypalProviderError[0].provider_error?.code === 'INSTRUMENT_DECLINED';
+            return paypalProviderError[0]?.provider_error?.code === 'INSTRUMENT_DECLINED';
         }
 
         return false;


### PR DESCRIPTION
## What?

Updated error checking

## Why?

We are getting an error message `Cannot read properties of undefined (reading 'privider_error')` because of a possible empty array. To avoid it we need to add an additional check.

<img width="935" alt="Screenshot 2024-09-30 at 14 47 26" src="https://github.com/user-attachments/assets/83349fe3-0c65-4352-b3f3-94061e668f6c">

## Testing / Proof

Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
