### PR TITLE
feat(checkout): PI-2943 Change HostedFormOptions interface name in core

### DIFF
--- a/packages/core/src/hosted-form/hosted-form-factory.ts
+++ b/packages/core/src/hosted-form/hosted-form-factory.ts
@@ -11,7 +11,7 @@ import { createSpamProtection, PaymentHumanVerificationHandler } from '../spam-p
 import HostedField from './hosted-field';
 import HostedFieldType from './hosted-field-type';
 import HostedForm from './hosted-form';
-import HostedFormOptions, {
+import LegacyHostedFormOptions, {
     HostedCardFieldOptionsMap,
     HostedStoredCardFieldOptionsMap,
 } from './hosted-form-options';
@@ -20,7 +20,7 @@ import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer
 export default class HostedFormFactory {
     constructor(private _store: ReadableCheckoutStore) {}
 
-    create(host: string, options: HostedFormOptions): HostedForm {
+    create(host: string, options: LegacyHostedFormOptions): HostedForm {
         const fieldTypes = Object.keys(options.fields) as HostedFieldType[];
         const fields = fieldTypes.reduce<HostedField[]>((result, type) => {
             const fields = options.fields as HostedStoredCardFieldOptionsMap &

--- a/packages/core/src/hosted-form/hosted-form-options.ts
+++ b/packages/core/src/hosted-form/hosted-form-options.ts
@@ -8,7 +8,7 @@ import {
     HostedInputValidateEvent,
 } from './iframe-content';
 
-export default interface HostedFormOptions {
+export default interface LegacyHostedFormOptions {
     fields: HostedFieldOptionsMap;
     styles?: HostedFieldStylesMap;
     onBlur?(data: HostedFieldBlurEventData): void;

--- a/packages/core/src/hosted-form/hosted-form.spec.ts
+++ b/packages/core/src/hosted-form/hosted-form.spec.ts
@@ -9,7 +9,7 @@ import { createSpamProtection, PaymentHumanVerificationHandler } from '../spam-p
 import HostedField from './hosted-field';
 import HostedFieldType from './hosted-field-type';
 import HostedForm from './hosted-form';
-import HostedFormOptions from './hosted-form-options';
+import LegacyHostedFormOptions from './hosted-form-options';
 import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
 import { getHostedFormOrderData } from './hosted-form-order-data.mock';
 import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
@@ -20,7 +20,7 @@ import {
 
 describe('HostedForm', () => {
     let callbacks: Pick<
-        HostedFormOptions,
+        LegacyHostedFormOptions,
         'onBlur' | 'onCardTypeChange' | 'onEnter' | 'onFocus' | 'onValidate'
     >;
     let eventListener: IframeEventListener<HostedInputEventMap>;

--- a/packages/core/src/hosted-form/hosted-form.ts
+++ b/packages/core/src/hosted-form/hosted-form.ts
@@ -9,7 +9,7 @@ import { PaymentHumanVerificationHandler } from '../spam-protection';
 
 import { InvalidHostedFormConfigError } from './errors';
 import HostedField from './hosted-field';
-import HostedFormOptions from './hosted-form-options';
+import LegacyHostedFormOptions from './hosted-form-options';
 import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
 import {
     HostedInputEnterEvent,
@@ -24,7 +24,7 @@ import {
 } from './stored-card-hosted-form-type';
 
 type HostedFormEventCallbacks = Pick<
-    HostedFormOptions,
+    LegacyHostedFormOptions,
     'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onEnter' | 'onValidate'
 >;
 

--- a/packages/core/src/hosted-form/index.ts
+++ b/packages/core/src/hosted-form/index.ts
@@ -1,7 +1,7 @@
 export { default as HostedFieldType } from './hosted-field-type';
 export { default as HostedForm } from './hosted-form';
 export { default as HostedFormFactory } from './hosted-form-factory';
-export { default as HostedFormOptions } from './hosted-form-options';
+export { default as LegacyHostedFormOptions } from './hosted-form-options';
 export { default as HostedFormOrderDataTransformer } from './hosted-form-order-data-transformer';
 export { default as HostedFormOrderData } from './hosted-form-order-data';
 export { default as createStoredCardHostedFormService } from './create-hosted-form-stored-card-service';

--- a/packages/core/src/hosted-form/stored-card-hosted-form-service.spec.ts
+++ b/packages/core/src/hosted-form/stored-card-hosted-form-service.spec.ts
@@ -7,14 +7,14 @@ import {
     StoredCardHostedFormInstrumentFieldsMock,
 } from './stored-card-hosted-form.mock';
 
-import { HostedForm, HostedFormFactory, HostedFormOptions } from '.';
+import { HostedForm, HostedFormFactory, LegacyHostedFormOptions } from '.';
 
 describe('StoredCardHostedFormService', () => {
     let formFactory: HostedFormFactory;
 
     let store: CheckoutStore;
     let service: StoredCardHostedFormService;
-    let initializeOptions: HostedFormOptions;
+    let initializeOptions: LegacyHostedFormOptions;
 
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreState());

--- a/packages/core/src/hosted-form/stored-card-hosted-form-service.ts
+++ b/packages/core/src/hosted-form/stored-card-hosted-form-service.ts
@@ -2,7 +2,7 @@ import { NotInitializedError, NotInitializedErrorType } from '../common/error/er
 
 import HostedForm from './hosted-form';
 import HostedFormFactory from './hosted-form-factory';
-import HostedFormOptions from './hosted-form-options';
+import LegacyHostedFormOptions from './hosted-form-options';
 import {
     StoredCardHostedFormData,
     StoredCardHostedFormInstrumentFields,
@@ -25,7 +25,7 @@ export default class StoredCardHostedFormService {
         await form.validate().then(() => form.submitStoredCard({ fields, data }));
     }
 
-    initialize(options: HostedFormOptions): Promise<void> {
+    initialize(options: LegacyHostedFormOptions): Promise<void> {
         const form = this._hostedFormFactory.create(this._host, options);
 
         return form.attach().then(() => {

--- a/packages/core/src/payment/strategies/moneris/moneris-payment-initialize-options.ts
+++ b/packages/core/src/payment/strategies/moneris/moneris-payment-initialize-options.ts
@@ -1,4 +1,4 @@
-import { HostedFormOptions } from '../../../hosted-form';
+import { LegacyHostedFormOptions } from '../../../hosted-form';
 
 import MonerisStylingProps from './moneris';
 
@@ -39,5 +39,5 @@ export default interface MonerisPaymentInitializeOptions {
     /**
      * Hosted Form Validation Options
      */
-    form?: HostedFormOptions;
+    form?: LegacyHostedFormOptions;
 }

--- a/packages/core/src/payment/strategies/moneris/moneris-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/moneris/moneris-payment-strategy.ts
@@ -9,7 +9,7 @@ import {
     NotInitializedError,
     NotInitializedErrorType,
 } from '../../../common/error/errors';
-import { HostedForm, HostedFormFactory, HostedFormOptions } from '../../../hosted-form';
+import { HostedForm, HostedFormFactory, LegacyHostedFormOptions } from '../../../hosted-form';
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { StoreCreditActionCreator } from '../../../store-credit';
@@ -236,7 +236,7 @@ export default class MonerisPaymentStrategy implements PaymentStrategy {
     }
 
     private async _mountCardVerificationfields(
-        formOptions: HostedFormOptions,
+        formOptions: LegacyHostedFormOptions,
     ): Promise<HostedForm> {
         const { config } = this._store.getState();
         const bigpayBaseUrl = config.getStoreConfig()?.paymentSettings.bigpayBaseUrl;


### PR DESCRIPTION
===> MERGE TOGETHER WITH CHECKOUT-JS PART https://github.com/bigcommerce/checkout-js/pull/2110

## What?
Rename `HostedFormOptions` in core for  `LegacyHostedFormOptions`

## Testing / Proof
Tested manually

@bigcommerce/team-checkout @bigcommerce/team-payments
