### PR TITLE
feat(payment): PAYPAL-4813 added buyer country as an option to Braintree PayPal messages config

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
@@ -274,6 +274,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
 
             expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
                 amount: 190,
+                buyerCountry: 'US',
                 placement: 'payment',
                 style: {
                     layout: 'text',

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -428,6 +428,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
         ) {
             const state = this.paymentIntegrationService.getState();
             const checkout = state.getCheckout();
+            const billingAddress = state.getBillingAddressOrThrow();
 
             if (!checkout) {
                 throw new MissingDataError(MissingDataErrorType.MissingCheckout);
@@ -436,6 +437,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             this.braintreeHostWindow.paypal
                 .Messages({
                     amount: checkout.subtotal,
+                    buyerCountry: billingAddress.countryCode,
                     placement: 'payment',
                     style: {
                         layout: 'text',

--- a/packages/braintree-utils/src/paypal.ts
+++ b/packages/braintree-utils/src/paypal.ts
@@ -71,6 +71,7 @@ export interface PaypalExpressCheckoutOptions {
 
 export interface MessagingOptions {
     amount: number;
+    buyerCountry?: string;
     placement: string;
     style?: MessagesStyleOptions;
 }


### PR DESCRIPTION
## What?
Added buyer country as an option to Braintree PayPal messages config

## Why?
To let shopper see PayPal Banner related to the billing country from billing address form

## Testing / Proof
Unit tests
Manual tests
CI

![Screenshot 2024-11-01 at 13 00 52](https://github.com/user-attachments/assets/0c26eab0-34c4-4ff9-9138-c75fa13af28b)

![Screenshot 2024-11-01 at 13 01 27](https://github.com/user-attachments/assets/38993497-6c02-47a2-9cef-32796110b739)

