### PR TITLE
feat(shipping): SHIPPING-3311 Update loadShippingCountries to allow for a default of no channel id

### DIFF
--- a/packages/core/src/shipping/shipping-country-action-creator.spec.ts
+++ b/packages/core/src/shipping/shipping-country-action-creator.spec.ts
@@ -71,5 +71,23 @@ describe('ShippingCountryActionCreator', () => {
                     ]);
                 });
         });
+
+        describe('when checkout is undefined', () => {
+            beforeEach(() => {
+                store = createCheckoutStore({ checkout: undefined });
+                shippingCountryActionCreator = new ShippingCountryActionCreator(
+                    requestSender,
+                    store,
+                );
+            });
+
+            it('passes null as channelId when checkout is undefined', () => {
+                const loadCountriesSpy = jest.spyOn(requestSender, 'loadCountries');
+
+                shippingCountryActionCreator.loadCountries().subscribe();
+
+                expect(loadCountriesSpy).toHaveBeenCalledWith(null, undefined);
+            });
+        });
     });
 });

--- a/packages/core/src/shipping/shipping-country-action-creator.ts
+++ b/packages/core/src/shipping/shipping-country-action-creator.ts
@@ -15,7 +15,9 @@ export default class ShippingCountryActionCreator {
 
     loadCountries(options?: RequestOptions): Observable<LoadShippingCountriesAction> {
         const { checkout } = this._store.getState();
-        const { channelId } = checkout.getCheckoutOrThrow();
+        const checkoutData = checkout.getCheckout();
+
+        const channelId = checkoutData ? checkoutData.channelId : null;
 
         return Observable.create((observer: Observer<LoadShippingCountriesAction>) => {
             observer.next(createAction(ShippingCountryActionType.LoadShippingCountriesRequested));

--- a/packages/core/src/shipping/shipping-country-request-sender.spec.ts
+++ b/packages/core/src/shipping/shipping-country-request-sender.spec.ts
@@ -47,6 +47,18 @@ describe('ShippingCountryRequestSender', () => {
             );
         });
 
+        it('loads shipping countries without channelId', async () => {
+            const output = await shippingCountryRequestSender.loadCountries(null);
+
+            expect(output).toEqual(response);
+            expect(requestSender.get).toHaveBeenCalledWith('/internalapi/v1/shipping/countries', {
+                headers: {
+                    'Accept-Language': 'en',
+                    ...SDK_VERSION_HEADERS,
+                },
+            });
+        });
+
         it('loads shipping countries with timeout', async () => {
             const options = { timeout: createTimeout() };
             const output = await shippingCountryRequestSender.loadCountries(2, options);

--- a/packages/core/src/shipping/shipping-country-request-sender.ts
+++ b/packages/core/src/shipping/shipping-country-request-sender.ts
@@ -7,10 +7,11 @@ export default class ShippingCountryRequestSender {
     constructor(private _requestSender: RequestSender, private _config: { locale?: string }) {}
 
     loadCountries(
-        channelId: number,
+        channelId: number | null,
         { timeout }: RequestOptions = {},
     ): Promise<Response<CountryResponseBody>> {
-        const url = `/internalapi/v1/shipping/countries?channel_id=${channelId}`;
+        const channelIdParam = channelId ? `?channel_id=${channelId}` : '';
+        const url = `/internalapi/v1/shipping/countries${channelIdParam}`;
 
         const headers = {
             'Accept-Language': this._config.locale,


### PR DESCRIPTION
## What?
- Allow for a default of `null` channel ID to be sent to the the `v1/shipping/countries` endpoint

## Why?
Merchants who attempt to call the `loadShippingCountries` endpoint before initialising a checkout will run into issues with the existing `getCheckoutOrThrow()` behaviour because the checkout is not yet initialised.

With this updated code, if there is no checkout, we set the `channel id` to null and proceed to send no channel ID to the `v1/shipping/countries` endpoint. 

This will result in the existing behaviour before we introduced the `channel id` property. 

As a result of this, it will mean that merchants will view the country selector based on the shipping zone location and NOT have it be channel aware.

## Testing / Proof
Existing Unit Test

ping @animesh1987 @bc-peng

