### PR TITLE
feat(payment): STRIPE-496 Stripe OCS  radio button size

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.spec.ts
@@ -379,6 +379,76 @@ describe('StripeOCSPaymentStrategy', () => {
 
             expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
         });
+
+        describe('Stripe Element styling', () => {
+            describe('RadioButton styling', () => {
+                it('should initialize with default style', async () => {
+                    stripeOptions = getStripeUPEInitializeOptionsMock(
+                        StripePaymentMethodType.OCS,
+                        style,
+                    );
+                    await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                    expect(stripeScriptLoader.getElements).toHaveBeenCalledWith(
+                        stripeUPEJsMock,
+                        expect.objectContaining({
+                            appearance: expect.objectContaining({
+                                rules: expect.objectContaining({
+                                    '.RadioIcon': {
+                                        width: '29.55px',
+                                    },
+                                    '.RadioIconOuter': {
+                                        strokeWidth: '3.38px',
+                                        stroke: '#ddd',
+                                    },
+                                    '.RadioIconOuter--checked': {
+                                        stroke: '#4496f6',
+                                    },
+                                    '.RadioIconInner': {
+                                        r: '28.77px',
+                                        fill: '#4496f6',
+                                    },
+                                }),
+                            }),
+                        }),
+                    );
+                });
+
+                it('should initialize with custom style', async () => {
+                    stripeOptions = getStripeUPEInitializeOptionsMock(StripePaymentMethodType.OCS, {
+                        ...style,
+                        radioIconOuterWidth: '52px',
+                        radioIconOuterStrokeWidth: '4px',
+                        radioIconInnerWidth: '25px',
+                    });
+                    await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                    expect(stripeScriptLoader.getElements).toHaveBeenCalledWith(
+                        stripeUPEJsMock,
+                        expect.objectContaining({
+                            appearance: expect.objectContaining({
+                                rules: expect.objectContaining({
+                                    '.RadioIcon': {
+                                        width: '59.09px',
+                                    },
+                                    '.RadioIconOuter': {
+                                        strokeWidth: '6.77px',
+                                        stroke: '#ddd',
+                                    },
+                                    '.RadioIconOuter--checked': {
+                                        stroke: '#4496f6',
+                                    },
+                                    '.RadioIconInner': {
+                                        r: '21.15px',
+                                        fill: '#4496f6',
+                                    },
+                                }),
+                            }),
+                        }),
+                    );
+                });
+            });
+        });
     });
 
     describe('#execute', () => {

--- a/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.ts
@@ -43,6 +43,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
     private stripeUPEClient?: StripeUPEClient;
     private stripeElements?: StripeElements;
     private selectedMethodId?: string;
+    private readonly stripeSVGSizeCoefficient = 0.88;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
@@ -238,6 +239,12 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         const titleColor = '#5f5f5f'; // TODO: get style from theme
         const radioColor = '#ddd'; // TODO: get style from theme
         const radioFocusColor = '#4496f6'; // TODO: get style from theme
+        const { radioIconOuterWidth, radioIconOuterStrokeWidth, radioIconInnerWidth } = style;
+        const radioIconSize = this._getRadioIconSizes(
+            radioIconOuterWidth,
+            radioIconOuterStrokeWidth,
+            radioIconInnerWidth,
+        );
 
         return {
             variables: {
@@ -265,23 +272,53 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
                     color: titleColor,
                 },
                 '.RadioIcon': {
-                    // 26px / 0.88 = 29.54
-                    width: '29.54px',
+                    width: radioIconSize.outerWidth,
                 },
                 '.RadioIconOuter': {
-                    // 1px / 26px * 0.88 = 0.034
-                    strokeWidth: '3.4',
+                    strokeWidth: radioIconSize.outerStrokeWidth,
                     stroke: radioColor,
                 },
                 '.RadioIconOuter--checked': {
                     stroke: radioFocusColor,
                 },
                 '.RadioIconInner': {
-                    // 17.16px / 26px * 0.88 = 0.58 / 2 = 29
-                    r: '29',
+                    r: radioIconSize.innerRadius,
                     fill: radioFocusColor,
                 },
             },
+        };
+    }
+
+    private _getRadioIconSizes(
+        realOuterWidth: string | number = 26,
+        realOuterStrokeWidth: string | number = 1,
+        realInnerWidth: string | number = 17,
+    ) {
+        const percentageCoefficient = this.stripeSVGSizeCoefficient * 100;
+
+        const outerWidth =
+            typeof realOuterWidth === 'string' ? parseInt(realOuterWidth, 10) : realOuterWidth;
+        const outerStrokeWidth =
+            typeof realOuterStrokeWidth === 'string'
+                ? parseInt(realOuterStrokeWidth, 10)
+                : realOuterStrokeWidth;
+        const innerWidth =
+            typeof realInnerWidth === 'string' ? parseInt(realInnerWidth, 10) : realInnerWidth;
+
+        const stripeEqualOuterWidth = (outerWidth / this.stripeSVGSizeCoefficient).toFixed(2);
+        const stripeEqualOuterStrokeWidth = (
+            (outerStrokeWidth / outerWidth) *
+            percentageCoefficient
+        ).toFixed(2);
+        const stripeEqualInnerRadius = (
+            ((innerWidth / outerWidth) * percentageCoefficient) /
+            2
+        ).toFixed(2);
+
+        return {
+            outerWidth: `${stripeEqualOuterWidth}px`,
+            outerStrokeWidth: `${stripeEqualOuterStrokeWidth}px`,
+            innerRadius: `${stripeEqualInnerRadius}px`,
         };
     }
 

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.ts
@@ -84,7 +84,7 @@ export default class StripeUPEIntegrationService {
         this.isMounted = true;
     }
 
-    mapAppearanceVariables(styles: { [key: string]: string }) {
+    mapAppearanceVariables(styles: NonNullable<StripeUPEPaymentInitializeOptions['style']>) {
         return {
             colorPrimary: styles.fieldInnerShadow,
             colorBackground: styles.fieldBackground,
@@ -96,7 +96,7 @@ export default class StripeUPEIntegrationService {
         };
     }
 
-    mapInputAppearanceRules(styles: { [key: string]: string }) {
+    mapInputAppearanceRules(styles: NonNullable<StripeUPEPaymentInitializeOptions['style']>) {
         return {
             borderColor: styles.fieldBorder,
             color: styles.fieldText,


### PR DESCRIPTION
## What?
Stripe OCS radio button size styling

## Why?
To add customisation for Stripe OCS radio buttons styles. To make it similar to BC accordion radio buttons and add customisation ability for merchants with custom checkouts.

## Testing / Proof
Before
<img width="601" alt="Screenshot 2024-11-06 at 14 56 09" src="https://github.com/user-attachments/assets/7edb9306-2a68-4541-b4ff-18881aafd78d">

After
<img width="606" alt="Screenshot 2024-11-06 at 14 37 08" src="https://github.com/user-attachments/assets/f0e38cbb-2c45-44a5-90ba-a169c8b8a803">


@bigcommerce/team-checkout @bigcommerce/team-payments
