### PR TITLE
CHECKOUT-8519: Switch messageformat library to be compatible with strict-dynamic CSP header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "core-js": "^3.31.0",
         "current-script-polyfill": "^1.0.0",
         "iframe-resizer": "^3.6.6",
+        "intl-messageformat": "^10.5.14",
         "local-storage-fallback": "^4.1.2",
         "lodash": "^4.17.15",
         "messageformat": "^2.3.0",
@@ -2070,6 +2071,75 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
+      "integrity": "sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.5.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
+      "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.8.tgz",
+      "integrity": "sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "@formatjs/icu-skeleton-parser": "1.8.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.2.tgz",
+      "integrity": "sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -14549,6 +14619,22 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.14.tgz",
+      "integrity": "sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "@formatjs/fast-memoize": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.7.8",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/intl-messageformat/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -27340,6 +27426,85 @@
         }
       }
     },
+    "@formatjs/ecma402-abstract": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
+      "integrity": "sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==",
+      "requires": {
+        "@formatjs/intl-localematcher": "0.5.4",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        }
+      }
+    },
+    "@formatjs/fast-memoize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
+      "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        }
+      }
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.8.tgz",
+      "integrity": "sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "@formatjs/icu-skeleton-parser": "1.8.2",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        }
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.2.tgz",
+      "integrity": "sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        }
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -36897,6 +37062,24 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "intl-messageformat": {
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.14.tgz",
+      "integrity": "sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "@formatjs/fast-memoize": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.7.8",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        }
       }
     },
     "invariant": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "core-js": "^3.31.0",
     "current-script-polyfill": "^1.0.0",
     "iframe-resizer": "^3.6.6",
+    "intl-messageformat": "^10.5.14",
     "local-storage-fallback": "^4.1.2",
     "lodash": "^4.17.15",
     "messageformat": "^2.3.0",

--- a/packages/core/src/locale/language-config.ts
+++ b/packages/core/src/locale/language-config.ts
@@ -6,10 +6,28 @@ export default interface LanguageConfig {
     locale: string;
     locales: Locales;
     translations: Translations;
+    /**
+     * @hidden This property is intended for toggling an experimental change only.
+     */
+    isCspNonceExperimentEnabled?: boolean;
+}
+
+export interface TransformedLanguageConfig {
+    defaultTranslations: Translations;
+    defaultLocale?: string;
+    fallbackTranslations?: Translations;
+    fallbackLocale?: string;
+    locale: string;
+    locales: Locales;
+    translations: TransformedTranslations;
 }
 
 export interface Translations {
     [key: string]: string | Translations;
+}
+
+export interface TransformedTranslations {
+    [key: string]: string;
 }
 
 export interface Locales {

--- a/packages/core/src/locale/language-service.spec.ts
+++ b/packages/core/src/locale/language-service.spec.ts
@@ -25,6 +25,7 @@ describe('LanguageService', () => {
                 'optimized_checkout.test.continue_as_guest_action': 'Continue as guest',
                 'optimized_checkout.test.email_label': 'Email Address',
                 'optimized_checkout.test.order_number_text': 'Your order number is {orderNumber}',
+                'optimized_checkout.test.thank_you_text': '<strong>Thank you<strong>',
             },
         };
 
@@ -51,6 +52,10 @@ describe('LanguageService', () => {
             );
         });
 
