### PR TITLE
fix(payment): PI-3029 MissingDataError: Unable to proceed because the…

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
@@ -630,6 +630,24 @@ describe('GooglePayGateway', () => {
 
             expect(mappedData).toStrictEqual(expectedData);
         });
+
+        it('should throw an error if nonce is not sent from Google', async () => {
+            const response = getCardDataResponse();
+
+            response.paymentMethodData.tokenizationData.token = '';
+
+            let error: MissingDataError | undefined;
+
+            try {
+                await gateway.mapToExternalCheckoutData(response);
+            } catch (err) {
+                if (err instanceof MissingDataError) {
+                    error = err;
+                }
+            } finally {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
     });
 
     describe('#mapToBillingAddressRequestBody', () => {

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -91,6 +91,10 @@ export default class GooglePayGateway {
             },
         } = response;
 
+        if (!nonce) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentToken);
+        }
+
         return Promise.resolve({
             nonce,
             card_information: { type, number },


### PR DESCRIPTION
… token required to submit a payment is missing.

## What?
Added nonce validation check in place where nonce should be sent from Google to FE

## Why?
This error is not reproducible. Added nonce validation check should help to indicate if the problem is caused by not receiving nonce from Google to FE. 
More informations in ticket comments section.

## Rollout/Rollback
Revert this PR

## Testing / Proof

![image](https://github.com/user-attachments/assets/7357f1c0-59d5-4ed6-b18b-531a37ef770e)
![Zrzut ekranu 2025-01-14 o 21 51 03](https://github.com/user-attachments/assets/224b93ed-d0fd-458c-8975-aa06d310edbb)


@bigcommerce/team-checkout @bigcommerce/team-payments
