### PR TITLE
fix(extension): CHECKOUT-8869 Fix Display Issue after Page Refresh

### DIFF
--- a/packages/core/src/extension/resizable-firame-creator.spec.ts
+++ b/packages/core/src/extension/resizable-firame-creator.spec.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events';
 
+import { UnexpectedDetachmentError } from '../common/dom/errors';
+
 import { ExtensionNotLoadedError } from './errors';
 import { Extension } from './extension';
 import { ExtensionInternalCommandType } from './extension-internal-commands';
@@ -142,6 +144,24 @@ describe('ResizableIframeCreator', () => {
                 'message',
                 expect.any(Function),
             );
+        }
+    });
+
+    it('throws error if container is removed before iframe finishes loading', async () => {
+        iframeCreator = new ResizableIframeCreator({
+            timeout: 1000,
+        });
+
+        setTimeout(() => {
+            container.remove();
+        });
+
+        try {
+            await iframeCreator.createFrame(url, 'checkout', initCallback, failedCallback);
+        } catch (error) {
+            expect(error).toBeInstanceOf(UnexpectedDetachmentError);
+            expect(initCallback).not.toHaveBeenCalled();
+            expect(failedCallback).not.toHaveBeenCalled();
         }
     });
 });

--- a/packages/core/src/extension/resizable-firame-creator.spec.ts
+++ b/packages/core/src/extension/resizable-firame-creator.spec.ts
@@ -117,13 +117,21 @@ describe('ResizableIframeCreator', () => {
     });
 
     it('throws error if not receiving "loaded" event within certain timeframe', async () => {
+        jest.spyOn(console, 'error').mockImplementation();
+
         try {
-            await iframeCreator.createFrame(url, 'checkout', initCallback, failedCallback);
+            await iframeCreator.createFrame(url, 'checkout', initCallback, () => {
+                throw Error('failedCallback execution failed');
+            });
         } catch (error) {
             expect(error).toBeInstanceOf(ExtensionNotLoadedError);
             expect(initCallback).not.toHaveBeenCalled();
-            expect(failedCallback).toHaveBeenCalled();
         }
+
+        // eslint-disable-next-line no-console
+        expect(console.error).toHaveBeenCalledWith(
+            'Extension rendering timed out after 0ms, and the callback function could not be executed. Error: failedCallback execution failed',
+        );
     });
 
     it('removes iframe from container element if unable to load', async () => {

--- a/packages/core/src/extension/resizable-iframe-creator.ts
+++ b/packages/core/src/extension/resizable-iframe-creator.ts
@@ -1,3 +1,4 @@
+import { DetachmentObserver, MutationObserverFactory } from '../common/dom';
 import { IFrameComponent, iframeResizer, isIframeEvent } from '../common/iframe';
 import { parseUrl } from '../common/url';
 
@@ -40,15 +41,17 @@ export default class ResizableIframeCreator {
         );
     }
 
-    private _toResizableFrame(
+    private async _toResizableFrame(
         iframe: HTMLIFrameElement,
         timeoutInterval: number,
         initCallback: () => void,
         failedCallback: () => void,
     ): Promise<IFrameComponent> {
+        const detachmentObserver = new DetachmentObserver(new MutationObserverFactory());
+
         // Can't simply listen to `load` event because it always gets triggered even if there's an error.
         // Instead, listen to the `load` inside the iframe and let the parent frame know when it happens.
-        return new Promise((resolve, reject) => {
+        const promise = new Promise<IFrameComponent>((resolve, reject) => {
             const timeout = window.setTimeout(() => {
                 failedCallback();
 
@@ -90,5 +93,7 @@ export default class ResizableIframeCreator {
 
             window.addEventListener('message', handleMessage);
         });
+
+        return detachmentObserver.ensurePresence([iframe], promise);
     }
 }

--- a/packages/core/src/extension/resizable-iframe-creator.ts
+++ b/packages/core/src/extension/resizable-iframe-creator.ts
@@ -53,7 +53,16 @@ export default class ResizableIframeCreator {
         // Instead, listen to the `load` inside the iframe and let the parent frame know when it happens.
         const promise = new Promise<IFrameComponent>((resolve, reject) => {
             const timeout = window.setTimeout(() => {
-                failedCallback();
+                try {
+                    failedCallback();
+                } catch (error) {
+                    if (error instanceof Error) {
+                        // eslint-disable-next-line no-console
+                        console.error(
+                            `Extension rendering timed out after ${timeoutInterval}ms, and the callback function could not be executed. Error: ${error.message}`,
+                        );
+                    }
+                }
 
                 reject(
                     new ExtensionNotLoadedError(


### PR DESCRIPTION
## What?
Fix the issue where the checkout extension in the selected shipping option fails to display after a page refresh, even though it works fine on the first run.

## Why?
When an extension iframe is removed before it has finished loading, particularly in cases where there is an existing consignment, this action creates a pending extension rendering promise, which can only be resolved or rejected by either a 60-second timeout or a message from the iframe.

Related code:
https://github.com/bigcommerce/checkout-sdk-js/blob/2e6f95f3718a37ef48e1c479136a699e95e6db6f/packages/core/src/extension/resizable-iframe-creator.ts#L91

This PR resolves the issue by rejecting the promise upon detecting the removal of the iframe from the DOM.

## Testing / Proof
### Manual testing

https://github.com/user-attachments/assets/3a4e0ab1-ae51-4c0a-9b9f-892e3094b376


@bigcommerce/team-checkout @bigcommerce/team-payments
