### PR TITLE
feat(payment): CHECKOUT-7859 Add Offline Payment Method

### DIFF
--- a/packages/hosted-form-v2/src/hosted-field-type.ts
+++ b/packages/hosted-form-v2/src/hosted-field-type.ts
@@ -4,6 +4,7 @@ enum HostedFieldType {
     CardName = 'cardName',
     CardNumber = 'cardNumber',
     Note = 'note',
+    Hidden = 'hidden',
 }
 
 export default HostedFieldType;

--- a/packages/hosted-form-v2/src/hosted-form-options.ts
+++ b/packages/hosted-form-v2/src/hosted-form-options.ts
@@ -47,6 +47,7 @@ export interface HostedCardFieldOptionsMap {
     [HostedFieldType.CardName]?: HostedCardFieldOptions;
     [HostedFieldType.CardNumber]?: HostedCardFieldOptions;
     [HostedFieldType.Note]?: HostedCardFieldOptions;
+    [HostedFieldType.Hidden]?: HostedCardFieldOptions;
 }
 
 export interface HostedCardFieldOptions {

--- a/packages/hosted-form-v2/src/hosted-input-validate-error-data.ts
+++ b/packages/hosted-form-v2/src/hosted-input-validate-error-data.ts
@@ -1,4 +1,4 @@
-import { HostedFieldType } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { default as HostedFieldType } from './hosted-field-type';
 
 export default interface HostedInputValidateErrorData {
     fieldType: string;
@@ -8,9 +8,9 @@ export default interface HostedInputValidateErrorData {
 
 export interface HostedInputValidateErrorDataMap {
     [HostedFieldType.CardCode]?: HostedInputValidateErrorData[];
-    [HostedFieldType.CardCodeVerification]?: HostedInputValidateErrorData[];
     [HostedFieldType.CardExpiry]?: HostedInputValidateErrorData[];
     [HostedFieldType.CardName]?: HostedInputValidateErrorData[];
     [HostedFieldType.CardNumber]?: HostedInputValidateErrorData[];
-    [HostedFieldType.CardNumberVerification]?: HostedInputValidateErrorData[];
+    [HostedFieldType.Note]?: HostedInputValidateErrorData[];
+    [HostedFieldType.Hidden]?: HostedInputValidateErrorData[];
 }

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
@@ -1,0 +1,167 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { IframeEventPoster } from '../common/iframe';
+import {
+    HostedFieldEventType,
+    HostedFieldSubmitManualOrderRequestEvent,
+} from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+import { ManualOrderPaymentRequestSender, OfflinePaymentMethodId } from '../payment';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputManualOrderPaymentHandler from './hosted-input-manual-order-payment-handler';
+import HostedInputStorage from './hosted-input-storage';
+import HostedInputValidator from './hosted-input-validator';
+
+describe('HostedInputManualOrderPaymentHandler', () => {
+    let inputAggregator: HostedInputAggregator;
+    let inputValidator: HostedInputValidator;
+    let inputStorage: HostedInputStorage;
+    let eventPoster: IframeEventPoster<HostedInputEvent>;
+    let manualOrderPaymentRequestSender: ManualOrderPaymentRequestSender;
+    let handler: HostedInputManualOrderPaymentHandler;
+
+    const parentOrigin = 'https://bigcommerce.com';
+    const pstToken = 'PST token';
+
+    beforeEach(() => {
+        inputAggregator = new HostedInputAggregator(window.parent);
+        inputValidator = new HostedInputValidator();
+        inputStorage = new HostedInputStorage();
+        eventPoster = new IframeEventPoster(parentOrigin, window.parent);
+        manualOrderPaymentRequestSender = manualOrderPaymentRequestSender =
+            new ManualOrderPaymentRequestSender(
+                { post: jest.fn() } as unknown as RequestSender,
+                parentOrigin,
+            );
+        handler = new HostedInputManualOrderPaymentHandler(
+            inputAggregator,
+            inputValidator,
+            inputStorage,
+            eventPoster,
+            manualOrderPaymentRequestSender,
+        );
+    });
+
+    it('should post validation results', async () => {
+        const event: HostedFieldSubmitManualOrderRequestEvent = {
+            type: HostedFieldEventType.SubmitManualOrderRequested,
+            payload: {
+                data: {
+                    paymentMethodId: 'card',
+                    paymentSessionToken: pstToken,
+                },
+            },
+        };
+        const validationResult = { isValid: true, errors: {} };
+
+        jest.spyOn(inputAggregator, 'getInputValues').mockReturnValue({});
+        jest.spyOn(inputValidator, 'validate').mockResolvedValue(validationResult);
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle(event);
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.Validated,
+            payload: validationResult,
+        });
+    });
+
+    it('should post submit failed event if validation fails', async () => {
+        const event: HostedFieldSubmitManualOrderRequestEvent = {
+            type: HostedFieldEventType.SubmitManualOrderRequested,
+            payload: {
+                data: {
+                    paymentMethodId: 'card',
+                    paymentSessionToken: pstToken,
+                },
+            },
+        };
+
+        jest.spyOn(inputAggregator, 'getInputValues').mockReturnValue({});
+        jest.spyOn(inputValidator, 'validate').mockResolvedValue({
+            isValid: false,
+            errors: {
+                cardCode: [
+                    {
+                        fieldType: HostedFieldType.CardCode,
+                        type: 'required',
+                        message: 'Missing required data',
+                    },
+                ],
+                cardExpiry: [],
+                cardName: [],
+                cardNumber: [],
+            },
+        });
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle(event);
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.SubmitManualOrderFailed,
+            payload: {
+                error: {
+                    code: 'invalid_hosted_form_value_error',
+                    message:
+                        'Unable to proceed due to invalid user input values. Missing required data',
+                },
+            },
+        });
+    });
+
+    it('should post submit succeeded event if card payment is successful', async () => {
+        const event: HostedFieldSubmitManualOrderRequestEvent = {
+            type: HostedFieldEventType.SubmitManualOrderRequested,
+            payload: {
+                data: {
+                    paymentMethodId: 'card',
+                    paymentSessionToken: pstToken,
+                },
+            },
+        };
+
+        jest.spyOn(inputAggregator, 'getInputValues').mockReturnValue({});
+        jest.spyOn(inputValidator, 'validate').mockResolvedValue({ isValid: true, errors: {} });
+        jest.spyOn(manualOrderPaymentRequestSender, 'submitPayment').mockResolvedValue({
+            body: { type: 'success' },
+        } as Response<unknown>);
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle(event);
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.SubmitManualOrderSucceeded,
+        });
+    });
+
+    it('should skip validation and post submit succeeded event if offline payment is successful', async () => {
+        const event: HostedFieldSubmitManualOrderRequestEvent = {
+            type: HostedFieldEventType.SubmitManualOrderRequested,
+            payload: {
+                data: {
+                    paymentMethodId: OfflinePaymentMethodId.Cod,
+                    paymentSessionToken: pstToken,
+                },
+            },
+        };
+
+        jest.spyOn(inputAggregator, 'getInputValues').mockReturnValue({});
+        jest.spyOn(inputValidator, 'validate').mockResolvedValue({ isValid: true, errors: {} });
+        jest.spyOn(manualOrderPaymentRequestSender, 'submitPayment').mockResolvedValue({
+            body: {
+                type: 'continue',
+                code: 'await_confirmation',
+                parameters: {},
+            },
+        } as Response<unknown>);
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle(event);
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.SubmitManualOrderSucceeded,
+        });
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
@@ -6,7 +6,7 @@ import {
     HostedFieldSubmitManualOrderRequestEvent,
 } from '../hosted-field-events';
 import HostedFieldType from '../hosted-field-type';
