### PR TITLE
feat(payment): PI-3068 moved my account logic to hosted card v2 package

### DIFF
--- a/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.ts
+++ b/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.ts
@@ -1,1 +1,2 @@
 export { createHostedFormService } from '../create-hosted-form-service';
+export { default as createStoredCardHostedFormService } from '../create-hosted-form-stored-card-service';

--- a/packages/hosted-form-v2/src/create-hosted-form-stored-card-service.spec.ts
+++ b/packages/hosted-form-v2/src/create-hosted-form-stored-card-service.spec.ts
@@ -1,0 +1,10 @@
+import createStoredCardHostedFormService from './create-hosted-form-stored-card-service';
+import StoredCardHostedFormService from './stored-card-hosted-form-service';
+
+describe('createStoredCardHostedFormService()', () => {
+    it('returns an instance of StoredCardHostedFormService', () => {
+        const service = createStoredCardHostedFormService('https://bigpay.integration.zone');
+
+        expect(service).toBeInstanceOf(StoredCardHostedFormService);
+    });
+});

--- a/packages/hosted-form-v2/src/create-hosted-form-stored-card-service.ts
+++ b/packages/hosted-form-v2/src/create-hosted-form-stored-card-service.ts
@@ -1,0 +1,13 @@
+import HostedFormFactory from './hosted-form-factory';
+import StoredCardHostedFormService from './stored-card-hosted-form-service';
+
+/**
+ * Creates an instance of `StoredCardHostedFormService`.
+ *
+ *
+ * @param host - Host url string parameter.
+ * @returns An instance of `StoredCardHostedFormService`.
+ */
+export default function createStoredCardHostedFormService(host: string) {
+    return new StoredCardHostedFormService(host, new HostedFormFactory());
+}

--- a/packages/hosted-form-v2/src/hosted-field-events.ts
+++ b/packages/hosted-form-v2/src/hosted-field-events.ts
@@ -2,25 +2,32 @@ import HostedFieldType from './hosted-field-type';
 import HostedFormManualOrderData from './hosted-form-manual-order-data';
 import { HostedFieldStylesMap } from './hosted-form-options';
 import HostedFormOrderData from './hosted-form-order-data';
+import {
+    StoredCardHostedFormData,
+    StoredCardHostedFormInstrumentFields,
+} from './stored-card-hosted-form-type';
 
 export enum HostedFieldEventType {
     AttachRequested = 'HOSTED_FIELD:ATTACH_REQUESTED',
     SubmitRequested = 'HOSTED_FIELD:SUBMITTED_REQUESTED',
     SubmitManualOrderRequested = 'HOSTED_FIELD:SUBMIT_MANUAL_ORDER_REQUESTED',
     ValidateRequested = 'HOSTED_FIELD:VALIDATE_REQUESTED',
+    StoredCardRequested = 'HOSTED_FIELD:STORED_CARD_REQUESTED',
 }
 
 export interface HostedFieldEventMap {
     [HostedFieldEventType.AttachRequested]: HostedFieldAttachEvent;
     [HostedFieldEventType.SubmitManualOrderRequested]: HostedFieldSubmitManualOrderRequestEvent;
     [HostedFieldEventType.ValidateRequested]: HostedFieldValidateRequestEvent;
+    [HostedFieldEventType.StoredCardRequested]: HostedFieldStoredCardRequestEvent;
 }
 
 export type HostedFieldEvent =
     | HostedFieldAttachEvent
     | HostedFieldSubmitRequestEvent
     | HostedFieldSubmitManualOrderRequestEvent
