### PR TITLE
feat(payment): STRIPE-528 Stripe UPE Link shouldSaveInstrument false if authenticated

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -679,11 +679,21 @@ describe('StripeUPEPaymentStrategy', () => {
                                 'getPaymentProviderCustomerOrThrow',
                             ).mockReturnValue({ stripeLinkAuthenticationState: true });
 
-                            await strategy.execute(getStripeUPEWithLinkOrderRequestBodyMock());
+                            await strategy.execute(
+                                getStripeUPEWithLinkOrderRequestBodyMock(undefined, true),
+                            );
 
                             expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
                             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalled();
-                            expect(paymentIntegrationService.submitPayment).toHaveBeenCalled();
+                            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                                expect.objectContaining({
+                                    paymentData: expect.objectContaining({
+                                        formattedPayload: expect.objectContaining({
+                                            vault_payment_instrument: false,
+                                        }),
+                                    }),
+                                }),
+                            );
                             expect(
                                 paymentIntegrationService.updateBillingAddress,
                             ).not.toHaveBeenCalled();
@@ -723,11 +733,21 @@ describe('StripeUPEPaymentStrategy', () => {
                                 'getBillingAddressOrThrow',
                             ).mockReturnValue(getBillingAddress());
 
-                            await strategy.execute(getStripeUPEWithLinkOrderRequestBodyMock());
+                            await strategy.execute(
+                                getStripeUPEWithLinkOrderRequestBodyMock(undefined, true),
+                            );
 
                             expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
                             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalled();
-                            expect(paymentIntegrationService.submitPayment).toHaveBeenCalled();
+                            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                                expect.objectContaining({
+                                    paymentData: expect.objectContaining({
+                                        formattedPayload: expect.objectContaining({
+                                            vault_payment_instrument: true,
+                                        }),
+                                    }),
+                                }),
+                            );
                             expect(
                                 paymentIntegrationService.updateBillingAddress,
                             ).toHaveBeenCalled();


### PR DESCRIPTION
## What?
We shouldn't send shouldSaveInstrument: true if Link is authenticated

## Testing / Proof
Before the fix:

https://github.com/user-attachments/assets/6269bf91-0254-4932-987c-06952625ae22


After the fix:

https://github.com/user-attachments/assets/2d0bac2b-fe00-4bf5-abec-2c91b501d9f3


@bigcommerce/team-checkout @bigcommerce/team-payments
