### PR TITLE
feat(payment): PAYPAL-4995 Unable to Change Payment Methods With Braintree if Stored Payments are Used

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
@@ -206,6 +206,16 @@ describe('BraintreeHostedForm', () => {
 
             expect(cardFields.teardown).toHaveBeenCalled();
         });
+
+        it('do not call teardown if fields are not initialized', async () => {
+            await subject.initialize({
+                ...formOptions,
+                fields: {},
+            });
+            await subject.deinitialize();
+
+            expect(cardFields.teardown).not.toHaveBeenCalled();
+        });
     });
 
     describe('#tokenize', () => {

--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -75,9 +75,11 @@ export default class BraintreeHostedForm {
     }
 
     async deinitialize(): Promise<void> {
-        this._isInitializedHostedForm = false;
+        if (this._isInitializedHostedForm) {
+            this._isInitializedHostedForm = false;
 
-        await this._cardFields?.teardown();
+            await this._cardFields?.teardown();
+        }
     }
 
     validate() {


### PR DESCRIPTION
## What?

Added check for teardown call in deinitialize method for avoiding **'teardown cannot be called after teardown.'** error message and for correct initialization of hosted fields in the Payment Step

## Why?

To fix an issue

## Testing / Proof

https://github.com/user-attachments/assets/87978eb2-a592-4f80-be0d-eb739684ffb9



@bigcommerce/team-checkout @bigcommerce/team-payments
