### PR TITLE
refactor(payment): PI-2701 [checkout-sdk-js types] Clear checkout-sdk-js types errors in test files for the TD Bank related packages

### DIFF
--- a/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
+++ b/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
@@ -65,10 +65,9 @@ describe('TDOnlineMartPaymentStrategy', () => {
         tdOnlineMartClientScriptInitializationOptions = {
             methodId: 'tdonlinemart',
         };
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        formPoster = {
-            postForm: jest.fn(),
-        } as unknown as FormPoster;
+
+        formPoster = new FormPoster();
+        jest.spyOn(formPoster, 'postForm').mockImplementation(jest.fn());
 
         tdOnlineMartPaymentStrategy = new TDOnlineMartPaymentStrategy(
             paymentIntegrationService,
@@ -109,6 +108,7 @@ describe('TDOnlineMartPaymentStrategy', () => {
         tdOnlineMartClient.createToken = jest.fn((callback) => {
             callback({
                 token: 'td-online-mart-token',
+                code: '',
             });
         });
 
@@ -253,6 +253,7 @@ describe('TDOnlineMartPaymentStrategy', () => {
             tdOnlineMartClient.createToken = jest.fn((callback) => {
                 callback({
                     token: '',
+                    code: '',
                 });
             });
 
@@ -271,8 +272,11 @@ describe('TDOnlineMartPaymentStrategy', () => {
             tdOnlineMartClient.createToken = jest.fn((callback) => {
                 callback({
                     error: {
+                        field: 'field',
+                        type: 'type',
                         message: 'error occurs',
                     },
+                    code: '',
                 });
             });
 
@@ -305,7 +309,11 @@ describe('TDOnlineMartPaymentStrategy', () => {
             beforeEach(() => {
                 jest.spyOn(paymentIntegrationService.getState(), 'getCartOrThrow').mockReturnValue({
                     ...getCart(),
-                    lineItems: { digitalItems: [] },
+                    lineItems: {
+                        digitalItems: [],
+                        physicalItems: [],
+                        giftCertificates: [],
+                    },
                 });
             });
 
@@ -506,14 +514,9 @@ describe('TDOnlineMartPaymentStrategy', () => {
             });
 
             it('execute 3DS challenge', async () => {
-                const postFormMock = jest.fn((_url, _options, resolveFn) =>
-                    Promise.resolve(resolveFn()),
-                );
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+                const postFormMock = jest.fn((_url, _options, resolveFn) => resolveFn());
 
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                // eslint-disable-next-line @typescript-eslint/no-misused-promises
                 jest.spyOn(formPoster, 'postForm').mockImplementation(postFormMock);
                 jest.spyOn(
                     TdOnlineMartAdditionalAction,

--- a/packages/td-bank-integration/src/td-online-mart-script-loader.spec.ts
+++ b/packages/td-bank-integration/src/td-online-mart-script-loader.spec.ts
@@ -2,13 +2,15 @@ import ScriptLoader from '@bigcommerce/script-loader/lib/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { TdOnlineMartHostWindow } from './td-online-mart';
+import { TDCustomCheckoutSDK, TdOnlineMartHostWindow } from './td-online-mart';
 import TDOnlineMartScriptLoader from './td-online-mart-script-loader';
+import { getTDOnlineMartClient } from './td-online-mart.mock';
 
 describe('TDOnlineMartScriptLoader', () => {
     let scriptLoader: ScriptLoader;
     let mockWindow: TdOnlineMartHostWindow;
     let tdOnlineMartScriptLoader: TDOnlineMartScriptLoader;
+    let tdOnlineMartClient: TDCustomCheckoutSDK;
 
     beforeEach(() => {
         scriptLoader = new ScriptLoader();
@@ -23,8 +25,11 @@ describe('TDOnlineMartScriptLoader', () => {
 
     describe('load method', () => {
         beforeEach(() => {
+            tdOnlineMartClient = getTDOnlineMartClient();
             scriptLoader.loadScript = jest.fn(() => {
-                mockWindow.customcheckout = jest.fn();
+                mockWindow.customcheckout = jest.fn(() => tdOnlineMartClient);
+
+                return Promise.resolve();
             });
         });
 
@@ -43,6 +48,8 @@ describe('TDOnlineMartScriptLoader', () => {
         it('throw error when custom checkout does not exist on window', async () => {
             scriptLoader.loadScript = jest.fn(() => {
                 mockWindow.customcheckout = undefined;
+
+                return Promise.resolve();
             });
 
             try {

--- a/packages/td-bank-integration/tsconfig.lib.json
+++ b/packages/td-bank-integration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": []
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.spec.ts"]
+}


### PR DESCRIPTION
## What?
Fixed types in the TD Online Mart integration packages test files

## Why?
Due to Typescript and Jest last updates

## Testing / Proof
![Zrzut ekranu 2024-10-31 o 09 30 29](https://github.com/user-attachments/assets/89e2c2ab-22c6-4fac-a786-6709a1f82a23)

@bigcommerce/team-checkout @bigcommerce/team-payments
