### PR TITLE
feat(payment): PAYPAL-4700 Google Pay defaulting to pickup in store option when checkout setting exclude it

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -288,12 +288,20 @@ export default class GooglePayGateway {
             this._getGooglePayShippingOption.bind(this),
         );
 
+        const recommendedShippingOption = consignment.availableShippingOptions?.find(
+            (shippingOption) => shippingOption.isRecommended,
+        );
+
         if (availableShippingOptions.length) {
             const selectedShippingOptionId =
-                consignment.selectedShippingOption?.id || availableShippingOptions[0]?.id;
+                consignment.selectedShippingOption?.id ||
+                recommendedShippingOption?.id ||
+                availableShippingOptions[0]?.id;
 
             if (!consignment.selectedShippingOption?.id && availableShippingOptions[0]) {
-                await this.handleShippingOptionChange(availableShippingOptions[0].id);
+                await this.handleShippingOptionChange(
+                    recommendedShippingOption?.id || availableShippingOptions[0].id,
+                );
             }
 
             return {


### PR DESCRIPTION
## What?

Add opportunity to select recommended option by default if existed

## Why?

To avoid situation with non-right selected option by default, when default shipping option exclude pick up

## Testing / Proof

https://github.com/user-attachments/assets/9655ed03-d2c6-4a8f-81f8-7cdb807dba88


@bigcommerce/team-checkout @bigcommerce/team-payments