-    | HostedFieldValidateRequestEvent;
+    | HostedFieldValidateRequestEvent
+    | HostedFieldStoredCardRequestEvent;
 
 export interface HostedFieldSubmitRequestEvent {
     type: HostedFieldEventType.SubmitRequested;
@@ -51,4 +58,12 @@ export interface HostedFieldSubmitManualOrderRequestEvent {
 
 export interface HostedFieldValidateRequestEvent {
     type: HostedFieldEventType.ValidateRequested;
+}
+
+export interface HostedFieldStoredCardRequestEvent {
+    type: HostedFieldEventType.StoredCardRequested;
+    payload: {
+        data: StoredCardHostedFormData;
+        fields: StoredCardHostedFormInstrumentFields;
+    };
 }

--- a/packages/hosted-form-v2/src/hosted-field.spec.ts
+++ b/packages/hosted-form-v2/src/hosted-field.spec.ts
@@ -1,0 +1,326 @@
+import {
+    getErrorPaymentResponseBody,
+    getResponse,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { DetachmentObserver } from './common/dom';
+import { RequestError } from './common/errors';
+import { IframeEventListener, IframeEventPoster } from './common/iframe';
+import { InvalidHostedFormConfigError, InvalidHostedFormError } from './errors';
+import HostedField from './hosted-field';
+import { HostedFieldEvent, HostedFieldEventType } from './hosted-field-events';
+import HostedFieldType from './hosted-field-type';
+import { getHostedFormOrderData } from './hosted-form-order-data.mock';
+import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
+import {
+    StoredCardHostedFormDataMock,
+    StoredCardHostedFormInstrumentFieldsMock,
+} from './stored-card-hosted-form.mock';
+
+describe('HostedField', () => {
+    let container: HTMLDivElement;
+    let field: HostedField;
+    let controlPannelField: HostedField;
+    let detachmentObserver: Pick<DetachmentObserver, 'ensurePresence'>;
+    let eventPoster: Pick<IframeEventPoster<HostedFieldEvent>, 'post' | 'setTarget'>;
+    let eventListener: Pick<IframeEventListener<HostedInputEventMap>, 'listen'>;
+    let orderId: number;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        detachmentObserver = { ensurePresence: jest.fn((_, promise) => promise) };
+        eventPoster = { post: jest.fn(), setTarget: jest.fn() };
+        eventListener = { listen: jest.fn() };
+        orderId = 1;
+
+        container.id = 'field-container-id';
+        document.body.appendChild(container);
+
+        controlPannelField = new HostedField(
+            HostedFieldType.CardNumber,
+            'field-container-id',
+            'Enter your card number here',
+            'Card number',
+            { default: { color: 'rgb(0, 0, 0)', fontFamily: 'Open Sans, Arial' } },
+            eventPoster as IframeEventPoster<HostedFieldEvent>,
+            eventListener as IframeEventListener<HostedInputEventMap>,
+            detachmentObserver as DetachmentObserver,
+            orderId,
+        );
+
+        field = new HostedField(
+            HostedFieldType.CardNumber,
+            'field-container-id',
+            'Enter your card number here',
+            'Card number',
+            { default: { color: 'rgb(0, 0, 0)', fontFamily: 'Open Sans, Arial' } },
+            eventPoster as IframeEventPoster<HostedFieldEvent>,
+            eventListener as IframeEventListener<HostedInputEventMap>,
+            detachmentObserver as DetachmentObserver,
+        );
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('attaches iframe to container', () => {
+        field.attach();
+
+        expect(document.querySelector('#field-container-id iframe')).toBeDefined();
+    });
+
+    it('sets iframe URL with version param', () => {
+        field.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(document.querySelector<HTMLIFrameElement>('#field-container-id iframe')!.src).toBe(
+            `${location.origin}/checkout/payment/hosted-field?version=1.0.0`,
+        );
+    });
+
+    it('sets iframe URL with version param for Control Panel Iframe', () => {
+        controlPannelField.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(document.querySelector<HTMLIFrameElement>('#field-container-id iframe')!.src).toBe(
+            `${location.origin}/admin/payments/${orderId}/hosted-form-field?version=1.0.0`,
+        );
+    });
+
+    it('sets target for event poster', async () => {
+        process.nextTick(() => {
+            // tslint:disable-next-line:no-non-null-assertion
+            document.querySelector('#field-container-id iframe')!.dispatchEvent(new Event('load'));
+        });
+
+        await field.attach();
+
+        expect(eventPoster.setTarget).toHaveBeenCalled();
+    });
+
+    it('ensures presence of iframe during attachment', async () => {
+        process.nextTick(() => {
+            // tslint:disable-next-line:no-non-null-assertion
+            document.querySelector('#field-container-id iframe')!.dispatchEvent(new Event('load'));
+        });
+
+        const promise = field.attach();
+
+        await promise;
+
+        expect(detachmentObserver.ensurePresence).toHaveBeenCalledWith(
+            [document.querySelector('#field-container-id iframe')],
+            promise,
+        );
+    });
+
+    it('notifies if able to attach', async () => {
+        jest.spyOn(eventPoster, 'post').mockResolvedValue({
+            type: HostedInputEventType.AttachSucceeded,
+        });
+
+        process.nextTick(() => {
+            // tslint:disable-next-line:no-non-null-assertion
+            document.querySelector('#field-container-id iframe')!.dispatchEvent(new Event('load'));
+        });
+
+        await field.attach();
+
+        expect(eventPoster.post).toHaveBeenCalledWith(
+            {
+                type: HostedFieldEventType.AttachRequested,
+                payload: {
+                    accessibilityLabel: 'Card number',
+                    fontUrls: [],
+                    placeholder: 'Enter your card number here',
+                    styles: { default: { color: 'rgb(0, 0, 0)', fontFamily: 'Open Sans, Arial' } },
+                    origin: document.location.origin,
+                    type: HostedFieldType.CardNumber,
+                },
+            },
+            {
+                successType: HostedInputEventType.AttachSucceeded,
+                errorType: HostedInputEventType.AttachFailed,
+            },
+        );
+    });
+
+    it('notifies with font URLs if available', async () => {
+        const linkElement = document.createElement('link');
+
+        linkElement.href = 'https://fonts.googleapis.com/css?family=Open+Sans&display=swap';
+        linkElement.rel = 'stylesheet';
+
+        document.head.appendChild(linkElement);
+
+        jest.spyOn(eventPoster, 'post').mockResolvedValue({
+            type: HostedInputEventType.AttachSucceeded,
+        });
+
+        process.nextTick(() => {
+            // tslint:disable-next-line:no-non-null-assertion
+            document.querySelector('#field-container-id iframe')!.dispatchEvent(new Event('load'));
+        });
+
+        await field.attach();
+
+        expect(eventPoster.post).toHaveBeenCalledWith(
+            {
+                type: HostedFieldEventType.AttachRequested,
+                payload: expect.objectContaining({
+                    type: HostedFieldType.CardNumber,
+                    fontUrls: ['https://fonts.googleapis.com/css?family=Open+Sans&display=swap'],
+                }),
+            },
+            expect.any(Object),
+        );
+    });
+
+    it('throws error if container is invalid', async () => {
+        container.remove();
+
+        try {
+            await field.attach();
+        } catch (error) {
+            expect(error).toBeInstanceOf(InvalidHostedFormConfigError);
+        }
+    });
+
+    it('sends request to submit payment data', async () => {
+        jest.spyOn(eventPoster, 'post').mockResolvedValue({
+            type: HostedInputEventType.SubmitSucceeded,
+        });
+
+        const fields = [HostedFieldType.CardExpiry, HostedFieldType.CardNumber];
+        const data = getHostedFormOrderData();
+
+        await field.submitForm(fields, data);
+
+        expect(eventPoster.post).toHaveBeenCalledWith(
+            {
+                type: HostedFieldEventType.SubmitRequested,
+                payload: { fields, data },
+            },
+            {
+                successType: HostedInputEventType.SubmitSucceeded,
+                errorType: HostedInputEventType.SubmitFailed,
+            },
+        );
+    });
+
+    it('sends request to submit stored card form data', async () => {
+        jest.spyOn(eventPoster, 'post').mockResolvedValue({
+            type: HostedInputEventType.StoredCardSucceeded,
+        });
+
+        await field.submitStoredCardForm(
+            StoredCardHostedFormInstrumentFieldsMock,
+            StoredCardHostedFormDataMock,
+        );
+
+        expect(eventPoster.post).toHaveBeenCalledWith(
+            {
+                type: HostedFieldEventType.StoredCardRequested,
+                payload: {
+                    fields: StoredCardHostedFormInstrumentFieldsMock,
+                    data: StoredCardHostedFormDataMock,
+                },
+            },
+            {
+                successType: HostedInputEventType.StoredCardSucceeded,
+                errorType: HostedInputEventType.StoredCardFailed,
+            },
+        );
+    });
+
+    it('sends request to submit manual order form data', async () => {
+        jest.spyOn(eventPoster, 'post').mockResolvedValue({
+            type: HostedInputEventType.StoredCardSucceeded,
+        });
+
+        const data = {
+            paymentMethodId: 'card',
+            paymentSessionToken: '123123123',
+        };
+
+        await controlPannelField.submitManualOrderForm(data);
+
+        expect(eventPoster.post).toHaveBeenCalledWith(
+            {
+                type: HostedFieldEventType.SubmitManualOrderRequested,
+                payload: { data },
+            },
+            {
+                successType: HostedInputEventType.SubmitManualOrderSucceeded,
+                errorType: HostedInputEventType.SubmitManualOrderFailed,
+            },
+        );
+    });
+
+    it('ensures presence of iframe during submission', async () => {
+        field.attach();
+
+        const fields = [HostedFieldType.CardExpiry, HostedFieldType.CardNumber];
+        const data = getHostedFormOrderData();
+        const promise = field.submitForm(fields, data);
+
+        await promise;
+
+        expect(detachmentObserver.ensurePresence).toHaveBeenCalledWith(
+            [document.querySelector('#field-container-id iframe')],
+            promise,
+        );
+    });
+
+    it('throws error if unable to submit payment', async () => {
+        jest.spyOn(eventPoster, 'post').mockRejectedValue({
+            type: HostedInputEventType.SubmitFailed,
+            payload: { error: { code: 'hosted_form_error', message: 'Invalid form' } },
+        });
+
+        const fields = [HostedFieldType.CardExpiry, HostedFieldType.CardNumber];
+        const data = getHostedFormOrderData();
+
+        try {
+            await field.submitForm(fields, data);
+        } catch (error) {
+            expect(error).toBeInstanceOf(InvalidHostedFormError);
+        }
+    });
+
+    it('forwards error if submission fails because of server error', async () => {
+        jest.spyOn(eventPoster, 'post').mockRejectedValue({
+            type: HostedInputEventType.SubmitFailed,
+            payload: {
+                // tslint:disable-next-line:no-non-null-assertion
+                error: getErrorPaymentResponseBody().errors![0],
+                response: getResponse(getErrorPaymentResponseBody()),
+            },
+        });
+
+        const fields = [HostedFieldType.CardExpiry, HostedFieldType.CardNumber];
+        const data = getHostedFormOrderData();
+
+        try {
+            await field.submitForm(fields, data);
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequestError);
+        }
+    });
+
+    it('forwards error if submission fails because of runtime error', async () => {
+        const rejection = new Error('Runtime error');
+
+        jest.spyOn(eventPoster, 'post').mockRejectedValue(rejection);
+
+        const fields = [HostedFieldType.CardExpiry, HostedFieldType.CardNumber];
+        const data = getHostedFormOrderData();
+
+        try {
+            await field.submitForm(fields, data);
+        } catch (error) {
+            expect(error).toEqual(rejection);
+        }
+    });
+});

--- a/packages/hosted-form-v2/src/hosted-form-factory.ts
+++ b/packages/hosted-form-v2/src/hosted-form-factory.ts
@@ -23,13 +23,13 @@ export default class HostedFormFactory {
                 new HostedField(
                     type,
                     fieldOptions.containerId,
-                    options.orderId,
                     fieldOptions.placeholder || '',
                     fieldOptions.accessibilityLabel || '',
                     options.styles || {},
                     new IframeEventPoster(host),
                     new IframeEventListener(host),
                     new DetachmentObserver(new MutationObserverFactory()),
+                    options.orderId,
                 ),
             ];
         }, []);

