### PR TITLE
feat(payment): PAYPAL-4884 send payment provider paymentId on payment start stage in Braintree LPMs payment strategy

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
@@ -263,6 +263,7 @@ describe('BraintreeFastlaneUtils', () => {
                     isFastlaneShippingOptionAutoSelectEnabled: true,
                 },
             };
+
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',
@@ -285,6 +286,7 @@ describe('BraintreeFastlaneUtils', () => {
                     isFastlaneShippingOptionAutoSelectEnabled: false,
                 },
             };
+
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',
@@ -303,6 +305,7 @@ describe('BraintreeFastlaneUtils', () => {
                     isFastlaneShippingOptionAutoSelectEnabled: true,
                 },
             };
+
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-initialize-options.ts
@@ -1,4 +1,4 @@
-export interface BraintreeLocalMethods {
+export interface BraintreeLocalMethodsPaymentInitializeOptions {
     /**
      * The CSS selector of a container where the payment widget should be inserted into.
      */
@@ -24,5 +24,5 @@ export interface BraintreeLocalMethods {
 }
 
 export interface WithBraintreeLocalMethodsPaymentInitializeOptions {
-    braintreelocalmethods?: BraintreeLocalMethods;
+    braintreelocalmethods?: BraintreeLocalMethodsPaymentInitializeOptions;
 }

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
@@ -1,44 +1,48 @@
 import {
     BraintreeInitializationData,
-    BraintreeIntegrationService,
+    BraintreeLocalPayment,
+    BraintreeLocalPaymentConfig,
     BraintreeLocalPaymentMethodRedirectAction,
+    BraintreeLocalPaymentsPayload,
+    BraintreeLPMPaymentStartData,
+    BraintreeLPMStartPaymentError,
+    BraintreeOrderSavedResponse,
     BraintreeRedirectError,
-    LocalPaymentInstance,
-    LocalPaymentsPayload,
+    BraintreeSdk,
     NonInstantLocalPaymentMethods,
-    onPaymentStartData,
-    StartPaymentError,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     InvalidArgumentError,
     MissingDataError,
     MissingDataErrorType,
     OrderFinalizationNotRequiredError,
-    OrderPaymentRequestBody,
     OrderRequestBody,
     PaymentArgumentInvalidError,
     PaymentInitializeOptions,
+    PaymentInstrumentMeta,
     PaymentIntegrationService,
     PaymentMethodInvalidError,
     PaymentRequestOptions,
     PaymentStrategy,
+    RequestOptions,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import {
-    BraintreeLocalMethods,
+    BraintreeLocalMethodsPaymentInitializeOptions,
     WithBraintreeLocalMethodsPaymentInitializeOptions,
-} from './braintree-local-methods-options';
+} from './braintree-local-methods-payment-initialize-options';
 
 export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStrategy {
-    private orderId?: string;
-    private localPaymentInstance?: LocalPaymentInstance;
-    private braintreeLocalMethods?: BraintreeLocalMethods;
+    private braintreelocalmethods?: BraintreeLocalMethodsPaymentInitializeOptions;
+    private braintreeLocalPayment?: BraintreeLocalPayment;
     private loadingIndicatorContainer?: string;
+    private orderId?: string;
+    private isLPMsUpdateExperimentEnabled = false;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
-        private braintreeIntegrationService: BraintreeIntegrationService,
+        private braintreeSdk: BraintreeSdk,
         private loadingIndicator: LoadingIndicator,
     ) {}
 
@@ -65,8 +69,7 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
             );
         }
 
-        this.braintreeLocalMethods = braintreelocalmethods;
-
+        this.braintreelocalmethods = braintreelocalmethods;
         this.loadingIndicatorContainer = braintreelocalmethods.container.split('#')[1];
 
         await this.paymentIntegrationService.loadPaymentMethod(gatewayId);
@@ -75,16 +78,23 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
         const paymentMethod = state.getPaymentMethodOrThrow<BraintreeInitializationData>(gatewayId);
         const { clientToken, config, initializationData } = paymentMethod;
 
