### PR TITLE
chore(payment): PAYPAL-4810 reduced test run duration for PPCP Ratepay Payment strategy from 24s to 70ms

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.spec.ts
@@ -62,6 +62,7 @@ describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
             paymentIntegrationService,
             paypalCommerceIntegrationService,
             loadingIndicator,
+            0,
         );
 
         jest.spyOn(loadingIndicator, 'show').mockReturnValue(undefined);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.ts
@@ -39,6 +39,8 @@ export default class PaypalCommerceRatepayPaymentStrategy implements PaymentStra
         private paymentIntegrationService: PaymentIntegrationService,
         private paypalCommerceIntegrationService: PayPalCommerceIntegrationService,
         private loadingIndicator: LoadingIndicator,
+        private pollingInterval: number = POLLING_INTERVAL,
+        private maxPollingIntervalTime: number = MAX_POLLING_TIME,
     ) {}
 
     async initialize(
@@ -309,7 +311,7 @@ export default class PaypalCommerceRatepayPaymentStrategy implements PaymentStra
         gatewayId?: string,
     ): Promise<void> {
         await new Promise<void>((resolve, reject) => {
-            const timeout = setTimeout(resolve, POLLING_INTERVAL);
+            const timeout = setTimeout(resolve, this.pollingInterval);
 
             this.stopPolling = () => {
                 clearTimeout(timeout);
@@ -320,7 +322,7 @@ export default class PaypalCommerceRatepayPaymentStrategy implements PaymentStra
         });
 
         try {
-            this.pollingTimer += POLLING_INTERVAL;
+            this.pollingTimer += this.pollingInterval;
 
             const orderStatus = await this.paypalCommerceIntegrationService.getOrderStatus(
                 'paypalcommercealternativemethods',
@@ -344,7 +346,7 @@ export default class PaypalCommerceRatepayPaymentStrategy implements PaymentStra
                 return rejectPromise();
             }
 
-            if (!isOrderApproved && this.pollingTimer < MAX_POLLING_TIME) {
+            if (!isOrderApproved && this.pollingTimer < this.maxPollingIntervalTime) {
                 return await this.initializePollingMechanism(
                     methodId,
                     resolvePromise,


### PR DESCRIPTION
## What?
Updated PPCP Ratepay Payment strategy to pass polling timeout through constructor and updated related tests

## Why?
To be able to set Polling timeout value in tests and reduce overall unit tests run on 24 seconds in checkout sdk project

## Testing / Proof
Before:
<img width="604" alt="Screenshot 2024-10-29 at 13 54 06" src="https://github.com/user-attachments/assets/6a1d3605-9915-4b51-91b6-8cf27bec1db5">

After:
<img width="561" alt="Screenshot 2024-10-29 at 13 53 17" src="https://github.com/user-attachments/assets/d3e636b9-18d4-4fb3-8b48-c1c804a383e6">


No need in manual testing
