### PR TITLE
feat(checkout): CHECKOUT-8606 Make Payment Note Required

### DIFF
--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.spec.ts
@@ -87,7 +87,25 @@ describe('HostedInputValidator', () => {
         });
     });
 
-    it('returns error if payment note is too long', async () => {
+    it('returns error if payment note is missing or too long', async () => {
+        expect(
+            await validator.validate({
+                ...validData,
+                note: '',
+            }),
+        ).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                note: [
+                    {
+                        fieldType: 'note',
+                        type: 'required',
+                        message: 'Manual payment description is required',
+                    },
+                ],
+            },
+        });
         expect(
             await validator.validate({
                 ...validData,

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.ts
@@ -131,7 +131,9 @@ export default class HostedInputValidator {
     }
 
     private _getNoteSchema(): StringSchema {
-        return string().max(128, 'Payment description cannot exceed 128 letters');
+        return string()
+            .required('Manual payment description is required')
+            .max(128, 'Payment description cannot exceed 128 letters');
     }
 
     private _getCardNumberSchema(): StringSchema {


### PR DESCRIPTION
## What?
Make hosted payment note field a required field for a payment.

## Why?
Product requirement.

## Testing / Proof

https://github.com/user-attachments/assets/26095fee-2d27-4b54-9d54-9d1ed027bf67



@bigcommerce/team-checkout @bigcommerce/team-payments
