### PR TITLE
feat(payment): STRIPE-484 Stripe OCS confirmation flow

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/is-stripe-error.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/is-stripe-error.spec.ts
@@ -1,0 +1,21 @@
+import { isStripeError } from './is-stripe-error';
+
+describe('isStripeError', () => {
+    it('should return false if the error is undefined', () => {
+        expect(isStripeError(undefined)).toBe(false);
+    });
+
+    it('should return false if the error is null', () => {
+        expect(isStripeError(null)).toBe(false);
+    });
+
+    it('should return false if the error does not contain type', () => {
+        expect(isStripeError({})).toBe(false);
+    });
+
+    it('should return true if the error is a StripeError', () => {
+        const error = { type: 'some type' };
+
+        expect(isStripeError(error)).toBe(true);
+    });
+});

--- a/packages/stripe-integration/src/stripe-upe/is-stripe-error.ts
+++ b/packages/stripe-integration/src/stripe-upe/is-stripe-error.ts
@@ -1,0 +1,5 @@
+import { StripeError } from './stripe-upe';
+
+export function isStripeError(error: unknown): error is StripeError {
+    return typeof error === 'object' && error !== null && 'type' in error;
+}

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
@@ -406,7 +406,7 @@ export interface StripeUPEClient {
     elements(options: StripeElementsOptions): StripeElements;
 }
 
-interface StripeUpeResult {
+export interface StripeUpeResult {
     paymentIntent?: PaymentIntent;
     error?: StripeError;
 }


### PR DESCRIPTION
## What?
New confirmation flow for Stripe OCS

## Why?
To unify confirmation flow for stripe payment methods. For this implementation decision of redirect or non redirect flow makes on stripe side.

## Testing / Proof
unit tests and manually tested
<img width="2560" alt="Screenshot 2024-11-04 at 15 01 18" src="https://github.com/user-attachments/assets/aa0f6766-5a8e-4348-9c07-44b51b78623f">


@bigcommerce/team-checkout @bigcommerce/team-payments
