### PR TITLE
refactor(payment): PAYPAL-4705 removed PAYPAL-4387.paypal_shipping_callbacks experiment form PPCP strategies

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -104,13 +104,6 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         state: 'New York',
     };
 
-    const paypalShippingCallbackAddressMock = {
-        city: 'New York',
-        country_code: 'US',
-        postal_code: '07564',
-        state: 'New York',
-    };
-
     const paypalSelectedShippingOptionPayloadMock = {
         amount: {
             currency_code: 'USD',
@@ -279,16 +272,6 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                         options.onShippingOptionsChange({
                             orderId: paypalOrderId,
                             selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
-                        });
-                    }
-                });
-
-                eventEmitter.on('onShippingChange', () => {
-                    if (options.onShippingChange) {
-                        options.onShippingChange({
-                            orderID: paypalOrderId,
-                            shipping_address: paypalShippingCallbackAddressMock,
-                            selected_shipping_option: paypalSelectedShippingOptionPayloadMock,
                         });
                     }
                 });
@@ -492,41 +475,6 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
-                onApprove: expect.any(Function),
-            });
-        });
-
-        it('initializes PayPal button to render (with shipping options feature enabled and shipping experiment is off)', async () => {
-            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        'PAYPAL-4387.paypal_shipping_callbacks': false,
-                    },
-                },
-            });
-
-            const paymentMethodWithShippingOptionsFeature = {
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isHostedCheckoutEnabled: true,
-                },
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
-
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                fundingSource: paypalSdk.FUNDING.PAYLATER,
-                style: paypalCommerceCreditOptions.style,
-                createOrder: expect.any(Function),
-                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -22,7 +22,6 @@ import {
     PayPalBuyNowInitializeOptions,
     PayPalCommerceButtonsOptions,
     ShippingAddressChangeCallbackPayload,
-    ShippingChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
@@ -164,25 +163,11 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
             onCancel: () => this.paymentIntegrationService.loadDefaultCheckout(),
         };
 
-        const isPaypalShippingCallbacksExperimentIsOn =
-            state.getStoreConfig()?.checkoutSettings.features[
-                'PAYPAL-4387.paypal_shipping_callbacks'
-            ];
-
-        const onShippingChangeCallbacks = isPaypalShippingCallbacksExperimentIsOn
-            ? {
-                  onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                      this.onShippingAddressChange(data),
-                  onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                      this.onShippingOptionsChange(data),
-              }
-            : {
-                  onShippingChange: (data: ShippingChangeCallbackPayload) =>
-                      this.onShippingChange(data),
-              };
-
         const hostedCheckoutCallbacks = {
-            ...onShippingChangeCallbacks,
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                this.onShippingAddressChange(data),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                this.onShippingOptionsChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -314,33 +299,6 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         );
 
         try {
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalCommerceIntegrationService.updateOrder();
-        } catch (error) {
-            if (typeof error === 'string') {
-                throw new Error(error);
-            }
-
-            throw error;
-        }
-    }
-
-    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
-        const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shipping_address.city,
-            countryCode: data.shipping_address.country_code,
-            postalCode: data.shipping_address.postal_code,
-            stateOrProvinceCode: data.shipping_address.state,
-        });
-
-        try {
-            await this.paymentIntegrationService.updateBillingAddress(address);
-            await this.paymentIntegrationService.updateShippingAddress(address);
-
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-                data.selected_shipping_option?.id,
-            );
-
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -45,8 +45,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
 
     const methodId = 'paypalcommercecredit';
     const defaultContainerId = 'paypal-commerce-credit-container-mock-id';
-    const paypalOrderId = 'ORDER_ID';
-    const approveDataOrderId = paypalOrderId;
+    const approveDataOrderId = 'ORDER_ID';
 
     const paypalCommerceCreditOptions: PayPalCommerceCreditCustomerInitializeOptions = {
         container: defaultContainerId,
@@ -168,30 +167,6 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                         options.onShippingOptionsChange({
                             orderId: approveDataOrderId,
                             selectedShippingOption: {
-                                amount: {
-                                    currency_code: 'USD',
-                                    value: '100',
-                                },
-                                id: '1',
-                                label: 'Free shipping',
-                                selected: true,
-                                type: 'type_shipping',
-                            },
-                        });
-                    }
-                });
-
-                eventEmitter.on('onShippingChange', () => {
-                    if (options.onShippingChange) {
-                        options.onShippingChange({
-                            orderID: paypalOrderId,
-                            shipping_address: {
-                                city: 'New York',
-                                country_code: 'US',
-                                postal_code: '07564',
-                                state: 'New York',
-                            },
-                            selected_shipping_option: {
                                 amount: {
                                     currency_code: 'USD',
                                     value: '100',
@@ -341,43 +316,6 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
-                onApprove: expect.any(Function),
-                onClick: expect.any(Function),
-            });
-        });
-
-        it('initializes paypal buttons with config related to hosted checkout feature and shipping callbacks experiment is off', async () => {
-            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        'PAYPAL-4387.paypal_shipping_callbacks': false,
-                    },
-                },
-            });
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isHostedCheckoutEnabled: true,
-                },
-            });
-
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                fundingSource: paypalSdk.FUNDING.PAYLATER,
-                style: {
-                    height: DefaultCheckoutButtonHeight,
-                    color: StyleButtonColor.silver,
-                    label: 'checkout',
-                },
-                createOrder: expect.any(Function),
-                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
             });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -369,7 +369,6 @@ export interface PayPalCommerceButtonsOptions {
     onClick?(data: ClickCallbackPayload, actions: ClickCallbackActions): Promise<void> | void;
     onError?(error: Error): void;
     onCancel?(): void;
-    onShippingChange?(data: ShippingChangeCallbackPayload): Promise<void>;
     onShippingAddressChange?(data: ShippingAddressChangeCallbackPayload): Promise<void>;
     onShippingOptionsChange?(data: ShippingOptionChangeCallbackPayload): Promise<void>;
 }
