### PR TITLE
fix(payment): PAYPAL-4952 removed extra data attribute from PayPal Commerce credit banner

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -119,9 +119,10 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
                 }
 
                 // TODO: remove this attributes reset when content service and PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
-                messagingContainer.removeAttribute('data-pp-style-text-color');
                 messagingContainer.removeAttribute('data-pp-style-logo-type');
                 messagingContainer.removeAttribute('data-pp-style-logo-position');
+                messagingContainer.removeAttribute('data-pp-style-text-color');
+                messagingContainer.removeAttribute('data-pp-style-text-size');
             }
 
             const paypalSdk = await this.paypalCommerceSdk.getPayPalMessages(


### PR DESCRIPTION
## What?
Removed extra data attribute from PayPal Commerce credit banner

## Why?
To let PayPal accept banner styles provided through messages config

## Testing / Proof
Manual tests on int

https://github.com/user-attachments/assets/726486c2-0f91-498a-ba21-dd24905a2c86