--- a/packages/hosted-form-v2/src/hosted-form-options.ts
+++ b/packages/hosted-form-v2/src/hosted-form-options.ts
@@ -10,7 +10,7 @@ import {
 
 export default interface HostedFormOptions {
     fields: HostedCardFieldOptionsMap;
-    orderId: number;
+    orderId?: number;
     styles?: HostedFieldStylesMap;
     onBlur?(data: HostedFieldBlurEventData): void;
     onCardTypeChange?(data: HostedFieldCardTypeChangeEventData): void;

--- a/packages/hosted-form-v2/src/hosted-form.spec.ts
+++ b/packages/hosted-form-v2/src/hosted-form.spec.ts
@@ -16,6 +16,10 @@ import HostedFormOptions from './hosted-form-options';
 import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
 import { getHostedFormOrderData } from './hosted-form-order-data.mock';
 import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
+import {
+    StoredCardHostedFormDataMock,
+    StoredCardHostedFormInstrumentFieldsMock,
+} from './stored-card-hosted-form.mock';
 
 describe('HostedForm', () => {
     let callbacks: Pick<
@@ -34,6 +38,7 @@ describe('HostedForm', () => {
         detach: jest.fn(),
         getType: jest.fn(),
         submitForm: jest.fn(),
+        submitStoredCardForm: jest.fn(),
         submitManualOrderForm: jest.fn(),
         validateForm: jest.fn(),
     };
@@ -221,6 +226,25 @@ describe('HostedForm', () => {
         await new Promise((resolve) => process.nextTick(resolve));
 
         expect(callbacks.onEnter).toHaveBeenCalledWith({ fieldType: HostedFieldType.CardCode });
+    });
+
+    it('submits stored card form data', async () => {
+        // tslint:disable-next-line:no-non-null-assertion
+        const field = fields.find((field) => field.getType() === HostedFieldType.CardNumber)!;
+
+        jest.spyOn(field, 'submitStoredCardForm').mockResolvedValue({
+            type: HostedInputEventType.StoredCardSucceeded,
+        });
+
+        await form.submitStoredCard({
+            fields: StoredCardHostedFormInstrumentFieldsMock,
+            data: StoredCardHostedFormDataMock,
+        });
+
+        expect(field.submitStoredCardForm).toHaveBeenCalledWith(
+            StoredCardHostedFormInstrumentFieldsMock,
+            StoredCardHostedFormDataMock,
+        );
     });
 
     it('validates form when enter key is pressed', async () => {

--- a/packages/hosted-form-v2/src/hosted-form.ts
+++ b/packages/hosted-form-v2/src/hosted-form.ts
@@ -16,9 +16,14 @@ import {
     HostedInputEnterEvent,
     HostedInputEventMap,
     HostedInputEventType,
+    HostedInputStoredCardSucceededEvent,
     HostedInputSubmitManualOrderSuccessEvent,
     HostedInputSubmitSuccessEvent,
 } from './iframe-content';
+import {
+    StoredCardHostedFormData,
+    StoredCardHostedFormInstrumentFields,
+} from './stored-card-hosted-form-type';
 
 type HostedFormEventCallbacks = Pick<
     HostedFormOptions,
@@ -103,6 +108,13 @@ export default class HostedForm implements HostedFormInterface {
         data: HostedFormManualOrderData;
     }): Promise<HostedInputSubmitManualOrderSuccessEvent | void> {
         return this._getFirstField().submitManualOrderForm(payload.data);
+    }
+
+    async submitStoredCard(payload: {
+        fields: StoredCardHostedFormInstrumentFields;
+        data: StoredCardHostedFormData;
+    }): Promise<HostedInputStoredCardSucceededEvent | void> {
+        return this._getFirstField().submitStoredCardForm(payload.fields, payload.data);
     }
 
     async submit(

--- a/packages/hosted-form-v2/src/iframe-content/hosted-card-expiry-input.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-card-expiry-input.spec.ts
@@ -7,6 +7,7 @@ import HostedCardExpiryInput from './hosted-card-expiry-input';
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent } from './hosted-input-events';
 import HostedInputManualOrderPaymentHandler from './hosted-input-manual-order-payment-handler';
+import HostedInputStoredCardHandler from './hosted-input-stored-card-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 
@@ -22,6 +23,7 @@ describe('HostedCardExpiryInput', () => {
     let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
     let inputValidator: Pick<HostedInputValidator, 'validate'>;
     let manualOrderPaymentHandler: Pick<HostedInputManualOrderPaymentHandler, 'handle'>;
+    let storedCardHandler: Pick<HostedInputStoredCardHandler, 'handle'>;
     let styles: HostedInputStylesMap;
 
     beforeEach(() => {
@@ -45,6 +47,7 @@ describe('HostedCardExpiryInput', () => {
             ),
         };
         manualOrderPaymentHandler = { handle: jest.fn() };
+        storedCardHandler = { handle: jest.fn() };
         styles = { default: { color: 'rgb(255, 255, 255)' } };
 
         container = document.createElement('form');
@@ -62,6 +65,7 @@ describe('HostedCardExpiryInput', () => {
             inputAggregator as HostedInputAggregator,
             inputValidator as HostedInputValidator,
             manualOrderPaymentHandler as HostedInputManualOrderPaymentHandler,
+            storedCardHandler as HostedInputStoredCardHandler,
             expiryFormatter as CardExpiryFormatter,
         );
     });

--- a/packages/hosted-form-v2/src/iframe-content/hosted-card-expiry-input.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-card-expiry-input.ts
@@ -7,6 +7,7 @@ import HostedInput from './hosted-input';
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent } from './hosted-input-events';
 import HostedInputManualOrderPaymentHandler from './hosted-input-manual-order-payment-handler';
+import HostedInputStoredCardHandler from './hosted-input-stored-card-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 
@@ -26,6 +27,7 @@ export default class HostedCardExpiryInput extends HostedInput {
         inputAggregator: HostedInputAggregator,
         inputValidator: HostedInputValidator,
         manualOrderPaymentHandler: HostedInputManualOrderPaymentHandler,
+        storedCardHandler: HostedInputStoredCardHandler,
         private _formatter: CardExpiryFormatter,
     ) {
         super(
@@ -41,6 +43,7 @@ export default class HostedCardExpiryInput extends HostedInput {
             inputAggregator,
             inputValidator,
             manualOrderPaymentHandler,
+            storedCardHandler,
         );
     }
 

--- a/packages/hosted-form-v2/src/iframe-content/hosted-card-number-input.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-card-number-input.spec.ts
@@ -9,6 +9,7 @@ import HostedInput from './hosted-input';
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
 import HostedInputManualOrderPaymentHandler from './hosted-input-manual-order-payment-handler';
+import HostedInputStoredCardHandler from './hosted-input-stored-card-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 
@@ -25,6 +26,7 @@ describe('HostedCardNumberInput', () => {
     let inputValidator: Pick<HostedInputValidator, 'validate'>;
     let numberFormatter: Pick<CardNumberFormatter, 'format' | 'unformat'>;
     let manualOrderPaymentHandler: Pick<HostedInputManualOrderPaymentHandler, 'handle'>;
+    let storedCardHandler: Pick<HostedInputStoredCardHandler, 'handle'>;
     let styles: HostedInputStylesMap;
 
     beforeEach(() => {
@@ -56,6 +58,7 @@ describe('HostedCardNumberInput', () => {
         };
         numberFormatter = { format: jest.fn(), unformat: (value) => value.replace(/ /g, '') };
         manualOrderPaymentHandler = { handle: jest.fn() };
+        storedCardHandler = { handle: jest.fn() };
         styles = { default: { color: 'rgb(255, 255, 255)' } };
 
         input = new HostedCardNumberInput(
@@ -71,6 +74,7 @@ describe('HostedCardNumberInput', () => {
             inputAggregator as HostedInputAggregator,
             inputValidator as HostedInputValidator,
             manualOrderPaymentHandler as HostedInputManualOrderPaymentHandler,
+            storedCardHandler as HostedInputStoredCardHandler,
             autocompleteFieldset,
             numberFormatter as CardNumberFormatter,
         );

--- a/packages/hosted-form-v2/src/iframe-content/hosted-card-number-input.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-card-number-input.ts
@@ -11,6 +11,7 @@ import HostedInput from './hosted-input';
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
 import HostedInputManualOrderPaymentHandler from './hosted-input-manual-order-payment-handler';
+import HostedInputStoredCardHandler from './hosted-input-stored-card-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 
@@ -31,6 +32,7 @@ export default class HostedCardNumberInput extends HostedInput {
         inputAggregator: HostedInputAggregator,
         inputValidator: HostedInputValidator,
         manualOrderPaymentHandler: HostedInputManualOrderPaymentHandler,
+        storedCardHandler: HostedInputStoredCardHandler,
         private _autocompleteFieldset: HostedAutocompleteFieldset,
         private _formatter: CardNumberFormatter,
     ) {
@@ -47,6 +49,7 @@ export default class HostedCardNumberInput extends HostedInput {
             inputAggregator,
             inputValidator,
             manualOrderPaymentHandler,
+            storedCardHandler,
         );
     }
 

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-events.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-events.ts
@@ -39,6 +39,8 @@ export interface HostedInputEventMap {
     [HostedInputEventType.SubmitManualOrderSucceeded]: HostedInputSubmitManualOrderSuccessEvent;
     [HostedInputEventType.SubmitManualOrderFailed]: HostedInputSubmitManualOrderErrorEvent;
     [HostedInputEventType.Validated]: HostedInputValidateEvent;
+    [HostedInputEventType.StoredCardFailed]: HostedInputStoredCardErrorEvent;
+    [HostedInputEventType.StoredCardSucceeded]: HostedInputStoredCardSucceededEvent;
 }
 
 // Events
@@ -53,7 +55,9 @@ export type HostedInputEvent =
     | HostedInputFocusEvent
     | HostedInputSubmitManualOrderSuccessEvent
     | HostedInputSubmitManualOrderErrorEvent
-    | HostedInputValidateEvent;
+    | HostedInputValidateEvent
+    | HostedInputStoredCardSucceededEvent
+    | HostedInputStoredCardErrorEvent;
 
 export interface HostedInputAttachSuccessEvent {
     type: HostedInputEventType.AttachSucceeded;
@@ -139,6 +143,19 @@ export interface HostedInputSubmitErrorEvent {
     type: HostedInputEventType.SubmitFailed;
     payload: {
         error: PaymentErrorData;
+        response?: Response<PaymentErrorResponseBody>;
+    };
+}
+
+export interface HostedInputStoredCardSucceededEvent {
+    type: HostedInputEventType.StoredCardSucceeded;
+}
+
+export interface HostedInputStoredCardErrorEvent {
+    type: HostedInputEventType.StoredCardFailed;
+    payload?: {
+        errors?: string[];
+        error?: PaymentErrorData;
         response?: Response<PaymentErrorResponseBody>;
     };
 }

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-factory.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-factory.ts
@@ -3,7 +3,7 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 import { appendWww, parseUrl } from '../common/url';
 import HostedFieldType from '../hosted-field-type';
-import { ManualOrderPaymentRequestSender } from '../payment';
+import { ManualOrderPaymentRequestSender, StorefrontStoredCardRequestSender } from '../payment';
 
 import CardExpiryFormatter from './card-expiry-formatter';
 import CardNumberFormatter from './card-number-formatter';
@@ -14,6 +14,7 @@ import HostedCardNumberInput from './hosted-card-number-input';
 import HostedInput from './hosted-input';
 import HostedInputAggregator from './hosted-input-aggregator';
 import HostedInputManualOrderPaymentHandler from './hosted-input-manual-order-payment-handler';
+import HostedInputStoredCardHandler from './hosted-input-stored-card-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 import mapToAccessibilityLabel from './map-to-accessibility-label';
@@ -105,6 +106,7 @@ export default class HostedInputFactory {
             new HostedInputAggregator(window.parent),
             new HostedInputValidator(),
             this._createManualOrderPaymentHandler(),
+            this._createStoredCardHandler(),
             new CardExpiryFormatter(),
         );
     }
@@ -131,6 +133,7 @@ export default class HostedInputFactory {
             new HostedInputAggregator(window.parent),
             new HostedInputValidator(),
             this._createManualOrderPaymentHandler(),
+            this._createStoredCardHandler(),
             new HostedAutocompleteFieldset(
                 form,
                 [HostedFieldType.CardCode, HostedFieldType.CardExpiry, HostedFieldType.CardName],
@@ -162,6 +165,7 @@ export default class HostedInputFactory {
             new HostedInputAggregator(window.parent),
             new HostedInputValidator(),
             this._createManualOrderPaymentHandler(),
+            this._createStoredCardHandler(),
         );
     }
 
@@ -172,6 +176,15 @@ export default class HostedInputFactory {
             getHostedInputStorage(),
             new IframeEventPoster(this._parentOrigin, window.parent),
             new ManualOrderPaymentRequestSender(createRequestSender(), this._paymentOrigin),
+        );
+    }
+
+    private _createStoredCardHandler(): HostedInputStoredCardHandler {
+        return new HostedInputStoredCardHandler(
+            new HostedInputAggregator(window.parent),
+            new HostedInputValidator(),
+            new IframeEventPoster(this._parentOrigin, window.parent),
+            new StorefrontStoredCardRequestSender(createRequestSender()),
         );
     }
 }

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-stored-card-handler.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-stored-card-handler.spec.ts
@@ -1,0 +1,171 @@
+import {
+    getErrorPaymentResponseBody,
+    getPaymentResponseBody,
+    getResponse,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { IframeEventPoster } from '../common/iframe';
+import { HostedFieldEventType } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+import HostedInputValidateResults from '../hosted-input-validate-results';
+import { StorefrontStoredCardRequestSender } from '../payment';
+import {
+    StoredCardHostedFormData,
+    StoredCardHostedFormInstrumentFields,
+} from '../stored-card-hosted-form-type';
+import {
+    StoredCardHostedFormDataMock,
+    StoredCardHostedFormInstrumentFieldsMock,
+    StoredCardHostedFormInstrumentFormMock,
+} from '../stored-card-hosted-form.mock';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputStoredCardHandler from './hosted-input-stored-card-handler';
+import HostedInputValidator from './hosted-input-validator';
+import HostedInputValues from './hosted-input-values';
+
+describe('HostedInputStoredCardHandler', () => {
+    let data: StoredCardHostedFormData;
+    let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'post'>;
+    let fields: StoredCardHostedFormInstrumentFields;
+    let handler: HostedInputStoredCardHandler;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
+    let inputValidator: Pick<HostedInputValidator, 'validate'>;
+    let requestSender: Pick<StorefrontStoredCardRequestSender, 'submitPaymentInstrument'>;
+    let values: HostedInputValues;
+    let validationResults: HostedInputValidateResults;
+
+    beforeEach(() => {
+        inputAggregator = { getInputValues: jest.fn() };
+        // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        inputValidator = { validate: jest.fn(() => []) };
+        eventPoster = { post: jest.fn() };
+        requestSender = { submitPaymentInstrument: jest.fn() };
+
+        handler = new HostedInputStoredCardHandler(
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            requestSender as StorefrontStoredCardRequestSender,
+        );
+
+        data = StoredCardHostedFormDataMock;
+        fields = StoredCardHostedFormInstrumentFieldsMock;
+
+        values = {
+            [HostedFieldType.CardCode]: '777',
+            [HostedFieldType.CardExpiry]: '03 / 30',
+            [HostedFieldType.CardName]: 'John Smith',
+            [HostedFieldType.CardNumber]: '4111 1111 1111 1111',
+        };
+
+        validationResults = {
+            isValid: true,
+            errors: {
+                cardCode: [],
+                cardExpiry: [],
+                cardName: [],
+                cardNumber: [],
+            },
+        };
+
+        jest.spyOn(inputAggregator, 'getInputValues').mockReturnValue(values);
+
+        // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        jest.spyOn(inputValidator, 'validate').mockReturnValue(validationResults);
+
+        jest.spyOn(requestSender, 'submitPaymentInstrument').mockResolvedValue(
+            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            getResponse(getPaymentResponseBody()),
+        );
+    });
+
+    it('validates user inputs', async () => {
+        jest.spyOn(inputValidator, 'validate');
+
+        await handler.handle({
+            type: HostedFieldEventType.StoredCardRequested,
+            payload: { data, fields },
+        });
+
+        expect(inputValidator.validate).toHaveBeenCalledWith(values);
+    });
+
+    it('posts event when validation happens', async () => {
+        const results = {
+            isValid: false,
+            errors: {
+                ...validationResults.errors,
+                cardNumber: [
+                    { fieldType: HostedFieldType.CardNumber, message: 'Card number is required' },
+                ],
+            },
+        };
+
+        // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        jest.spyOn(inputValidator, 'validate').mockResolvedValue(results);
+
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle({
+            type: HostedFieldEventType.StoredCardRequested,
+            payload: { data, fields },
+        });
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.Validated,
+            payload: results,
+        });
+    });
+
+    it('makes vaulting request with expected payload', async () => {
+        await handler.handle({
+            type: HostedFieldEventType.StoredCardRequested,
+            payload: { data, fields },
+        });
+
+        expect(requestSender.submitPaymentInstrument).toHaveBeenCalledWith(
+            StoredCardHostedFormDataMock,
+            StoredCardHostedFormInstrumentFormMock,
+        );
+    });
+
+    it('posts event with payload if vaulting submission succeeds', async () => {
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle({
+            type: HostedFieldEventType.StoredCardRequested,
+            payload: { data, fields },
+        });
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.StoredCardSucceeded,
+        });
+    });
+
+    it('posts event if vaulting submission fails', async () => {
+        const response = getResponse(getErrorPaymentResponseBody());
+
+        jest.spyOn(eventPoster, 'post');
+
+        jest.spyOn(requestSender, 'submitPaymentInstrument').mockRejectedValue(response);
+
+        await handler.handle({
+            type: HostedFieldEventType.StoredCardRequested,
+            payload: { data, fields },
+        });
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.StoredCardFailed,
+        });
+    });
+});

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-stored-card-handler.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-stored-card-handler.ts
@@ -1,0 +1,62 @@
+import { IframeEventPoster } from '../common/iframe';
+import { HostedFieldStoredCardRequestEvent } from '../hosted-field-events';
+import { StorefrontStoredCardRequestSender } from '../payment';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputValidator from './hosted-input-validator';
+
+export default class HostedInputStoredCardHandler {
+    constructor(
+        private _inputAggregator: HostedInputAggregator,
+        private _inputValidator: HostedInputValidator,
+        private _eventPoster: IframeEventPoster<HostedInputEvent>,
+        private _storedCardRequestSender: StorefrontStoredCardRequestSender,
+    ) {}
+
+    handle: (event: HostedFieldStoredCardRequestEvent) => Promise<void> = async (event) => {
+        const {
+            payload: { data, fields },
+        } = event;
+        const values = this._inputAggregator.getInputValues();
+        const results = await this._inputValidator.validate(values);
+
+        this._eventPoster.post({
+            type: HostedInputEventType.Validated,
+            payload: results,
+        });
+
+        if (!results.isValid) {
+            return this._eventPoster.post({
+                type: HostedInputEventType.StoredCardFailed,
+            });
+        }
+
+        const { defaultInstrument, ...billingAddress } = fields;
+
+        const [expiryMonth, expiryYear] = values.cardExpiry ? values.cardExpiry.split('/') : [];
+
+        try {
+            await this._storedCardRequestSender.submitPaymentInstrument(data, {
+                billingAddress,
+                instrument: {
+                    type: 'card',
+                    cardholderName: values.cardName || '',
+                    number: values.cardNumber ? values.cardNumber.replace(/ /g, '') : '',
+                    expiryMonth: Number(expiryMonth.trim()),
+                    expiryYear: Number(`20${expiryYear.trim()}`),
+                    verificationValue: values.cardCode ?? '',
+                },
+                defaultInstrument,
+            });
+
+            this._eventPoster.post({
+                type: HostedInputEventType.StoredCardSucceeded,
+            });
+        } catch (error) {
+            this._eventPoster.post({
+                type: HostedInputEventType.StoredCardFailed,
+            });
+        }
+    };
+}

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input.spec.ts
@@ -12,6 +12,7 @@ import HostedInput from './hosted-input';
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
 import HostedInputManualOrderPaymentHandler from './hosted-input-manual-order-payment-handler';
+import HostedInputStoredCardHandler from './hosted-input-stored-card-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 import HostedInputValues from './hosted-input-values';
@@ -26,6 +27,7 @@ describe('HostedInput', () => {
     let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'setTarget' | 'post'>;
     let fontUrls: string[];
     let input: HostedInput;
+    let storedCardHandler: Pick<HostedInputStoredCardHandler, 'handle'>;
     let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
     let inputValidator: Pick<HostedInputValidator, 'validate'>;
     let manualOrderPaymentHandler: Pick<HostedInputManualOrderPaymentHandler, 'handle'>;
@@ -65,6 +67,7 @@ describe('HostedInput', () => {
         fontUrls = ['https://fonts.googleapis.com/css?family=Open+Sans&display=swap'];
 
         manualOrderPaymentHandler = { handle: jest.fn() };
+        storedCardHandler = { handle: jest.fn() };
 
         inputAggregator = {
             getInputValues: jest.fn(() => values),
@@ -99,6 +102,7 @@ describe('HostedInput', () => {
             inputAggregator as HostedInputAggregator,
             inputValidator as HostedInputValidator,
             manualOrderPaymentHandler as HostedInputManualOrderPaymentHandler,
+            storedCardHandler as HostedInputStoredCardHandler,
         );
     });
 
@@ -149,6 +153,7 @@ describe('HostedInput', () => {
             inputAggregator as HostedInputAggregator,
             inputValidator as HostedInputValidator,
             manualOrderPaymentHandler as HostedInputManualOrderPaymentHandler,
+            storedCardHandler as HostedInputStoredCardHandler,
         );
 
         input.attach();
@@ -175,6 +180,7 @@ describe('HostedInput', () => {
             inputAggregator as HostedInputAggregator,
             inputValidator as HostedInputValidator,
             manualOrderPaymentHandler as HostedInputManualOrderPaymentHandler,
+            storedCardHandler as HostedInputStoredCardHandler,
         );
 
         input.attach();
@@ -201,6 +207,7 @@ describe('HostedInput', () => {
             inputAggregator as HostedInputAggregator,
             inputValidator as HostedInputValidator,
             manualOrderPaymentHandler as HostedInputManualOrderPaymentHandler,
+            storedCardHandler as HostedInputStoredCardHandler,
         );
 
         cardNumberInput.attach();

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input.ts
@@ -12,6 +12,7 @@ import HostedFieldType from '../hosted-field-type';
 import HostedInputAggregator from './hosted-input-aggregator';
 import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
 import HostedInputManualOrderPaymentHandler from './hosted-input-manual-order-payment-handler';
+import HostedInputStoredCardHandler from './hosted-input-stored-card-handler';
 import HostedInputStyles, { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 import HostedInputWindow from './hosted-input-window';
@@ -38,6 +39,7 @@ export default class HostedInput {
         protected _inputAggregator: HostedInputAggregator,
         protected _inputValidator: HostedInputValidator,
         protected _manualOrderPaymentHandler: HostedInputManualOrderPaymentHandler,
+        protected _storedCardHandler: HostedInputStoredCardHandler,
     ) {
         this._input = document.createElement('input');
 
@@ -52,6 +54,11 @@ export default class HostedInput {
         this._eventListener.addListener(
             HostedFieldEventType.SubmitManualOrderRequested,
             this._manualOrderPaymentHandler.handle,
+        );
+
+        this._eventListener.addListener(
+            HostedFieldEventType.StoredCardRequested,
+            this._storedCardHandler.handle,
         );
 
         this._configureInput();

--- a/packages/hosted-form-v2/src/index.ts
+++ b/packages/hosted-form-v2/src/index.ts
@@ -7,3 +7,4 @@ export { default as HostedFormFactory } from './hosted-form-factory';
 export { HostedFormInterface } from './hosted-form';
 export { default as HostedForm } from './hosted-form';
 export { default as HostedFormOrderData } from './hosted-form-order-data';
+export { default as createStoredCardHostedFormService } from './create-hosted-form-stored-card-service';

--- a/packages/hosted-form-v2/src/payment/index.ts
+++ b/packages/hosted-form-v2/src/payment/index.ts
@@ -1,2 +1,3 @@
 export { ManualOrderPaymentRequestSender } from './manual-order-payment-request-sender';
 export { OfflinePaymentMethods, OfflinePaymentMethodTypes } from './Instrument';
+export { default as StorefrontStoredCardRequestSender } from './storefront-stored-card-request-sender';

--- a/packages/hosted-form-v2/src/payment/storefront-stored-card-request-sender.spec.ts
+++ b/packages/hosted-form-v2/src/payment/storefront-stored-card-request-sender.spec.ts
@@ -1,0 +1,56 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import {
+    StoredCardHostedFormDataMock,
+    StoredCardHostedFormInstrumentFormAPIMock,
+    StoredCardHostedFormInstrumentFormMock,
+} from '../stored-card-hosted-form.mock';
+
+import StorefrontStoredCardRequestSender from './storefront-stored-card-request-sender';
+
+describe('StorefrontStoredCardRequestSender', () => {
+    let requestSender: RequestSender;
+    let storefrontStoredCardRequestSender: StorefrontStoredCardRequestSender;
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+        storefrontStoredCardRequestSender = new StorefrontStoredCardRequestSender(requestSender);
+
+        // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        jest.spyOn(requestSender, 'post').mockResolvedValue(undefined);
+    });
+
+    describe('#submitPaymentMethod', () => {
+        const headers = {
+            Authorization: StoredCardHostedFormDataMock.vaultToken,
+            Accept: 'application/vnd.bc.v1+json',
+            'Content-Type': 'application/vnd.bc.v1+json',
+        };
+
+        it('saves payment method', async () => {
+            await storefrontStoredCardRequestSender.submitPaymentInstrument(
+                StoredCardHostedFormDataMock,
+                StoredCardHostedFormInstrumentFormMock,
+            );
+
+            const { instrument, billingAddress } = StoredCardHostedFormInstrumentFormAPIMock;
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                `${StoredCardHostedFormDataMock.paymentsUrl}/stores/${StoredCardHostedFormDataMock.storeHash}/customers/${StoredCardHostedFormDataMock.shopperId}/stored_instruments`,
+                {
+                    body: JSON.stringify({
+                        instrument,
+                        billing_address: billingAddress,
+                        provider_id: StoredCardHostedFormDataMock.providerId,
+                        default_instrument:
+                            StoredCardHostedFormInstrumentFormAPIMock.default_Instrument,
+                        currency_code: StoredCardHostedFormDataMock.currencyCode,
+                    }),
+                    headers,
+                },
+            );
+        });
+    });
+});

--- a/packages/hosted-form-v2/src/payment/storefront-stored-card-request-sender.ts
+++ b/packages/hosted-form-v2/src/payment/storefront-stored-card-request-sender.ts
@@ -1,0 +1,58 @@
+import { RequestSender } from '@bigcommerce/request-sender';
+
+import {
+    StoredCardHostedFormData,
+    StoredCardHostedFormInstrumentForm,
+} from '../stored-card-hosted-form-type';
+
+export default class StorefrontStoredCardRequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    async submitPaymentInstrument(
+        requestInitializationData: StoredCardHostedFormData,
+        storeInstrumentFormData: StoredCardHostedFormInstrumentForm,
+    ): Promise<void> {
+        const { providerId, currencyCode, paymentsUrl, shopperId, storeHash, vaultToken } =
+            requestInitializationData;
+
+        const { billingAddress, instrument, defaultInstrument } = storeInstrumentFormData;
+        const url = `${paymentsUrl}/stores/${storeHash}/customers/${shopperId}/stored_instruments`;
+        const options = {
+            headers: {
+                Authorization: vaultToken,
+                Accept: 'application/vnd.bc.v1+json',
+                'Content-Type': 'application/vnd.bc.v1+json',
+            },
+            body: JSON.stringify({
+                instrument: {
+                    type: instrument.type,
+                    cardholder_name: instrument.cardholderName,
+                    number: instrument.number,
+                    expiry_month: instrument.expiryMonth,
+                    expiry_year: instrument.expiryYear,
+                    verification_value: instrument.verificationValue,
+                },
+                billing_address: {
+                    email: billingAddress.email,
+                    address1: billingAddress.address1,
+                    ...(billingAddress.address2 && { address2: billingAddress.address2 }),
+                    city: billingAddress.city,
+                    postal_code: billingAddress.postalCode,
+                    country_code: billingAddress.countryCode,
+                    ...(billingAddress.company && { company: billingAddress.company }),
+                    first_name: billingAddress.firstName,
+                    last_name: billingAddress.lastName,
+                    ...(billingAddress.phone && { phone: billingAddress.phone }),
+                    ...(billingAddress.stateOrProvinceCode && {
+                        state_or_province_code: billingAddress.stateOrProvinceCode,
+                    }),
+                },
+                provider_id: providerId,
+                default_instrument: defaultInstrument,
+                currency_code: currencyCode,
+            }),
+        };
+
+        await this._requestSender.post<void>(url, options);
+    }
+}

--- a/packages/hosted-form-v2/src/stored-card-hosted-form-service.spec.ts
+++ b/packages/hosted-form-v2/src/stored-card-hosted-form-service.spec.ts
@@ -1,0 +1,143 @@
+import LegacyHostedFormOptions from './hosted-form-options';
+import StoredCardHostedFormService from './stored-card-hosted-form-service';
+import {
+    StoredCardHostedFormDataMock,
+    StoredCardHostedFormInstrumentFieldsMock,
+} from './stored-card-hosted-form.mock';
+
+import { HostedForm, HostedFormFactory } from '.';
+
+describe('StoredCardHostedFormService', () => {
+    let formFactory: HostedFormFactory;
+    let service: StoredCardHostedFormService;
+    let initializeOptions: LegacyHostedFormOptions;
+
+    beforeEach(() => {
+        formFactory = new HostedFormFactory();
+
+        service = new StoredCardHostedFormService('https://bigpay.integration.zone', formFactory);
+    });
+
+    describe('when hosted form is enabled', () => {
+        let form: Pick<HostedForm, 'attach' | 'submit' | 'validate' | 'submitStoredCard'>;
+
+        beforeEach(() => {
+            form = {
+                attach: jest.fn(() => Promise.resolve()),
+                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                submit: jest.fn(() => Promise.resolve()),
+                validate: jest.fn(() => Promise.resolve()),
+                submitStoredCard: jest.fn(() => Promise.resolve()),
+            };
+            initializeOptions = {
+                fields: {
+                    cardCode: {
+                        containerId: 'cardCode',
+                    },
+                    cardExpiry: {
+                        containerId: 'cardExpiry',
+                    },
+                    cardNumber: {
+                        containerId: 'cardNumber',
+                    },
+                    cardName: {
+                        containerId: 'cardName',
+                    },
+                },
+            };
+
+            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            jest.spyOn(formFactory, 'create').mockReturnValue(form);
+        });
+
+        it('creates hosted form', async () => {
+            await service.initialize(initializeOptions);
+
+            expect(formFactory.create).toHaveBeenCalledWith(
+                'https://bigpay.integration.zone',
+                initializeOptions,
+            );
+        });
+
+        it('attaches hosted form to container', async () => {
+            await service.initialize(initializeOptions);
+
+            expect(form.attach).toHaveBeenCalled();
+        });
+
+        it('submits payment data with hosted form', async () => {
+            await service.initialize(initializeOptions);
+            await service.submitStoredCard(
+                StoredCardHostedFormInstrumentFieldsMock,
+                StoredCardHostedFormDataMock,
+            );
+
+            expect(form.submitStoredCard).toHaveBeenCalledWith({
+                fields: StoredCardHostedFormInstrumentFieldsMock,
+                data: StoredCardHostedFormDataMock,
+            });
+        });
+
+        it('validates user input before submitting data', async () => {
+            await service.initialize(initializeOptions);
+            await service.submitStoredCard(
+                StoredCardHostedFormInstrumentFieldsMock,
+                StoredCardHostedFormDataMock,
+            );
+
+            expect(form.validate).toHaveBeenCalled();
+        });
+
+        it('does not submit payment data with hosted form if validation fails', async () => {
+            jest.spyOn(form, 'validate').mockRejectedValue(new Error());
+
+            try {
+                await service.initialize(initializeOptions);
+                await service.submitStoredCard(
+                    StoredCardHostedFormInstrumentFieldsMock,
+                    StoredCardHostedFormDataMock,
+                );
+            } catch (error) {
+                expect(form.submit).not.toHaveBeenCalled();
+            }
+        });
+    });
+
+    describe('when hosted form is enabled but hosted fields are not present for rendering', () => {
+        let form: Pick<HostedForm, 'attach' | 'submit' | 'validate' | 'submitStoredCard'>;
+
+        beforeEach(() => {
+            form = {
+                attach: jest.fn(() => Promise.resolve()),
+                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                submit: jest.fn(() => Promise.resolve()),
+                validate: jest.fn(() => Promise.resolve()),
+                submitStoredCard: jest.fn(() => Promise.resolve()),
+            };
+            initializeOptions = {
+                fields: {},
+            };
+
+            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            jest.spyOn(formFactory, 'create').mockReturnValue(form);
+        });
+
+        it('does not submit with hosted form', async () => {
+            await service.initialize(initializeOptions);
+            await service.submitStoredCard(
+                StoredCardHostedFormInstrumentFieldsMock,
+                StoredCardHostedFormDataMock,
+            );
+
+            expect(form.submit).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/hosted-form-v2/src/stored-card-hosted-form-service.ts
+++ b/packages/hosted-form-v2/src/stored-card-hosted-form-service.ts
@@ -1,0 +1,40 @@
+import { NotInitializedError, NotInitializedErrorType } from './common/errors';
+import HostedForm from './hosted-form';
+import HostedFormFactory from './hosted-form-factory';
+import LegacyHostedFormOptions from './hosted-form-options';
+import {
+    StoredCardHostedFormData,
+    StoredCardHostedFormInstrumentFields,
+} from './stored-card-hosted-form-type';
+
+export default class StoredCardHostedFormService {
+    protected _hostedForm?: HostedForm;
+    constructor(protected _host: string, protected _hostedFormFactory: HostedFormFactory) {}
+
+    async submitStoredCard(
+        fields: StoredCardHostedFormInstrumentFields,
+        data: StoredCardHostedFormData,
+    ): Promise<void> {
+        const form = this._hostedForm;
+
+        if (!form) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        await form.validate().then(() => form.submitStoredCard({ fields, data }));
+    }
+
+    initialize(options: LegacyHostedFormOptions): Promise<void> {
+        const form = this._hostedFormFactory.create(this._host, options);
+
+        return form.attach().then(() => {
+            this._hostedForm = form;
+        });
+    }
+
+    deinitialize() {
+        if (this._hostedForm) {
+            this._hostedForm.detach();
+        }
+    }
+}

--- a/packages/hosted-form-v2/src/stored-card-hosted-form-type.ts
+++ b/packages/hosted-form-v2/src/stored-card-hosted-form-type.ts
@@ -1,0 +1,46 @@
+export interface StoredCardHostedFormData {
+    currencyCode: string;
+    paymentsUrl: string;
+    providerId: string;
+    shopperId: string;
+    storeHash: string;
+    vaultToken: string;
+}
+
+export interface StoredCardHostedFormPaymentInstrument {
+    type: string;
+    cardholderName: string;
+    number: string;
+    expiryMonth: number;
+    expiryYear: number;
+    verificationValue: string;
+}
+
+export interface StoredCardHostedFormBillingAddress {
+    address1: string;
+    address2?: string;
+    city: string;
+    postalCode: string;
+    countryCode: string;
+    company?: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone?: string;
+    stateOrProvinceCode?: string;
+}
+
+export interface StoredCardHostedFormInstrumentForm {
+    billingAddress: StoredCardHostedFormBillingAddress;
+    instrument: StoredCardHostedFormPaymentInstrument;
+    defaultInstrument: boolean;
+}
+
+export interface StoredCardHostedFormInstrumentFields extends StoredCardHostedFormBillingAddress {
+    defaultInstrument: boolean;
+}
+
+export interface StoredCardHostedFormPayload {
+    fields: StoredCardHostedFormInstrumentFields;
+    data: StoredCardHostedFormData;
+}

--- a/packages/hosted-form-v2/src/stored-card-hosted-form.mock.ts
+++ b/packages/hosted-form-v2/src/stored-card-hosted-form.mock.ts
@@ -1,0 +1,78 @@
+const StoredCardHostedFormDataMock = {
+    currencyCode: 'USD',
+    paymentsUrl: 'https//test.com',
+    providerId: 'bluesnapdirect',
+    shopperId: '12345',
+    storeHash: '12345',
+    vaultToken: 'token124',
+};
+
+const StoredCardHostedFormBillingAddressAPIMock = {
+    email: 'string@mail.com',
+    address1: '57 Balsham Road',
+    city: 'Harthill',
+    postal_code: 'S31 6EN',
+    country_code: 'NL',
+    company: 'String',
+    first_name: 'John',
+    last_name: 'Smith',
+    phone: '123456789',
+    state_or_province_code: 'BEL',
+};
+
+const StoredCardHostedFormBillingAddressMock = {
+    address1: '57 Balsham Road',
+    address2: '',
+    city: 'Harthill',
+    postalCode: 'S31 6EN',
+    countryCode: 'NL',
+    company: 'String',
+    firstName: 'John',
+    lastName: 'Smith',
+    email: 'string@mail.com',
+    phone: '123456789',
+    stateOrProvinceCode: 'BEL',
+};
+
+const StoredCardHostedFormPaymentInstrumentAPIMock = {
+    type: 'card',
+    cardholder_name: 'John Smith',
+    number: '4111111111111111',
+    expiry_month: 3,
+    expiry_year: 2030,
+    verification_value: '777',
+};
+
+const StoredCardHostedFormPaymentInstrumentMock = {
+    type: 'card',
+    cardholderName: 'John Smith',
+    number: '4111111111111111',
+    expiryMonth: 3,
+    expiryYear: 2030,
+    verificationValue: '777',
+};
+
+const StoredCardHostedFormInstrumentFormMock = {
+    billingAddress: StoredCardHostedFormBillingAddressMock,
+    instrument: StoredCardHostedFormPaymentInstrumentMock,
+    defaultInstrument: true,
+};
+
+const StoredCardHostedFormInstrumentFormAPIMock = {
+    billingAddress: StoredCardHostedFormBillingAddressAPIMock,
+    instrument: StoredCardHostedFormPaymentInstrumentAPIMock,
+    default_Instrument: true,
+};
+const StoredCardHostedFormInstrumentFieldsMock = {
+    ...StoredCardHostedFormBillingAddressMock,
+    defaultInstrument: true,
+};
+
+export {
+    StoredCardHostedFormDataMock,
+    StoredCardHostedFormBillingAddressMock,
+    StoredCardHostedFormPaymentInstrumentMock,
+    StoredCardHostedFormInstrumentFormMock,
+    StoredCardHostedFormInstrumentFieldsMock,
+    StoredCardHostedFormInstrumentFormAPIMock,
+};

--- a/packages/payment-integrations-test-utils/src/index.ts
+++ b/packages/payment-integrations-test-utils/src/index.ts
@@ -22,6 +22,7 @@ export {
     getPaymentMethodsMeta,
     getResponse,
     getPaymentResponse,
+    getPaymentResponseBody,
     getErrorResponse,
     getErrorResponseBody,
     getTimeoutResponse,

--- a/packages/payment-integrations-test-utils/src/test-utils/index.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/index.ts
@@ -31,6 +31,7 @@ export {
     getCreditCardInstrument,
     getVaultedInstrument,
     getErrorPaymentResponseBody,
+    getPaymentResponseBody,
     getInstruments,
 } from './payments.mock';
 

--- a/packages/payment-integrations-test-utils/src/test-utils/payments.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payments.mock.ts
@@ -161,3 +161,16 @@ export function getErrorPaymentResponseBody(): PaymentResponseBody {
         errors: [{ code: 'insufficient_funds', message: 'Insufficient funds' }],
     };
 }
+
+export function getPaymentResponseBody(): PaymentResponseBody {
+    return {
+        status: 'ok',
+        id: 'b12e69cb-d76e-4d86-8d3d-94e8a07c9051',
+        avs_result: {},
+        cvv_result: {},
+        three_ds_result: {},
+        fraud_review: true,
+        transaction_type: 'purchase',
+        errors: [],
+    };
+}


### PR DESCRIPTION
## What?
Moved my account logic to the hosted card v2 package.
1) Added StoredCardHostedFormService to the hosted fields v2 for storing credit cards on the My Account Page;
2) Added  [hosted-field.spec.ts](https://github.com/bigcommerce/checkout-sdk-js/compare/master...vitalii-koshovyi:checkout-sdk-js:PI-3068?expand=1#diff-42cc2634edd489146a40c17ba992db4b66239e1730f9b4b59403d544363350e1) test, due to the absence.
But still need to improve coverage for the submitManualOrderForm and submitStoredCardForm methods, didn't do that due to the already huge changes;
3) [ Added additional logic](https://github.com/bigcommerce/checkout-sdk-js/compare/master...vitalii-koshovyi:checkout-sdk-js:PI-3068?expand=1#diff-94b877bfbfcbbe11028cacdaf107f342764cd73b5eee4ddfa68167e1892ab53bR54) to use different iframe URLs for the storefront and CP fields usage. If you have better ideas on how to implement that, please share them with me.


## Why?
Storefront account payments could use hosted fields without importing whole SDK.

## Testing / Proof

https://github.com/user-attachments/assets/c6abacb4-c3f1-4f0b-a374-03a919aa5ade


https://github.com/user-attachments/assets/9ac77d3e-4244-42b6-b79e-9d2d363b6ff6

*logs in the console show that modified version of SDK loaded both in the microapp and in the iframe

@bigcommerce/team-checkout @bigcommerce/team-payments
