### PR TITLE
feat(payment): PAYPAL-4324 added Apple Pay SDK for supporting third party browsers

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-initialize-options.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-initialize-options.ts
@@ -13,6 +13,11 @@ export default interface ApplePayButtonInitializeOptions {
     requiresShipping?: boolean;
 
     /**
+     * Enabling a new version of Apple Pay with using Apple Pay SDK
+     */
+    isWebBrowserSupported?: boolean;
+
+    /**
      * The options that are required to initialize Buy Now functionality.
      */
     buyNowInitializeOptions?: {

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
@@ -27,6 +27,7 @@ import {
 import ApplePayButtonInitializeOptions from './apple-pay-button-initialize-options';
 import ApplePayButtonMethodType from './apple-pay-button-method-type';
 import ApplePayButtonStrategy, { ButtonStyleOption } from './apple-pay-button-strategy';
+import ApplePayScriptLoader from './apple-pay-script-loader';
 import ApplePaySessionFactory from './apple-pay-session-factory';
 import {
     getApplePayButtonInitializationOptions,
@@ -44,6 +45,7 @@ describe('ApplePayButtonStrategy', () => {
     let strategy: ApplePayButtonStrategy;
     let applePaySession: MockApplePaySession;
     let braintreeSdk: BraintreeSdk;
+    let applePayScriptLoader: ApplePayScriptLoader;
 
     beforeEach(() => {
         applePaySession = new MockApplePaySession();
@@ -56,9 +58,11 @@ describe('ApplePayButtonStrategy', () => {
         requestSender = createRequestSender();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
         braintreeSdk = new BraintreeSdk(new BraintreeScriptLoader(getScriptLoader(), window));
+        applePayScriptLoader = new ApplePayScriptLoader(getScriptLoader());
 
         jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve(getResponse({})));
         jest.spyOn(requestSender, 'get').mockReturnValue(Promise.resolve(getResponse({})));
+        jest.spyOn(applePayScriptLoader, 'loadSdk').mockReturnValue(Promise.resolve());
 
         jest.spyOn(applePayFactory, 'create').mockReturnValue(applePaySession);
 
@@ -67,6 +71,7 @@ describe('ApplePayButtonStrategy', () => {
             paymentIntegrationService,
             applePayFactory,
             braintreeSdk,
+            applePayScriptLoader,
         );
 
         container = document.createElement('div');
@@ -88,6 +93,30 @@ describe('ApplePayButtonStrategy', () => {
             jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValue(
                 paymentIntegrationService.getState(),
             );
+        });
+
+        it('load Apple Pay SDK if isWebBrowserSupported is true', async () => {
+            const checkoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+
+            await strategy.initialize(checkoutButtonInitializeOptions);
+
+            expect(paymentIntegrationService.verifyCheckoutSpamProtection).toHaveBeenCalled();
+
+            expect(applePayScriptLoader.loadSdk).toHaveBeenCalled();
+        });
+
+        it('do not load Apple Pay SDK if isWebBrowserSupported is false', async () => {
+            const checkoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+
+            (
+                checkoutButtonInitializeOptions.applepay as ApplePayButtonInitializeOptions
+            ).isWebBrowserSupported = false;
+
+            await strategy.initialize(checkoutButtonInitializeOptions);
+
+            expect(paymentIntegrationService.verifyCheckoutSpamProtection).toHaveBeenCalled();
+
+            expect(applePayScriptLoader.loadSdk).not.toHaveBeenCalled();
         });
 
         it('creates the button', async () => {
@@ -632,6 +661,24 @@ describe('ApplePayButtonStrategy', () => {
                 ).mockImplementation(() => applePayPaymentMethod);
             };
 
+            it('style should be valid', async () => {
+                await strategy.initialize(checkoutButtonInitializeOptions);
+
+                const button = container.firstChild as HTMLElement;
+
+                expect(button.getAttribute('style')).toContain(
+                    '--apple-pay-button-width: 100%; --apple-pay-button-height: 40px; --apple-pay-button-border-radius: 4px;',
+                );
+            });
+
+            it('type should be plain', async () => {
+                await strategy.initialize(checkoutButtonInitializeOptions);
+
+                const button = container.firstChild as HTMLElement;
+
+                expect(button.getAttribute('type')).toContain('plain');
+            });
+
             it('should be black', async () => {
                 mockGetPaymentMethod(ButtonStyleOption.Black);
 
@@ -639,7 +686,7 @@ describe('ApplePayButtonStrategy', () => {
 
                 const button = container.firstChild as HTMLElement;
 
-                expect(button.getAttribute('style')).toContain('background-color: rgb(0, 0, 0)');
+                expect(button.getAttribute('buttonstyle')).toContain('black');
             });
 
             it('should be white', async () => {
@@ -649,22 +696,62 @@ describe('ApplePayButtonStrategy', () => {
 
                 const button = container.firstChild as HTMLElement;
 
-                expect(button.getAttribute('style')).toContain(
-                    'background-color: rgb(255, 255, 255)',
-                );
+                expect(button.getAttribute('buttonstyle')).toContain('white');
             });
 
-            it('should be white border', async () => {
+            it('should be white-outline', async () => {
                 mockGetPaymentMethod(ButtonStyleOption.WhiteBorder);
 
                 await strategy.initialize(checkoutButtonInitializeOptions);
 
                 const button = container.firstChild as HTMLElement;
 
-                const style = button.getAttribute('style');
+                expect(button.getAttribute('buttonstyle')).toContain('white-outline');
+            });
 
-                expect(style).toContain('background-color: rgb(255, 255, 255)');
-                expect(style).toContain('border: 0.5px solid #000');
+            describe('when isWebBrowserSupported is false', () => {
+                beforeEach(() => {
+                    (
+                        checkoutButtonInitializeOptions.applepay as ApplePayButtonInitializeOptions
+                    ).isWebBrowserSupported = false;
+                });
+
+                it('should be black', async () => {
+                    mockGetPaymentMethod(ButtonStyleOption.Black);
+
+                    await strategy.initialize(checkoutButtonInitializeOptions);
+
+                    const button = container.firstChild as HTMLElement;
+
+                    expect(button.getAttribute('style')).toContain(
+                        'background-color: rgb(0, 0, 0)',
+                    );
+                });
+
+                it('should be white', async () => {
+                    mockGetPaymentMethod(ButtonStyleOption.White);
+
+                    await strategy.initialize(checkoutButtonInitializeOptions);
+
+                    const button = container.firstChild as HTMLElement;
+
+                    expect(button.getAttribute('style')).toContain(
+                        'background-color: rgb(255, 255, 255)',
+                    );
+                });
+
+                it('should be white border', async () => {
+                    mockGetPaymentMethod(ButtonStyleOption.WhiteBorder);
+
+                    await strategy.initialize(checkoutButtonInitializeOptions);
+
+                    const button = container.firstChild as HTMLElement;
+
+                    const style = button.getAttribute('style');
+
+                    expect(style).toContain('background-color: rgb(255, 255, 255)');
+                    expect(style).toContain('border: 0.5px solid #000');
+                });
             });
         });
     });

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
@@ -105,7 +105,7 @@ describe('ApplePayButtonStrategy', () => {
             expect(applePayScriptLoader.loadSdk).toHaveBeenCalled();
         });
 
-        it('do not load Apple Pay SDK if isWebBrowserSupported is false', async () => {
+        it('does not load Apple Pay SDK if isWebBrowserSupported is false', async () => {
             const checkoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
 
             (

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -179,30 +179,30 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
             );
         }
 
-        const applePayButton = this._getApplePayButton(styleOption);
+        const applePayButton = this._isWebBrowserSupported
+            ? this._createThirdPartyButton(styleOption)
+            : this._createNativeButton(styleOption);
 
         container.appendChild(applePayButton);
 
         return applePayButton;
     }
 
-    private _getApplePayButton(styleOption?: ButtonStyleOption): HTMLElement {
-        let applePayButton: HTMLElement;
+    private _createThirdPartyButton(styleOption?: ButtonStyleOption): HTMLElement {
+        const applePayButton = document.createElement('apple-pay-button');
 
-        if (this._isWebBrowserSupported) {
-            applePayButton = document.createElement('apple-pay-button');
+        applePayButton.setAttribute('buttonstyle', getButtonStyle(styleOption));
+        applePayButton.setAttribute('type', 'plain');
+        applePayButton.setAttribute(
+            'style',
+            '--apple-pay-button-width: 100%; --apple-pay-button-height: 40px; --apple-pay-button-border-radius: 4px;',
+        );
 
-            applePayButton.setAttribute('buttonstyle', getButtonStyle(styleOption));
-            applePayButton.setAttribute('type', 'plain');
-            applePayButton.setAttribute(
-                'style',
-                '--apple-pay-button-width: 100%; --apple-pay-button-height: 40px; --apple-pay-button-border-radius: 4px;',
-            );
+        return applePayButton;
+    }
 
-            return applePayButton;
-        }
-
-        applePayButton = document.createElement('div');
+    private _createNativeButton(styleOption?: ButtonStyleOption): HTMLElement {
+        const applePayButton = document.createElement('div');
 
         applePayButton.setAttribute('role', 'button');
         applePayButton.setAttribute('aria-label', 'Apple Pay button');

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -138,30 +138,30 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
             );
         }
 
-        const applePayButton = this._getApplePayButton();
+        const applePayButton = this._isWebBrowserSupported
+            ? this._createThirdPartyButton()
+            : this._createNativeButton();
 
         container.appendChild(applePayButton);
 
         return applePayButton;
     }
 
-    private _getApplePayButton(): HTMLElement {
-        let applePayButton: HTMLElement;
+    private _createThirdPartyButton(): HTMLElement {
+        const applePayButton = document.createElement('apple-pay-button');
 
-        if (this._isWebBrowserSupported) {
-            applePayButton = document.createElement('apple-pay-button');
+        applePayButton.setAttribute('buttonstyle', 'black');
+        applePayButton.setAttribute('type', 'plain');
+        applePayButton.setAttribute(
+            'style',
+            '--apple-pay-button-width: 100%; --apple-pay-button-height: 36px; --apple-pay-button-border-radius: 4px;',
+        );
 
-            applePayButton.setAttribute('buttonstyle', 'black');
-            applePayButton.setAttribute('type', 'plain');
-            applePayButton.setAttribute(
-                'style',
-                '--apple-pay-button-width: 100%; --apple-pay-button-height: 36px; --apple-pay-button-border-radius: 4px;',
-            );
+        return applePayButton;
+    }
 
-            return applePayButton;
-        }
-
-        applePayButton = document.createElement('div');
+    private _createNativeButton(): HTMLElement {
+        const applePayButton = document.createElement('div');
 
         applePayButton.setAttribute('type', 'button');
         applePayButton.setAttribute('aria-label', 'Apple Pay');

--- a/packages/apple-pay-integration/src/apple-pay-script-loader.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-script-loader.spec.ts
@@ -1,0 +1,37 @@
+import { getScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
+
+import ApplePayScriptLoader from './apple-pay-script-loader';
+import { MockApplePaySession } from './mocks/apple-pay-payment.mock';
+
+describe('ApplePayScriptLoader', () => {
+    let applePayScriptLoader: ApplePayScriptLoader;
+    let scriptLoader: ScriptLoader;
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'ApplePaySession', {
+            writable: true,
+            value: MockApplePaySession,
+        });
+
+        scriptLoader = getScriptLoader();
+        applePayScriptLoader = new ApplePayScriptLoader(scriptLoader);
+
+        jest.spyOn(scriptLoader, 'loadScript').mockReturnValue(Promise.resolve());
+    });
+
+    it('load ApplePaySDK', async () => {
+        await applePayScriptLoader.loadSdk();
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            'https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js',
+            {
+                async: true,
+                attributes: {
+                    integrity:
+                        'sha384-vh0JXIPFX+H2WsQVoWR8E10Q1mo5IZQ92/a42dBIbtW8DCQaLrOC16Au8awuZUwA',
+                    crossorigin: 'anonymous',
+                },
+            },
+        );
+    });
+});

--- a/packages/apple-pay-integration/src/apple-pay-script-loader.ts
+++ b/packages/apple-pay-integration/src/apple-pay-script-loader.ts
@@ -1,0 +1,25 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { assertApplePayWindow } from './apple-pay-session-factory';
+
+export default class ApplePayScriptLoader {
+    private sdkVersion = '1.latest';
+
+    constructor(private scriptLoader: ScriptLoader) {}
+
+    async loadSdk() {
+        await this.scriptLoader.loadScript(
+            `https://applepay.cdn-apple.com/jsapi/${this.sdkVersion}/apple-pay-sdk.js`,
+            {
+                async: true,
+                attributes: {
+                    integrity:
+                        'sha384-vh0JXIPFX+H2WsQVoWR8E10Q1mo5IZQ92/a42dBIbtW8DCQaLrOC16Au8awuZUwA',
+                    crossorigin: 'anonymous',
+                },
+            },
+        );
+
+        assertApplePayWindow(window);
+    }
+}

--- a/packages/apple-pay-integration/src/create-apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/create-apple-pay-button-strategy.ts
@@ -1,5 +1,5 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { getScriptLoader } from '@bigcommerce/script-loader';
+import { getScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 
 import { BraintreeScriptLoader, BraintreeSdk } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
@@ -8,6 +8,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import ApplePayButtonStrategy from './apple-pay-button-strategy';
+import ApplePayScriptLoader from './apple-pay-script-loader';
 import ApplePaySessionFactory from './apple-pay-session-factory';
 
 const createApplePayButtonStrategy: CheckoutButtonStrategyFactory<ApplePayButtonStrategy> = (
@@ -20,6 +21,7 @@ const createApplePayButtonStrategy: CheckoutButtonStrategyFactory<ApplePayButton
         paymentIntegrationService,
         new ApplePaySessionFactory(),
         new BraintreeSdk(new BraintreeScriptLoader(getScriptLoader(), window)),
+        new ApplePayScriptLoader(new ScriptLoader()),
     );
 };
 

--- a/packages/apple-pay-integration/src/create-apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/create-apple-pay-customer-strategy.ts
@@ -1,5 +1,5 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { getScriptLoader } from '@bigcommerce/script-loader';
+import { getScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 
 import { BraintreeScriptLoader, BraintreeSdk } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
@@ -8,6 +8,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import ApplePayCustomerStrategy from './apple-pay-customer-strategy';
+import ApplePayScriptLoader from './apple-pay-script-loader';
 import ApplePaySessionFactory from './apple-pay-session-factory';
 
 const createApplePayCustomerStrategy: CustomerStrategyFactory<ApplePayCustomerStrategy> = (
@@ -20,6 +21,7 @@ const createApplePayCustomerStrategy: CustomerStrategyFactory<ApplePayCustomerSt
         paymentIntegrationService,
         new ApplePaySessionFactory(),
         new BraintreeSdk(new BraintreeScriptLoader(getScriptLoader(), window)),
+        new ApplePayScriptLoader(new ScriptLoader()),
     );
 };
 

--- a/packages/apple-pay-integration/src/mocks/apple-pay-button.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-button.mock.ts
@@ -11,6 +11,7 @@ export function getApplePayButtonInitializationOptions(): CheckoutButtonInitiali
         methodId: ApplePayButtonMethodType.APPLEPAY,
         applepay: {
             onPaymentAuthorize: jest.fn(),
+            isWebBrowserSupported: true,
         },
     };
 }
@@ -26,6 +27,7 @@ export function getApplePayButtonInitializationOptionsWithBuyNow(): CheckoutButt
                 getBuyNowCartRequestBody: jest.fn().mockReturnValue(getBuyNowCartRequestBody()),
             },
             requiresShipping: false,
+            isWebBrowserSupported: true,
         },
     };
 }


### PR DESCRIPTION
## What?

Added Apple Pay SDK for supporting third party browsers

## Why?

For be able to place an order using Apple Pay via third party browsers

Related PRs:
https://github.com/bigcommerce/bigcommerce/pull/61473
https://github.com/bigcommerce/terraform-launchdarkly/pull/2094
https://github.com/bigcommerce/checkout-js/pull/2154

## Testing / Proof

_Safari | When the experiment is enabled/disabled_

- [x] PDP
- [x] Preview cart
- [x] Cart
- [x] Top of checkout btns
- [x] Buttons on customer step when top of checkout feature is disabled
  
_Chrome | When the experiment is enabled | Was tested by using prod store with prod environment with overwriting artefacts_

- [x] PDP
- [x] Preview cart

**We will only be able to finish testing it after all related changes have been deployed in Tier 1, especially this changes, we will turn on an experiment for test store**

- [ ] Cart
- [ ] Top of checkout btns
- [ ] Buttons on customer step when top of checkout feature is disabled

Screen record of how it works with third party browsers:

https://github.com/user-attachments/assets/c30bbf25-11e7-41ef-b776-87e2b01040e8

Some screenshots:

- Chrome <img width="1289" alt="Chrome-ApplePay_new_implementation_exp_is_enabled" src="https://github.com/user-attachments/assets/84a8e7bb-50b4-4c33-b249-8742f0696358" />
- Safari <img width="1399" alt="Safary-ApplePay_new_implementation_exp_is_enabled" src="https://github.com/user-attachments/assets/9dd42382-fa8e-4f11-a2f5-42660daf49f9" />


@bigcommerce/team-checkout @bigcommerce/team-payments
