### PR TITLE
feat(payment): STRIPE-461 New Stripe OCS strategy

### DIFF
--- a/packages/stripe-integration/src/index.ts
+++ b/packages/stripe-integration/src/index.ts
@@ -1,6 +1,7 @@
 export { default as createStripeV3PaymentStrategy } from './stripev3/create-stripev3-payment-strategy';
 export { default as createStripeUPEPaymentStrategy } from './stripe-upe/create-stripe-upe-payment-strategy';
 export { default as createStripeUPECustomerStrategy } from './stripe-upe/create-stripe-upe-customer-strategy';
+export { default as createStripeOCSPaymentStrategy } from './stripe-upe/create-stripe-ocs-payment-strategy';
 
 export { default as StripeScriptLoader } from './stripev3/stripev3-script-loader';
 export { default as StripeUPEScriptLoader } from './stripe-upe/stripe-upe-script-loader';

--- a/packages/stripe-integration/src/stripe-upe/create-stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/create-stripe-ocs-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createStripeOCSPaymentStrategy from './create-stripe-ocs-payment-strategy';
+import StripeOCSPaymentStrategy from './stripe-ocs-payment-strategy';
+
+describe('createStripeOCSPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('create stripe ocs payment strategy', () => {
+        const strategy = createStripeOCSPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(StripeOCSPaymentStrategy);
+    });
+});

--- a/packages/stripe-integration/src/stripe-upe/create-stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/create-stripe-ocs-payment-strategy.ts
@@ -5,21 +5,20 @@ import {
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
+import StripeOCSPaymentStrategy from './stripe-ocs-payment-strategy';
 import StripeUPEIntegrationService from './stripe-upe-integration-service';
-import StripeUPEPaymentStrategy from './stripe-upe-payment-strategy';
 import StripeUPEScriptLoader from './stripe-upe-script-loader';
 
-const createStripeUPEPaymentStrategy: PaymentStrategyFactory<StripeUPEPaymentStrategy> = (
+const createStripeOCSPaymentStrategy: PaymentStrategyFactory<StripeOCSPaymentStrategy> = (
     paymentIntegrationService,
 ) => {
-    return new StripeUPEPaymentStrategy(
+    return new StripeOCSPaymentStrategy(
         paymentIntegrationService,
         new StripeUPEScriptLoader(getScriptLoader()),
         new StripeUPEIntegrationService(paymentIntegrationService),
     );
 };
 
-export default toResolvableModule(createStripeUPEPaymentStrategy, [
-    { gateway: 'stripeupe' },
-    { gateway: 'stripeupe', id: 'klarna' },
+export default toResolvableModule(createStripeOCSPaymentStrategy, [
+    { gateway: 'stripeupe', id: 'stripe_ocs' },
 ]);

--- a/packages/stripe-integration/src/stripe-upe/create-stripe-upe-customer-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/create-stripe-upe-customer-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createStripeUPECustomerStrategy from './create-stripe-upe-customer-strategy';
+import StripeUPECustomerStrategy from './stripe-upe-customer-strategy';
+
+describe('createStripeUPECustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('create stripe upe customer strategy', () => {
+        const strategy = createStripeUPECustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(StripeUPECustomerStrategy);
+    });
+});

--- a/packages/stripe-integration/src/stripe-upe/create-stripe-upe-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/create-stripe-upe-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createStripeUPEPaymentStrategy from './create-stripe-upe-payment-strategy';
+import StripeUPEPaymentStrategy from './stripe-upe-payment-strategy';
+
+describe('createStripeUPEPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('create stripe upe payment strategy', () => {
+        const strategy = createStripeUPEPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(StripeUPEPaymentStrategy);
+    });
+});

--- a/packages/stripe-integration/src/stripe-upe/is-stripe-payment-event.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/is-stripe-payment-event.spec.ts
@@ -1,0 +1,36 @@
+import { isStripePaymentEvent } from './is-stripe-payment-event';
+
+describe('isStripePaymentEvent', () => {
+    it('should return false if event undefined', () => {
+        expect(isStripePaymentEvent(undefined)).toBe(false);
+    });
+
+    it('should return false if event null', () => {
+        expect(isStripePaymentEvent(null)).toBe(false);
+    });
+
+    it('should return false if event does not have value property', () => {
+        const eventMock = {
+            collapsed: false,
+        };
+
+        expect(isStripePaymentEvent(eventMock)).toBe(false);
+    });
+
+    it('should return false if event does not have collapsed property', () => {
+        const eventMock = {
+            value: {},
+        };
+
+        expect(isStripePaymentEvent(eventMock)).toBe(false);
+    });
+
+    it('should return true if event is StripePaymentEvent', () => {
+        const eventMock = {
+            collapsed: false,
+            value: {},
+        };
+
+        expect(isStripePaymentEvent(eventMock)).toBe(true);
+    });
+});

--- a/packages/stripe-integration/src/stripe-upe/is-stripe-payment-event.ts
+++ b/packages/stripe-integration/src/stripe-upe/is-stripe-payment-event.ts
@@ -1,0 +1,5 @@
+import { StripePaymentEvent } from './stripe-upe';
+
+export const isStripePaymentEvent = (event: unknown): event is StripePaymentEvent => {
+    return typeof event === 'object' && event !== null && 'value' in event && 'collapsed' in event;
+};