-import { ManualOrderPaymentRequestSender, OfflinePaymentMethodId } from '../payment';
+import { ManualOrderPaymentRequestSender, OfflinePaymentMethodIds } from '../payment';
 
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
@@ -141,7 +141,7 @@ describe('HostedInputManualOrderPaymentHandler', () => {
             type: HostedFieldEventType.SubmitManualOrderRequested,
             payload: {
                 data: {
-                    paymentMethodId: OfflinePaymentMethodId.Cod,
+                    paymentMethodId: OfflinePaymentMethodIds.Cod,
                     paymentSessionToken: pstToken,
                 },
             },

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
@@ -6,7 +6,7 @@ import {
     HostedFieldSubmitManualOrderRequestEvent,
 } from '../hosted-field-events';
 import HostedFieldType from '../hosted-field-type';
-import { ManualOrderPaymentRequestSender, OfflinePaymentMethodIds } from '../payment';
+import { ManualOrderPaymentRequestSender, OfflinePaymentMethods } from '../payment';
 
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
@@ -141,7 +141,7 @@ describe('HostedInputManualOrderPaymentHandler', () => {
             type: HostedFieldEventType.SubmitManualOrderRequested,
             payload: {
                 data: {
-                    paymentMethodId: OfflinePaymentMethodIds.Cod,
+                    paymentMethodId: OfflinePaymentMethods.Cod,
                     paymentSessionToken: pstToken,
                 },
             },

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
@@ -55,11 +55,11 @@ export default class HostedInputManualOrderPaymentHandler {
                 get(response.body, 'type') === 'failure' && isString(get(response.body, 'code'));
             const isError = get(response.body, 'type') === 'error';
 
-            const isSuccessOfflineOrder =
+            const isSuccessfulOfflineOrder =
                 isOfflinePaymentMethodId(data.paymentMethodId) &&
                 get(response.body, 'type') === 'continue' &&
                 get(response.body, 'code') === 'await_confirmation';
-            const isSuccess = get(response.body, 'type') === 'success' || isSuccessOfflineOrder;
+            const isSuccess = get(response.body, 'type') === 'success' || isSuccessfulOfflineOrder;
 
             if (isFailure) {
                 this._eventPoster.post({

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
@@ -5,6 +5,7 @@ import { IframeEventPoster } from '../common/iframe';
 import { InvalidHostedFormValueError, PaymentErrorResponseBody } from '../errors';
 import { HostedFieldSubmitManualOrderRequestEvent } from '../hosted-field-events';
 import { ManualOrderPaymentRequestSender } from '../payment';
+import { isOfflinePaymentMethodId } from '../utils';
 
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
@@ -52,8 +53,13 @@ export default class HostedInputManualOrderPaymentHandler {
 
             const isFailure =
                 get(response.body, 'type') === 'failure' && isString(get(response.body, 'code'));
-            const isSuccess = get(response.body, 'type') === 'success';
             const isError = get(response.body, 'type') === 'error';
+
+            const isSuccessOfflineOrder =
+                isOfflinePaymentMethodId(data.paymentMethodId) &&
+                get(response.body, 'type') === 'continue' &&
+                get(response.body, 'code') === 'await_confirmation';
+            const isSuccess = get(response.body, 'type') === 'success' || isSuccessOfflineOrder;
 
             if (isFailure) {
                 this._eventPoster.post({

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validate-error-data.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validate-error-data.ts
@@ -12,4 +12,5 @@ export interface HostedInputValidateErrorDataMap {
     [HostedFieldType.CardName]?: HostedInputValidateErrorData[];
     [HostedFieldType.CardNumber]?: HostedInputValidateErrorData[];
     [HostedFieldType.Note]?: HostedInputValidateErrorData[];
+    [HostedFieldType.Hidden]?: HostedInputValidateErrorData[];
 }

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input.spec.ts
@@ -135,6 +135,32 @@ describe('HostedInput', () => {
         expect(element.inputMode).toBe('text');
     });
 
+    it('renders hidden field as normal field', () => {
+        input = new HostedInput(
+            HostedFieldType.Hidden,
+            container,
+            '',
+            'Hidden field',
+            '',
+            styles,
+            fontUrls,
+            eventListener as IframeEventListener<HostedFieldEventMap>,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            manualOrderPaymentHandler as HostedInputManualOrderPaymentHandler,
+        );
+
+        input.attach();
+
+        const element = container.querySelector('input')!;
+
+        expect(element.id).toBe('hidden');
+        expect(element.placeholder).toBe('');
+        expect(element.getAttribute('aria-label')).toBe('Hidden field');
+        expect(element.inputMode).toBe('text');
+    });
+
     it('renders payment note field', () => {
         input = new HostedInput(
             HostedFieldType.Note,

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input.ts
@@ -145,6 +145,7 @@ export default class HostedInput {
 
             case 'card-name':
             case 'note':
+            case 'hidden':
                 this._input.type = 'text';
                 this._input.inputMode = 'text';
                 break;

--- a/packages/hosted-form-v2/src/iframe-content/map-to-accessibility-label.ts
+++ b/packages/hosted-form-v2/src/iframe-content/map-to-accessibility-label.ts
@@ -16,5 +16,8 @@ export default function mapToAccessibilityLabel(type: HostedFieldType): string {
 
         case HostedFieldType.Note:
             return 'Payment note';
+
+        case HostedFieldType.Hidden:
+            return 'Hidden field';
     }
 }

--- a/packages/hosted-form-v2/src/payment/Instrument.ts
+++ b/packages/hosted-form-v2/src/payment/Instrument.ts
@@ -3,7 +3,7 @@ export enum InstrumentType {
     ManualPayment = 'manual_payment',
 }
 
-export enum OfflinePaymentMethodId {
+export enum OfflinePaymentMethodIds {
     BankDeposit = 'bigcommerce_offline.bank_deposit',
     Cheque = 'bigcommerce_offline.cheque',
     Cod = 'bigcommerce_offline.cod',
@@ -11,7 +11,7 @@ export enum OfflinePaymentMethodId {
     MoneyOrder = 'bigcommerce_offline.money_order',
 }
 
-export enum OfflinePaymentMethodType {
+export enum OfflinePaymentMethodTypes {
     BankDeposit = 'bank_deposit',
     Cheque = 'cheque',
     Cod = 'cod',
@@ -19,14 +19,15 @@ export enum OfflinePaymentMethodType {
     MoneyOrder = 'money_order',
 }
 
-export const offlinePaymentMethodTypeMap: {
-    [key in OfflinePaymentMethodId]: OfflinePaymentMethodType;
-} = {
-    [OfflinePaymentMethodId.BankDeposit]: OfflinePaymentMethodType.BankDeposit,
-    [OfflinePaymentMethodId.Cheque]: OfflinePaymentMethodType.Cheque,
-    [OfflinePaymentMethodId.Cod]: OfflinePaymentMethodType.Cod,
-    [OfflinePaymentMethodId.InStore]: OfflinePaymentMethodType.InStore,
-    [OfflinePaymentMethodId.MoneyOrder]: OfflinePaymentMethodType.MoneyOrder,
+export const offlinePaymentMethodTypeMap: Record<
+    OfflinePaymentMethodIds,
+    OfflinePaymentMethodTypes
+> = {
+    [OfflinePaymentMethodIds.BankDeposit]: OfflinePaymentMethodTypes.BankDeposit,
+    [OfflinePaymentMethodIds.Cheque]: OfflinePaymentMethodTypes.Cheque,
+    [OfflinePaymentMethodIds.Cod]: OfflinePaymentMethodTypes.Cod,
+    [OfflinePaymentMethodIds.InStore]: OfflinePaymentMethodTypes.InStore,
+    [OfflinePaymentMethodIds.MoneyOrder]: OfflinePaymentMethodTypes.MoneyOrder,
 };
 
 interface CardInstrument {
@@ -46,7 +47,7 @@ interface ManualPaymentInstrument {
 }
 
 interface OfflinePaymentInstrument {
-    type: OfflinePaymentMethodType;
+    type: OfflinePaymentMethodTypes;
 }
 
 export type Instrument = CardInstrument | ManualPaymentInstrument | OfflinePaymentInstrument;

--- a/packages/hosted-form-v2/src/payment/Instrument.ts
+++ b/packages/hosted-form-v2/src/payment/Instrument.ts
@@ -3,7 +3,9 @@ export enum InstrumentType {
     ManualPayment = 'manual_payment',
 }
 
-export enum OfflinePaymentMethodIds {
+export const manualPaymentMethod = 'bigcommerce.manual_payment';
+
+export enum OfflinePaymentMethods {
     BankDeposit = 'bigcommerce_offline.bank_deposit',
     Cheque = 'bigcommerce_offline.cheque',
     Cod = 'bigcommerce_offline.cod',
@@ -19,16 +21,14 @@ export enum OfflinePaymentMethodTypes {
     MoneyOrder = 'money_order',
 }
 
-export const offlinePaymentMethodTypeMap: Record<
-    OfflinePaymentMethodIds,
-    OfflinePaymentMethodTypes
-> = {
-    [OfflinePaymentMethodIds.BankDeposit]: OfflinePaymentMethodTypes.BankDeposit,
-    [OfflinePaymentMethodIds.Cheque]: OfflinePaymentMethodTypes.Cheque,
-    [OfflinePaymentMethodIds.Cod]: OfflinePaymentMethodTypes.Cod,
-    [OfflinePaymentMethodIds.InStore]: OfflinePaymentMethodTypes.InStore,
-    [OfflinePaymentMethodIds.MoneyOrder]: OfflinePaymentMethodTypes.MoneyOrder,
-};
+export const offlinePaymentMethodTypeMap: Record<OfflinePaymentMethods, OfflinePaymentMethodTypes> =
+    {
+        [OfflinePaymentMethods.BankDeposit]: OfflinePaymentMethodTypes.BankDeposit,
+        [OfflinePaymentMethods.Cheque]: OfflinePaymentMethodTypes.Cheque,
+        [OfflinePaymentMethods.Cod]: OfflinePaymentMethodTypes.Cod,
+        [OfflinePaymentMethods.InStore]: OfflinePaymentMethodTypes.InStore,
+        [OfflinePaymentMethods.MoneyOrder]: OfflinePaymentMethodTypes.MoneyOrder,
+    };
 
 interface CardInstrument {
     type: InstrumentType.Card;

--- a/packages/hosted-form-v2/src/payment/Instrument.ts
+++ b/packages/hosted-form-v2/src/payment/Instrument.ts
@@ -3,6 +3,32 @@ export enum InstrumentType {
     ManualPayment = 'manual_payment',
 }
 
+export enum OfflinePaymentMethodId {
+    BankDeposit = 'bigcommerce_offline.bank_deposit',
+    Cheque = 'bigcommerce_offline.cheque',
+    Cod = 'bigcommerce_offline.cod',
+    InStore = 'bigcommerce_offline.in_store',
+    MoneyOrder = 'bigcommerce_offline.money_order',
+}
+
+export enum OfflinePaymentMethodType {
+    BankDeposit = 'bank_deposit',
+    Cheque = 'cheque',
+    Cod = 'cod',
+    InStore = 'in_store',
+    MoneyOrder = 'money_order',
+}
+
+export const offlinePaymentMethodTypeMap: {
+    [key in OfflinePaymentMethodId]: OfflinePaymentMethodType;
+} = {
+    [OfflinePaymentMethodId.BankDeposit]: OfflinePaymentMethodType.BankDeposit,
+    [OfflinePaymentMethodId.Cheque]: OfflinePaymentMethodType.Cheque,
+    [OfflinePaymentMethodId.Cod]: OfflinePaymentMethodType.Cod,
+    [OfflinePaymentMethodId.InStore]: OfflinePaymentMethodType.InStore,
+    [OfflinePaymentMethodId.MoneyOrder]: OfflinePaymentMethodType.MoneyOrder,
+};
+
 interface CardInstrument {
     type: InstrumentType.Card;
     name: string;
@@ -19,4 +45,8 @@ interface ManualPaymentInstrument {
     note: string;
 }
 
-export type Instrument = CardInstrument | ManualPaymentInstrument;
+interface OfflinePaymentInstrument {
+    type: OfflinePaymentMethodType;
+}
+
+export type Instrument = CardInstrument | ManualPaymentInstrument | OfflinePaymentInstrument;

--- a/packages/hosted-form-v2/src/payment/index.ts
+++ b/packages/hosted-form-v2/src/payment/index.ts
@@ -1,2 +1,2 @@
 export { ManualOrderPaymentRequestSender } from './manual-order-payment-request-sender';
-export { OfflinePaymentMethodId, OfflinePaymentMethodType } from './Instrument';
+export { OfflinePaymentMethodIds, OfflinePaymentMethodTypes } from './Instrument';

--- a/packages/hosted-form-v2/src/payment/index.ts
+++ b/packages/hosted-form-v2/src/payment/index.ts
@@ -1,1 +1,2 @@
 export { ManualOrderPaymentRequestSender } from './manual-order-payment-request-sender';
+export { OfflinePaymentMethodId, OfflinePaymentMethodType } from './Instrument';

--- a/packages/hosted-form-v2/src/payment/index.ts
+++ b/packages/hosted-form-v2/src/payment/index.ts
@@ -1,2 +1,2 @@
 export { ManualOrderPaymentRequestSender } from './manual-order-payment-request-sender';
-export { OfflinePaymentMethodIds, OfflinePaymentMethodTypes } from './Instrument';
+export { OfflinePaymentMethods, OfflinePaymentMethodTypes } from './Instrument';

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
@@ -4,7 +4,7 @@ import ContentType from '../common/http-request/content-type';
 import HostedFormManualOrderData from '../hosted-form-manual-order-data';
 import { HostedInputValues } from '../iframe-content';
 
-import { InstrumentType, OfflinePaymentMethodId, OfflinePaymentMethodType } from './Instrument';
+import { InstrumentType, OfflinePaymentMethodIds, OfflinePaymentMethodTypes } from './Instrument';
 import {
     ManualOrderPaymentRequestSender,
     manualPaymentMethodId,
@@ -118,7 +118,7 @@ describe('ManualOrderPaymentRequestSender', () => {
             parameters: {},
         } as unknown as Response<unknown>;
 
-        requestInitializationData.paymentMethodId = OfflinePaymentMethodId.BankDeposit;
+        requestInitializationData.paymentMethodId = OfflinePaymentMethodIds.BankDeposit;
         (requestSender.post as jest.Mock).mockResolvedValue(response);
 
         const result = await manualOrderPaymentRequestSender.submitPayment(
@@ -137,9 +137,9 @@ describe('ManualOrderPaymentRequestSender', () => {
                 },
                 body: {
                     instrument: {
-                        type: OfflinePaymentMethodType.BankDeposit,
+                        type: OfflinePaymentMethodTypes.BankDeposit,
                     },
-                    payment_method_id: OfflinePaymentMethodId.BankDeposit,
+                    payment_method_id: OfflinePaymentMethodIds.BankDeposit,
                     form_nonce: undefined,
                 },
             }),

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
@@ -4,10 +4,10 @@ import ContentType from '../common/http-request/content-type';
 import HostedFormManualOrderData from '../hosted-form-manual-order-data';
 import { HostedInputValues } from '../iframe-content';
 
-import { InstrumentType, OfflinePaymentMethodIds, OfflinePaymentMethodTypes } from './Instrument';
+import {InstrumentType, manualPaymentMethod, OfflinePaymentMethods, OfflinePaymentMethodTypes} from './Instrument';
 import {
     ManualOrderPaymentRequestSender,
-    manualPaymentMethodId,
+
 } from './manual-order-payment-request-sender';
 
 describe('ManualOrderPaymentRequestSender', () => {
@@ -29,7 +29,7 @@ describe('ManualOrderPaymentRequestSender', () => {
             paymentOrigin,
         );
         requestInitializationData = {
-            paymentMethodId: manualPaymentMethodId,
+            paymentMethodId: manualPaymentMethod,
             paymentSessionToken: pstToken,
         } as HostedFormManualOrderData;
         response = { body: {} } as Response<unknown>;
@@ -61,7 +61,7 @@ describe('ManualOrderPaymentRequestSender', () => {
                         type: InstrumentType.ManualPayment,
                         note: testingManualPaymentNote,
                     },
-                    payment_method_id: manualPaymentMethodId,
+                    payment_method_id: manualPaymentMethod,
                     form_nonce: undefined,
                 },
             }),
@@ -118,7 +118,7 @@ describe('ManualOrderPaymentRequestSender', () => {
             parameters: {},
         } as unknown as Response<unknown>;
 
-        requestInitializationData.paymentMethodId = OfflinePaymentMethodIds.BankDeposit;
+        requestInitializationData.paymentMethodId = OfflinePaymentMethods.BankDeposit;
         (requestSender.post as jest.Mock).mockResolvedValue(response);
 
         const result = await manualOrderPaymentRequestSender.submitPayment(
@@ -139,7 +139,7 @@ describe('ManualOrderPaymentRequestSender', () => {
                     instrument: {
                         type: OfflinePaymentMethodTypes.BankDeposit,
                     },
-                    payment_method_id: OfflinePaymentMethodIds.BankDeposit,
+                    payment_method_id: OfflinePaymentMethods.BankDeposit,
                     form_nonce: undefined,
                 },
             }),

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
@@ -1,0 +1,148 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import ContentType from '../common/http-request/content-type';
+import HostedFormManualOrderData from '../hosted-form-manual-order-data';
+import { HostedInputValues } from '../iframe-content';
+
+import { InstrumentType, OfflinePaymentMethodId, OfflinePaymentMethodType } from './Instrument';
+import {
+    ManualOrderPaymentRequestSender,
+    manualPaymentMethodId,
+} from './manual-order-payment-request-sender';
+
+describe('ManualOrderPaymentRequestSender', () => {
+    let requestSender: RequestSender;
+    let paymentOrigin: string;
+    let manualOrderPaymentRequestSender: ManualOrderPaymentRequestSender;
+    let requestInitializationData: HostedFormManualOrderData;
+    let instrumentFormData: HostedInputValues;
+    let response: Response<unknown>;
+
+    const pstToken = 'PST token';
+    const testingManualPaymentNote = 'payment note';
+
+    beforeEach(() => {
+        requestSender = { post: jest.fn() } as unknown as RequestSender;
+        paymentOrigin = 'https://example.com';
+        manualOrderPaymentRequestSender = new ManualOrderPaymentRequestSender(
+            requestSender,
+            paymentOrigin,
+        );
+        requestInitializationData = {
+            paymentMethodId: manualPaymentMethodId,
+            paymentSessionToken: pstToken,
+        } as HostedFormManualOrderData;
+        response = { body: {} } as Response<unknown>;
+    });
+
+    it('submits manual payment', async () => {
+        (requestSender.post as jest.Mock).mockResolvedValue(response);
+
+        instrumentFormData = {
+            note: testingManualPaymentNote,
+        } as HostedInputValues;
+
+        const result = await manualOrderPaymentRequestSender.submitPayment(
+            requestInitializationData,
+            instrumentFormData,
+        );
+
+        expect(result).toBe(response);
+        expect(requestSender.post).toHaveBeenCalledWith(
+            `${paymentOrigin}/payments`,
+            expect.objectContaining({
+                headers: {
+                    Accept: ContentType.Json,
+                    'Content-Type': ContentType.Json,
+                    'X-Payment-Session-Token': pstToken,
+                },
+                body: {
+                    instrument: {
+                        type: InstrumentType.ManualPayment,
+                        note: testingManualPaymentNote,
+                    },
+                    payment_method_id: manualPaymentMethodId,
+                    form_nonce: undefined,
+                },
+            }),
+        );
+    });
+
+    it('submits card payment', async () => {
+        (requestSender.post as jest.Mock).mockResolvedValue(response);
+
+        requestInitializationData.paymentMethodId = 'card';
+        instrumentFormData = {
+            cardName: 'John Doe',
+            cardNumber: '4111 1111 1111 1111',
+            cardExpiry: '12/23',
+            cardCode: '123',
+        } as HostedInputValues;
+
+        const result = await manualOrderPaymentRequestSender.submitPayment(
+            requestInitializationData,
+            instrumentFormData,
+        );
+
+        expect(result).toBe(response);
+        expect(requestSender.post).toHaveBeenCalledWith(
+            `${paymentOrigin}/payments`,
+            expect.objectContaining({
+                headers: {
+                    Accept: ContentType.Json,
+                    'Content-Type': ContentType.Json,
+                    'X-Payment-Session-Token': pstToken,
+                },
+                body: {
+                    instrument: {
+                        type: InstrumentType.Card,
+                        name: 'John Doe',
+                        number: '4111111111111111',
+                        expires: {
+                            month: 12,
+                            year: 2023,
+                        },
+                        verification_value: '123',
+                    },
+                    payment_method_id: 'card',
+                    form_nonce: undefined,
+                },
+            }),
+        );
+    });
+
+    it('submits offline payment', async () => {
+        response = {
+            type: 'continue',
+            code: 'await_confirmation',
+            parameters: {},
+        } as unknown as Response<unknown>;
+
+        requestInitializationData.paymentMethodId = OfflinePaymentMethodId.BankDeposit;
+        (requestSender.post as jest.Mock).mockResolvedValue(response);
+
+        const result = await manualOrderPaymentRequestSender.submitPayment(
+            requestInitializationData,
+            instrumentFormData,
+        );
+
+        expect(result).toBe(response);
+        expect(requestSender.post).toHaveBeenCalledWith(
+            `${paymentOrigin}/payments`,
+            expect.objectContaining({
+                headers: {
+                    Accept: ContentType.Json,
+                    'Content-Type': ContentType.Json,
+                    'X-Payment-Session-Token': pstToken,
+                },
+                body: {
+                    instrument: {
+                        type: OfflinePaymentMethodType.BankDeposit,
+                    },
+                    payment_method_id: OfflinePaymentMethodId.BankDeposit,
+                    form_nonce: undefined,
+                },
+            }),
+        );
+    });
+});

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
@@ -4,11 +4,13 @@ import ContentType from '../common/http-request/content-type';
 import HostedFormManualOrderData from '../hosted-form-manual-order-data';
 import { HostedInputValues } from '../iframe-content';
 
-import {InstrumentType, manualPaymentMethod, OfflinePaymentMethods, OfflinePaymentMethodTypes} from './Instrument';
 import {
-    ManualOrderPaymentRequestSender,
-
-} from './manual-order-payment-request-sender';
+    InstrumentType,
+    manualPaymentMethod,
+    OfflinePaymentMethods,
+    OfflinePaymentMethodTypes,
+} from './Instrument';
+import { ManualOrderPaymentRequestSender } from './manual-order-payment-request-sender';
 
 describe('ManualOrderPaymentRequestSender', () => {
     let requestSender: RequestSender;

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.ts
@@ -5,9 +5,12 @@ import HostedFormManualOrderData from '../hosted-form-manual-order-data';
 import { HostedInputValues } from '../iframe-content';
 import { isOfflinePaymentMethodId } from '../utils';
 
-import { Instrument, InstrumentType, offlinePaymentMethodTypeMap } from './Instrument';
-
-export const manualPaymentMethodId = 'bigcommerce.manual_payment';
+import {
+    Instrument,
+    InstrumentType,
+    manualPaymentMethod,
+    offlinePaymentMethodTypeMap,
+} from './Instrument';
 
 export class ManualOrderPaymentRequestSender {
     constructor(private _requestSender: RequestSender, private _paymentOrigin: string) {}
@@ -21,7 +24,7 @@ export class ManualOrderPaymentRequestSender {
 
         let instrument: Instrument;
 
-        if (paymentMethodId === manualPaymentMethodId) {
+        if (paymentMethodId === manualPaymentMethod) {
             instrument = {
                 type: InstrumentType.ManualPayment,
                 note: instrumentFormData.note ?? '',

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.ts
@@ -3,10 +3,11 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 import ContentType from '../common/http-request/content-type';
 import HostedFormManualOrderData from '../hosted-form-manual-order-data';
 import { HostedInputValues } from '../iframe-content';
+import { isOfflinePaymentMethodId } from '../utils';
 
-import { Instrument, InstrumentType } from './Instrument';
+import { Instrument, InstrumentType, offlinePaymentMethodTypeMap } from './Instrument';
 
-const manualPaymentMethodId = 'bigcommerce.manual_payment';
+export const manualPaymentMethodId = 'bigcommerce.manual_payment';
 
 export class ManualOrderPaymentRequestSender {
     constructor(private _requestSender: RequestSender, private _paymentOrigin: string) {}
@@ -24,6 +25,10 @@ export class ManualOrderPaymentRequestSender {
             instrument = {
                 type: InstrumentType.ManualPayment,
                 note: instrumentFormData.note ?? '',
+            };
+        } else if (isOfflinePaymentMethodId(paymentMethodId)) {
+            instrument = {
+                type: offlinePaymentMethodTypeMap[paymentMethodId],
             };
         } else {
             const [expiryMonth, expiryYear] = instrumentFormData.cardExpiry

--- a/packages/hosted-form-v2/src/utils/index.ts
+++ b/packages/hosted-form-v2/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { isOfflinePaymentMethodId } from './isOfflinePaymentMethodId';

--- a/packages/hosted-form-v2/src/utils/isOfflinePaymentMethodId.ts
+++ b/packages/hosted-form-v2/src/utils/isOfflinePaymentMethodId.ts
@@ -1,0 +1,5 @@
+import { OfflinePaymentMethodId } from '../payment';
+
+export const isOfflinePaymentMethodId = (id: string): id is OfflinePaymentMethodId => {
+    return Object.values(OfflinePaymentMethodId).includes(id as OfflinePaymentMethodId);
+};

--- a/packages/hosted-form-v2/src/utils/isOfflinePaymentMethodId.ts
+++ b/packages/hosted-form-v2/src/utils/isOfflinePaymentMethodId.ts
@@ -1,5 +1,5 @@
-import { OfflinePaymentMethodIds } from '../payment';
+import { OfflinePaymentMethods } from '../payment';
 
-export const isOfflinePaymentMethodId = (id: string): id is OfflinePaymentMethodIds => {
-    return Object.values(OfflinePaymentMethodIds).includes(id as OfflinePaymentMethodIds);
+export const isOfflinePaymentMethodId = (id: string): id is OfflinePaymentMethods => {
+    return Object.values(OfflinePaymentMethods).includes(id as OfflinePaymentMethods);
 };

--- a/packages/hosted-form-v2/src/utils/isOfflinePaymentMethodId.ts
+++ b/packages/hosted-form-v2/src/utils/isOfflinePaymentMethodId.ts
@@ -1,5 +1,5 @@
-import { OfflinePaymentMethodId } from '../payment';
+import { OfflinePaymentMethodIds } from '../payment';
 
-export const isOfflinePaymentMethodId = (id: string): id is OfflinePaymentMethodId => {
-    return Object.values(OfflinePaymentMethodId).includes(id as OfflinePaymentMethodId);
+export const isOfflinePaymentMethodId = (id: string): id is OfflinePaymentMethodIds => {
+    return id in OfflinePaymentMethodIds;
 };

--- a/packages/hosted-form-v2/src/utils/isOfflinePaymentMethodId.ts
+++ b/packages/hosted-form-v2/src/utils/isOfflinePaymentMethodId.ts
@@ -1,5 +1,5 @@
 import { OfflinePaymentMethodIds } from '../payment';
 
 export const isOfflinePaymentMethodId = (id: string): id is OfflinePaymentMethodIds => {
-    return id in OfflinePaymentMethodIds;
+    return Object.values(OfflinePaymentMethodIds).includes(id as OfflinePaymentMethodIds);
 };


### PR DESCRIPTION
## What?
Add offline payment method support to `hosted-form-v2` package.

## Why?
Facilitating the creation of a manual order with offline payment methods.

## Testing / Proof
Manual testing

https://github.com/user-attachments/assets/227fc02b-9a68-4a4e-9868-07609917b15a

@bigcommerce/team-checkout @bigcommerce/team-payments
