### PR TITLE
feat(payment): PAYPAL-4737 Apple Pay button style does not apply to storefront

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-initialize-options.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-initialize-options.ts
@@ -20,11 +20,6 @@ export default interface ApplePayButtonInitializeOptions {
     };
 
     /**
-     * The class name of the ApplePay button style.
-     */
-    buttonClassName?: string;
-
-    /**
      * A callback that gets called when a payment is successfully completed.
      */
     onPaymentAuthorize(): void;

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
@@ -1,6 +1,5 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
-import { merge } from 'lodash';
 
 import {
     BraintreeScriptLoader,
@@ -103,10 +102,6 @@ describe('ApplePayButtonStrategy', () => {
             expect(paymentIntegrationService.verifyCheckoutSpamProtection).toHaveBeenCalled();
 
             expect(children).toHaveLength(1);
-
-            expect(Boolean(container.getElementsByClassName('apple-pay-checkout-button')[0])).toBe(
-                true,
-            );
         });
 
         it('doesnt call verifyCheckoutSpamProtection if cart undefined', async () => {
@@ -118,18 +113,6 @@ describe('ApplePayButtonStrategy', () => {
             await strategy.initialize(checkoutButtonInitializeOptions);
 
             expect(paymentIntegrationService.verifyCheckoutSpamProtection).toHaveBeenCalledTimes(0);
-        });
-
-        it('creates the button with a custom style class name', async () => {
-            const customClass = 'testClassName';
-            const CheckoutButtonInitializeOptions = merge(
-                getApplePayButtonInitializationOptions(),
-                { applepay: { buttonClassName: customClass } },
-            );
-
-            await strategy.initialize(CheckoutButtonInitializeOptions);
-
-            expect(Boolean(container.getElementsByClassName(customClass)[0])).toBe(true);
         });
 
         it('throws error when payment data is empty', async () => {

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
@@ -26,7 +26,7 @@ import {
 
 import ApplePayButtonInitializeOptions from './apple-pay-button-initialize-options';
 import ApplePayButtonMethodType from './apple-pay-button-method-type';
-import ApplePayButtonStrategy from './apple-pay-button-strategy';
+import ApplePayButtonStrategy, { ButtonStyleOption } from './apple-pay-button-strategy';
 import ApplePaySessionFactory from './apple-pay-session-factory';
 import {
     getApplePayButtonInitializationOptions,
@@ -617,6 +617,55 @@ describe('ApplePayButtonStrategy', () => {
                     }
                 }
             }
+        });
+
+        describe('button styling', () => {
+            const checkoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            const applePayPaymentMethod = getApplePay();
+
+            const mockGetPaymentMethod = (styleOption: ButtonStyleOption) => {
+                applePayPaymentMethod.initializationData.styleOption = styleOption;
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockImplementation(() => applePayPaymentMethod);
+            };
+
+            it('should be black', async () => {
+                mockGetPaymentMethod(ButtonStyleOption.Black);
+
+                await strategy.initialize(checkoutButtonInitializeOptions);
+
+                const button = container.firstChild as HTMLElement;
+
+                expect(button.getAttribute('style')).toContain('background-color: rgb(0, 0, 0)');
+            });
+
+            it('should be white', async () => {
+                mockGetPaymentMethod(ButtonStyleOption.White);
+
+                await strategy.initialize(checkoutButtonInitializeOptions);
+
+                const button = container.firstChild as HTMLElement;
+
+                expect(button.getAttribute('style')).toContain(
+                    'background-color: rgb(255, 255, 255)',
+                );
+            });
+
+            it('should be white border', async () => {
+                mockGetPaymentMethod(ButtonStyleOption.WhiteBorder);
+
+                await strategy.initialize(checkoutButtonInitializeOptions);
+
+                const button = container.firstChild as HTMLElement;
+
+                const style = button.getAttribute('style');
+
+                expect(style).toContain('background-color: rgb(255, 255, 255)');
+                expect(style).toContain('border: 0.5px solid #000');
+            });
         });
     });
 

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -34,7 +34,7 @@ enum DefaultLabels {
     Shipping = 'Shipping',
 }
 
-enum ButtonStyleOption {
+export enum ButtonStyleOption {
     Black = 'black',
     White = 'white',
     WhiteBorder = 'white-border',

--- a/packages/apple-pay-integration/src/mocks/apple-pay-method.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-method.mock.ts
@@ -1,10 +1,11 @@
-export function getApplePay() {
+import { PaymentMethod } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export function getApplePay(): PaymentMethod {
     return {
         id: 'applepay',
         logoUrl: '',
         method: 'credit-card',
         supportedCards: [],
-        providesShippingAddress: false,
         config: {
             displayName: '',
             helpText: '',


### PR DESCRIPTION
## What?

Added styling for Apple Pay button

## Why?

To not use styling from strorefront and for consistency

## Testing / Proof

https://github.com/user-attachments/assets/e0639db2-cddb-47fa-a974-dcf35063ee69

https://github.com/user-attachments/assets/88241155-1567-4e3d-822b-113c27fbe5b5

@bigcommerce/team-checkout @bigcommerce/team-payments