@@ -382,12 +381,6 @@ export interface ShippingOptionChangeCallbackPayload {
 export interface ShippingAddressChangeCallbackPayload {
     orderId: string;
     shippingAddress: PayPalAddress;
-}
-
-export interface ShippingChangeCallbackPayload {
-    orderID: string;
-    shipping_address: PaypalAddressCallbackData;
-    selected_shipping_option: PayPalSelectedShippingOption;
 }
 
 export interface ClickCallbackPayload {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -91,13 +91,6 @@ describe('PayPalCommerceButtonStrategy', () => {
         state: 'New York',
     };
 
-    const paypalShippingCallbackAddressMock = {
-        city: 'New York',
-        country_code: 'US',
-        postal_code: '07564',
-        state: 'New York',
-    };
-
     const paypalSelectedShippingOptionPayloadMock = {
         amount: {
             currency_code: 'USD',
@@ -253,16 +246,6 @@ describe('PayPalCommerceButtonStrategy', () => {
                         options.onShippingOptionsChange({
                             orderId: paypalOrderId,
                             selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
-                        });
-                    }
-                });
-
-                eventEmitter.on('onShippingChange', () => {
-                    if (options.onShippingChange) {
-                        options.onShippingChange({
-                            orderID: paypalOrderId,
-                            shipping_address: paypalShippingCallbackAddressMock,
-                            selected_shipping_option: paypalSelectedShippingOptionPayloadMock,
                         });
                     }
                 });
@@ -443,41 +426,6 @@ describe('PayPalCommerceButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
-                onApprove: expect.any(Function),
-            });
-        });
-
-        it('initializes PayPal button to render (with shipping options feature enabled and shipping callback experiment is off)', async () => {
-            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        'PAYPAL-4387.paypal_shipping_callbacks': false,
-                    },
-                },
-            });
-
-            const paymentMethodWithShippingOptionsFeature = {
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isHostedCheckoutEnabled: true,
-                },
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
-
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: paypalCommerceOptions.style,
-                createOrder: expect.any(Function),
-                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -15,7 +15,6 @@ import {
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
-    ShippingChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
@@ -115,25 +114,11 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
             onCancel: () => this.paymentIntegrationService.loadDefaultCheckout(),
         };
 
