### PR TITLE
feat(payment): PAYPAL-4952 updated PayPal Commerce credit strategies with BNPL configuration implementation

### DIFF
--- a/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-payment-method.mock.ts
+++ b/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-payment-method.mock.ts
@@ -47,6 +47,31 @@ export default function getPayPalCommercePaymentMethod(): PaymentMethod {
             shouldRenderFields: true,
             shouldRunAcceleratedCheckout: false,
             isHostedCheckoutEnabled: false,
+            paypalBNPLConfiguration: [
+                {
+                    id: 'checkout',
+                    name: 'Checkout page',
+                    status: true,
+                    styles: {
+                        layout: 'text',
+                        'logo-type': 'alternative',
+                        'text-color': 'white',
+                        'text-size': '10',
+                    },
+                },
+                {
+                    id: 'cart',
+                    name: 'Cart page',
+                    status: true,
+                    styles: {
+                        layout: 'text',
+                        'logo-type': 'alternative',
+                        'logo-position': 'right',
+                        'text-color': 'white',
+                        'text-size': '10',
+                    },
+                },
+            ],
         },
         type: 'PAYMENT_TYPE_API',
     };

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -888,6 +888,28 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
     });
 
     describe('PayPal Commerce Credit messages logic', () => {
+        it('does not render PayPal message if banner is disabled in paypalBNPLConfiguration', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: [
+                        {
+                            id: 'checkout',
+                            status: false,
+                        },
+                    ],
+                },
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
         it('initializes PayPal Messages component', async () => {
             await strategy.initialize(initializationOptions);
 
@@ -896,6 +918,14 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                 placement: 'cart',
                 style: {
                     layout: 'text',
+                    logo: {
+                        position: 'right',
+                        type: 'alternative',
+                    },
+                    text: {
+                        color: 'white',
+                        size: 10,
+                    },
                 },
             });
         });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -113,9 +113,7 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
             let bannerConfiguration: PayPalBNPLConfigurationItem | undefined;
 
             if (paypalBNPLConfiguration) {
-                bannerConfiguration = (paypalBNPLConfiguration || []).find(
-                    ({ id }) => id === 'cart',
-                );
+                bannerConfiguration = paypalBNPLConfiguration.find(({ id }) => id === 'cart');
 
                 if (!bannerConfiguration?.status) {
                     return;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
@@ -74,9 +74,7 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
 
         // TODO: remove paypalBNPLConfiguration check when PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
         if (paypalBNPLConfiguration && document.getElementById(bannerContainerId)) {
-            const bannerConfiguration = (paypalBNPLConfiguration || []).find(
-                ({ id }) => id === 'checkout',
-            );
+            const bannerConfiguration = paypalBNPLConfiguration.find(({ id }) => id === 'checkout');
 
             if (!bannerConfiguration?.status) {
                 return;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
@@ -11,7 +11,10 @@ import {
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
+    getPaypalMessagesStylesFromBNPLConfig,
     MessagingOptions,
+    PayPalBNPLConfigurationItem,
+    PayPalCommerceInitializationData,
     PayPalCommerceSdk,
     PayPalMessagesSdk,
 } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
@@ -23,7 +26,6 @@ import {
     ClickCallbackActions,
     PayPalCommerceButtons,
     PayPalCommerceButtonsOptions,
-    PayPalCommerceInitializationData,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCreditPaymentInitializeOptions, {
@@ -66,9 +68,29 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        // TODO: update paypalBNPLConfiguration with empty array as default value when PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
+        const { paypalBNPLConfiguration, orderId } = paymentMethod.initializationData || {};
+        const { bannerContainerId = '', container } = paypalOptions;
 
-        const { bannerContainerId = '' } = paypalOptions;
+        // TODO: remove paypalBNPLConfiguration check when PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
+        if (paypalBNPLConfiguration && document.getElementById(bannerContainerId)) {
+            const bannerConfiguration = (paypalBNPLConfiguration || []).find(
+                ({ id }) => id === 'checkout',
+            );
 
+            if (!bannerConfiguration?.status) {
+                return;
+            }
+
+            const paypalMessages = await this.paypalCommerceSdk.getPayPalMessages(
+                paymentMethod,
+                state.getCartOrThrow().currency.code,
+            );
+
+            return this.renderMessages(paypalMessages, bannerContainerId, bannerConfiguration);
+        }
+
+        // TODO: this condition can be removed when PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
         if (document.getElementById(bannerContainerId)) {
             const paypalMessages = await this.paypalCommerceSdk.getPayPalMessages(
                 paymentMethod,
@@ -82,15 +104,15 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
         // The PayPal button and fields should not be rendered when shopper was redirected to Checkout page
         // after using smart payment button on PDP or Cart page. In this case backend returns order id if
         // it is available in checkout session. Therefore, it is not necessary to render PayPal button.
-        if (paymentMethod.initializationData?.orderId) {
-            this.orderId = paymentMethod.initializationData?.orderId;
+        if (orderId) {
+            this.orderId = orderId;
 
             return;
         }
 
         await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
 
-        this.loadingIndicatorContainer = paypalOptions?.container?.split('#')[1];
+        this.loadingIndicatorContainer = container?.split('#')[1];
 
         this.renderButton(methodId, paypalOptions);
     }
@@ -248,20 +270,27 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
      * Render Pay Later Messages
      *
      * */
-    private renderMessages(paypalMessages: PayPalMessagesSdk, bannerContainerId: string): void {
+    private renderMessages(
+        paypalMessages: PayPalMessagesSdk,
+        bannerContainerId: string,
+        bannerConfiguration?: PayPalBNPLConfigurationItem, // TODO: this should not be optional when PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
+    ): void {
         const checkout = this.paymentIntegrationService.getState().getCheckoutOrThrow();
-
         const grandTotal = checkout.outstandingBalance;
+        // TODO: default style can be removed when PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
+        const style = bannerConfiguration
+            ? getPaypalMessagesStylesFromBNPLConfig(bannerConfiguration)
+            : {
+                  layout: 'text',
+                  logo: {
+                      type: 'inline',
+                  },
+              };
 
         const paypalMessagesOptions: MessagingOptions = {
             amount: grandTotal,
             placement: 'payment',
-            style: {
-                layout: 'text',
-                logo: {
-                    type: 'inline',
-                },
-            },
+            style,
         };
 
         paypalMessages.Messages(paypalMessagesOptions).render(`#${bannerContainerId}`);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -552,12 +552,13 @@ export interface PayPalCommerceFieldsStyleOptions {
 /**
  *
  * PayPalCommerce Messages
- *
  */
+// TODO: This interface can be removed once the PayPaySDK interface is removed
 export interface PayPalCommerceMessages {
     render(id: string): void;
 }
 
+// TODO: This interface can be removed once the PayPaySDK interface is removed
 export interface PayPalCommerceMessagesOptions {
     amount: number;
     placement: string;
@@ -565,6 +566,7 @@ export interface PayPalCommerceMessagesOptions {
     fundingSource?: string;
 }
 
+// TODO: This interface can be removed once the PayPaySDK interface is removed
 export interface PayPalCommerceMessagesStyleOptions {
     layout?: string;
 }

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -16,7 +16,7 @@ export type EnableFundingType = FundingType | string;
 export interface PayPalCommerceInitializationData {
     attributionId?: string;
     availableAlternativePaymentMethods: FundingType;
-    // buttonStyle?: PayPalButtonStyleOptions; // TODO: PayPalButtonStyleOptions interface will be moved in the future
+    buttonStyle?: PayPalButtonStyleOptions;
     buyerCountry?: string;
     clientId: string;
     clientToken?: string;
@@ -37,7 +37,8 @@ export interface PayPalCommerceInitializationData {
     orderId?: string;
     shouldRenderFields?: boolean;
     shouldRunAcceleratedCheckout?: boolean; // TODO: remove when PPCP Fastlane A/B test will be finished
-    // paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>; // TODO: PayPalButtonStyleOptions interface will be moved in the future
+    paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>;
+    paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[];
 }
 
 /**
@@ -263,16 +264,24 @@ export interface PayPalCommerceFieldsStyleOptions {
 /**
  *
  * PayLater Messages related types
- *
+ * doc: https://developer.paypal.com/docs/checkout/pay-later/us/integrate/reference
  */
 export interface MessagingRender {
     render(container: string): void;
 }
 
 export interface MessagesStyleOptions {
-    layout?: 'text' | 'flex';
+    color?: string; // 'blue' | 'black' | 'white' | 'white-no-border' | 'gray' | 'monochrome' | 'grayscale'
+    layout?: string; // 'text' | 'flex'
     logo?: {
-        type: 'none' | 'inline' | 'primary';
+        type?: string; // 'primary' | 'alternative' | 'inline' | 'none'
+        position?: string; // 'left' | 'right' | 'top'
+    };
+    ratio?: string; // '1x1' | '1x4' | '8x1' | '20x1'
+    text?: {
+        align?: string; // 'left' | 'right' | 'center'
+        color?: string; // 'black' | 'white' | 'monochrome' | 'grayscale'
+        size?: number; // from 10 to 16
     };
 }
 
@@ -280,6 +289,13 @@ export interface MessagingOptions {
     amount: number;
     placement: string;
     style?: MessagesStyleOptions;
+}
+
+export interface PayPalBNPLConfigurationItem {
+    id: string;
+    name: string;
+    status: boolean;
+    styles: Record<string, string>;
 }
 
 /**

--- a/packages/paypal-commerce-utils/src/utils/get-fastlane-styles.ts
+++ b/packages/paypal-commerce-utils/src/utils/get-fastlane-styles.ts
@@ -1,5 +1,6 @@
-import { FastlaneStylesSettings, PayPalFastlaneStylesOption } from '../index';
 import { omitBy } from 'lodash';
+
+import { FastlaneStylesSettings, PayPalFastlaneStylesOption } from '../index';
 
 function isInvalidStyleOption(styleOption: unknown) {
     return typeof styleOption !== 'string';

--- a/packages/paypal-commerce-utils/src/utils/get-paypal-messages-styles-from-bnpl-config.spec.ts
+++ b/packages/paypal-commerce-utils/src/utils/get-paypal-messages-styles-from-bnpl-config.spec.ts
@@ -1,0 +1,36 @@
+import getPaypalMessagesStylesFromBNPLConfig from './get-paypal-messages-styles-from-bnpl-config';
+
+describe('getPaypalMessagesStylesFromBNPLConfig', () => {
+    it('returns PayPal Commerce Messages Style Options from BNPL Config', () => {
+        const input = {
+            id: 'checkout',
+            name: 'Checkout page',
+            status: true,
+            styles: {
+                color: 'white-no-border',
+                layout: 'text',
+                'logo-type': 'alternative',
+                'logo-position': 'right',
+                ratio: '8x1',
+                'text-color': 'white',
+                'text-size': '10',
+            },
+        };
+
+        const expectedOutput = {
+            color: 'white-no-border',
+            layout: 'text',
+            logo: {
+                type: 'alternative',
+                position: 'right',
+            },
+            ratio: '8x1',
+            text: {
+                color: 'white',
+                size: 10,
+            },
+        };
+
+        expect(getPaypalMessagesStylesFromBNPLConfig(input)).toStrictEqual(expectedOutput);
+    });
+});

--- a/packages/paypal-commerce-utils/src/utils/get-paypal-messages-styles-from-bnpl-config.ts
+++ b/packages/paypal-commerce-utils/src/utils/get-paypal-messages-styles-from-bnpl-config.ts
@@ -1,0 +1,47 @@
+import { MessagesStyleOptions, PayPalBNPLConfigurationItem } from '../paypal-commerce-types';
+
+function getPaypalMessagesStylesFromBNPLConfig({
+    styles,
+}: PayPalBNPLConfigurationItem): MessagesStyleOptions {
+    const messagesStyles: MessagesStyleOptions = {};
+
+    if (styles.color) {
+        messagesStyles.color = styles.color;
+    }
+
+    if (styles.layout) {
+        messagesStyles.layout = styles.layout;
+    }
+
+    if (styles['logo-type'] || styles['logo-position']) {
+        messagesStyles.logo = {};
+
+        if (styles['logo-type']) {
+            messagesStyles.logo.type = styles['logo-type'];
+        }
+
+        if (styles['logo-position']) {
+            messagesStyles.logo.position = styles['logo-position'];
+        }
+    }
+
+    if (styles.ratio) {
+        messagesStyles.ratio = styles.ratio;
+    }
+
+    if (styles['text-color'] || styles['text-size']) {
+        messagesStyles.text = {};
+
+        if (styles['text-color']) {
+            messagesStyles.text.color = styles['text-color'];
+        }
+
+        if (styles['text-size']) {
+            messagesStyles.text.size = +styles['text-size'];
+        }
+    }
+
+    return messagesStyles;
+}
+
+export default getPaypalMessagesStylesFromBNPLConfig;

--- a/packages/paypal-commerce-utils/src/utils/index.ts
+++ b/packages/paypal-commerce-utils/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { default as isPayPalCommerceAcceleratedCheckoutCustomer } from './is-paypal-commerce-accelerated-checkout-customer';
-
 export { default as isPayPalFastlaneCustomer } from './is-paypal-fastlane-customer';
 export { default as getFastlaneStyles } from './get-fastlane-styles';
+export { default as getPaypalMessagesStylesFromBNPLConfig } from './get-paypal-messages-styles-from-bnpl-config';


### PR DESCRIPTION
## What?
Updated PayPal Commerce credit strategies with BNPL configuration implementation

## Why?
So merchants PayPal BNPL Configurator changes in Control Panel will be reflected on storefront and checkout pages

## Testing / Proof
Unit tests
Manual tests
CI

Checkout page grey logo styling:
<img width="1174" alt="Screenshot 2024-12-23 at 14 18 00" src="https://github.com/user-attachments/assets/667a08c1-1fed-4d78-8894-891ebdf6ccf8" />
![Screenshot 2024-12-23 at 14 17 45](https://github.com/user-attachments/assets/41314879-d542-4149-a001-027362d29630)

Checkout page blue logo styling:
<img width="1190" alt="Screenshot 2024-12-23 at 14 18 48" src="https://github.com/user-attachments/assets/32e865dc-9d39-44fd-9f35-938f9e60ef8a" />
<img width="786" alt="Screenshot 2024-12-23 at 14 18 40" src="https://github.com/user-attachments/assets/e03aadb9-1fb3-413f-8865-2baf522d8d9f" />

Cart page banner grey logo: 
<img width="695" alt="Screenshot 2024-12-23 at 14 34 02" src="https://github.com/user-attachments/assets/8a3677eb-eb60-4a3c-abfd-f69140063ebd" />