### PR TITLE
refactor(payment): PI-2678 fixed Typescript errors in apple-pay-integration package

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
@@ -20,6 +20,7 @@ import {
     getCart,
     getCheckout,
     getConsignment,
+    getResponse,
     getShippingOption,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
@@ -54,9 +55,9 @@ describe('ApplePayCustomerStrategy', () => {
         paymentIntegrationService = new PaymentIntegrationServiceMock();
         braintreeSdk = new BraintreeSdk(new BraintreeScriptLoader(getScriptLoader(), window));
 
-        jest.spyOn(requestSender, 'post').mockReturnValue(true);
+        jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve(getResponse({})));
 
-        jest.spyOn(requestSender, 'get').mockReturnValue(true);
+        jest.spyOn(requestSender, 'get').mockReturnValue(Promise.resolve(getResponse({})));
 
         jest.spyOn(applePayFactory, 'create').mockReturnValue(applePaySession);
 
@@ -390,7 +391,7 @@ describe('ApplePayCustomerStrategy', () => {
         });
 
         it('gets shipping options sorted correctly with recommended option first', async () => {
-            jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockResolvedValue(true);
+            jest.spyOn(paymentIntegrationService, 'updateShippingAddress');
 
             const CheckoutButtonInitializeOptions = getApplePayCustomerInitializationOptions();
             const newCheckout = {
@@ -461,7 +462,9 @@ describe('ApplePayCustomerStrategy', () => {
         });
 
         it('throws error if call to update address fails', async () => {
-            jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockRejectedValue(false);
+            jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockReturnValue(
+                Promise.reject(paymentIntegrationService.getState()),
+            );
 
             const customerInitializeOptions = getApplePayCustomerInitializationOptions();
 
@@ -550,7 +553,9 @@ describe('ApplePayCustomerStrategy', () => {
         });
 
         it('submits payment when shopper authorises', async () => {
-            jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockResolvedValue(true);
+            jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockReturnValue(
+                Promise.resolve(paymentIntegrationService.getState()),
+            );
 
             const authEvent = {
                 payment: {
@@ -587,7 +592,9 @@ describe('ApplePayCustomerStrategy', () => {
         });
 
         it('returns an error if autorize payment fails', async () => {
-            jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockResolvedValue(true);
+            jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockReturnValue(
+                Promise.resolve(paymentIntegrationService.getState()),
+            );
             jest.spyOn(paymentIntegrationService, 'submitPayment').mockRejectedValue(false);
 
             const authEvent = {
@@ -664,7 +671,7 @@ describe('ApplePayCustomerStrategy', () => {
                             transactionIdentifier: {},
                         },
                     },
-                };
+                } as ApplePayJS.ApplePayPaymentAuthorizedEvent;
 
                 await strategy.initialize(initializeOptions);
                 await new Promise((resolve) => process.nextTick(resolve));
@@ -699,7 +706,7 @@ describe('ApplePayCustomerStrategy', () => {
                             transactionIdentifier: {},
                         },
                     },
-                };
+                } as ApplePayJS.ApplePayPaymentAuthorizedEvent;
 
                 await strategy.initialize(initializeOptions);
                 await new Promise((resolve) => process.nextTick(resolve));
@@ -827,7 +834,7 @@ describe('ApplePayCustomerStrategy', () => {
         });
 
         it('submits payment when shopper authorises without phone number', async () => {
-            jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockResolvedValue(true);
+            jest.spyOn(paymentIntegrationService, 'updateShippingAddress');
 
             const authEvent = {
                 payment: {

--- a/packages/apple-pay-integration/src/apple-pay-payment-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-payment-strategy.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getOrderRequestBody,
+    getResponse,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
@@ -51,7 +52,7 @@ describe('ApplePayPaymentStrategy', () => {
         applePayFactory = new ApplePaySessionFactory();
         paymentMethod = getApplePay();
 
-        jest.spyOn(requestSender, 'post').mockReturnValue(true);
+        jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve(getResponse({})));
 
         jest.spyOn(applePayFactory, 'create').mockReturnValue(applePaySession);
 
@@ -65,7 +66,7 @@ describe('ApplePayPaymentStrategy', () => {
 
     describe('#initialize()', () => {
         beforeEach(() => {
-            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockReturnValue(
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValue(
                 paymentIntegrationService.getState(),
             );
 
@@ -112,7 +113,7 @@ describe('ApplePayPaymentStrategy', () => {
 
     describe('#execute()', () => {
         beforeEach(() => {
-            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockReturnValue(
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValue(
                 paymentIntegrationService.getState(),
             );
 
@@ -239,7 +240,7 @@ describe('ApplePayPaymentStrategy', () => {
                         transactionIdentifier: {},
                     },
                 },
-            };
+            } as ApplePayJS.ApplePayPaymentAuthorizedEvent;
 
             await strategy.initialize({ methodId: 'applepay' });
             await new Promise((resolve) => process.nextTick(resolve));
@@ -292,7 +293,7 @@ describe('ApplePayPaymentStrategy', () => {
                         transactionIdentifier: {},
                     },
                 },
-            };
+            } as ApplePayJS.ApplePayPaymentAuthorizedEvent;
 
             await strategy.initialize({ methodId: 'applepay' });
             await new Promise((resolve) => process.nextTick(resolve));

--- a/packages/apple-pay-integration/src/mocks/apple-pay-payment.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-payment.mock.ts
@@ -2,6 +2,10 @@ export class MockApplePaySession {
     static supportsVersion: () => boolean;
     static canMakePayments: () => boolean;
 
+    addEventListener = jest.fn();
+    dispatchEvent = jest.fn();
+    removeEventListener = jest.fn();
+
     completePayment = jest.fn();
 
     begin = jest.fn();

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "typeRoots": ["node_modules/@types"],
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "experimentalDecorators": true,


### PR DESCRIPTION
## What?
Fixed Typescript errors in apple-pay-integration package

## Why?
Due to Typescript and Jest last updates

## Testing / Proof
<img width="771" alt="Screenshot 2024-10-03 at 12 40 56" src="https://github.com/user-attachments/assets/f9759aa1-6201-43a6-b947-c9c266f44c73">
