### PR TITLE
feat(shipping): SHIPPING-3311 Update loadShippingCountries to support channelId as an optional param

### DIFF
--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -501,7 +501,9 @@ export default class CheckoutService {
      * @param options - Options for loading the available shipping countries.
      * @returns A promise that resolves to the current state.
      */
-    loadShippingCountries(options?: RequestOptions): Promise<CheckoutSelectors> {
+    loadShippingCountries(
+        options?: RequestOptions<{ channelId?: number }>,
+    ): Promise<CheckoutSelectors> {
         const action = this._shippingCountryActionCreator.loadCountries(options);
 
         return this._dispatch(action, { queueId: 'shippingCountries' });
@@ -575,7 +577,9 @@ export default class CheckoutService {
      * @param options - Options for loading the shipping address form fields.
      * @returns A promise that resolves to the current state.
      */
-    loadShippingAddressFields(options?: RequestOptions): Promise<CheckoutSelectors> {
+    loadShippingAddressFields(
+        options?: RequestOptions<{ channelId: number }>,
+    ): Promise<CheckoutSelectors> {
         return this.loadShippingCountries(options);
     }
 

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -246,7 +246,9 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         return this._storeProjection.getState();
     }
 
-    async loadShippingCountries(options?: RequestOptions): Promise<PaymentIntegrationSelectors> {
+    async loadShippingCountries(
+        options?: RequestOptions<{ channelId?: number }>,
+    ): Promise<PaymentIntegrationSelectors> {
         await this._store.dispatch(this._shippingCountryActionCreator.loadCountries(options));
 
         return this._storeProjection.getState();

--- a/packages/core/src/shipping/shipping-country-action-creator.ts
+++ b/packages/core/src/shipping/shipping-country-action-creator.ts
@@ -12,10 +12,10 @@ export default class ShippingCountryActionCreator {
         private _shippingCountryRequestSender: ShippingCountryRequestSender,
         private _store: CheckoutStore,
     ) {}
-
-    loadCountries(options?: RequestOptions): Observable<LoadShippingCountriesAction> {
-        const { checkout } = this._store.getState();
-        const { channelId } = checkout.getCheckoutOrThrow();
+    loadCountries(
+        options?: RequestOptions<{ channelId?: number }>,
+    ): Observable<LoadShippingCountriesAction> {
+        const channelId = this.getChannelId(options?.params?.channelId);
 
         return Observable.create((observer: Observer<LoadShippingCountriesAction>) => {
             observer.next(createAction(ShippingCountryActionType.LoadShippingCountriesRequested));
@@ -40,5 +40,16 @@ export default class ShippingCountryActionCreator {
                     );
                 });
         });
+    }
+
+    private getChannelId(channelIdParam?: number): number {
+        if (channelIdParam) {
+            return channelIdParam;
+        }
+
+        const { checkout } = this._store.getState();
+        const data = checkout.getCheckoutOrThrow();
+
+        return data.channelId;
     }
 }


### PR DESCRIPTION
## What?
- Update the checkout-sdk-js `loadShippingCountries` call to support an optional `channelId` parameter

## Why?
We have discovered that merchants using the CDN version of the checkout-sdk-js are calling the `loadShippingCountries` method without having an initialised checkout.

```
"const state = await service.loadShippingCountries();"

Error loading shipping countries: MissingDataError: Unable to proceed because checkout data is unavailable.
   e webpack://checkoutKit/packages/core/src/common/error/errors/standard-error.ts:21
   e webpack://checkoutKit/packages/core/src/common/error/errors/missing-data-error.ts:31
   e webpack://checkoutKit/packages/core/src/checkout/checkout-selector.ts:93
   OE guard.ts:3
   e checkout-selector.ts:91
   n Lodash
   loadCountries shipping-country-action-creator.ts:18
   loadShippingCountries checkout-service.ts:505
```

To correct for this, we have allowed merchants to pass in an optional `channelId` parameter to the `loadShippingCountries` method call 

## Testing / Proof
TBC