-        if (!clientToken || !initializationData) {
+        this.isLPMsUpdateExperimentEnabled =
+            state.getStoreConfigOrThrow().checkoutSettings.features[
+                'PAYPAL-4853.add_new_payment_flow_for_braintree_lpms'
+            ] || false;
+
+        if (!clientToken || !initializationData || !config.merchantId) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         try {
-            this.braintreeIntegrationService.initialize(clientToken);
-            await this.braintreeIntegrationService.loadBraintreeLocalMethods(
-                this.getLocalPaymentInstance.bind(this),
-                config.merchantId || '',
-            );
+            this.braintreeSdk.initialize(clientToken);
+
+            if (!this.isNonInstantPaymentMethod(methodId)) {
+                this.braintreeLocalPayment = await this.braintreeSdk.getBraintreeLocalPayment(
+                    config.merchantId,
+                );
+            }
         } catch (error: unknown) {
             this.handleError(error);
         }
@@ -95,7 +105,6 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
     }
 
     async deinitialize(): Promise<void> {
-        this.orderId = undefined;
         this.toggleLoadingIndicator(false);
 
         return Promise.resolve();
@@ -103,42 +112,37 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
 
     async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
         const { payment, ...order } = payload;
-        const sessionId = await this.braintreeIntegrationService.getSessionId();
 
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
         }
 
-        this.toggleLoadingIndicator(true);
-
-        return this.isNonInstantPaymentMethod(payment.methodId)
-            ? this.executeWithNotInstantLPM(payment, sessionId)
-            : this.executeWithInstantLPM(payment.methodId, order, options, sessionId);
-    }
-
-    private async executeWithNotInstantLPM(
-        payment: OrderPaymentRequestBody,
-        sessionId?: string,
-    ): Promise<void> {
         const { methodId } = payment;
 
-        const paymentData = {
-            formattedPayload: {
-                vault_payment_instrument: null,
-                set_as_default_stored_instrument: null,
-                method: methodId,
-                device_info: sessionId || null,
-            },
-        };
+        this.toggleLoadingIndicator(true);
 
-        await this.paymentIntegrationService.submitOrder();
+        if (this.isNonInstantPaymentMethod(methodId)) {
+            await this.executeWithNotInstantLPM(methodId);
+        } else {
+            await this.executeWithInstantLPM(methodId, order, options);
+        }
+    }
 
+    private async executeWithNotInstantLPM(methodId: string): Promise<void> {
         try {
+            const basicPaymentData = await this.getLPMsBasicPaymentData();
+
+            await this.paymentIntegrationService.submitOrder();
             await this.paymentIntegrationService.submitPayment({
                 methodId,
-                paymentData,
+                paymentData: {
+                    ...basicPaymentData,
+                    formattedPayload: {
+                        method: methodId,
+                    },
+                },
             });
-        } catch (error) {
+        } catch (error: unknown) {
             if (this.isBraintreeRedirectError(error)) {
                 const redirectUrl = error.body.additional_action_required.data.redirect_url;
 
@@ -151,7 +155,7 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
                 });
             }
 
-            this.toggleLoadingIndicator(false);
+            this.handleError(error);
 
             return Promise.reject(error);
         }
@@ -161,12 +165,30 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
         methodId: string,
         order: Omit<OrderRequestBody, 'payment'>,
         options?: PaymentRequestOptions,