+        it('returns translated HTML strings', () => {
+            expect(langService.translate('test.thank_you_text')).toBe('<strong>Thank you<strong>');
+        });
+
         it('pluralizes strings using ICU format', () => {
             expect(langService.translate('test.item_count_text', { count: 0 })).toBe('0 Items');
             expect(langService.translate('test.item_count_text', { count: 1 })).toBe('1 Item');
@@ -70,7 +75,7 @@ describe('LanguageService', () => {
 
             expect(langService.translate('test.days_text', { count: 1 })).toBe('1 den');
             expect(langService.translate('test.days_text', { count: 2 })).toBe('2 dny');
-            expect(langService.translate('test.days_text', { count: 1.5 })).toBe('1.5 dne');
+            expect(langService.translate('test.days_text', { count: 1.5 })).toBe('1,5 dne');
             expect(langService.translate('test.days_text', { count: 100 })).toBe('100 dní');
         });
 

--- a/packages/core/src/locale/language-service.ts
+++ b/packages/core/src/locale/language-service.ts
@@ -1,3 +1,4 @@
+import { IntlMessageFormat } from 'intl-messageformat';
 import { isObject, union } from 'lodash';
 import MessageFormat from 'messageformat';
 
@@ -5,7 +6,12 @@ import { bindDecorator as bind } from '@bigcommerce/checkout-sdk/utility';
 
 import { Logger } from '../common/log';
 
-import LanguageConfig, { Locales, Translations } from './language-config';
+import LanguageConfig, {
+    Locales,
+    TransformedLanguageConfig,
+    TransformedTranslations,
+    Translations,
+} from './language-config';
 
 const DEFAULT_LOCALE = 'en';
 const KEY_PREFIX = 'optimized_checkout';
@@ -23,8 +29,9 @@ const KEY_PREFIX = 'optimized_checkout';
 export default class LanguageService {
     private _locale: string;
     private _locales: Locales;
-    private _translations: Translations;
+    private _translations: TransformedTranslations;
     private _formatters: { [key: string]: any };
+    private _isCspNonceExperimentEnabled: boolean;
 
     /**
      * @internal
@@ -36,6 +43,7 @@ export default class LanguageService {
         this._locales = locales;
         this._translations = translations;
         this._formatters = {};
+        this._isCspNonceExperimentEnabled = config.isCspNonceExperimentEnabled ?? true;
     }
 
     /**
@@ -95,6 +103,19 @@ export default class LanguageService {
             return prefixedKey;
         }
 
+        if (this._isCspNonceExperimentEnabled) {
+            if (!this._formatters[prefixedKey]) {
+                this._formatters[prefixedKey] = new IntlMessageFormat(
+                    this._translations[prefixedKey] || '',
+                    this._locales[prefixedKey],
+                    undefined,
+                    { ignoreTag: true },
+                );
+            }
+
+            return this._formatters[prefixedKey].format(this._transformData(data));
+        }
+
         if (!this._formatters[prefixedKey]) {
             const messageFormat = new MessageFormat(this._locales[prefixedKey]);
 
@@ -106,8 +127,8 @@ export default class LanguageService {
         return this._formatters[prefixedKey](this._transformData(data));
     }
 
-    private _transformConfig(config: Partial<LanguageConfig> = {}): LanguageConfig {
-        const output: LanguageConfig = {
+    private _transformConfig(config: Partial<LanguageConfig> = {}): TransformedLanguageConfig {
+        const output: TransformedLanguageConfig = {
             defaultLocale: '',
             defaultTranslations: {},
             translations: {},
@@ -143,9 +164,9 @@ export default class LanguageService {
 
     private _flattenObject(
         object: Translations,
-        result: Translations = {},
+        result: TransformedTranslations = {},
         parentKey = '',
-    ): Translations {
+    ): TransformedTranslations {
         try {
             Object.keys(object).forEach((key) => {
                 const value = object[key];


### PR DESCRIPTION
## What/Why?
Switch to using `intl-messageformat` instead of `messageformat` for translations, as the latter is incompatible with the CSP `script-src 'nonce-xxx' 'strict-dynamic'`  header used in checkout.

When translating messages at runtime, `messageformat` relies on `new Function` (similar to `eval`), which violates the `strict-dynamic` rule because it disallows any unsafe `eval` expressions (https://github.com/messageformat/messageformat/issues/180). In contrast, `intl-messageformat` does not use any unsafe `eval` expressions.

`intl-messageformat` can serve as a drop-in replacement for `messageformat`, as both libraries adhere to the [ICU MessageFormat](https://unicode-org.github.io/icu/userguide/format_parse/messages/) standards.

## Testing / Proof
### Before
https://github.com/user-attachments/assets/1cd8f7c1-2df6-4f27-be88-1398476f552a

### After
https://github.com/user-attachments/assets/85d5949b-ab88-43f0-b51d-9eb355d319dd


