### PR TITLE
feat(payment): STRIPE-525 Stripe UPE new confirmation flow

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.ts
@@ -11,14 +11,12 @@ import {
     PaymentInitializeOptions,
     PaymentIntegrationSelectors,
     PaymentIntegrationService,
-    PaymentMethodCancelledError,
     PaymentMethodFailedError,
     PaymentRequestOptions,
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import formatLocale from './format-locale';
-import { isStripeError } from './is-stripe-error';
 import { isStripePaymentEvent } from './is-stripe-payment-event';
 import { isStripeUPEPaymentMethodLike } from './is-stripe-upe-payment-method-like';
 import {
@@ -406,20 +404,8 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
 
             return confirmationResult;
         } catch (error: unknown) {
-            this._throwStripeError(stripeError);
+            this.stripeUPEIntegrationService.throwStripeError(stripeError);
         }
-    }
-
-    private _throwStripeError(stripeError?: unknown): never {
-        if (isStripeError(stripeError)) {
-            this.stripeUPEIntegrationService.throwDisplayableStripeError(stripeError);
-
-            if (this.stripeUPEIntegrationService.isCancellationError(stripeError)) {
-                throw new PaymentMethodCancelledError();
-            }
-        }
-
-        throw new PaymentMethodFailedError();
     }
 
     private _onStripeElementChange(

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.mock.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-integration-service.mock.ts
@@ -19,7 +19,7 @@ export const getStripeUPEIntegrationServiceMock = () =>
         }),
         isCancellationError: jest.fn(() => false),
         isPaymentCompleted: jest.fn(() => Promise.resolve(false)),
-        mapStripePaymentData: jest.fn(() => ({
+        mapStripePaymentData: jest.fn((return_url?: string) => ({
             elements: getStripeUPEJsMock().elements({}),
             redirect: StripeStringConstants.IF_REQUIRED,
             confirmParams: {
@@ -30,11 +30,14 @@ export const getStripeUPEIntegrationServiceMock = () =>
                         name: 'firstName lastName',
                     },
                 },
-                return_url: 'return.url',
+                ...(return_url ? { return_url } : {}),
             },
         })),
         isAdditionalActionError: jest.fn(() => false),
         isRedirectAction: jest.fn(() => false),
         isOnPageAdditionalAction: jest.fn(() => false),
         updateStripePaymentIntent: jest.fn(() => Promise.resolve()),
+        throwStripeError: jest.fn(() => {
+            throw new Error('throw stripe error');
+        }),
     } as unknown as StripeUPEIntegrationService);

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.mock.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.mock.ts
@@ -107,6 +107,7 @@ export function getStripeUPEOrderRequestBodyMock(
     return {
         payment: {
             methodId: stripePaymentMethodType,
+            gatewayId: 'stripeupe',
             paymentData: {
                 shouldSaveInstrument,
             },
@@ -201,5 +202,14 @@ export function getRetrievePaymentIntentResponseSucceeded() {
             id: 'pi_1234',
             status: 'succeeded',
         },
+    };
+}
+
+export function getRetrievePaymentIntentResponseWithError() {
+    return {
+        paymentIntent: {
+            id: 'pi_1234',
+        },
+        error: new Error('retrieve_payment_intent_response_with_error'),
     };
 }

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
@@ -464,6 +464,7 @@ export interface StripeUPEInitializationData {
     stripePublishableKey: string;
     stripeConnectedAccount: string;
     shopperLanguage: string;
+    newConfirmationFlow?: boolean;
 }
 
 export interface StripeElementUpdateOptions {


### PR DESCRIPTION
## What?
Stripe UPE confirmation flow refactoring

## Why?
To simplify confirmation logic and make it similar for different Stripe APMs

## Testing / Proof

### Credit Card
#### general flow

https://github.com/user-attachments/assets/7091b72b-fadd-439b-a57a-b63f2f65f67e

#### 3ds success flow

https://github.com/user-attachments/assets/b9539a74-5e7e-4160-826f-468517cfd3fb

#### 3ds failed flow

https://github.com/user-attachments/assets/5a11a652-8b4c-4c57-93a4-ce7ce22c1457

### Alipay (redirect)
#### Success flow

https://github.com/user-attachments/assets/80b28934-c3b8-448e-9cef-fc86ad3863a5

#### Failed flow

https://github.com/user-attachments/assets/875bbf25-e3c0-4230-92f0-33929a37300b

#### Cancelation flow

https://github.com/user-attachments/assets/4df05eb1-ac13-4d43-b270-1787745c2296

### Klarna (redirect)

https://github.com/user-attachments/assets/950bcf47-7c9c-4ca6-8646-7abb385a9b5d

### US Bank Account (on page confirmation)
#### Success flow

https://github.com/user-attachments/assets/2539781b-01f2-4f03-8f6a-1cd788fd7aa1

#### Fail flow

https://github.com/user-attachments/assets/8cd01b64-d689-4c45-8ab0-cad32fa77222

### Stripe LINK
#### Link authenticated

https://github.com/user-attachments/assets/1c56bd5e-3725-49dd-aeb3-d2c6d8737e95

#### Link auth on payment step

https://github.com/user-attachments/assets/a7cf2d4d-5735-41be-a454-749e8d2b85f9

#### Stripe Link guest user

https://github.com/user-attachments/assets/87f4d1d6-2a26-4953-bcec-5050eb99dd32

### Vaulted instrument
#### Vaulting

https://github.com/user-attachments/assets/75a8af59-e027-47b2-a939-750213a1966a

#### Pay with vaulted instrument

https://github.com/user-attachments/assets/ed2db42e-9602-42bf-9df7-2d89d4109cd6

### Unit test coverage:
<img width="2558" alt="Screenshot 2024-11-28 at 16 32 53" src="https://github.com/user-attachments/assets/42a45648-3aaf-4592-a8d2-031fcb4799cb">

### Functional test
<img width="998" alt="Screenshot 2024-12-16 at 15 28 16" src="https://github.com/user-attachments/assets/0a56b75f-9632-467a-9aa8-890af4874d09" />
<img width="996" alt="Screenshot 2024-12-16 at 15 28 29" src="https://github.com/user-attachments/assets/9d46ab8d-ef99-4e15-8013-5333a9b89f35" />




@bigcommerce/team-checkout @bigcommerce/team-payments
