### PR TITLE
[DO NOT MERGE]feat(payment): PI-00000 WP Access manual order fix

### DIFF
--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
@@ -5,7 +5,6 @@ import { IframeEventPoster } from '../common/iframe';
 import { InvalidHostedFormValueError, PaymentErrorResponseBody } from '../errors';
 import { HostedFieldSubmitManualOrderRequestEvent } from '../hosted-field-events';
 import { ManualOrderPaymentRequestSender } from '../payment';
-import { isOfflinePaymentMethodId } from '../utils';
 
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
@@ -56,7 +55,6 @@ export default class HostedInputManualOrderPaymentHandler {
             const isError = get(response.body, 'type') === 'error';
 
             const isSuccessfulOfflineOrder =
-                isOfflinePaymentMethodId(data.paymentMethodId) &&
                 get(response.body, 'type') === 'continue' &&
                 get(response.body, 'code') === 'await_confirmation';
             const isSuccess = get(response.body, 'type') === 'success' || isSuccessfulOfflineOrder;


### PR DESCRIPTION
## What?
WP Access returns the same response as an Offline payment method, so I propose to remove type guard check
to fix manual orders for the WP Access for the new manual orders UI

## Why?
When using the new manual UI make payment via Access Worldpay with authorize&capture payment settings.

The manual order UI page will get stuck during the payment process. This is due to payment returns awaiting confirmation status.

## Testing / Proof


https://github.com/user-attachments/assets/4f22ed56-b6fc-4eb1-acaf-e02e9ea2939b


@bigcommerce/team-checkout @bigcommerce/team-payments
