### PR TITLE
feat(extension): CHECKOUT-8964 Introduce GetConsignment Extension Command

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -45,6 +45,7 @@ import {
     ExtensionActionType,
     ExtensionCommandType,
     ExtensionEventBroadcaster,
+    ExtensionMessageType,
     ExtensionMessenger,
     ExtensionRegion,
     ExtensionRequestSender,
@@ -1566,6 +1567,21 @@ describe('CheckoutService', () => {
             checkoutService.clearExtensionCache(region);
 
             expect(extensionMessenger.clearCacheByRegion).toHaveBeenCalledWith(region);
+        });
+
+        it('posts a message to an extension', async () => {
+            jest.spyOn(extensionMessenger, 'post');
+
+            const message = {
+                type: ExtensionMessageType.CurrentConsignments,
+                payload: {
+                    consignments: [],
+                },
+            };
+
+            checkoutService.postMessageToExtension('xxx', message);
+
+            expect(extensionMessenger.post).toHaveBeenCalledWith('xxx', message);
         });
 
         it('handles extension commands', () => {

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -1573,7 +1573,7 @@ describe('CheckoutService', () => {
             jest.spyOn(extensionMessenger, 'post');
 
             const message = {
-                type: ExtensionMessageType.CurrentConsignments,
+                type: ExtensionMessageType.GetConsignments,
                 payload: {
                     consignments: [],
                 },

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -1449,7 +1449,7 @@ export default class CheckoutService {
      *
      * @alpha
      * @param extensionId - The ID of an extension to post the event to.
-     * @param message -The message to post to an extension.
+     * @param message - The message to post to an extension.
      */
     postMessageToExtension(extensionId: string, message: ExtensionMessage): void {
         this._extensionMessenger.post(extensionId, message);

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -25,6 +25,7 @@ import {
     ExtensionActionCreator,
     ExtensionCommandMap,
     ExtensionEventBroadcaster,
+    ExtensionMessage,
     ExtensionMessenger,
     ExtensionRegion,
 } from '../extension';
@@ -1441,6 +1442,17 @@ export default class CheckoutService {
      */
     clearExtensionCache(region: ExtensionRegion): void {
         this._extensionMessenger.clearCacheByRegion(region);
+    }
+
+    /**
+     * Posts a message to a checkout extension.
+     *
+     * @alpha
+     * @param extensionId - The ID of an extension to post the event to.
+     * @param message -The message to post to an extension.
+     */
+    postMessageToExtension(extensionId: string, message: ExtensionMessage): void {
+        this._extensionMessenger.post(extensionId, message);
     }
 
     /**

--- a/packages/core/src/extension/extension-commands.ts
+++ b/packages/core/src/extension/extension-commands.ts
@@ -1,12 +1,14 @@
 export type ExtensionCommand =
     | ReloadCheckoutCommand
     | ShowLoadingIndicatorCommand
-    | SetIframeStyleCommand;
+    | SetIframeStyleCommand
+    | GetConsignmentsCommand;
 
 export enum ExtensionCommandType {
     ReloadCheckout = 'EXTENSION:RELOAD_CHECKOUT',
     ShowLoadingIndicator = 'EXTENSION:SHOW_LOADING_INDICATOR',
     SetIframeStyle = 'EXTENSION:SET_IFRAME_STYLE',
+    GetConsignments = 'EXTENSION:GET_CONSIGNMENTS',
 }
 
 export interface ExtensionCommandContext {
@@ -33,8 +35,13 @@ export interface SetIframeStyleCommand {
     };
 }
 
+export interface GetConsignmentsCommand {
+    type: ExtensionCommandType.GetConsignments;
+}
+
 export interface ExtensionCommandMap {
     [ExtensionCommandType.ReloadCheckout]: ReloadCheckoutCommand;
     [ExtensionCommandType.ShowLoadingIndicator]: ShowLoadingIndicatorCommand;
     [ExtensionCommandType.SetIframeStyle]: SetIframeStyleCommand;
+    [ExtensionCommandType.GetConsignments]: GetConsignmentsCommand;
 }

--- a/packages/core/src/extension/extension-message.ts
+++ b/packages/core/src/extension/extension-message.ts
@@ -1,0 +1,16 @@
+import { Consignment } from '../shipping';
+
+import { ExtensionEvent } from './extension-events';
+
+export const enum ExtensionMessageType {
+    CurrentConsignments = 'EXTENSION:CURRENT_CONSIGNMENTS',
+}
+
+export interface CurrentConsignmentsMessage {
+    type: ExtensionMessageType.CurrentConsignments;
+    payload: {
+        consignments: Consignment[];
+    };
+}
+
+export type ExtensionMessage = ExtensionEvent | CurrentConsignmentsMessage;

--- a/packages/core/src/extension/extension-message.ts
+++ b/packages/core/src/extension/extension-message.ts
@@ -3,14 +3,14 @@ import { Consignment } from '../shipping';
 import { ExtensionEvent } from './extension-events';
 
 export const enum ExtensionMessageType {
-    CurrentConsignments = 'EXTENSION:CURRENT_CONSIGNMENTS',
+    GetConsignments = 'EXTENSION:GET_CONSIGNMENTS',
 }
 
-export interface CurrentConsignmentsMessage {
-    type: ExtensionMessageType.CurrentConsignments;
+export interface GetConsignmentsMessage {
+    type: ExtensionMessageType.GetConsignments;
     payload: {
         consignments: Consignment[];
     };
 }
 
-export type ExtensionMessage = ExtensionEvent | CurrentConsignmentsMessage;
+export type ExtensionMessage = ExtensionEvent | GetConsignmentsMessage;

--- a/packages/core/src/extension/extension-messenger.ts
+++ b/packages/core/src/extension/extension-messenger.ts
@@ -10,7 +10,7 @@ import {
     ExtensionCommandMap,
     ExtensionCommandType,
 } from './extension-commands';
-import { ExtensionEvent } from './extension-events';
+import { ExtensionMessage } from './extension-message';
 
 export class ExtensionMessenger {
     private _extensions: Extension[] | undefined;
@@ -20,7 +20,7 @@ export class ExtensionMessenger {
         private _listeners: {
             [extensionId: string]: IframeEventListener<ExtensionCommandMap>;
         } = {},
-        private _posters: { [extensionId: string]: IframeEventPoster<ExtensionEvent> } = {},
+        private _posters: { [extensionId: string]: IframeEventPoster<ExtensionMessage> } = {},
     ) {}
 
     clearCacheByRegion(region: string): void {
@@ -85,21 +85,22 @@ export class ExtensionMessenger {
         listener.stopListen();
     }
 
-    post(extensionId: string, event: ExtensionEvent): void {
+    post(extensionId: string, message: ExtensionMessage): void {
         try {
             if (!this._posters[extensionId]) {
                 const extension = this._getExtensionById(extensionId);
 
-                this._posters[extensionId] = createExtensionEventPoster<ExtensionEvent>(extension);
+                this._posters[extensionId] =
+                    createExtensionEventPoster<ExtensionMessage>(extension);
             }
 
-            this._posters[extensionId].post(event);
+            this._posters[extensionId].post(message);
         } catch (error) {
             this.clearCacheById(extensionId);
             // eslint-disable-next-line no-console
             console.log(
                 `Unable to post event to extension(${extensionId}) because extension iframe is not mounted.\nThe event that could not be delivered:`,
-                event,
+                message,
             );
         }
     }

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -3,6 +3,7 @@ export { getExtensions } from './extension.mock';
 export { ExtensionActionType } from './extension-actions';
 export { ExtensionActionCreator } from './extension-action-creator';
 export { ExtensionEventType } from './extension-events';
+export { ExtensionMessageType, ExtensionMessage } from './extension-message';
 export { ExtensionEventBroadcaster } from './extension-event-broadcaster';
 export { createExtensionEventBroadcaster } from './create-extension-event-broadcaster';
 export { ExtensionIframe } from './extension-iframe';


### PR DESCRIPTION
## What?
Introduce a new checkout extension command, `GetConsignments`

## Why?
To pass consignment data to an extension.

## Testing / Proof
![Screenshot 2025-01-21 at 11 17 42 AM](https://github.com/user-attachments/assets/e8946d5b-5b08-42c2-9c5d-30ed4e4318d9)
