### PR TITLE
feat(payment): PAYPAL-4800 added ability to skip shipping step

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
@@ -256,6 +256,17 @@ describe('BraintreeFastlaneUtils', () => {
         });
 
         it('preselects shipping option with first shipping option', async () => {
+            const paymentMethodWithShippingAutoselect = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isFastlaneShippingOptionAutoSelectEnabled: true,
+                },
+            };
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingAutoselect);
             await subject.initializeBraintreeFastlaneOrThrow(methodId, undefined);
             await subject.runPayPalAuthenticationFlowOrThrow(undefined, true);
 
@@ -264,6 +275,42 @@ describe('BraintreeFastlaneUtils', () => {
                     ? consignments[0]?.availableShippingOptions[0].id
                     : undefined,
             );
+        });
+
+        it('doesnt select shipping option if isFastlaneShippingOptionAutoSelectEnabled false', async () => {
+            const paymentMethodWithShippingAutoselect = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isFastlaneShippingOptionAutoSelectEnabled: false,
+                },
+            };
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingAutoselect);
+            await subject.initializeBraintreeFastlaneOrThrow(methodId, undefined);
+            await subject.runPayPalAuthenticationFlowOrThrow(undefined, true);
+
+            expect(paymentIntegrationService.selectShippingOption).not.toHaveBeenCalled();
+        });
+
+        it('select shipping option if isFastlaneShippingOptionAutoSelectEnabled true', async () => {
+            const paymentMethodWithShippingAutoselect = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isFastlaneShippingOptionAutoSelectEnabled: true,
+                },
+            };
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingAutoselect);
+            await subject.initializeBraintreeFastlaneOrThrow(methodId, undefined);
+            await subject.runPayPalAuthenticationFlowOrThrow(undefined, true);
+
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalled();
         });
 
         it('doesnt preselect shipping option', async () => {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
@@ -86,6 +86,8 @@ export default class BraintreeFastlaneUtils {
      * Authentication methods
      *
      * */
+    // Remove this rule disabling after method refactor
+    // eslint-disable-next-line complexity
     async runPayPalAuthenticationFlowOrThrow(
         email?: string,
         shouldSetShippingOption?: boolean,
@@ -99,6 +101,9 @@ export default class BraintreeFastlaneUtils {
             const cart = state.getCartOrThrow();
             const customer = state.getCustomer();
             const billingAddress = state.getBillingAddress();
+            const { isFastlaneShippingOptionAutoSelectEnabled } =
+                state.getPaymentMethodOrThrow<BraintreeInitializationData>(methodId)
+                    .initializationData || {};
 
             const customerEmail = email || customer?.email || billingAddress?.email || '';
 
@@ -180,7 +185,7 @@ export default class BraintreeFastlaneUtils {
             if (shippingAddresses.length > 0 && cart.lineItems.physicalItems.length > 0) {
                 await this.paymentIntegrationService.updateShippingAddress(shippingAddresses[0]);
 
-                if (shouldSetShippingOption) {
+                if (shouldSetShippingOption && isFastlaneShippingOptionAutoSelectEnabled) {
                     await this.setShippingOption();
                 }
             }

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -106,6 +106,7 @@ export interface BraintreeInitializationData {
     isAcceleratedCheckoutEnabled?: boolean;
     isFastlaneStylingEnabled?: boolean;
     isFastlaneEnabled?: boolean;
+    isFastlaneShippingOptionAutoSelectEnabled?: boolean;
     fastlaneStyles?: FastlaneStylesSettings;
     isBraintreeAnalyticsV2Enabled?: boolean;
     shouldRunAcceleratedCheckout?: boolean; // TODO: only for BT AXO A/B testing purposes, hence should be removed after testing


### PR DESCRIPTION
## What?
Added ability to skip shipping step

## Why?
To skip shipping step

## Testing / Proof


https://github.com/user-attachments/assets/e212a742-ae31-4398-a5f4-587658396810


https://github.com/user-attachments/assets/fe81911b-8766-4b3e-b3a2-78b7cfc45c0f


@bigcommerce/team-checkout @bigcommerce/team-payments
