### PR TITLE
refactor(payment): PAYPAL-4705 removed PAYPAL-3996.paypal_fastlane_shipping_update experiment

### DIFF
--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
@@ -9,7 +9,6 @@ import { PaymentMethod } from '@bigcommerce/checkout-sdk/payment-integration-api
 import {
     getBillingAddress,
     getCart,
-    getConfig,
     getCountries,
     getCustomer,
     getPaymentMethod,
@@ -130,12 +129,6 @@ describe('BraintreeFastlaneShippingStrategy', () => {
         jest.spyOn(store.getState().cart, 'getCart').mockReturnValue(getCart());
         jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(getCart());
         jest.spyOn(store.getState().countries, 'getCountries').mockReturnValue(getCountries());
-        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            getConfig().storeConfig,
-        );
         jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue({
             ...getCustomer(),
             isGuest: true,
@@ -580,19 +573,6 @@ describe('BraintreeFastlaneShippingStrategy', () => {
 
     describe('#handleBraintreeFastlaneShippingAddressChange', () => {
         beforeEach(() => {
-            const storeConfig = getConfig().storeConfig;
-
-            const storeConfigWithAFeature = {
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        ...storeConfig.checkoutSettings.features,
-                        'PAYPAL-3996.paypal_fastlane_shipping_update': true,
-                    },
-                },
-            };
-
             jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeFastlane').mockImplementation(
                 () => braintreeFastlane,
             );
@@ -609,12 +589,6 @@ describe('BraintreeFastlaneShippingStrategy', () => {
                     isFastlaneEnabled: true,
                 },
             });
-            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                storeConfigWithAFeature,
-            );
             jest.spyOn(
                 store.getState().paymentProviderCustomer,
                 'getPaymentProviderCustomer',

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
@@ -429,10 +429,8 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
         return isEqual(this._normalizeAddress(firstAddress), this._normalizeAddress(secondAddress));
     }
 
-    // TODO: reimplement this method when PAYPAL-3996.paypal_fastlane_shipping_update and Fastlane features will be rolled out to 100%
     private async _shouldUseBraintreeFastlaneShippingComponent(methodId: string): Promise<boolean> {
         const state = this._store.getState();
-        const features = state.config.getStoreConfigOrThrow().checkoutSettings.features;
         const paymentProviderCustomer = state.paymentProviderCustomer.getPaymentProviderCustomer();
         const braintreePaymentProviderCustomer = isBraintreeAcceleratedCheckoutCustomer(
             paymentProviderCustomer,
@@ -443,8 +441,6 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
         // Info: to avoid loading payment method we should check for values
         // that does not require api calls first
         if (
-            features &&
-            features['PAYPAL-3996.paypal_fastlane_shipping_update'] &&
             !!braintreePaymentProviderCustomer &&
             braintreePaymentProviderCustomer !== BraintreeFastlaneAuthenticationState.CANCELED
         ) {

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
@@ -484,20 +484,6 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
                 instruments: [bcInstrumentMock],
             });
 
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue({
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        ...storeConfig.checkoutSettings.features,
-                        'PAYPAL-3996.paypal_fastlane_shipping_update': true,
-                    },
-                },
-            });
-
             await strategy.initialize({
                 ...initializationOptions,
                 paypalcommercefastlane: {
@@ -528,20 +514,6 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 instruments: [bcInstrumentMock],
-            });
-
-            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue({
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        ...storeConfig.checkoutSettings.features,
-                        'PAYPAL-3996.paypal_fastlane_shipping_update': true,
-                    },
-                },
             });
 
             jest.spyOn(paypalFastlane.profile, 'showShippingAddressSelector').mockImplementation(

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
@@ -129,15 +129,10 @@ export default class PayPalCommerceFastlaneShippingStrategy implements ShippingS
         return !customerAuthenticationState && paypalConnectSessionId === cart.id;
     }
 
-    // TODO: reimplement this method when PAYPAL-3996.paypal_fastlane_shipping_update and Fastlane features will be rolled out to 100%
     private _shouldUsePayPalFastlaneShippingComponent(): boolean {
-        const state = this._store.getState();
-        const features = state.config.getStoreConfigOrThrow().checkoutSettings.features;
         const customerAuthenticationState = this._getPayPalCustomerAuthenticationState();
 
         return (
-            features &&
-            features['PAYPAL-3996.paypal_fastlane_shipping_update'] &&
             !!customerAuthenticationState &&
             customerAuthenticationState !== PayPalFastlaneAuthenticationState.CANCELED
         );


### PR DESCRIPTION
## What?
Removed PAYPAL-3996.paypal_fastlane_shipping_update experiment

## Why?
It was rolled out a long time ago, so should be cleaned up

## Testing / Proof
Unit tests
Manual tests
CI


https://github.com/user-attachments/assets/4c9f41f1-d0ef-4232-b275-e15d3dc098e6