-        sessionId?: string,
     ): Promise<void> {
-        if (!this.localPaymentInstance) {
+        if (!this.braintreeLocalPayment) {
             throw new PaymentMethodInvalidError();
         }
 
+        await new Promise((resolve, reject): void => {
+            this.braintreeLocalPayment?.startPayment(
+                this.getInstantLPMConfig(methodId, order, options),
+                this.getInstantLPMCallback(resolve, reject, methodId, order, options),
+            );
+        });
+    }
+
+    private async getLPMsBasicPaymentData(): Promise<PaymentInstrumentMeta> {
+        const { deviceData } = await this.braintreeSdk.getDataCollectorOrThrow();
+
+        return { deviceSessionId: deviceData };
+    }
+
+    private getInstantLPMConfig(
+        methodId: string,
+        order: Omit<OrderRequestBody, 'payment'>,
+        options?: RequestOptions,
+    ): BraintreeLocalPaymentConfig {
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
         const billing = state.getBillingAddressOrThrow();
@@ -175,79 +197,121 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
         const isShippingRequired = lineItems.physicalItems.length > 0;
         const grandTotal = state.getCheckoutOrThrow().outstandingBalance;
 
-        return new Promise((resolve, reject) => {
-            this.localPaymentInstance?.startPayment(
-                {
-                    paymentType: methodId,
-                    amount: grandTotal,
-                    fallback: {
-                        url: 'url-placeholder',
-                        buttonText: 'button placeholder',
+        return {
+            paymentType: methodId,
+            amount: grandTotal,
+            fallback: {
+                url: 'url-placeholder',
+                buttonText: 'button placeholder',
+            },
+            currencyCode: currency.code,
+            shippingAddressRequired: isShippingRequired,
+            email,
+            givenName: firstName,
+            surname: lastName,
+            address: {
+                countryCode,
+            },
+            onPaymentStart: async (data: BraintreeLPMPaymentStartData, start: () => void) => {
+                if (!this.isLPMsUpdateExperimentEnabled) {
+                    this.orderId = data.paymentId;
+
+                    start();
+
+                    return;
+                }
+
+                const basicPaymentData = await this.getLPMsBasicPaymentData();
+                const paymentData = {
+                    ...basicPaymentData,
+                    formattedPayload: {
+                        method: methodId,
+                        [`${methodId}_account`]: {
+                            order_id: data.paymentId,
+                        },
                     },
-                    currencyCode: currency.code,
-                    shippingAddressRequired: isShippingRequired,
-                    email,
-                    givenName: firstName,
-                    surname: lastName,
-                    address: {
-                        countryCode,
-                    },
-                    onPaymentStart: (data: onPaymentStartData, start: () => void) => {
-                        // Call start to initiate the popup
-                        this.orderId = data.paymentId;
+                };
+
+                try {
+                    // Submit order and payment should be performed to pass order_id to the backend
+                    await this.paymentIntegrationService.submitOrder(order, options);
+                    await this.paymentIntegrationService.submitPayment({
+                        methodId,
+                        paymentData,
+                    });
+                } catch (error: unknown) {
+                    if (
+                        this.isBraintreeOrderSavedResponse(error) &&
+                        error.body.additional_action_required.data.order_id_saved_successfully
+                    ) {
+                        // Start method call initiates the popup
                         start();
-                    },
-                },
-                async (
-                    startPaymentError: StartPaymentError | null,
-                    payloadData: LocalPaymentsPayload,
-                ) => {
-                    if (startPaymentError) {
-                        if (startPaymentError.code !== 'LOCAL_PAYMENT_WINDOW_CLOSED') {
-                            reject(() => this.handleError(startPaymentError));
-                        }
 
-                        this.toggleLoadingIndicator(false);
-                        reject();
-                    } else {
-                        if (!this.orderId) {
-                            throw PaymentMethodInvalidError;
-                        }
-
-                        const paymentData = {
-                            formattedPayload: {
-                                device_info: sessionId || null,
-                                method: methodId,
-                                [`${methodId}_account`]: {
-                                    email: cart.email,
-                                    token: payloadData.nonce,
-                                    order_id: this.orderId,
-                                },
-                                vault_payment_instrument: null,
-                                set_as_default_stored_instrument: null,
-                            },
-                        };
-
-                        try {
-                            await this.paymentIntegrationService.submitOrder(order, options);
-                            await this.paymentIntegrationService.submitPayment({
-                                methodId,
-                                paymentData,
-                            });
-                            resolve();
-                        } catch (error: unknown) {
-                            reject(() => this.handleError(error));
-                        }
+                        return;
                     }
-                },
-            );
-        });
+
+                    throw error;
+                }
+            },
+        };
     }
 
-    private getLocalPaymentInstance(localPaymentInstance: LocalPaymentInstance) {
-        if (!this.localPaymentInstance) {
-            this.localPaymentInstance = localPaymentInstance;
-        }
+    private getInstantLPMCallback(
+        resolve: (value: unknown) => void,
+        reject: (reason?: unknown) => void,
+        methodId: string,
+        order: Omit<OrderRequestBody, 'payment'>,
+        options?: RequestOptions,
+    ) {
+        const state = this.paymentIntegrationService.getState();
+        const cart = state.getCartOrThrow();
+
+        return async (
+            startPaymentError: BraintreeLPMStartPaymentError | undefined,
+            payloadData: BraintreeLocalPaymentsPayload,
+        ) => {
+            if (startPaymentError) {
+                if (startPaymentError.code === 'LOCAL_PAYMENT_WINDOW_CLOSED') {
+                    this.toggleLoadingIndicator(false);
+
+                    return reject();
+                }
+
+                this.toggleLoadingIndicator(false);
+
+                return reject(new PaymentMethodInvalidError());
+            }
+
+            const basicPaymentData = await this.getLPMsBasicPaymentData();
+            const paymentData = {
+                ...basicPaymentData,
+                formattedPayload: {
+                    method: methodId,
+                    [`${methodId}_account`]: {
+                        email: cart.email,
+                        token: payloadData.nonce,
+                        ...(!this.isLPMsUpdateExperimentEnabled ? { order_id: this.orderId } : {}),
+                    },
+                },
+            };
+
+            try {
+                if (!this.isLPMsUpdateExperimentEnabled) {
+                    await this.paymentIntegrationService.submitOrder(order, options);
+                }
+
+                await this.paymentIntegrationService.submitPayment({
+                    methodId,
+                    paymentData,
+                });
+
+                return resolve(undefined);
+            } catch (error: unknown) {
+                this.handleError(error);
+
+                return reject(error);
+            }
+        };
     }
 
     /**
@@ -264,7 +328,7 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
     }
 
     private handleError(error: unknown) {
-        const { onError } = this.braintreeLocalMethods || {};
+        const { onError } = this.braintreelocalmethods || {};
 
         this.toggleLoadingIndicator(false);
 
@@ -294,5 +358,21 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
         }
 
         return !!body.additional_action_required?.data.redirect_url;
+    }
+
+    private isBraintreeOrderSavedResponse(
+        response: unknown,
+    ): response is BraintreeOrderSavedResponse {
+        if (typeof response !== 'object' || response === null) {
+            return false;
+        }
+
+        const { body }: Partial<BraintreeOrderSavedResponse> = response;
+
+        if (!body) {
+            return false;
+        }
+
+        return body.additional_action_required?.data.hasOwnProperty('order_id_saved_successfully');
     }
 }

--- a/packages/braintree-integration/src/braintree-local-payment-methods/create-braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/create-braintree-local-methods-payment-strategy.ts
@@ -2,8 +2,8 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import {
     BraintreeHostWindow,
-    BraintreeIntegrationService,
     BraintreeScriptLoader,
+    BraintreeSdk,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     PaymentStrategyFactory,
@@ -17,14 +17,13 @@ const createBraintreeLocalMethodsPaymentStrategy: PaymentStrategyFactory<
     BraintreeLocalMethodsPaymentStrategy
 > = (paymentIntegrationService) => {
     const braintreeHostWindow: BraintreeHostWindow = window;
-    const braintreeIntegrationService = new BraintreeIntegrationService(
+    const braintreeSdk = new BraintreeSdk(
         new BraintreeScriptLoader(getScriptLoader(), braintreeHostWindow),
-        braintreeHostWindow,
     );
 
     return new BraintreeLocalMethodsPaymentStrategy(
         paymentIntegrationService,
-        braintreeIntegrationService,
+        braintreeSdk,
         new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
     );
 };

--- a/packages/braintree-integration/src/index.ts
+++ b/packages/braintree-integration/src/index.ts
@@ -20,7 +20,7 @@ export { default as createBraintreePaypalCreditCustomerStrategy } from './braint
  * Braintree LPMs strategies
  */
 export { default as createBraintreeLocalMethodsPaymentStrategy } from './braintree-local-payment-methods/create-braintree-local-methods-payment-strategy';
-export { WithBraintreeLocalMethodsPaymentInitializeOptions } from './braintree-local-payment-methods/braintree-local-methods-options';
+export { WithBraintreeLocalMethodsPaymentInitializeOptions } from './braintree-local-payment-methods/braintree-local-methods-payment-initialize-options';
 
 /**
  * Braintree AXO strategies

--- a/packages/braintree-integration/src/mocks/braintree.mock.ts
+++ b/packages/braintree-integration/src/mocks/braintree.mock.ts
@@ -36,10 +36,11 @@ export function getBraintreeLocalMethods() {
     return {
         id: 'braintreelocalmethods',
         logoUrl: '',
-        method: 'giropay',
+        method: 'ideal',
         supportedCards: [],
         config: {
-            displayName: 'Giropay',
+            displayName: 'Ideal',
+            merchantId: 'someMerchantId',
         },
         initializationData: {
             isAcceleratedCheckoutEnabled: false,

--- a/packages/braintree-utils/src/braintree-integration-service.spec.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.spec.ts
@@ -75,9 +75,6 @@ describe('BraintreeIntegrationService', () => {
         jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockResolvedValue(
             paypalCheckoutCreatorMock,
         );
-        jest.spyOn(braintreeScriptLoader, 'loadBraintreeLocalMethods').mockResolvedValue(
-            getModuleCreatorMock(),
-        );
 
         jest.spyOn(braintreeScriptLoader, 'load3DS').mockResolvedValue(threeDSecureCreatorMock);
     });
@@ -361,16 +358,6 @@ describe('BraintreeIntegrationService', () => {
             };
 
             expect(braintreeIntegrationService.mapToLegacyShippingAddress(props)).toEqual(expects);
-        });
-    });
-
-    describe('#loadBraintreeLocalMethods()', () => {
-        it('loads local payment methods', async () => {
-            braintreeIntegrationService.initialize(clientToken);
-
-            await braintreeIntegrationService.loadBraintreeLocalMethods(jest.fn(), '');
-
-            expect(braintreeScriptLoader.loadBraintreeLocalMethods).toHaveBeenCalled();
         });
     });
 

--- a/packages/braintree-utils/src/braintree-integration-service.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.ts
@@ -26,8 +26,6 @@ import {
     BraintreeShippingAddressOverride,
     BraintreeTokenizationDetails,
     BraintreeTokenizePayload,
-    GetLocalPaymentInstance,
-    LocalPaymentInstance,
     PAYPAL_COMPONENTS,
 } from './types';
 import isBraintreeError from './utils/is-braintree-error';
@@ -48,7 +46,6 @@ export default class BraintreeIntegrationService {
     private clientToken?: string;
     private dataCollectors: BraintreeDataCollectors = {};
     private paypalCheckout?: BraintreePaypalCheckout;
-    private braintreeLocalMethods?: LocalPaymentInstance;
     private braintreePaypal?: Promise<BraintreePaypal>;
 
     constructor(
@@ -187,35 +184,6 @@ export default class BraintreeIntegrationService {
         );
 
         return this.paypalCheckout;
-    }
-
-    async loadBraintreeLocalMethods(
-        getLocalPaymentInstance: GetLocalPaymentInstance,
-        merchantAccountId: string,
-    ) {
-        const client = await this.getClient();
-        const braintreeLocalMethods = await this.braintreeScriptLoader.loadBraintreeLocalMethods();
-
-        if (!this.braintreeLocalMethods) {
-            this.braintreeLocalMethods = await braintreeLocalMethods.create(
-                {
-                    client,
-                    merchantAccountId,
-                },
-                (
-                    localPaymentErr: BraintreeError | undefined,
-                    localPaymentInstance: LocalPaymentInstance,
-                ) => {
-                    if (localPaymentErr) {
-                        throw new Error(localPaymentErr.message);
-                    }
-
-                    getLocalPaymentInstance(localPaymentInstance);
-                },
-            );
-        }
-
-        return this.braintreeLocalMethods;
     }
 
     async getDataCollector(

--- a/packages/braintree-utils/src/braintree-script-loader.spec.ts
+++ b/packages/braintree-utils/src/braintree-script-loader.spec.ts
@@ -246,7 +246,7 @@ describe('BraintreeScriptLoader', () => {
         });
     });
 
-    describe('#loadBraintreeLocalMethods', () => {
+    describe('#loadLocalPayment', () => {
         let localPayment: BraintreeLocalPaymentCreator;
 
         beforeEach(() => {
@@ -263,7 +263,7 @@ describe('BraintreeScriptLoader', () => {
         it('loads local payment methods', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
 
-            await braintreeScriptLoader.loadBraintreeLocalMethods();
+            await braintreeScriptLoader.loadLocalPayment();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
                 `//js.braintreegateway.com/web/${BRAINTREE_SDK_STABLE_VERSION}/js/local-payment.min.js`,
@@ -281,8 +281,8 @@ describe('BraintreeScriptLoader', () => {
         it('does not load module if it is already in the window', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
 
-            await braintreeScriptLoader.loadBraintreeLocalMethods();
-            await braintreeScriptLoader.loadBraintreeLocalMethods();
+            await braintreeScriptLoader.loadLocalPayment();
+            await braintreeScriptLoader.loadLocalPayment();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledTimes(1);
         });

--- a/packages/braintree-utils/src/braintree-script-loader.ts
+++ b/packages/braintree-utils/src/braintree-script-loader.ts
@@ -59,7 +59,7 @@ export default class BraintreeScriptLoader {
         );
     }
 
-    async loadBraintreeLocalMethods(): Promise<BraintreeLocalPaymentCreator> {
+    async loadLocalPayment(): Promise<BraintreeLocalPaymentCreator> {
         return this.loadBraintreeModuleOrThrow<BraintreeLocalPaymentCreator>(
             BraintreeModuleName.LocalPayment,
             'local-payment.min.js',

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -91,8 +91,9 @@ export interface BraintreeSDK {
 }
 
 export type BraintreeLocalPaymentCreator = BraintreeModuleCreator<
-    LocalPaymentInstance,
-    BraintreeLocalPaymentCreateConfig
+    BraintreeLocalPayment,
+    BraintreeLocalPaymentCreateConfig,
+    BraintreeError | undefined
 >;
 
 export interface BraintreeLocalPaymentCreateConfig extends BraintreeModuleCreatorConfig {
@@ -487,7 +488,7 @@ export interface BraintreeVisaCheckout extends BraintreeModule {
  * Braintree Local Methods
  *
  */
-export interface LocalPaymentInstanceConfig {
+export interface BraintreeLocalPaymentConfig {
     paymentType: string;
     amount: number;
     fallback: {
@@ -502,32 +503,30 @@ export interface LocalPaymentInstanceConfig {
     address: {
         countryCode: string;
     };
-    onPaymentStart(data: onPaymentStartData, start: () => Promise<void>): void;
+    onPaymentStart(data: BraintreeLPMPaymentStartData, start: () => Promise<void>): Promise<void>;
 }
 
-export interface StartPaymentError {
+export interface BraintreeLPMStartPaymentError {
     code: string;
 }
 
-export interface onPaymentStartData {
+export interface BraintreeLPMPaymentStartData {
     paymentId: string;
 }
 
-export interface LocalPaymentsPayload {
+export interface BraintreeLocalPaymentsPayload {
     nonce: string;
 }
 
-export interface LocalPaymentInstance extends BraintreeModule {
+export interface BraintreeLocalPayment extends BraintreeModule {
     startPayment(
-        config: LocalPaymentInstanceConfig,
+        config: BraintreeLocalPaymentConfig,
         callback: (
-            startPaymentError: StartPaymentError,
-            payload: LocalPaymentsPayload,
+            startPaymentError: BraintreeLPMStartPaymentError | undefined,
+            payload: BraintreeLocalPaymentsPayload,
         ) => Promise<void>,
     ): void;
 }
-
-export type GetLocalPaymentInstance = (localPaymentInstance: LocalPaymentInstance) => void;
 
 /**
  *

--- a/packages/braintree-utils/src/mocks/braintree.mock.ts
+++ b/packages/braintree-utils/src/mocks/braintree.mock.ts
@@ -1,4 +1,3 @@
-// TODO: separate mock in this file to different files by group
 import { PaymentMethod } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import {
@@ -7,6 +6,10 @@ import {
     BraintreeFastlaneProfileData,
     BraintreeGooglePaymentDataRequest,
     BraintreeHostedFields,
+    BraintreeLocalPayment,
+    BraintreeLocalPaymentConfig,
+    BraintreeLocalPaymentsPayload,
+    BraintreeLPMStartPaymentError,
     BraintreePaypal,
     BraintreePaypalCheckout,
     BraintreePaypalCheckoutCreator,
@@ -14,7 +17,6 @@ import {
     BraintreeTokenizePayload,
     BraintreeVenmoCheckout,
     BraintreeVisaCheckout,
-    LocalPaymentInstance,
     TotalPriceStatusType,
     VisaCheckoutInitOptions,
 } from '../types';
@@ -212,17 +214,26 @@ export function getBraintreeFastlaneAuthenticationResultMock() {
     };
 }
 
-export function getBraintreeLocalPaymentMock(): LocalPaymentInstance {
+export function getBraintreeLocalPaymentMock(
+    orderId = '111',
+    startCallback: () => Promise<void> = () => Promise.resolve(),
+    startPaymentError: BraintreeLPMStartPaymentError | undefined = undefined,
+): BraintreeLocalPayment {
     return {
-        // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         startPayment: jest.fn(
-            (_options: unknown, onPaymentStart: (payload: { paymentId: string }) => void) => {
-                onPaymentStart({ paymentId: '123456' });
+            async (
+                config: BraintreeLocalPaymentConfig,
+                callback: (
+                    startPaymentError: BraintreeLPMStartPaymentError | undefined,
+                    payload: BraintreeLocalPaymentsPayload,
+                ) => Promise<void>,
+            ) => {
+                await config.onPaymentStart({ paymentId: orderId }, startCallback);
+                await callback(startPaymentError, { nonce: 'braintree lpm nonce' });
             },
         ),
-        teardown: jest.fn(() => Promise.resolve()),
+        teardown: () => Promise.resolve(),
     };
 }
 

--- a/packages/braintree-utils/src/types.ts
+++ b/packages/braintree-utils/src/types.ts
@@ -672,3 +672,13 @@ export interface BraintreeRedirectError {
         };
     };
 }
+
+export interface BraintreeOrderSavedResponse {
+    body: {
+        additional_action_required: {
+            data: {
+                order_id_saved_successfully: string;
+            };
+        };
+    };
+}


### PR DESCRIPTION
## What?
This PR contains several major updates for Braintree LPMs payment strategy (next "strategy"):
- Braintree LMPs SDK implementation was removed from BraintreeIntegrationService class;
- Braintree LMPs SDK implementation was moved to BraintreeSDK class;
- BraintreeIntegrationService was switched with BraintreeSDK in "strategy";
- "strategy" was updated with new flow for instant LPMs (and covered with experiment) due to incoming webhooks implementation changes on BE side

## Why?
There are several reasons:
- BraintreeIntegrationService is deprecated and should be removed in the future;
- BE is preparing braking changes, which may brake current LPMs implementation on FE side;

## Testing / Proof
Lint and unit test run passed successfully
Test coverage of LPMs strategies is above 80%

Manual tests: 

https://github.com/user-attachments/assets/54efeb1d-7276-496d-83f6-bdc9489382ec


