### PR TITLE
feat(payment): PAYPAL-4783 added shipping autoselect flag

### DIFF
--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -26,6 +26,7 @@ export interface PayPalCommerceInitializationData {
     isDeveloperModeApplicable?: boolean;
     intent?: PayPalCommerceIntent;
     isAcceleratedCheckoutEnabled?: boolean; // PayPal Fastlane related
+    isFastlaneShippingOptionAutoSelectEnabled?: boolean; // PayPal Fastlane related
     isFastlaneStylingEnabled?: boolean;
     isHostedCheckoutEnabled?: boolean;
     isPayPalCommerceAnalyticsV2Enabled?: boolean; // PayPal Fastlane related


### PR DESCRIPTION
## What?
Added shipping autoselect flag which affects skipping of shipping step when using fastlane

## Why?
To create ability for customer to complete order without entering shipping information step because it is already set up

## Testing / Proof

https://github.com/user-attachments/assets/b0d63f85-786b-4c80-9d38-c01207744dbd


https://github.com/user-attachments/assets/e1f73154-5595-46a4-b044-fca5d8bc23a2



@bigcommerce/team-checkout @bigcommerce/team-payments
