### PR TITLE
feat(payment): CHECKOUT-8901 Add Async Payment Methods

### DIFF
--- a/packages/hosted-form-v2/src/hosted-form-service.ts
+++ b/packages/hosted-form-v2/src/hosted-form-service.ts
@@ -3,6 +3,7 @@ import HostedForm from './hosted-form';
 import HostedFormFactory from './hosted-form-factory';
 import HostedFormManualOrderData from './hosted-form-manual-order-data';
 import HostedFormOptions from './hosted-form-options';
+import { HostedInputSubmitManualOrderSuccessEvent } from './iframe-content';
 
 export default class HostedFormService {
     protected _hostedForm?: HostedForm;
@@ -23,7 +24,9 @@ export default class HostedFormService {
         }
     }
 
-    async submitManualOrderPayment(data: HostedFormManualOrderData): Promise<void> {
+    async submitManualOrderPayment(
+        data: HostedFormManualOrderData,
+    ): Promise<HostedInputSubmitManualOrderSuccessEvent | void> {
         const form = this._hostedForm;
 
         if (!form) {
@@ -31,6 +34,7 @@ export default class HostedFormService {
         }
 
         await form.validate();
-        await form.submitManualOrderPayment({ data });
+
+        return form.submitManualOrderPayment({ data });
     }
 }

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-events.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-events.ts
@@ -110,6 +110,9 @@ export interface HostedInputEnterEvent {
 }
 export interface HostedInputSubmitManualOrderSuccessEvent {
     type: HostedInputEventType.SubmitManualOrderSucceeded;
+    payload: {
+        response: Response<unknown>;
+    };
 }
 
 export interface HostedInputSubmitManualOrderErrorEvent {

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
@@ -121,18 +121,24 @@ describe('HostedInputManualOrderPaymentHandler', () => {
                 },
             },
         };
+        const response = {
+            body: { type: 'success' },
+        };
 
         jest.spyOn(inputAggregator, 'getInputValues').mockReturnValue({});
         jest.spyOn(inputValidator, 'validate').mockResolvedValue({ isValid: true, errors: {} });
-        jest.spyOn(manualOrderPaymentRequestSender, 'submitPayment').mockResolvedValue({
-            body: { type: 'success' },
-        } as Response<unknown>);
+        jest.spyOn(manualOrderPaymentRequestSender, 'submitPayment').mockResolvedValue(
+            response as Response<unknown>,
+        );
         jest.spyOn(eventPoster, 'post');
 
         await handler.handle(event);
 
         expect(eventPoster.post).toHaveBeenCalledWith({
             type: HostedInputEventType.SubmitManualOrderSucceeded,
+            payload: {
+                response,
+            },
         });
     });
 
@@ -146,22 +152,63 @@ describe('HostedInputManualOrderPaymentHandler', () => {
                 },
             },
         };
+        const response = {
+            body: {
+                type: 'continue',
+                code: 'complete_offline',
+                parameters: {},
+            },
+        };
 
         jest.spyOn(inputAggregator, 'getInputValues').mockReturnValue({});
         jest.spyOn(inputValidator, 'validate').mockResolvedValue({ isValid: true, errors: {} });
-        jest.spyOn(manualOrderPaymentRequestSender, 'submitPayment').mockResolvedValue({
-            body: {
-                type: 'continue',
-                code: 'await_confirmation',
-                parameters: {},
-            },
-        } as Response<unknown>);
+        jest.spyOn(manualOrderPaymentRequestSender, 'submitPayment').mockResolvedValue(
+            response as Response<unknown>,
+        );
         jest.spyOn(eventPoster, 'post');
 
         await handler.handle(event);
 
         expect(eventPoster.post).toHaveBeenCalledWith({
             type: HostedInputEventType.SubmitManualOrderSucceeded,
+            payload: {
+                response,
+            },
+        });
+    });
+
+    it('should post submit succeeded event if async payment is successful', async () => {
+        const event: HostedFieldSubmitManualOrderRequestEvent = {
+            type: HostedFieldEventType.SubmitManualOrderRequested,
+            payload: {
+                data: {
+                    paymentMethodId: 'asyncThirdPartyPayment',
+                    paymentSessionToken: pstToken,
+                },
+            },
+        };
+        const response = {
+            body: {
+                type: 'continue',
+                code: 'await_confirmation',
+                parameters: {},
+            },
+        };
+
+        jest.spyOn(inputAggregator, 'getInputValues').mockReturnValue({});
+        jest.spyOn(inputValidator, 'validate').mockResolvedValue({ isValid: true, errors: {} });
+        jest.spyOn(manualOrderPaymentRequestSender, 'submitPayment').mockResolvedValue(
+            response as Response<unknown>,
+        );
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle(event);
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.SubmitManualOrderSucceeded,
+            payload: {
+                response,
+            },
         });
     });
 });

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.ts
@@ -58,8 +58,14 @@ export default class HostedInputManualOrderPaymentHandler {
             const isSuccessfulOfflineOrder =
                 isOfflinePaymentMethodId(data.paymentMethodId) &&
                 get(response.body, 'type') === 'continue' &&
+                get(response.body, 'code') === 'complete_offline';
+            const isSuccessfulAsyncOrder =
+                get(response.body, 'type') === 'continue' &&
                 get(response.body, 'code') === 'await_confirmation';
-            const isSuccess = get(response.body, 'type') === 'success' || isSuccessfulOfflineOrder;
+            const isSuccess =
+                get(response.body, 'type') === 'success' ||
+                isSuccessfulOfflineOrder ||
+                isSuccessfulAsyncOrder;
 
             if (isFailure) {
                 this._eventPoster.post({
@@ -78,6 +84,9 @@ export default class HostedInputManualOrderPaymentHandler {
             } else if (isSuccess) {
                 this._eventPoster.post({
                     type: HostedInputEventType.SubmitManualOrderSucceeded,
+                    payload: {
+                        response,
+                    },
                 });
             }
         } catch (error) {

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
@@ -116,7 +116,7 @@ describe('ManualOrderPaymentRequestSender', () => {
     it('submits offline payment', async () => {
         response = {
             type: 'continue',
-            code: 'await_confirmation',
+            code: 'complete_offline',
             parameters: {},
         } as unknown as Response<unknown>;
 


### PR DESCRIPTION
## What?
Add async payment methods support by passing payment reponse to the UI side, such as `manual-order-ui`.

## Why?
The UI side can react to an async order accordingly, such as displaying a modal.

## Testing / Proof
### manual testing

https://github.com/user-attachments/assets/e65cc969-7e5e-4077-abae-fcb8b6097258
