### PR TITLE
feat(payment): STRIPE-414 remove experiment for GPay shipping options

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
@@ -21,18 +21,6 @@ describe('GooglePayGateway', () => {
     let gateway: GooglePayGateway;
     let paymentIntegrationService: PaymentIntegrationService;
 
-    const getGenericInitialDataWithShippingOptions = (isExperimentEnabled = true) => {
-        const genericData = getGeneric();
-
-        return {
-            ...genericData,
-            initializationData: {
-                ...genericData.initializationData!,
-                isShippingOptionsEnabled: isExperimentEnabled,
-            },
-        };
-    };
-
     beforeEach(() => {
         jest.clearAllMocks();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
@@ -187,7 +175,7 @@ describe('GooglePayGateway', () => {
             const expectedRequiredData = {
                 emailRequired: true,
                 shippingAddressRequired: true,
-                shippingOptionRequired: false,
+                shippingOptionRequired: true,
                 shippingAddressParameters: {
                     phoneNumberRequired: true,
                     allowedCountryCodes: ['AU', 'US', 'JP'],
@@ -220,7 +208,7 @@ describe('GooglePayGateway', () => {
                 'getShippingAddress',
             ).mockReturnValueOnce(undefined);
 
-            await gateway.initialize(getGenericInitialDataWithShippingOptions);
+            await gateway.initialize(getGeneric);
 
             await expect(gateway.getRequiredData()).resolves.toStrictEqual(expectedRequiredData);
         });
@@ -238,7 +226,7 @@ describe('GooglePayGateway', () => {
         it('should return only offer callback intent when shipping not required', async () => {
             const expectedCallbackIntents = [CallbackIntentsType.OFFER];
 
-            await gateway.initialize(getGenericInitialDataWithShippingOptions);
+            await gateway.initialize(getGeneric);
 
             expect(gateway.getCallbackIntents()).toStrictEqual(expectedCallbackIntents);
         });
@@ -255,26 +243,13 @@ describe('GooglePayGateway', () => {
                 'getShippingAddress',
             ).mockReturnValueOnce(undefined);
 
-            await gateway.initialize(getGenericInitialDataWithShippingOptions);
+            await gateway.initialize(getGeneric);
 
             expect(gateway.getCallbackIntents()).toStrictEqual(expectedCallbackIntents);
         });
     });
 
     describe('#getCallbackTriggers', () => {
-        it('should return only initialize trigger when shipping experiment disabled', async () => {
-            const expectedCallbackTriggers = {
-                availableTriggers: [CallbackTriggerType.INITIALIZE],
-                initializationTrigger: [CallbackTriggerType.INITIALIZE],
-                addressChangeTriggers: [],
-                shippingOptionsChangeTriggers: [],
-            };
-
-            await gateway.initialize(getGeneric);
-
-            expect(gateway.getCallbackTriggers()).toStrictEqual(expectedCallbackTriggers);
-        });
-
         it('should return initialize triggers', async () => {
             const expectedCallbackTriggers = {
                 availableTriggers: [
@@ -290,7 +265,7 @@ describe('GooglePayGateway', () => {
                 shippingOptionsChangeTriggers: [CallbackTriggerType.SHIPPING_OPTION],
             };
 
-            await gateway.initialize(getGenericInitialDataWithShippingOptions);
+            await gateway.initialize(getGeneric);
 
             expect(gateway.getCallbackTriggers()).toStrictEqual(expectedCallbackTriggers);
         });

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -117,12 +117,12 @@ export default class GooglePayGateway {
                 phoneNumberRequired: true,
                 ...(allowedCountryCodes && { allowedCountryCodes }),
             },
-            shippingOptionRequired: this._isGooglePayShippingOptionsAvailable(),
+            shippingOptionRequired: true,
         };
     }
 
     getCallbackIntents(): CallbackIntentsType[] {
-        if (this._isGooglePayShippingOptionsAvailable() && this._isShippingAddressRequired()) {
+        if (this._isShippingAddressRequired()) {
             return [
                 CallbackIntentsType.OFFER,
                 CallbackIntentsType.SHIPPING_ADDRESS,
@@ -134,21 +134,17 @@ export default class GooglePayGateway {
     }
 
     getCallbackTriggers(): { [key: string]: CallbackTriggerType[] } {
-        const isGooglePayShippingOptionsAvailable = this._isGooglePayShippingOptionsAvailable();
-        const availableTriggers = isGooglePayShippingOptionsAvailable
-            ? [
-                  CallbackTriggerType.INITIALIZE,
-                  CallbackTriggerType.SHIPPING_ADDRESS,
-                  CallbackTriggerType.SHIPPING_OPTION,
-              ]
-            : [CallbackTriggerType.INITIALIZE];
+        const availableTriggers = [
+            CallbackTriggerType.INITIALIZE,
+            CallbackTriggerType.SHIPPING_ADDRESS,
+            CallbackTriggerType.SHIPPING_OPTION,
+        ];
         const initializationTrigger = [CallbackTriggerType.INITIALIZE];
-        const addressChangeTriggers = isGooglePayShippingOptionsAvailable
-            ? [CallbackTriggerType.INITIALIZE, CallbackTriggerType.SHIPPING_ADDRESS]
-            : [];
-        const shippingOptionsChangeTriggers = isGooglePayShippingOptionsAvailable
-            ? [CallbackTriggerType.SHIPPING_OPTION]
-            : [];
+        const addressChangeTriggers = [
+            CallbackTriggerType.INITIALIZE,
+            CallbackTriggerType.SHIPPING_ADDRESS,
+        ];
+        const shippingOptionsChangeTriggers = [CallbackTriggerType.SHIPPING_OPTION];
 
         return {
             availableTriggers,
@@ -349,10 +345,6 @@ export default class GooglePayGateway {
 
     protected setGatewayIdentifier(gateway?: string) {
         this._gatewayIdentifier = gateway || this.getGatewayIdentifier();
-    }
-
-    private _isGooglePayShippingOptionsAvailable(): boolean {
-        return !!this.getGooglePayInitializationData().isShippingOptionsEnabled;
     }
 
     private _isShippingAddressRequired(): boolean {

--- a/packages/google-pay-integration/src/types.ts
+++ b/packages/google-pay-integration/src/types.ts
@@ -297,7 +297,6 @@ interface GooglePayBaseInitializationData {
     googleMerchantId: string;
     googleMerchantName: string;
     isThreeDSecureEnabled: boolean;
-    isShippingOptionsEnabled?: boolean;
     nonce?: string;
     platformToken: string;
     storeCountry?: string;


### PR DESCRIPTION
## What?
Remove experiment for GooglePay shipping options

## Why?
This feature was deployed on production for all stores. Experiment can be removed.

## Testing / Proof
Unit tests and manually tested


https://github.com/user-attachments/assets/4ca7716f-169f-4eca-bbc9-aebb1e4c9380


https://github.com/user-attachments/assets/c8822d6b-9d7b-4408-9aee-fa7eff848f93


https://github.com/user-attachments/assets/3e44a1f8-56a1-40b7-bbc0-bf85064bf8a7


https://github.com/user-attachments/assets/9cc29ab3-dff4-4784-897b-ce7e2a4b4088



@bigcommerce/team-checkout @bigcommerce/team-payments
