### PR TITLE
fix(payment): STRIPE-509 Update Stripe element on PI update

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/create-stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/create-stripe-ocs-payment-strategy.ts
@@ -12,10 +12,12 @@ import StripeUPEScriptLoader from './stripe-upe-script-loader';
 const createStripeOCSPaymentStrategy: PaymentStrategyFactory<StripeOCSPaymentStrategy> = (
     paymentIntegrationService,
 ) => {
+    const stripeScriptLoader = new StripeUPEScriptLoader(getScriptLoader());
+
     return new StripeOCSPaymentStrategy(
         paymentIntegrationService,
-        new StripeUPEScriptLoader(getScriptLoader()),
-        new StripeUPEIntegrationService(paymentIntegrationService),
+        stripeScriptLoader,
+        new StripeUPEIntegrationService(paymentIntegrationService, stripeScriptLoader),
     );
 };
 

--- a/packages/stripe-integration/src/stripe-upe/create-stripe-upe-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/create-stripe-upe-payment-strategy.ts
@@ -12,10 +12,12 @@ import StripeUPEScriptLoader from './stripe-upe-script-loader';
 const createStripeUPEPaymentStrategy: PaymentStrategyFactory<StripeUPEPaymentStrategy> = (
     paymentIntegrationService,
 ) => {
+    const stripeScriptLoader = new StripeUPEScriptLoader(getScriptLoader());
+
     return new StripeUPEPaymentStrategy(
         paymentIntegrationService,
-        new StripeUPEScriptLoader(getScriptLoader()),
-        new StripeUPEIntegrationService(paymentIntegrationService),
+        stripeScriptLoader,
+        new StripeUPEIntegrationService(paymentIntegrationService, stripeScriptLoader),
     );
 };
 

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -93,7 +93,10 @@ describe('StripeUPEPaymentStrategy', () => {
 
         jest.spyOn(paymentIntegrationService, 'subscribe');
 
-        stripeUPEIntegrationService = new StripeUPEIntegrationService(paymentIntegrationService);
+        stripeUPEIntegrationService = new StripeUPEIntegrationService(
+            paymentIntegrationService,
+            stripeScriptLoader,
+        );
         strategy = new StripeUPEPaymentStrategy(
             paymentIntegrationService,
             stripeScriptLoader,

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-script-loader.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-script-loader.ts
@@ -55,11 +55,21 @@ export default class StripeUPEScriptLoader {
 
             Object.assign(this.stripeWindow, { bcStripeElements: stripeElements });
         } else {
-            stripeElements.update(options);
-            await stripeElements.fetchUpdates();
+            await this.updateStripeElements(options);
         }
 
         return stripeElements;
+    }
+
+    async updateStripeElements(options: StripeElementsOptions) {
+        const stripeElements = this.stripeWindow.bcStripeElements;
+
+        if (!stripeElements) {
+            return;
+        }
+
+        stripeElements.update(options);
+        await stripeElements.fetchUpdates();
     }
 
     private async load() {


### PR DESCRIPTION
## What?
Update Stripe UI element after updates on BE side.

## Why?
For some cases after BE synchronisation some options for Stripe payment state can be changed or can be changed PaymentIntent. And we need to update Stripe UI element as well to operate with actual stripe state data.

## Testing / Proof
Unit test and manually tested.

###Before:

https://github.com/user-attachments/assets/62bc7942-409d-486c-aa80-0866252b81cd

###After:

https://github.com/user-attachments/assets/707d3b2b-90a1-46a3-828b-b96b253be564

With redirect

https://github.com/user-attachments/assets/1b98ecba-168d-4695-b48c-431b89a46a03

On page confirmation

https://github.com/user-attachments/assets/488cc67c-a703-4aba-b0e7-2a5560035be0



@bigcommerce/team-checkout @bigcommerce/team-payments