--- a/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.spec.ts
@@ -1,0 +1,1212 @@
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    InvalidArgumentError,
+    NotInitializedError,
+    OrderFinalizationNotRequiredError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethodCancelledError,
+    PaymentMethodFailedError,
+    RequestError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getCart,
+    getCheckout,
+    getErrorPaymentResponseBody,
+    getResponse,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import StripeOCSPaymentStrategy from './stripe-ocs-payment-strategy';
+import {
+    StripeElementType,
+    StripePaymentMethodType,
+    StripeStringConstants,
+    StripeUPEClient,
+} from './stripe-upe';
+import { WithStripeUPEPaymentInitializeOptions } from './stripe-upe-initialize-options';
+import StripeUPEIntegrationService from './stripe-upe-integration-service';
+import { getStripeUPEIntegrationServiceMock } from './stripe-upe-integration-service.mock';
+import StripeUPEScriptLoader from './stripe-upe-script-loader';
+import {
+    getStripeOCSOrderRequestBodyMock,
+    getStripeUPE,
+    getStripeUPEInitializeOptionsMock,
+    getStripeUPEJsMock,
+    StripeEventMock,
+} from './stripe-upe.mock';
+
+describe('StripeOCSPaymentStrategy', () => {
+    let stripeOCSPaymentStrategy: StripeOCSPaymentStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let stripeScriptLoader: StripeUPEScriptLoader;
+    let stripeUPEIntegrationService: StripeUPEIntegrationService;
+    let stripeOptions: PaymentInitializeOptions & WithStripeUPEPaymentInitializeOptions;
+    let stripeUPEJsMock: StripeUPEClient;
+
+    const testColor = '#123456';
+    const style = {
+        labelText: testColor,
+        fieldText: testColor,
+        fieldPlaceholderText: testColor,
+        fieldErrorText: testColor,
+        fieldBackground: testColor,
+        fieldInnerShadow: testColor,
+        fieldBorder: testColor,
+    };
+
+    beforeEach(() => {
+        const scriptLoader = createScriptLoader();
+
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        stripeScriptLoader = new StripeUPEScriptLoader(scriptLoader);
+        stripeUPEIntegrationService = getStripeUPEIntegrationServiceMock();
+        stripeOCSPaymentStrategy = new StripeOCSPaymentStrategy(
+            paymentIntegrationService,
+            stripeScriptLoader,
+            stripeUPEIntegrationService,
+        );
+
+        stripeOptions = getStripeUPEInitializeOptionsMock(StripePaymentMethodType.OCS, style);
+        stripeUPEJsMock = getStripeUPEJsMock();
+
+        jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+            jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+        );
+        jest.spyOn(stripeScriptLoader, 'getElements').mockImplementation(jest.fn());
+        jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValue(
+            paymentIntegrationService.getState(),
+        );
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            getStripeUPE(),
+        );
+        jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+            Promise.resolve(stripeUPEJsMock.elements({})),
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('#initialize', () => {
+        it('throws error if no stripe initialization options', async () => {
+            await expect(
+                stripeOCSPaymentStrategy.initialize({
+                    ...stripeOptions,
+                    stripeupe: undefined,
+                }),
+            ).rejects.toThrow(NotInitializedError);
+            expect(
+                stripeUPEIntegrationService.initCheckoutEventsSubscription,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('throws error if no container id in stripe options', async () => {
+            await expect(
+                stripeOCSPaymentStrategy.initialize({
+                    ...stripeOptions,
+                    stripeupe: {
+                        ...stripeOptions.stripeupe,
+                        render: jest.fn(),
+                        containerId: '',
+                    },
+                }),
+            ).rejects.toThrow(NotInitializedError);
+            expect(
+                stripeUPEIntegrationService.initCheckoutEventsSubscription,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('throws error if no gatewayId option', async () => {
+            await expect(
+                stripeOCSPaymentStrategy.initialize({
+                    ...stripeOptions,
+                    gatewayId: undefined,
+                }),
+            ).rejects.toThrow(InvalidArgumentError);
+            expect(
+                stripeUPEIntegrationService.initCheckoutEventsSubscription,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('throws error if payment method does not like stripe payment method', async () => {
+            const stripePaymentMethod = getStripeUPE();
+            const onErrorMock = jest.fn();
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...stripePaymentMethod,
+                initializationData: undefined,
+            });
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    containerId: 'containerId',
+                    render: jest.fn(),
+                    onError: onErrorMock,
+                },
+            });
+
+            expect(onErrorMock).toHaveBeenCalled();
+        });
+
+        it('throws error if payment method does not have clientToken', async () => {
+            const stripePaymentMethod = getStripeUPE();
+            const onErrorMock = jest.fn();
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...stripePaymentMethod,
+                clientToken: undefined,
+            });
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    containerId: 'containerId',
+                    render: jest.fn(),
+                    onError: onErrorMock,
+                },
+            });
+
+            expect(onErrorMock).toHaveBeenCalled();
+        });
+
+        it('should initialize', async () => {
+            const onErrorMock = jest.fn();
+            const renderMock = jest.fn();
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    containerId: 'containerId',
+                    render: renderMock,
+                    onError: onErrorMock,
+                },
+            });
+
+            expect(stripeScriptLoader.getElements).toHaveBeenCalled();
+            expect(onErrorMock).not.toHaveBeenCalled();
+            expect(stripeScriptLoader.getStripeClient).toHaveBeenCalled();
+            expect(stripeUPEIntegrationService.initCheckoutEventsSubscription).toHaveBeenCalled();
+        });
+
+        it('should initialize and get postal code when shipping address unavailable', async () => {
+            const onErrorMock = jest.fn();
+            const renderMock = jest.fn();
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(StripeEventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+            }));
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getShippingAddress').mockReturnValue(
+                undefined,
+            );
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    create: createMock,
+                }),
+            );
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    containerId: 'containerId',
+                    render: renderMock,
+                    onError: onErrorMock,
+                },
+            });
+
+            expect(createMock).toHaveBeenCalledWith(StripeElementType.PAYMENT, {
+                fields: {
+                    billingDetails: {
+                        email: StripeStringConstants.NEVER,
+                        address: {
+                            country: StripeStringConstants.NEVER,
+                            city: StripeStringConstants.NEVER,
+                            postalCode: StripeStringConstants.NEVER,
+                        },
+                    },
+                },
+                wallets: {
+                    applePay: StripeStringConstants.NEVER,
+                    googlePay: StripeStringConstants.NEVER,
+                },
+                layout: {
+                    type: 'accordion',
+                    defaultCollapsed: false,
+                    radios: true,
+                    spacedAccordionItems: false,
+                    visibleAccordionItemsCount: 0,
+                },
+            });
+            expect(onErrorMock).not.toHaveBeenCalled();
+            expect(stripeUPEIntegrationService.mountElement).toHaveBeenCalled();
+        });
+
+        it('should initialize if postal code unavailable', async () => {
+            const onErrorMock = jest.fn();
+            const renderMock = jest.fn();
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(StripeEventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+            }));
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getShippingAddress').mockReturnValue(
+                undefined,
+            );
+            jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue(
+                undefined,
+            );
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    create: createMock,
+                }),
+            );
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    containerId: 'containerId',
+                    render: renderMock,
+                    onError: onErrorMock,
+                },
+            });
+
+            expect(createMock).toHaveBeenCalledWith(StripeElementType.PAYMENT, {
+                fields: {
+                    billingDetails: {
+                        email: StripeStringConstants.NEVER,
+                        address: {
+                            country: StripeStringConstants.NEVER,
+                            city: StripeStringConstants.NEVER,
+                            postalCode: StripeStringConstants.AUTO,
+                        },
+                    },
+                },
+                wallets: {
+                    applePay: StripeStringConstants.NEVER,
+                    googlePay: StripeStringConstants.NEVER,
+                },
+                layout: {
+                    type: 'accordion',
+                    defaultCollapsed: false,
+                    radios: true,
+                    spacedAccordionItems: false,
+                    visibleAccordionItemsCount: 0,
+                },
+            });
+            expect(onErrorMock).not.toHaveBeenCalled();
+        });
+
+        it('initialize accordion close handled', async () => {
+            const onErrorMock = jest.fn();
+            const collapseMock = jest.fn();
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(StripeEventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+                collapse: collapseMock,
+            }));
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    getElement: createMock,
+                }),
+            );
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    containerId: 'containerId',
+                    render: jest.fn(),
+                    onError: onErrorMock,
+                    handleClosePaymentMethod: jest.fn().mockImplementation((callback) => {
+                        callback();
+                    }),
+                },
+            });
+
+            expect(onErrorMock).not.toHaveBeenCalled();
+            expect(collapseMock).toHaveBeenCalled();
+        });
+
+        it('should not collapse accordion if element not initialized', async () => {
+            const onErrorMock = jest.fn();
+            const collapseMock = jest.fn();
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve(stripeUPEJsMock.elements({})),
+            );
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    containerId: 'containerId',
+                    render: jest.fn(),
+                    onError: onErrorMock,
+                    handleClosePaymentMethod: jest.fn().mockImplementation((callback) => {
+                        callback();
+                    }),
+                },
+            });
+
+            expect(onErrorMock).not.toHaveBeenCalled();
+            expect(collapseMock).not.toHaveBeenCalled();
+        });
+
+        it('loads stripe js only once per initialization', async () => {
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+            expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('#execute', () => {
+        it('throw error if stripe client not initialized', async () => {
+            await expect(stripeOCSPaymentStrategy.execute({})).rejects.toThrow(NotInitializedError);
+        });
+
+        it('throw error if there are no gateway id', async () => {
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+            await expect(
+                stripeOCSPaymentStrategy.execute({
+                    payment: {
+                        methodId: '',
+                        gatewayId: '',
+                    },
+                }),
+            ).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('throw error if there are no method id', async () => {
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+            await expect(
+                stripeOCSPaymentStrategy.execute({
+                    payment: {
+                        methodId: '',
+                        gatewayId: 'stripeupe',
+                    },
+                }),
+            ).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('execute with store credits', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getCheckoutOrThrow',
+            ).mockReturnValueOnce({
+                ...getCheckout(),
+                isStoreCreditApplied: true,
+            });
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.applyStoreCredit).toHaveBeenCalledWith(true);
+        });
+
+        it('execute without additional actions with selected method in accordion', async () => {
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.applyStoreCredit).not.toHaveBeenCalled();
+            expect(stripeUPEIntegrationService.updateStripePaymentIntent).toHaveBeenCalledWith(
+                'stripeupe',
+                'stripe_ocs',
+            );
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: 'stripe_ocs',
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                        credit_card_token: {
+                            token: 'clientToken',
+                        },
+                        confirm: false,
+                        payment_method_id: undefined,
+                    },
+                },
+            });
+        });
+
+        it('execute with selected payment method id without ui handled', async () => {
+            const eventMock = {
+                ...StripeEventMock,
+                collapsed: false,
+            };
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(eventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+            }));
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    create: createMock,
+                }),
+            );
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    render: jest.fn(),
+                    containerId: 'containerId',
+                },
+            });
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: 'stripe_ocs',
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                        credit_card_token: {
+                            token: 'clientToken',
+                        },
+                        confirm: false,
+                        payment_method_id: 'card',
+                    },
+                },
+            });
+        });
+
+        it('execute with selected payment method id', async () => {
+            const eventMock = {
+                ...StripeEventMock,
+                collapsed: false,
+            };
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(eventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+            }));
+            const paymentMethodSelectMock = jest.fn();
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    create: createMock,
+                }),
+            );
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    render: jest.fn(),
+                    containerId: 'containerId',
+                    paymentMethodSelect: paymentMethodSelectMock,
+                },
+            });
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: 'stripe_ocs',
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                        credit_card_token: {
+                            token: 'clientToken',
+                        },
+                        confirm: false,
+                        payment_method_id: 'card',
+                    },
+                },
+            });
+            expect(paymentMethodSelectMock).toHaveBeenCalledWith('stripeupe-stripe_ocs');
+        });
+
+        it('does not change selected payment method id if accordion collapsed', async () => {
+            const eventMock = {
+                ...StripeEventMock,
+                collapsed: true,
+            };
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(eventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+            }));
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    create: createMock,
+                }),
+            );
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeupe: {
+                    render: jest.fn(),
+                    containerId: 'containerId',
+                },
+            });
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: 'stripe_ocs',
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                        credit_card_token: {
+                            token: 'clientToken',
+                        },
+                        confirm: false,
+                        payment_method_id: undefined,
+                    },
+                },
+            });
+        });
+
+        it('execute without additional actions without client token', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValueOnce(getStripeUPE());
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValueOnce({
+                ...getStripeUPE(),
+                clientToken: undefined,
+            });
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: 'stripe_ocs',
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                        credit_card_token: {
+                            token: '',
+                        },
+                        confirm: false,
+                        payment_method_id: undefined,
+                    },
+                },
+            });
+        });
+
+        it('payment payload without cart', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCart').mockReturnValue(undefined);
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: 'stripe_ocs',
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: '',
+                        credit_card_token: {
+                            token: 'clientToken',
+                        },
+                        confirm: false,
+                        payment_method_id: undefined,
+                    },
+                },
+            });
+        });
+
+        it('payment payload without cart ID', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCart').mockReturnValue({
+                ...getCart(),
+                id: '',
+            });
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: 'stripe_ocs',
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: '',
+                        credit_card_token: {
+                            token: 'clientToken',
+                        },
+                        confirm: false,
+                        payment_method_id: undefined,
+                    },
+                },
+            });
+        });
+    });
+
+    describe('#execute, with additional action', () => {
+        let errorResponse: RequestError;
+        let confirmPaymentMock: jest.Mock;
+        let retrievePaymentIntentMock: jest.Mock;
+
+        const mockFirstPaymentRequest = (payload: unknown) => {
+            jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
+                Promise.reject(payload),
+            );
+        };
+
+        beforeEach(() => {
+            jest.spyOn(stripeUPEIntegrationService, 'isAdditionalActionError').mockReturnValue(
+                true,
+            );
+
+            errorResponse = new RequestError(
+                getResponse({
+                    ...getErrorPaymentResponseBody(),
+                    errors: [{ code: 'additional_action_required' }],
+                    additional_action_required: {
+                        type: 'additional_action_requires_payment_method',
+                        data: {
+                            redirect_url: 'https://redirect-url.com',
+                            token: 'token',
+                        },
+                    },
+                    status: 'error',
+                }),
+            );
+
+            confirmPaymentMock = jest.fn();
+            retrievePaymentIntentMock = jest.fn();
+
+            stripeUPEJsMock = {
+                ...getStripeUPEJsMock(),
+                confirmPayment: confirmPaymentMock,
+                retrievePaymentIntent: retrievePaymentIntentMock,
+            };
+            jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+            );
+        });
+
+        it('throws not request error', async () => {
+            mockFirstPaymentRequest(new Error('Not request'));
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+            await expect(
+                stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+            ).rejects.toThrow(Error);
+        });
+
+        it('throws not additional action error', async () => {
+            mockFirstPaymentRequest(errorResponse);
+            jest.spyOn(stripeUPEIntegrationService, 'isAdditionalActionError').mockReturnValue(
+                false,
+            );
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+            await expect(
+                stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+            ).rejects.toThrow(Error);
+        });
+
+        it('throws generic error', async () => {
+            mockFirstPaymentRequest(errorResponse);
+            jest.spyOn(stripeUPEIntegrationService, 'isRedirectAction').mockReturnValue(false);
+            jest.spyOn(stripeUPEIntegrationService, 'isOnPageAdditionalAction').mockReturnValue(
+                false,
+            );
+            confirmPaymentMock = jest.fn().mockRejectedValue(new Error('stripe error'));
+            retrievePaymentIntentMock = jest.fn().mockResolvedValue({
+                paymentIntent: undefined,
+            });
+
+            stripeUPEJsMock = {
+                ...getStripeUPEJsMock(),
+                confirmPayment: confirmPaymentMock,
+                retrievePaymentIntent: retrievePaymentIntentMock,
+            };
+            jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+            );
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+            await expect(
+                stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+            ).rejects.toThrow(RequestError);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
+            expect(confirmPaymentMock).not.toHaveBeenCalled();
+        });
+
+        describe('redirect additional action', () => {
+            beforeEach(() => {
+                jest.spyOn(stripeUPEIntegrationService, 'isRedirectAction').mockReturnValue(true);
+                jest.spyOn(stripeUPEIntegrationService, 'isOnPageAdditionalAction').mockReturnValue(
+                    false,
+                );
+                jest.spyOn(stripeUPEIntegrationService, 'isPaymentCompleted').mockResolvedValue(
+                    false,
+                );
+            });
+
+            it('should skip redirect action if payment already confirmed', async () => {
+                const stripeErrorMock = new Error('stripe error');
+
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: { status: 'succeeded' },
+                    error: stripeErrorMock,
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+                jest.spyOn(stripeUPEIntegrationService, 'isPaymentCompleted').mockResolvedValue(
+                    true,
+                );
+                jest.spyOn(
+                    stripeUPEIntegrationService,
+                    'throwPaymentConfirmationProceedMessage',
+                ).mockImplementation(() => {
+                    throw new Error();
+                });
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(Error);
+
+                expect(
+                    stripeUPEIntegrationService.throwPaymentConfirmationProceedMessage,
+                ).toHaveBeenCalled();
+                expect(confirmPaymentMock).not.toHaveBeenCalled();
+                expect(
+                    stripeUPEIntegrationService.throwDisplayableStripeError,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('throws stripe error on confirmation', async () => {
+                const stripeErrorMock = new Error('stripe error');
+
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: { status: 'succeeded' },
+                    error: stripeErrorMock,
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(Error);
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(
+                    stripeUPEIntegrationService.throwDisplayableStripeError,
+                ).toHaveBeenCalledWith(stripeErrorMock);
+            });
+
+            it('throws non stripe error on confirmation', async () => {
+                const stripeErrorMock = new Error('stripe error');
+
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: { status: 'succeeded' },
+                    error: stripeErrorMock,
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+                jest.spyOn(
+                    stripeUPEIntegrationService,
+                    'throwDisplayableStripeError',
+                ).mockReturnValue(undefined);
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(PaymentMethodFailedError);
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(
+                    stripeUPEIntegrationService.throwDisplayableStripeError,
+                ).toHaveBeenCalledWith(stripeErrorMock);
+            });
+
+            it('throws error if no confirmation error and no payment intent data', async () => {
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: undefined,
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(RequestError);
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(
+                    stripeUPEIntegrationService.throwDisplayableStripeError,
+                ).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('on page additional action', () => {
+            beforeEach(() => {
+                jest.spyOn(stripeUPEIntegrationService, 'isRedirectAction').mockReturnValue(false);
+                jest.spyOn(stripeUPEIntegrationService, 'isOnPageAdditionalAction').mockReturnValue(
+                    true,
+                );
+                jest.spyOn(stripeUPEIntegrationService, 'isPaymentCompleted').mockResolvedValue(
+                    false,
+                );
+            });
+
+            it('throw stripe confirmation error without response data', async () => {
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockRejectedValue(new Error('stripe error'));
+                retrievePaymentIntentMock = jest.fn().mockRejectedValue(new Error('stripe error'));
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                    retrievePaymentIntent: retrievePaymentIntentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+                await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                    methodId: 'stripe_ocs',
+                    paymentData: {
+                        formattedPayload: {
+                            cart_id: '',
+                            credit_card_token: {
+                                token: 'clientToken',
+                            },
+                            confirm: false,
+                            payment_method_id: undefined,
+                        },
+                    },
+                });
+            });
+
+            it('throw stripe confirmation without error and payment intent', async () => {
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockRejectedValue(new Error('stripe error'));
+                retrievePaymentIntentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: undefined,
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                    retrievePaymentIntent: retrievePaymentIntentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(RequestError);
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
+            });
+
+            it('throw stripe confirmation without error', async () => {
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockRejectedValue(new Error('stripe error'));
+                retrievePaymentIntentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: { status: 'succeeded' },
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                    retrievePaymentIntent: retrievePaymentIntentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+                await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            });
+
+            it('throw dispayable stripe confirmation error', async () => {
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: { status: 'succeeded' },
+                    error: new Error('stripe error'),
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(Error);
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).not.toHaveBeenCalled();
+                expect(stripeUPEIntegrationService.isCancellationError).not.toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
+            });
+
+            it('throw cancellation stripe confirmation error', async () => {
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: { status: 'succeeded' },
+                    error: new Error('stripe error'),
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+                jest.spyOn(
+                    stripeUPEIntegrationService,
+                    'throwDisplayableStripeError',
+                ).mockReturnValue(undefined);
+
+                jest.spyOn(stripeUPEIntegrationService, 'isCancellationError').mockReturnValue(
+                    true,
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(PaymentMethodCancelledError);
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).not.toHaveBeenCalled();
+                expect(stripeUPEIntegrationService.isCancellationError).toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
+            });
+
+            it('throw stripe payment method error', async () => {
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: { status: 'succeeded' },
+                    error: new Error('stripe error'),
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+                jest.spyOn(
+                    stripeUPEIntegrationService,
+                    'throwDisplayableStripeError',
+                ).mockReturnValue(undefined);
+
+                jest.spyOn(stripeUPEIntegrationService, 'isCancellationError').mockReturnValue(
+                    false,
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(PaymentMethodFailedError);
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).not.toHaveBeenCalled();
+                expect(stripeUPEIntegrationService.isCancellationError).toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
+            });
+
+            it('submit if confirmation response not contain payment intent', async () => {
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockRejectedValue(new Error('stripe error'));
+                retrievePaymentIntentMock = jest.fn().mockRejectedValue(new Error('stripe error'));
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                    retrievePaymentIntent: retrievePaymentIntentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+                jest.spyOn(stripeUPEIntegrationService, 'isPaymentCompleted').mockResolvedValue(
+                    true,
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+                await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+                expect(confirmPaymentMock).not.toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            });
+
+            it('throw default error if second payment submit fails', async () => {
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: { status: 'succeeded' },
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeUPEJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                    retrievePaymentIntent: retrievePaymentIntentMock,
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+                jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
+                    Promise.reject(new Error('error')),
+                );
+                jest.spyOn(
+                    stripeUPEIntegrationService,
+                    'throwPaymentConfirmationProceedMessage',
+                ).mockImplementation(() => {
+                    throw new Error();
+                });
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(Error);
+
+                expect(confirmPaymentMock).toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).not.toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(
+                    stripeUPEIntegrationService.throwPaymentConfirmationProceedMessage,
+                ).toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws an error to inform that order finalization is not required', async () => {
+            await expect(stripeOCSPaymentStrategy.finalize()).rejects.toBeInstanceOf(
+                OrderFinalizationNotRequiredError,
+            );
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes stripe payment strategy', async () => {
+            const unmountMock = jest.fn();
+            const getElementMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: unmountMock,
+                on: jest.fn((_, callback) => callback(StripeEventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+                collapse: jest.fn(),
+            }));
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    getElement: getElementMock,
+                }),
+            );
+
+            await stripeOCSPaymentStrategy.initialize(getStripeUPEInitializeOptionsMock());
+            await stripeOCSPaymentStrategy.deinitialize();
+
+            expect(stripeUPEIntegrationService.deinitialize).toHaveBeenCalled();
+            expect(unmountMock).toHaveBeenCalled();
+        });
+
+        it('when stripe element not initialized', async () => {
+            await stripeOCSPaymentStrategy.initialize(getStripeUPEInitializeOptionsMock());
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    getElement: () => null,
+                }),
+            );
+
+            await stripeOCSPaymentStrategy.deinitialize();
+
+            expect(stripeUPEIntegrationService.deinitialize).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.ts
@@ -1,0 +1,416 @@
+import {
+    InvalidArgumentError,
+    isRequestError,
+    MissingDataError,
+    MissingDataErrorType,
+    NotInitializedError,
+    NotInitializedErrorType,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    Payment,
+    PaymentInitializeOptions,
+    PaymentIntegrationSelectors,
+    PaymentIntegrationService,
+    PaymentMethodCancelledError,
+    PaymentMethodFailedError,
+    PaymentRequestOptions,
+    PaymentStrategy,
+    RequestError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import formatLocale from './format-locale';
+import { isStripePaymentEvent } from './is-stripe-payment-event';
+import { isStripeUPEPaymentMethodLike } from './is-stripe-upe-payment-method-like';
+import {
+    StripeElement,
+    StripeElements,
+    StripeElementType,
+    StripeEventType,
+    StripeStringConstants,
+    StripeUPEAppearanceOptions,
+    StripeUPEClient,
+} from './stripe-upe';
+import StripeUPEPaymentInitializeOptions, {
+    WithStripeUPEPaymentInitializeOptions,
+} from './stripe-upe-initialize-options';
+import StripeUPEIntegrationService from './stripe-upe-integration-service';
+import StripeUPEScriptLoader from './stripe-upe-script-loader';
+
+export default class StripeOCSPaymentStrategy implements PaymentStrategy {
+    private stripeUPEClient?: StripeUPEClient;
+    private stripeElements?: StripeElements;
+    private selectedMethodId?: string;
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private scriptLoader: StripeUPEScriptLoader,
+        private stripeUPEIntegrationService: StripeUPEIntegrationService,
+    ) {}
+
+    async initialize(
+        options: PaymentInitializeOptions & WithStripeUPEPaymentInitializeOptions,
+    ): Promise<void> {
+        const { stripeupe, methodId, gatewayId } = options;
+
+        if (!stripeupe?.containerId) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (!gatewayId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "gatewayId" argument is not provided.',
+            );
+        }
+
+        try {
+            await this._initializeStripeElement(stripeupe, gatewayId, methodId);
+        } catch (error) {
+            if (error instanceof Error) {
+                stripeupe.onError?.(error);
+            }
+        }
+
+        this.stripeUPEIntegrationService.initCheckoutEventsSubscription(
+            gatewayId,
+            methodId,
+            stripeupe,
+            this.stripeElements,
+        );
+    }
+
+    async execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
+        const { payment, ...order } = orderRequest;
+        const { methodId, gatewayId } = payment || {};
+
+        if (!this.stripeUPEClient) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (!gatewayId || !methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "gatewayId" or "methodId" argument is not provided.',
+            );
+        }
+
+        const state = this.paymentIntegrationService.getState();
+        const { isStoreCreditApplied } = state.getCheckoutOrThrow();
+
+        if (isStoreCreditApplied) {
+            await this.paymentIntegrationService.applyStoreCredit(isStoreCreditApplied);
+        }
+
+        await this.stripeUPEIntegrationService.updateStripePaymentIntent(gatewayId, methodId);
+
+        await this.paymentIntegrationService.submitOrder(order, options);
+
+        const { clientToken } = state.getPaymentMethodOrThrow(methodId);
+        const paymentPayload = this._getPaymentPayload(methodId, clientToken || '');
+
+        try {
+            await this.paymentIntegrationService.submitPayment(paymentPayload);
+        } catch (error) {
+            await this._processAdditionalAction(error, methodId);
+        }
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<void> {
+        this.stripeElements?.getElement(StripeElementType.PAYMENT)?.unmount();
+        this.stripeUPEIntegrationService.deinitialize();
+        this.stripeElements = undefined;
+        this.stripeUPEClient = undefined;
+
+        return Promise.resolve();
+    }
+
+    private async _initializeStripeElement(
+        stripeupe: StripeUPEPaymentInitializeOptions,
+        gatewayId: string,
+        methodId: string,
+    ) {
+        const state = await this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
+            params: { method: methodId },
+        });
+        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+
+        if (!isStripeUPEPaymentMethodLike(paymentMethod)) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const {
+            clientToken,
+            initializationData: { stripePublishableKey, stripeConnectedAccount, shopperLanguage },
+        } = paymentMethod;
+
+        if (!clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        this.stripeUPEClient = await this._loadStripeJs(
+            stripePublishableKey,
+            stripeConnectedAccount,
+        );
+
+        const { containerId, style, render, paymentMethodSelect, handleClosePaymentMethod } =
+            stripeupe;
+
+        this.stripeElements = await this.scriptLoader.getElements(this.stripeUPEClient, {
+            clientSecret: clientToken,
+            locale: formatLocale(shopperLanguage),
+            appearance: this._getElementAppearance(style),
+            fonts: [
+                {
+                    cssSrc: 'https://fonts.googleapis.com/css?family=Montserrat:700,500,400%7CKarla:400&display=swap', // TODO: get style from theme
+                },
+            ],
+        });
+
+        const { getBillingAddress, getShippingAddress } = state;
+        const { postalCode } = getShippingAddress() || getBillingAddress() || {};
+
+        const stripeElement: StripeElement =
+            this.stripeElements.getElement(StripeElementType.PAYMENT) ||
+            this.stripeElements.create(StripeElementType.PAYMENT, {
+                fields: {
+                    billingDetails: {
+                        email: StripeStringConstants.NEVER,
+                        address: {
+                            country: StripeStringConstants.NEVER,
+                            city: StripeStringConstants.NEVER,
+                            postalCode: postalCode
+                                ? StripeStringConstants.NEVER
+                                : StripeStringConstants.AUTO,
+                        },
+                    },
+                },
+                wallets: {
+                    applePay: StripeStringConstants.NEVER,
+                    googlePay: StripeStringConstants.NEVER,
+                },
+                layout: {
+                    type: 'accordion',
+                    defaultCollapsed: false,
+                    radios: true,
+                    spacedAccordionItems: false,
+                    visibleAccordionItemsCount: 0,
+                },
+            });
+
+        this.stripeUPEIntegrationService.mountElement(stripeElement, containerId);
+
+        stripeElement.on('ready', () => {
+            render();
+        });
+
+        stripeElement.on('change', (event: StripeEventType) => {
+            this._onStripeElementChange(event, gatewayId, methodId, paymentMethodSelect);
+        });
+
+        handleClosePaymentMethod?.(this._collapseStripeElement.bind(this));
+    }
+
+    private async _loadStripeJs(
+        stripePublishableKey: string,
+        stripeConnectedAccount: string,
+    ): Promise<StripeUPEClient> {
+        if (this.stripeUPEClient) {
+            return this.stripeUPEClient;
+        }
+
+        return this.scriptLoader.getStripeClient(stripePublishableKey, stripeConnectedAccount);
+    }
+
+    private _getElementAppearance(
+        style?: StripeUPEPaymentInitializeOptions['style'],
+    ): StripeUPEAppearanceOptions | undefined {
+        if (!style) {
+            return;
+        }
+
+        const titleFontSize = '15px'; // TODO: get style from theme
+        const titleFontWeight = '700'; // TODO: get style from theme
+        const titleColor = '#5f5f5f'; // TODO: get style from theme
+        const radioColor = '#ddd'; // TODO: get style from theme
+        const radioFocusColor = '#4496f6'; // TODO: get style from theme
+
+        return {
+            variables: {
+                ...this.stripeUPEIntegrationService.mapAppearanceVariables(style),
+                fontFamily: 'Montserrat, Arial, Helvetica', // TODO: get style from theme
+            },
+            rules: {
+                '.Input': this.stripeUPEIntegrationService.mapInputAppearanceRules(style),
+                '.AccordionItem': {
+                    borderRadius: 0,
+                    borderWidth: 0,
+                    borderBottomWidth: '1px',
+                    boxShadow: 'none',
+                    fontSize: titleFontSize,
+                    fontWeight: titleFontWeight,
+                    padding: '13px 20px 13px 18px',
+                },
+                '.TabLabel, .AccordionItem': {
+                    fontSize: titleFontSize,
+                    fontWeight: titleFontWeight,
+                    color: titleColor,
+                },
+                '.TabLabel--selected, .AccordionItem--selected': {
+                    fontWeight: titleFontWeight,
+                    color: titleColor,
+                },
+                '.RadioIcon': {
+                    // 26px / 0.88 = 29.54
+                    width: '29.54px',
+                },
+                '.RadioIconOuter': {
+                    // 1px / 26px * 0.88 = 0.034
+                    strokeWidth: '3.4',
+                    stroke: radioColor,
+                },
+                '.RadioIconOuter--checked': {
+                    stroke: radioFocusColor,
+                },
+                '.RadioIconInner': {
+                    // 17.16px / 26px * 0.88 = 0.58 / 2 = 29
+                    r: '29',
+                    fill: radioFocusColor,
+                },
+            },
+        };
+    }
+
+    private _collapseStripeElement() {
+        const stripeElement = this.stripeElements?.getElement(StripeElementType.PAYMENT);
+
+        stripeElement?.collapse();
+    }
+
+    private _getPaymentPayload(methodId: string, token: string): Payment {
+        const cartId = this.paymentIntegrationService.getState().getCart()?.id || '';
+        const formattedPayload = {
+            cart_id: cartId,
+            credit_card_token: { token },
+            confirm: false,
+            payment_method_id: this.selectedMethodId,
+        };
+
+        return {
+            methodId,
+            paymentData: {
+                formattedPayload,
+            },
+        };
+    }
+
+    private async _processAdditionalAction(
+        error: unknown,
+        methodId: string,
+    ): Promise<PaymentIntegrationSelectors | never> {
+        if (
+            !isRequestError(error) ||
+            !this.stripeUPEIntegrationService.isAdditionalActionError(error.body.errors)
+        ) {
+            throw error;
+        }
+
+        if (!this.stripeUPEClient || !this.stripeElements) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const {
+            data: { token, redirect_url },
+        } = error.body.additional_action_required;
+        const stripePaymentData = this.stripeUPEIntegrationService.mapStripePaymentData(
+            this.stripeElements,
+            redirect_url,
+        );
+        const isPaymentCompleted = await this.stripeUPEIntegrationService.isPaymentCompleted(
+            methodId,
+            this.stripeUPEClient,
+        );
+
+        if (
+            this.stripeUPEIntegrationService.isRedirectAction(error.body.additional_action_required)
+        ) {
+            if (isPaymentCompleted) {
+                this.stripeUPEIntegrationService.throwPaymentConfirmationProceedMessage();
+            }
+
+            const { paymentIntent, error: stripeError } = await this.stripeUPEClient.confirmPayment(
+                stripePaymentData,
+            );
+
+            if (stripeError) {
+                this.stripeUPEIntegrationService.throwDisplayableStripeError(stripeError);
+                throw new PaymentMethodFailedError();
+            }
+
+            if (!paymentIntent) {
+                throw new RequestError();
+            }
+        } else if (
+            this.stripeUPEIntegrationService.isOnPageAdditionalAction(
+                error.body.additional_action_required,
+            )
+        ) {
+            let result;
+            let isConfirmCatchError = false;
+
+            try {
+                result = !isPaymentCompleted
+                    ? await this.stripeUPEClient.confirmPayment(stripePaymentData)
+                    : await this.stripeUPEClient.retrievePaymentIntent(token);
+            } catch (error) {
+                try {
+                    result = await this.stripeUPEClient.retrievePaymentIntent(token);
+                } catch (error) {
+                    isConfirmCatchError = true;
+                }
+            }
+
+            if (result?.error) {
+                this.stripeUPEIntegrationService.throwDisplayableStripeError(result.error);
+
+                if (this.stripeUPEIntegrationService.isCancellationError(result.error)) {
+                    throw new PaymentMethodCancelledError();
+                }
+
+                throw new PaymentMethodFailedError();
+            }
+
+            if (!result?.paymentIntent && !isConfirmCatchError) {
+                throw new RequestError();
+            }
+
+            const paymentPayload = this._getPaymentPayload(
+                methodId,
+                isConfirmCatchError ? token : result?.paymentIntent?.id,
+            );
+
+            try {
+                return await this.paymentIntegrationService.submitPayment(paymentPayload);
+            } catch (error) {
+                this.stripeUPEIntegrationService.throwPaymentConfirmationProceedMessage();
+            }
+        }
+
+        throw error;
+    }
+
+    private _onStripeElementChange(
+        event: StripeEventType,
+        gatewayId: string,
+        methodId: string,
+        paymentMethodSelect?: (id: string) => void,
+    ) {
+        if (!isStripePaymentEvent(event) || event.collapsed) {
+            return;
+        }
+
+        this.selectedMethodId = event.value.type;
+        paymentMethodSelect?.(`${gatewayId}-${methodId}`);
+    }
+}

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
@@ -34,6 +34,7 @@ export default interface StripeUPEPaymentInitializeOptions {
     style?: {
         [key: string]: string;
     };
+
     onError?(error?: Error): void;
 
     render(): void;
@@ -41,6 +42,10 @@ export default interface StripeUPEPaymentInitializeOptions {
     initStripeElementUpdateTrigger?(
         updateTriggerFn: (payload: StripeElementUpdateOptions) => void,
     ): void;
+
+    paymentMethodSelect?(id: string): void;
+
+    handleClosePaymentMethod?(collapseElement: () => void): void;
 }
 
 export interface WithStripeUPEPaymentInitializeOptions {

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.mock.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.mock.ts
@@ -1,0 +1,40 @@
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { StripeStringConstants } from './stripe-upe';
+import StripeUPEIntegrationService from './stripe-upe-integration-service';
+import { getStripeUPEJsMock } from './stripe-upe.mock';
+
+export const getStripeUPEIntegrationServiceMock = () =>
+    ({
+        deinitialize: jest.fn(),
+        initCheckoutEventsSubscription: jest.fn(),
+        mountElement: jest.fn(),
+        mapAppearanceVariables: jest.fn(),
+        mapInputAppearanceRules: jest.fn(),
+        throwDisplayableStripeError: jest.fn((message?: string) => {
+            throw new Error(message);
+        }),
+        throwPaymentConfirmationProceedMessage: jest.fn(() => {
+            throw new PaymentMethodFailedError('PaymentMethodFailedError');
+        }),
+        isCancellationError: jest.fn(() => false),
+        isPaymentCompleted: jest.fn(() => Promise.resolve(false)),
+        mapStripePaymentData: jest.fn(() => ({
+            elements: getStripeUPEJsMock().elements({}),
+            redirect: StripeStringConstants.IF_REQUIRED,
+            confirmParams: {
+                payment_method_data: {
+                    billing_details: {
+                        email: 'test@email.com',
+                        address: 'address',
+                        name: 'firstName lastName',
+                    },
+                },
+                return_url: 'return.url',
+            },
+        })),
+        isAdditionalActionError: jest.fn(() => false),
+        isRedirectAction: jest.fn(() => false),
+        isOnPageAdditionalAction: jest.fn(() => false),
+        updateStripePaymentIntent: jest.fn(() => Promise.resolve()),
+    } as unknown as StripeUPEIntegrationService);

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.spec.ts
@@ -1,0 +1,647 @@
+import {
+    MissingDataError,
+    NotInitializedError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethodFailedError,
+    StoreConfig,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getBillingAddress,
+    getConfig,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import {
+    StripeElement,
+    StripeElements,
+    StripeError,
+    StripePaymentMethodType,
+    StripeUPEClient,
+} from './stripe-upe';
+import StripeUPEPaymentInitializeOptions, {
+    WithStripeUPEPaymentInitializeOptions,
+} from './stripe-upe-initialize-options';
+import StripeUPEIntegrationService from './stripe-upe-integration-service';
+import {
+    getStripeUPE,
+    getStripeUPEInitializeOptionsMock,
+    getStripeUPEJsMock,
+} from './stripe-upe.mock';
+
+describe('StripeUPEIntegrationService', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+    let stripeUPEIntegrationService: StripeUPEIntegrationService;
+    let initializeOptions: PaymentInitializeOptions & WithStripeUPEPaymentInitializeOptions;
+    let stripeupeMock: StripeUPEPaymentInitializeOptions;
+    let stripeUPEJsMock: StripeUPEClient;
+    const gatewayId = 'stripeupe';
+    const methodId = StripePaymentMethodType.OCS;
+    const testColor = '#123456';
+    const style = {
+        labelText: testColor,
+        fieldText: testColor,
+        fieldPlaceholderText: testColor,
+        fieldErrorText: testColor,
+        fieldBackground: testColor,
+        fieldInnerShadow: testColor,
+        fieldBorder: testColor,
+    };
+    let stripeElementsMock: StripeElements;
+    let stripeElementMock: StripeElement;
+
+    beforeEach(() => {
+        initializeOptions = getStripeUPEInitializeOptionsMock(StripePaymentMethodType.OCS, style);
+
+        if (!initializeOptions.stripeupe) {
+            initializeOptions.stripeupe = {
+                containerId: 'container',
+                render: jest.fn(),
+            };
+        }
+
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        stripeUPEIntegrationService = new StripeUPEIntegrationService(paymentIntegrationService);
+        stripeupeMock = {
+            containerId: 'container',
+            render: jest.fn(),
+        };
+
+        stripeElementMock = {
+            mount: jest.fn(),
+            destroy: jest.fn(),
+            unmount: jest.fn(),
+            on: jest.fn(),
+            update: jest.fn(),
+            collapse: jest.fn(),
+        };
+
+        stripeElementsMock = {
+            create: jest.fn(),
+            getElement: jest.fn(() => stripeElementMock),
+            update: jest.fn(),
+            fetchUpdates: jest.fn(),
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('#deinitialize', () => {
+        it('should clear subscription', () => {
+            const subscriptionMock = jest.fn();
+
+            jest.spyOn(paymentIntegrationService, 'subscribe').mockImplementation(
+                () => subscriptionMock,
+            );
+
+            stripeUPEIntegrationService.initCheckoutEventsSubscription(
+                gatewayId,
+                methodId,
+                stripeupeMock,
+                stripeElementsMock,
+            );
+            stripeUPEIntegrationService.deinitialize();
+
+            expect(subscriptionMock).toHaveBeenCalled();
+            // eslint-disable-next-line @typescript-eslint/dot-notation, dot-notation
+            expect(stripeUPEIntegrationService['isMounted']).toBe(false);
+        });
+
+        it('should not unsibscribe when subscription is not set', () => {
+            jest.spyOn(paymentIntegrationService, 'subscribe').mockImplementation(undefined);
+
+            stripeUPEIntegrationService.initCheckoutEventsSubscription(
+                gatewayId,
+                methodId,
+                stripeupeMock,
+                stripeElementsMock,
+            );
+            stripeUPEIntegrationService.deinitialize();
+
+            // eslint-disable-next-line @typescript-eslint/dot-notation, dot-notation
+            expect(stripeUPEIntegrationService['checkoutEventsUnsubscribe']).toBeUndefined();
+        });
+    });
+
+    describe('#initCheckoutEventsSubscription', () => {
+        beforeEach(() => {
+            const state = paymentIntegrationService.getState();
+
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValue(state);
+            jest.spyOn(paymentIntegrationService, 'subscribe').mockImplementation(
+                (subscriber, ...filters) => {
+                    subscriber(state);
+                    filters.forEach((filter) => filter(state));
+
+                    return jest.fn();
+                },
+            );
+        });
+
+        it('skip subscription actions if no stripe elements initialized', () => {
+            stripeUPEIntegrationService.initCheckoutEventsSubscription(
+                gatewayId,
+                methodId,
+                stripeupeMock,
+                undefined,
+            );
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+        });
+
+        it('skip subscription actions if no stripe payment element found', () => {
+            stripeElementsMock.getElement = () => null;
+
+            stripeUPEIntegrationService.initCheckoutEventsSubscription(
+                gatewayId,
+                methodId,
+                stripeupeMock,
+                stripeElementsMock,
+            );
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+        });
+
+        it('throws error if loadPaymentMethod fails', async () => {
+            stripeupeMock.onError = jest.fn();
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockRejectedValue(
+                new Error(),
+            );
+
+            stripeUPEIntegrationService.initCheckoutEventsSubscription(
+                gatewayId,
+                methodId,
+                stripeupeMock,
+                stripeElementsMock,
+            );
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalled();
+            expect(stripeupeMock.onError).toHaveBeenCalled();
+            expect(stripeElementMock.unmount).not.toHaveBeenCalled();
+        });
+
+        it('unmount stripe payment element if loadPaymentMethod fails', async () => {
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockRejectedValue(
+                new Error(),
+            );
+            jest.spyOn(document, 'getElementById').mockReturnValue(document.createElement('div'));
+
+            stripeUPEIntegrationService.mountElement(stripeElementMock, stripeupeMock.containerId);
+            stripeUPEIntegrationService.initCheckoutEventsSubscription(
+                gatewayId,
+                methodId,
+                stripeupeMock,
+                stripeElementsMock,
+            );
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(stripeElementMock.unmount).toHaveBeenCalled();
+            // eslint-disable-next-line @typescript-eslint/dot-notation, dot-notation
+            expect(stripeUPEIntegrationService['isMounted']).toBe(false);
+        });
+
+        it('mount stripe payment element if not mounted', async () => {
+            jest.spyOn(document, 'getElementById').mockReturnValue(document.createElement('div'));
+
+            stripeUPEIntegrationService.initCheckoutEventsSubscription(
+                gatewayId,
+                methodId,
+                stripeupeMock,
+                stripeElementsMock,
+            );
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(stripeElementsMock.fetchUpdates).toHaveBeenCalled();
+            expect(stripeElementMock.mount).toHaveBeenCalled();
+            // eslint-disable-next-line @typescript-eslint/dot-notation, dot-notation
+            expect(stripeUPEIntegrationService['isMounted']).toBe(true);
+        });
+
+        it('does not mount stripe payment element if already mounted', async () => {
+            jest.spyOn(document, 'getElementById').mockReturnValue(document.createElement('div'));
+
+            stripeUPEIntegrationService.mountElement(stripeElementMock, stripeupeMock.containerId);
+            stripeUPEIntegrationService.initCheckoutEventsSubscription(
+                gatewayId,
+                methodId,
+                stripeupeMock,
+                stripeElementsMock,
+            );
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(stripeElementsMock.fetchUpdates).not.toHaveBeenCalled();
+            expect(stripeElementMock.mount).toHaveBeenCalledTimes(1);
+            // eslint-disable-next-line @typescript-eslint/dot-notation, dot-notation
+            expect(stripeUPEIntegrationService['isMounted']).toBe(true);
+        });
+    });
+
+    describe('#mountElement', () => {
+        it('should mount stripe element', () => {
+            jest.spyOn(document, 'getElementById').mockReturnValue(document.createElement('div'));
+
+            stripeUPEIntegrationService.mountElement(stripeElementMock, stripeupeMock.containerId);
+
+            expect(stripeElementMock.mount).toHaveBeenCalled();
+            // eslint-disable-next-line @typescript-eslint/dot-notation, dot-notation
+            expect(stripeUPEIntegrationService['isMounted']).toBe(true);
+        });
+
+        it('should not mount stripe element if container is not found', () => {
+            jest.spyOn(document, 'getElementById').mockReturnValue(null);
+
+            stripeUPEIntegrationService.mountElement(stripeElementMock, stripeupeMock.containerId);
+
+            expect(stripeElementMock.mount).not.toHaveBeenCalled();
+            // eslint-disable-next-line @typescript-eslint/dot-notation, dot-notation
+            expect(stripeUPEIntegrationService['isMounted']).toBe(false);
+        });
+    });
+
+    describe('#mapAppearanceVariables', () => {
+        it('should map appearance variables', () => {
+            expect(stripeUPEIntegrationService.mapAppearanceVariables(style)).toEqual({
+                colorPrimary: testColor,
+                colorBackground: testColor,
+                colorText: testColor,
+                colorDanger: testColor,
+                colorTextSecondary: testColor,
+                colorTextPlaceholder: testColor,
+                colorIcon: testColor,
+            });
+        });
+    });
+
+    describe('#mapInputAppearanceRules', () => {
+        it('should map appearance variables', () => {
+            expect(stripeUPEIntegrationService.mapInputAppearanceRules(style)).toEqual({
+                borderColor: testColor,
+                color: testColor,
+                boxShadow: testColor,
+            });
+        });
+    });
+
+    describe('#throwDisplayableStripeError', () => {
+        it('should throw displayable stripe error', () => {
+            try {
+                stripeUPEIntegrationService.throwDisplayableStripeError({
+                    type: 'invalid_request_error',
+                    message: 'error message',
+                } as StripeError);
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+                expect((error as Error).message).toBe('error message');
+            }
+        });
+
+        it('should not throw if it is not stripe error', () => {
+            let err;
+
+            try {
+                stripeUPEIntegrationService.throwDisplayableStripeError({
+                    type: 'any_other_code',
+                    message: 'error message',
+                } as StripeError);
+            } catch (error) {
+                err = error;
+            } finally {
+                expect(err).toBeUndefined();
+            }
+        });
+    });
+
+    describe('#throwPaymentConfirmationProceedMessage', () => {
+        it('throw default error', () => {
+            try {
+                stripeUPEIntegrationService.throwPaymentConfirmationProceedMessage();
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
+            }
+        });
+    });
+
+    describe('#isCancellationError', () => {
+        it('should return true if error is cancellation error', () => {
+            expect(
+                stripeUPEIntegrationService.isCancellationError({
+                    type: 'invalid_request_error',
+                    message: 'error message',
+                    payment_intent: {
+                        last_payment_error: {
+                            message: 'PaymentIntent was canceled.',
+                        },
+                    },
+                } as StripeError),
+            ).toBe(true);
+        });
+
+        it('should return false if error is undefined', () => {
+            expect(stripeUPEIntegrationService.isCancellationError(undefined)).toBe(false);
+        });
+
+        it('should return false if error does not contain last payment error', () => {
+            expect(
+                stripeUPEIntegrationService.isCancellationError({
+                    type: 'invalid_request_error',
+                    message: 'error message',
+                    payment_intent: {},
+                } as StripeError),
+            ).toBe(false);
+        });
+
+        it('should return false if error in not cancellation error', () => {
+            expect(
+                stripeUPEIntegrationService.isCancellationError({
+                    type: 'invalid_request_error',
+                    message: 'error message',
+                    payment_intent: {
+                        last_payment_error: {
+                            message: 'PaymentIntent was finished.',
+                        },
+                    },
+                } as StripeError),
+            ).toBe(false);
+        });
+    });
+
+    describe('#isPaymentCompleted', () => {
+        const setConfirmationExperiment = (enabled = true) => {
+            const storeConfig: StoreConfig = {
+                ...getConfig().storeConfig,
+                checkoutSettings: {
+                    ...getConfig().storeConfig.checkoutSettings,
+                    features: {
+                        'PI-626.Block_unnecessary_payment_confirmation_for_StripeUPE': enabled,
+                    },
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue(storeConfig);
+        };
+
+        beforeEach(() => {
+            setConfirmationExperiment(true);
+            stripeUPEJsMock = {
+                ...getStripeUPEJsMock(),
+                retrievePaymentIntent: jest.fn().mockResolvedValue({
+                    paymentIntent: {
+                        status: 'succeeded',
+                    },
+                }),
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(getStripeUPE(StripePaymentMethodType.CreditCard));
+        });
+
+        it('returns true if payment intent already completed', async () => {
+            expect(
+                await stripeUPEIntegrationService.isPaymentCompleted(
+                    StripePaymentMethodType.CreditCard,
+                    stripeUPEJsMock,
+                ),
+            ).toBe(true);
+        });
+
+        it('returns false if no client token provided', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...getStripeUPE(StripePaymentMethodType.CreditCard),
+                clientToken: undefined,
+            });
+
+            expect(
+                await stripeUPEIntegrationService.isPaymentCompleted(
+                    StripePaymentMethodType.CreditCard,
+                    stripeUPEJsMock,
+                ),
+            ).toBe(false);
+        });
+
+        it('returns false if no stripe client', async () => {
+            expect(
+                await stripeUPEIntegrationService.isPaymentCompleted(
+                    StripePaymentMethodType.CreditCard,
+                    undefined,
+                ),
+            ).toBe(false);
+        });
+
+        it('returns false if experiment disabled', async () => {
+            setConfirmationExperiment(false);
+
+            expect(
+                await stripeUPEIntegrationService.isPaymentCompleted(
+                    StripePaymentMethodType.CreditCard,
+                    stripeUPEJsMock,
+                ),
+            ).toBe(false);
+        });
+
+        it('returns false if no payment intent retrieved', async () => {
+            stripeUPEJsMock = {
+                ...getStripeUPEJsMock(),
+                retrievePaymentIntent: jest.fn().mockResolvedValue({
+                    paymentIntent: undefined,
+                }),
+            };
+
+            expect(
+                await stripeUPEIntegrationService.isPaymentCompleted(
+                    StripePaymentMethodType.CreditCard,
+                    stripeUPEJsMock,
+                ),
+            ).toBe(false);
+        });
+
+        it('returns false if payment status not succeed', async () => {
+            stripeUPEJsMock = {
+                ...getStripeUPEJsMock(),
+                retrievePaymentIntent: jest.fn().mockResolvedValue({
+                    paymentIntent: {
+                        status: 'failed',
+                    },
+                }),
+            };
+
+            expect(
+                await stripeUPEIntegrationService.isPaymentCompleted(
+                    StripePaymentMethodType.CreditCard,
+                    stripeUPEJsMock,
+                ),
+            ).toBe(false);
+        });
+    });
+
+    describe('#mapStripePaymentData', () => {
+        beforeEach(() => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue(
+                getBillingAddress(),
+            );
+        });
+
+        it('throws error if stipe elements does not initialized', () => {
+            try {
+                stripeUPEIntegrationService.mapStripePaymentData(undefined);
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+            }
+        });
+
+        it('throws error if billing address not defined', () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue(
+                undefined,
+            );
+
+            try {
+                stripeUPEIntegrationService.mapStripePaymentData(stripeElementsMock);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws error if email not defined', () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue({
+                ...getBillingAddress(),
+                email: undefined,
+            });
+
+            try {
+                stripeUPEIntegrationService.mapStripePaymentData(stripeElementsMock);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws error if firstName not defined', () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue({
+                ...getBillingAddress(),
+                firstName: '',
+            });
+
+            try {
+                stripeUPEIntegrationService.mapStripePaymentData(stripeElementsMock);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws error if lastName not defined', () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue({
+                ...getBillingAddress(),
+                lastName: '',
+            });
+
+            try {
+                stripeUPEIntegrationService.mapStripePaymentData(stripeElementsMock);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('returns mapped payment data', () => {
+            expect(
+                stripeUPEIntegrationService.mapStripePaymentData(
+                    stripeElementsMock,
+                    'redirect.url',
+                ),
+            ).toEqual({
+                elements: stripeElementsMock,
+                redirect: 'if_required',
+                confirmParams: {
+                    payment_method_data: {
+                        billing_details: {
+                            email: 'test@bigcommerce.com',
+                            address: {
+                                city: 'Some City',
+                                country: 'US',
+                                line1: '12345 Testing Way',
+                                line2: '',
+                                postal_code: '95555',
+                            },
+                            name: 'Test Tester',
+                        },
+                    },
+                    return_url: 'redirect.url',
+                },
+            });
+        });
+    });
+
+    describe('#isAdditionalActionError', () => {
+        it('should return true if error is additional action error', () => {
+            expect(
+                stripeUPEIntegrationService.isAdditionalActionError([
+                    { code: 'additional_action_required' },
+                ]),
+            ).toBe(true);
+        });
+
+        it('should return false if error is not additional action error', () => {
+            expect(stripeUPEIntegrationService.isAdditionalActionError([])).toBe(false);
+        });
+    });
+
+    describe('#isRedirectAction', () => {
+        it('should return true if additional action is redirect action', () => {
+            expect(
+                stripeUPEIntegrationService.isRedirectAction({
+                    type: 'redirect_to_url',
+                    data: { redirect_url: 'url' },
+                }),
+            ).toBe(true);
+        });
+
+        it('should return false if additional action is not redirect action', () => {
+            expect(
+                stripeUPEIntegrationService.isRedirectAction({
+                    type: 'additional_action_requires_payment_method',
+                    data: { token: 'token' },
+                }),
+            ).toBe(false);
+        });
+    });
+
+    describe('#isOnPageAdditionalAction', () => {
+        it('should return true if additional action is on page action', () => {
+            expect(
+                stripeUPEIntegrationService.isOnPageAdditionalAction({
+                    type: 'additional_action_requires_payment_method',
+                    data: { token: 'token' },
+                }),
+            ).toBe(true);
+        });
+
+        it('should return false if additional action is not on page action', () => {
+            expect(
+                stripeUPEIntegrationService.isOnPageAdditionalAction({
+                    type: 'redirect_to_url',
+                    data: { redirect_url: 'url' },
+                }),
+            ).toBe(false);
+        });
+    });
+
+    describe('#updateStripePaymentIntent', () => {
+        it('should trigger payment intent update', async () => {
+            await stripeUPEIntegrationService.updateStripePaymentIntent(gatewayId, methodId);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.ts
@@ -1,0 +1,231 @@
+import { includes, some } from 'lodash';
+
+import {
+    Address,
+    MissingDataError,
+    MissingDataErrorType,
+    NotInitializedError,
+    NotInitializedErrorType,
+    PaymentIntegrationSelectors,
+    PaymentIntegrationService,
+    PaymentMethodFailedError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import {
+    AddressOptions,
+    StripeAdditionalActionRequired,
+    StripeConfirmPaymentData,
+    StripeElement,
+    StripeElements,
+    StripeElementType,
+    StripeError,
+    StripeStringConstants,
+    StripeUPEClient,
+    StripeUPEPaymentIntentStatus,
+} from './stripe-upe';
+import StripeUPEPaymentInitializeOptions from './stripe-upe-initialize-options';
+
+export default class StripeUPEIntegrationService {
+    private isMounted = false;
+    private checkoutEventsUnsubscribe?: () => void;
+
+    constructor(private paymentIntegrationService: PaymentIntegrationService) {}
+
+    deinitialize(): void {
+        this.checkoutEventsUnsubscribe?.();
+        this.isMounted = false;
+    }
+
+    initCheckoutEventsSubscription(
+        gatewayId: string,
+        methodId: string,
+        stripeupe: StripeUPEPaymentInitializeOptions,
+        stripeElements?: StripeElements,
+    ): void {
+        this.checkoutEventsUnsubscribe = this.paymentIntegrationService.subscribe(
+            async () => {
+                const paymentElement = stripeElements?.getElement(StripeElementType.PAYMENT);
+
+                if (!paymentElement) {
+                    return;
+                }
+
+                try {
+                    await this.updateStripePaymentIntent(gatewayId, methodId);
+                } catch (error) {
+                    if (this.isMounted) {
+                        paymentElement.unmount();
+                        this.isMounted = false;
+                    }
+
+                    if (error instanceof Error) {
+                        stripeupe.onError?.(error);
+                    }
+
+                    return;
+                }
+
+                if (!this.isMounted) {
+                    await stripeElements?.fetchUpdates();
+                    this.mountElement(paymentElement, stripeupe.containerId);
+                }
+            },
+            (state) => state.getCheckout()?.outstandingBalance,
+            (state) => state.getCheckout()?.coupons,
+        );
+    }
+
+    mountElement(stripeElement: StripeElement, containerId: string): void {
+        if (!document.getElementById(containerId)) {
+            return;
+        }
+
+        stripeElement.mount(`#${containerId}`);
+        this.isMounted = true;
+    }
+
+    mapAppearanceVariables(styles: { [key: string]: string }) {
+        return {
+            colorPrimary: styles.fieldInnerShadow,
+            colorBackground: styles.fieldBackground,
+            colorText: styles.labelText,
+            colorDanger: styles.fieldErrorText,
+            colorTextSecondary: styles.labelText,
+            colorTextPlaceholder: styles.fieldPlaceholderText,
+            colorIcon: styles.fieldPlaceholderText,
+        };
+    }
+
+    mapInputAppearanceRules(styles: { [key: string]: string }) {
+        return {
+            borderColor: styles.fieldBorder,
+            color: styles.fieldText,
+            boxShadow: styles.fieldInnerShadow,
+        };
+    }
+
+    throwDisplayableStripeError(stripeError: StripeError) {
+        if (
+            includes(['card_error', 'invalid_request_error', 'validation_error'], stripeError.type)
+        ) {
+            throw new Error(stripeError.message);
+        }
+    }
+
+    throwPaymentConfirmationProceedMessage() {
+        // INFO: for case if payment was successfully confirmed on Stripe side but on BC side something go wrong, request failed and order status hasn't changed yet
+        // For shopper we need to show additional message that BC is waiting for stripe confirmation, to prevent additional payment creation
+        throw new PaymentMethodFailedError(
+            "We've received your order and are processing your payment. Once the payment is verified, your order will be completed. We will send you an email when it's completed. Please note, this process may take a few minutes depending on the processing times of your chosen method.",
+        );
+    }
+
+    isCancellationError(stripeError?: StripeError): boolean {
+        const errorMessage = stripeError?.payment_intent.last_payment_error?.message;
+
+        return !!errorMessage && errorMessage.indexOf('canceled') !== -1;
+    }
+
+    async isPaymentCompleted(
+        methodId: string,
+        stripeUPEClient?: StripeUPEClient,
+    ): Promise<boolean> {
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        const { features } = state.getStoreConfigOrThrow().checkoutSettings;
+
+        if (
+            !paymentMethod.clientToken ||
+            !stripeUPEClient ||
+            !features['PI-626.Block_unnecessary_payment_confirmation_for_StripeUPE']
+        ) {
+            return false;
+        }
+
+        const { paymentIntent } = await stripeUPEClient.retrievePaymentIntent(
+            paymentMethod.clientToken,
+        );
+
+        return paymentIntent?.status === StripeUPEPaymentIntentStatus.SUCCEEDED;
+    }
+
+    mapStripePaymentData(
+        stripeElements?: StripeElements,
+        returnUrl?: string,
+    ): StripeConfirmPaymentData {
+        const billingAddress = this.paymentIntegrationService.getState().getBillingAddress();
+        const { firstName, lastName, email } = billingAddress || {};
+        const address = this._mapStripeAddress(billingAddress);
+
+        if (!stripeElements) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (!email || !address || !address.city || !address.country || !firstName || !lastName) {
+            throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
+        }
+
+        return {
+            elements: stripeElements,
+            redirect: StripeStringConstants.IF_REQUIRED,
+            confirmParams: {
+                payment_method_data: {
+                    billing_details: {
+                        email,
+                        address,
+                        name: `${firstName} ${lastName}`,
+                    },
+                },
+                ...(returnUrl && { return_url: returnUrl }),
+            },
+        };
+    }
+
+    isAdditionalActionError(errors: Array<{ code: string }>): boolean {
+        return some(errors, { code: 'additional_action_required' });
+    }
+
+    isRedirectAction(additionalAction: StripeAdditionalActionRequired): boolean {
+        const {
+            type,
+            data: { redirect_url },
+        } = additionalAction;
+
+        return type === 'redirect_to_url' && !!redirect_url;
+    }
+
+    isOnPageAdditionalAction(additionalAction: StripeAdditionalActionRequired): boolean {
+        const {
+            type,
+            data: { token },
+        } = additionalAction;
+
+        return type === 'additional_action_requires_payment_method' && !!token;
+    }
+
+    async updateStripePaymentIntent(
+        gatewayId: string,
+        methodId: string,
+    ): Promise<PaymentIntegrationSelectors> {
+        // INFO: to trigger payment intent update on the BE side we need to make stripe config request
+        return this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
+            params: { method: methodId },
+        });
+    }
+
+    private _mapStripeAddress(address?: Address): AddressOptions {
+        if (address) {
+            const { city, address1, address2, countryCode: country, postalCode } = address;
+
+            return {
+                city,
+                country,
+                postal_code: postalCode,
+                line1: address1,
+                line2: address2,
+            };
+        }
+
+        throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
+    }
+}

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -39,6 +39,7 @@ import {
     StripeUPEClient,
 } from './stripe-upe';
 import { WithStripeUPEPaymentInitializeOptions } from './stripe-upe-initialize-options';
+import StripeUPEIntegrationService from './stripe-upe-integration-service';
 import StripeUPEPaymentStrategy from './stripe-upe-payment-strategy';
 import StripeUPEScriptLoader from './stripe-upe-script-loader';
 import {
@@ -60,6 +61,7 @@ describe('StripeUPEPaymentStrategy', () => {
     let strategy: StripeUPEPaymentStrategy;
     let stripeScriptLoader: StripeUPEScriptLoader;
     let paymentIntegrationService: PaymentIntegrationService;
+    let stripeUPEIntegrationService: StripeUPEIntegrationService;
 
     beforeEach(() => {
         paymentIntegrationService = new PaymentIntegrationServiceMock();
@@ -91,7 +93,12 @@ describe('StripeUPEPaymentStrategy', () => {
 
         jest.spyOn(paymentIntegrationService, 'subscribe');
 
-        strategy = new StripeUPEPaymentStrategy(paymentIntegrationService, stripeScriptLoader);
+        stripeUPEIntegrationService = new StripeUPEIntegrationService(paymentIntegrationService);
+        strategy = new StripeUPEPaymentStrategy(
+            paymentIntegrationService,
+            stripeScriptLoader,
+            stripeUPEIntegrationService,
+        );
 
         const mockElement = document.createElement('div');
 

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.mock.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.mock.ts
@@ -50,6 +50,7 @@ export function getStripeUPEJsMock(): StripeUPEClient {
                 on: jest.fn((_, callback) => callback(StripeEventMock)),
                 update: jest.fn(),
                 destroy: jest.fn(),
+                collapse: jest.fn(),
             })),
             getElement: jest.fn().mockReturnValue(null),
             update: jest.fn(),
@@ -72,6 +73,7 @@ export function getFailingStripeUPEJsMock(): StripeUPEClient {
                 on: jest.fn((_, callback) => callback(StripeEventMock)),
                 update: jest.fn(),
                 destroy: jest.fn(),
+                collapse: jest.fn(),
             })),
             getElement: jest.fn().mockReturnValue(null),
             update: jest.fn(),
@@ -108,6 +110,17 @@ export function getStripeUPEOrderRequestBodyMock(
             paymentData: {
                 shouldSaveInstrument,
             },
+        },
+    };
+}
+
+export function getStripeOCSOrderRequestBodyMock(
+    stripePaymentMethodType: StripePaymentMethodType = StripePaymentMethodType.OCS,
+): OrderRequestBody {
+    return {
+        payment: {
+            methodId: stripePaymentMethodType,
+            gatewayId: 'stripeupe',
         },
     };
 }

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
@@ -53,6 +53,12 @@ export interface StripeElement {
      * https://docs.stripe.com/js/elements_object/update_payment_element
      */
     update(options?: StripeElementsCreateOptions): void;
+
+    /**
+     * This method collapses the Payment Element into a row of payment method tabs.
+     * https://docs.stripe.com/js/elements_object/collapse_payment_element
+     */
+    collapse(): void;
 }
 
 export interface StripeEvent {
@@ -92,6 +98,7 @@ export interface StripePaymentEvent extends StripeEvent {
     value: {
         type: StripePaymentMethodType;
     };
+    collapsed?: boolean;
 }
 
 interface Address {
@@ -201,6 +208,14 @@ export interface TermOptions {
     card?: AutoOrNever;
 }
 
+export interface StripeLayoutOptions {
+    type?: 'accordion' | 'tabs';
+    defaultCollapsed?: boolean;
+    radios?: boolean;
+    spacedAccordionItems?: boolean;
+    visibleAccordionItemsCount?: number;
+}
+
 /**
  * All available options are here https://stripe.com/docs/js/elements_object/create_payment_element
  */
@@ -213,6 +228,8 @@ export interface StripeElementsCreateOptions {
     validation?: validationElement;
     display?: { name: DisplayName };
     terms?: TermOptions;
+    layout?: StripeLayoutOptions;
+    paymentMethodOrder?: string[];
 }
 
 interface validationElement {
@@ -302,13 +319,12 @@ export interface StripeUPEAppearanceOptions {
         colorIconRedirect?: string;
         spacingUnit?: string;
         borderRadius?: string;
+        fontFamily?: string;
     };
 
     rules?: {
-        '.Input'?: {
-            borderColor?: string;
-            color?: string;
-            boxShadow?: string;
+        [key: string]: {
+            [key: string]: string | number;
         };
     };
 }
@@ -336,13 +352,18 @@ export interface StripeElementsOptions {
      * Make sure that you have TLS enabled on any page that includes the client secret.
      * Refer to our docs to accept a payment and learn about how client_secret should be handled.
      */
-    clientSecret: string;
+    clientSecret?: string;
 
     /**
      * Match the design of your site with the appearance option.
      * The layout of each Element stays consistent, but you can modify colors, fonts, borders, padding, and more.
      */
     appearance?: StripeUPEAppearanceOptions;
+
+    mode?: string;
+    amount?: number;
+    currency?: string;
+    paymentMethodTypes?: string[];
 }
 
 export interface StripeUpdateElementsOptions {
@@ -407,6 +428,7 @@ export enum StripePaymentMethodType {
     GIROPAY = 'giropay',
     ALIPAY = 'alipay',
     KLARNA = 'klarna',
+    OCS = 'stripe_ocs',
 }
 
 type AutoOrNever = StripeStringConstants.AUTO | StripeStringConstants.NEVER;
@@ -446,4 +468,19 @@ export interface StripeUPEInitializationData {
 
 export interface StripeElementUpdateOptions {
     shouldShowTerms?: boolean;
+}
+
+export interface StripeAdditionalActionRequired {
+    type: string;
+    data: {
+        token?: string;
+        redirect_url?: string;
+    };
+}
+
+export interface StripeAdditionalActionResponseBody {
+    additional_action_required: StripeAdditionalActionRequired;
+    three_ds_result: {
+        token?: string;
+    };
 }


### PR DESCRIPTION
## What?
Add new payment strategy for Stripe OCS

## Why?
To deploy new Stripe OCS accordion implementation

## Testing / Proof
Regression:
Credit card

https://github.com/user-attachments/assets/07c660ee-5c72-431d-a972-970c26e88221

Credit card + 3ds

https://github.com/user-attachments/assets/20ef22f5-f6ca-4547-acf8-49795a59b32d


GPay

https://github.com/user-attachments/assets/8c3bb7cf-fdea-47f9-b4d5-c6cc69e2d2b7

With redirect:

https://github.com/user-attachments/assets/0b3644c5-5baa-43dc-b8e0-103f1dde109c

https://github.com/user-attachments/assets/a1ae6366-5bad-409f-9da3-5fd2696bf1cc

On page confirmation

https://github.com/user-attachments/assets/e7b1455f-0e89-46a8-8be3-ba57918346fc

New implementation:

https://github.com/user-attachments/assets/2d667fe4-4000-4f2f-b545-ab01e1a175d4


Uploading Screen Recording 2024-10-22 at 21.29.58.mov…




@bigcommerce/team-checkout @bigcommerce/team-payments