-        const isPaypalShippingCallbacksExperimentIsOn =
-            state.getStoreConfig()?.checkoutSettings.features[
-                'PAYPAL-4387.paypal_shipping_callbacks'
-            ];
-
-        const onShippingChangeCallbacks = isPaypalShippingCallbacksExperimentIsOn
-            ? {
-                  onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                      this.onShippingAddressChange(data),
-                  onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                      this.onShippingOptionsChange(data),
-              }
-            : {
-                  onShippingChange: (data: ShippingChangeCallbackPayload) =>
-                      this.onShippingChange(data),
-              };
-
         const hostedCheckoutCallbacks = {
-            ...onShippingChangeCallbacks,
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                this.onShippingAddressChange(data),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                this.onShippingOptionsChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -255,33 +240,6 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
         );
 
         try {
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalCommerceIntegrationService.updateOrder();
-        } catch (error) {
-            if (typeof error === 'string') {
-                throw new Error(error);
-            }
-
-            throw error;
-        }
-    }
-
-    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
-        const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shipping_address.city,
-            countryCode: data.shipping_address.country_code,
-            postalCode: data.shipping_address.postal_code,
-            stateOrProvinceCode: data.shipping_address.state,
-        });
-
-        try {
-            await this.paymentIntegrationService.updateBillingAddress(address);
-            await this.paymentIntegrationService.updateShippingAddress(address);
-
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-                data.selected_shipping_option?.id,
-            );
-
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -43,8 +43,7 @@ describe('PayPalCommerceCustomerStrategy', () => {
 
     const methodId = 'paypalcommerce';
     const defaultContainerId = 'paypal-commerce-container-mock-id';
-    const paypalOrderId = 'ORDER_ID';
-    const approveDataOrderId = paypalOrderId;
+    const approveDataOrderId = 'ORDER_ID';
     const storeConfig = getConfig().storeConfig;
 
     const paypalCommerceOptions: PayPalCommerceCustomerInitializeOptions = {
@@ -163,30 +162,6 @@ describe('PayPalCommerceCustomerStrategy', () => {
                         options.onShippingOptionsChange({
                             orderId: approveDataOrderId,
                             selectedShippingOption: {
-                                amount: {
-                                    currency_code: 'USD',
-                                    value: '100',
-                                },
-                                id: '1',
-                                label: 'Free shipping',
-                                selected: true,
-                                type: 'type_shipping',
-                            },
-                        });
-                    }
-                });
-
-                eventEmitter.on('onShippingChange', () => {
-                    if (options.onShippingChange) {
-                        options.onShippingChange({
-                            orderID: paypalOrderId,
-                            shipping_address: {
-                                city: 'New York',
-                                country_code: 'US',
-                                postal_code: '07564',
-                                state: 'New York',
-                            },
-                            selected_shipping_option: {
                                 amount: {
                                     currency_code: 'USD',
                                     value: '100',
@@ -337,43 +312,6 @@ describe('PayPalCommerceCustomerStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
-                onApprove: expect.any(Function),
-                onClick: expect.any(Function),
-            });
-        });
-
-        it('initializes paypal buttons with config related to hosted checkout feature and sipping callbacks experiment is off', async () => {
-            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue({
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        'PAYPAL-4387.paypal_shipping_callbacks': false,
-                    },
-                },
-            });
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isHostedCheckoutEnabled: true,
-                },
-            });
-
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: {
-                    height: DefaultCheckoutButtonHeight,
-                    color: StyleButtonColor.silver,
-                    label: 'checkout',
-                },
-                createOrder: expect.any(Function),
-                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
             });

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -20,7 +20,6 @@ import {
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
-    ShippingChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
@@ -122,25 +121,11 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
             ...(onClick && { onClick: () => onClick() }),
         };
 
-        const isPaypalShippingCallbacksExperimentIsOn =
-            state.getStoreConfig()?.checkoutSettings.features[
-                'PAYPAL-4387.paypal_shipping_callbacks'
-            ];
-
-        const onShippingChangeCallbacks = isPaypalShippingCallbacksExperimentIsOn
-            ? {
-                  onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                      this.onShippingAddressChange(data),
-                  onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                      this.onShippingOptionsChange(data),
-              }
-            : {
-                  onShippingChange: (data: ShippingChangeCallbackPayload) =>
-                      this.onShippingChange(data),
-              };
-
         const hostedCheckoutCallbacks = {
-            ...onShippingChangeCallbacks,
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                this.onShippingAddressChange(data),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                this.onShippingOptionsChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -239,29 +224,6 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         );
 
         try {
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalCommerceIntegrationService.updateOrder();
-        } catch (error) {
-            this.handleError(error);
-        }
-    }
-
-    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
-        const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shipping_address.city,
-            countryCode: data.shipping_address.country_code,
-            postalCode: data.shipping_address.postal_code,
-            stateOrProvinceCode: data.shipping_address.state,
-        });
-
-        try {
-            await this.paymentIntegrationService.updateBillingAddress(address);
-            await this.paymentIntegrationService.updateShippingAddress(address);
-
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-                data.selected_shipping_option?.id,
-            );
-
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {


### PR DESCRIPTION
## What?
Removed PAYPAL-4387.paypal_shipping_callbacks experiment form PPCP strategies

## Why?
Experiment was rolled out a half a year ago, so its time to make some cleanup

## Testing / Proof
Unit tests
Manual tests
CI

Placing order with PayPal with Pay Now feature on Cart page:

https://github.com/user-attachments/assets/a1fd187c-81fc-4261-a6be-246b34918219


Placing order with PayPal with Pay Now feature on Checkout page:

https://github.com/user-attachments/assets/ed75c5ac-a9e7-45d9-b3e2-e0e2d7b512d0


Placing order with PayPal Pay Later with Pay Now feature on Cart page:

https://github.com/user-attachments/assets/305fa316-c185-41a8-817a-443ae94b9bb9


Placing order with PayPal Pay Later with Pay Now feature on Checkout page:

https://github.com/user-attachments/assets/e38b2a95-eda4-4b62-b002-a81fd96edd4b


Placing order with PayPal when Pay Now feature is off on Cart page:

https://github.com/user-attachments/assets/744bd2c5-48ab-4255-a17c-2e269b18cc11


