### PR TITLE
fix(extension): CHECKOUT-8960 Fix Broadcast Interruption

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -1509,7 +1509,7 @@ describe('CheckoutService', () => {
         });
     });
 
-    describe('#loadExtensions()', () => {
+    describe('#CheckoutExtension', () => {
         it('loads extensions', async () => {
             await checkoutService.loadExtensions();
 
@@ -1542,9 +1542,7 @@ describe('CheckoutService', () => {
                 queueId: 'extensions',
             });
         });
-    });
 
-    describe('#renderExtension()', () => {
         it('render extensions', async () => {
             const action = () => of(createAction(ExtensionActionType.RenderExtensionSucceeded));
 
@@ -1559,9 +1557,17 @@ describe('CheckoutService', () => {
             expect(extensionActionCreator.renderExtension).toHaveBeenCalledWith(container, region);
             expect(extensionEventBroadcaster.listen).toHaveBeenCalled();
         });
-    });
 
-    describe('#handleExtensionCommand()', () => {
+        it('removes extension cache', async () => {
+            jest.spyOn(extensionMessenger, 'clearCacheByRegion');
+
+            const region = ExtensionRegion.ShippingShippingAddressFormBefore;
+
+            checkoutService.clearExtensionCache(region);
+
+            expect(extensionMessenger.clearCacheByRegion).toHaveBeenCalledWith(region);
+        });
+
         it('handles extension commands', () => {
             const extensions = getExtensions();
             const handler = jest.fn();

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -1433,6 +1433,17 @@ export default class CheckoutService {
     }
 
     /**
+     * Clear cache for a checkout extension when removing it from UI.
+     * This function should be used whenver an extension is removed from the UI.
+     *
+     * @alpha
+     * @param region - The name of an area where the extension should be presented.
+     */
+    clearExtensionCache(region: ExtensionRegion): void {
+        this._extensionMessenger.clearCacheByRegion(region);
+    }
+
+    /**
      * Manages the command handler for an extension.
      *
      * @alpha

--- a/packages/core/src/extension/extension-messenger.spec.ts
+++ b/packages/core/src/extension/extension-messenger.spec.ts
@@ -164,16 +164,19 @@ describe('ExtensionMessenger', () => {
     });
 
     describe('#post()', () => {
-        it('should throw ExtensionNotFoundError if the extension is not rendered yet', () => {
-            const container = document.createElement('div');
-
-            document.querySelector = jest.fn().mockReturnValue(container);
+        it('should log out the error if an extension has not yet been rendered', () => {
+            document.querySelector = jest.fn().mockReturnValue(undefined);
 
             extensionMessenger = new ExtensionMessenger(store, {}, {});
 
-            expect(() => extensionMessenger.post(extension.id, event.data)).toThrow(
-                ExtensionNotFoundError,
-            );
+            jest.spyOn(extensionMessenger, 'clearCacheById');
+            jest.spyOn(console, 'log');
+
+            extensionMessenger.post(extension.id, event.data);
+
+            expect(extensionMessenger.clearCacheById).toHaveBeenCalledWith(extension.id);
+            // eslint-disable-next-line no-console
+            expect(console.log).toHaveBeenCalled();
         });
 
         it('should post to an extension', () => {


### PR DESCRIPTION
## What?
Introduce a new checkout service method to clear outdated poster whenever an extension is unmounted.

Handle message post failures gracefully by clearing the poster cache and logging the loss message.

## Why?
The event poster within the extension messenger is not cleared/rebuilt after an extension iframe is unmounted. 

Continuing to deliver messages through this outdated poster disrupts event broadcasting.

## Testing / Proof
https://github.com/user-attachments/assets/83c132a2-b798-4a81-868a-6d7af2ee3866


@bigcommerce/team-checkout