### PR TITLE
fix(payment): PAYPAL-4704 fixed duplicate credit card payment

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
@@ -278,10 +278,15 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
 
     private async _initializeBraintreeSdk(): Promise<void> {
         // TODO: This is a temporary solution when we load braintree to get client token (should be fixed after PAYPAL-4122)
-        await this._paymentIntegrationService.loadPaymentMethod(ApplePayGatewayType.BRAINTREE);
-
         const state = this._paymentIntegrationService.getState();
-        const braintreePaymentMethod = state.getPaymentMethod(ApplePayGatewayType.BRAINTREE);
+        let braintreePaymentMethod =
+            state.getPaymentMethod(ApplePayGatewayType.BRAINTREE_FASTLANE) ||
+            state.getPaymentMethod(ApplePayGatewayType.BRAINTREE);
+
+        if (!braintreePaymentMethod) {
+            await this._paymentIntegrationService.loadPaymentMethod(ApplePayGatewayType.BRAINTREE);
+            braintreePaymentMethod = state.getPaymentMethod(ApplePayGatewayType.BRAINTREE);
+        }
 
         if (
             !braintreePaymentMethod ||

--- a/packages/apple-pay-integration/src/apple-pay.ts
+++ b/packages/apple-pay-integration/src/apple-pay.ts
@@ -1,3 +1,4 @@
 export enum ApplePayGatewayType {
     BRAINTREE = 'braintree',
+    BRAINTREE_FASTLANE = 'braintreeacceleratedcheckout',
 }


### PR DESCRIPTION
## What?
Fixed BT credit card duplicate when fastlane turned on

## Why?
To fix issue

## Testing / Proof

Without Fastlane

https://github.com/user-attachments/assets/adc8121c-4680-4b6d-b237-03f984f32118

With Fastlane



https://github.com/user-attachments/assets/122c5a85-48eb-4371-99b7-bd05f6c9fa94


@bigcommerce/team-checkout @bigcommerce/team-payments
