### PR TITLE
fix(payment): PAYPAL-2750 Skip 3D Secure when GooglePay card network tokenized

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-braintree-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-braintree-gateway.spec.ts
@@ -126,6 +126,7 @@ describe('GooglePayBraintreeGateway', () => {
                     number: '1111',
                     type: 'VISA',
                     bin: '401288',
+                    isNetworkTokenized: false,
                 },
             };
 
@@ -172,6 +173,7 @@ describe('GooglePayBraintreeGateway', () => {
                 type: 'type',
                 number: '1234',
                 bin: 'bin',
+                isNetworkTokenized: false,
             };
 
             await googlePayBraintreeGateway.initialize(() => braintree);
@@ -189,6 +191,26 @@ describe('GooglePayBraintreeGateway', () => {
                 type: 'type',
                 number: '1234',
                 bin: 'bin',
+                isNetworkTokenized: false,
+            };
+
+            await googlePayBraintreeGateway.initialize(() => braintree);
+
+            const nonce = await googlePayBraintreeGateway.getNonce('googlepaybraintree');
+
+            expect(braintreeSdk.getBraintreeThreeDS).not.toHaveBeenCalled();
+            expect(nonce).toBe('token');
+        });
+
+        it('get nonce when card is network tokenized', async () => {
+            const braintree = getBraintree();
+
+            braintree.initializationData!.isThreeDSecureEnabled = true;
+            braintree.initializationData!.card_information = {
+                type: 'type',
+                number: '1234',
+                bin: 'bin',
+                isNetworkTokenized: true,
             };
 
             await googlePayBraintreeGateway.initialize(() => braintree);

--- a/packages/google-pay-integration/src/gateways/google-pay-braintree-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-braintree-gateway.ts
@@ -62,10 +62,10 @@ export default class GooglePayBraintreeGateway extends GooglePayGateway {
 
         const {
             isThreeDSecureEnabled,
-            card_information: { bin },
+            card_information: { bin, isNetworkTokenized },
         } = initializationData;
 
-        if (isThreeDSecureEnabled) {
+        if (isThreeDSecureEnabled && !isNetworkTokenized) {
             const threeDSecure = await this._braintreeSdk.getBraintreeThreeDS();
 
             const { orderAmount } = this._service.getState().getOrderOrThrow();
@@ -106,6 +106,8 @@ export default class GooglePayBraintreeGateway extends GooglePayGateway {
 
         data.nonce = token.androidPayCards[0].nonce;
         data.card_information.bin = token.androidPayCards[0].details.bin;
+        data.card_information.isNetworkTokenized =
+            token.androidPayCards[0].details.isNetworkTokenized;
 
         return data;
     }

--- a/packages/google-pay-integration/src/types.ts
+++ b/packages/google-pay-integration/src/types.ts
@@ -291,7 +291,7 @@ export interface GooglePayHostWindow extends Window {
 }
 
 interface GooglePayBaseInitializationData {
-    card_information?: { type: string; number: string; bin?: string };
+    card_information?: { type: string; number: string; bin?: string; isNetworkTokenized?: boolean };
     gateway: string;
     gatewayMerchantId?: string;
     googleMerchantId: string;
@@ -363,7 +363,7 @@ export type GooglePayInitializationData =
 
 export interface GooglePaySetExternalCheckoutData {
     nonce: string;
-    card_information: { type: string; number: string; bin?: string };
+    card_information: { type: string; number: string; bin?: string; isNetworkTokenized?: boolean };
     cart_id?: string;
 }
 
@@ -393,6 +393,7 @@ export interface GooglePayBraintreeTokenObject {
             nonce: string;
             details: {
                 bin: string;
+                isNetworkTokenized?: boolean;
             };
         },
     ];


### PR DESCRIPTION
## What?
Get the [isNetworkTokenized ](https://braintree.github.io/braintree-web/current/GooglePayment.html#~tokenizePayload) property returned by Braintree sdk for GooglePay payments and pass to BC payment initializationData.

Skip 3D Secure if isNetworkTokenized is true

## Why?
Fix issue https://github.com/bigcommerce/checkout-sdk-js/issues/2750 where payment fails when requesting 3D Secure lookup on network tokenized card from GooglePay

## Testing / Proof
I'm unable to fully test on sandbox because all cards in the GooglePay sandbox return isNetworkTokenized: false, but see screenshots below where the isNetworkTokenized property is passed to the BC checkout and 3D Secure lookup is requested as the value is false.

<img width="679" alt="image" src="https://github.com/user-attachments/assets/2c10342a-35e0-4a29-955e-819574afea80">


<img width="626" alt="image" src="https://github.com/user-attachments/assets/4458834f-d024-4e81-8990-fec54b0bb9c8">

@bigcommerce/team-checkout @bigcommerce/team-payments

