### PR TITLE
feat(payment): PAYMENTS-10280 Add validation on hosted form card holder name to not have PAN

### DIFF
--- a/packages/core/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
@@ -113,22 +113,25 @@ describe('HostedInputValidator', () => {
         });
     });
 
-    it('returns error if card number is entered in card name field', async () => {
-        expect(await validator.validate({ ...validData, cardName: '4111 1111 1111 1111' })).toEqual(
-            {
-                isValid: false,
-                errors: {
-                    ...validResults.errors,
-                    cardName: [
-                        {
-                            fieldType: 'cardName',
-                            type: 'invalid_card_name',
-                            message: 'Credit card name must be valid',
-                        },
-                    ],
-                },
+    it('returns error if card name field includes a valid card number', async () => {
+        expect(
+            await validator.validate({
+                ...validData,
+                cardName: 'text before 4111 1111 1111 1111 and after',
+            }),
+        ).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardName: [
+                    {
+                        fieldType: 'cardName',
+                        type: 'invalid_card_name',
+                        message: 'Credit card name must be valid',
+                    },
+                ],
             },
-        );
+        });
     });
 
     it('does not return error if card name is not required', async () => {

--- a/packages/core/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
@@ -113,6 +113,24 @@ describe('HostedInputValidator', () => {
         });
     });
 
+    it('returns error if card number is entered in card name field', async () => {
+        expect(await validator.validate({ ...validData, cardName: '4111 1111 1111 1111' })).toEqual(
+            {
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardName: [
+                        {
+                            fieldType: 'cardName',
+                            type: 'invalid_card_name',
+                            message: 'Credit card name must be valid',
+                        },
+                    ],
+                },
+            },
+        );
+    });
+
     it('does not return error if card name is not required', async () => {
         expect(await validator.validate(omit(validData, HostedFieldType.CardName))).toEqual({
             ...validResults,

--- a/packages/core/src/hosted-form/iframe-content/hosted-input-validator.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input-validator.ts
@@ -154,7 +154,14 @@ export default class HostedInputValidator {
     }
 
     private _getCardNameSchema(): StringSchema {
-        return string().max(200).required('Full name is required');
+        return string()
+            .max(200)
+            .required('Full name is required')
+            .test({
+                message: 'Credit card name must be valid',
+                name: 'invalid_card_name',
+                test: (value) => !number(value).isValid,
+            });
     }
 
     private _getCardNumberSchema(): StringSchema {

--- a/packages/core/src/hosted-form/iframe-content/hosted-input-validator.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input-validator.ts
@@ -160,7 +160,22 @@ export default class HostedInputValidator {
             .test({
                 message: 'Credit card name must be valid',
                 name: 'invalid_card_name',
-                test: (value) => !number(value).isValid,
+                test: (value) => {
+                    // Get all numbers from the input value after removing whitespaces
+                    const numbers = value.replace(/\s/g, '').match(/[0-9]+/g);
+
+                    if (!numbers?.length) {
+                        return true;
+                    }
+
+                    for (const num of numbers) {
+                        if (number(num).isValid) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                },
             });
     }
 

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.spec.ts
@@ -145,6 +145,24 @@ describe('HostedInputValidator', () => {
         });
     });
 
+    it('returns error if card number is entered in card name field', async () => {
+        expect(await validator.validate({ ...validData, cardName: '4111 1111 1111 1111' })).toEqual(
+            {
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardName: [
+                        {
+                            fieldType: 'cardName',
+                            type: 'invalid_card_name',
+                            message: 'Credit card name must be valid',
+                        },
+                    ],
+                },
+            },
+        );
+    });
+
     it('does not return error if card name is not required', async () => {
         expect(await validator.validate(omit(validData, HostedFieldType.CardName))).toEqual({
             ...validResults,

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.spec.ts
@@ -145,22 +145,25 @@ describe('HostedInputValidator', () => {
         });
     });
 
-    it('returns error if card number is entered in card name field', async () => {
-        expect(await validator.validate({ ...validData, cardName: '4111 1111 1111 1111' })).toEqual(
-            {
-                isValid: false,
-                errors: {
-                    ...validResults.errors,
-                    cardName: [
-                        {
-                            fieldType: 'cardName',
-                            type: 'invalid_card_name',
-                            message: 'Credit card name must be valid',
-                        },
-                    ],
-                },
+    it('returns error if card name field includes a valid card number', async () => {
+        expect(
+            await validator.validate({
+                ...validData,
+                cardName: 'text before 4111 1111 1111 1111 and after',
+            }),
+        ).toEqual({
+            isValid: false,
+            errors: {
+                ...validResults.errors,
+                cardName: [
+                    {
+                        fieldType: 'cardName',
+                        type: 'invalid_card_name',
+                        message: 'Credit card name must be valid',
+                    },
+                ],
             },
-        );
+        });
     });
 
     it('does not return error if card name is not required', async () => {

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.ts
@@ -133,7 +133,22 @@ export default class HostedInputValidator {
             .test({
                 message: 'Credit card name must be valid',
                 name: 'invalid_card_name',
-                test: (value) => !number(value).isValid,
+                test: (value) => {
+                    // Get all numbers from the input value after removing whitespaces
+                    const numbers = value.replace(/\s/g, '').match(/[0-9]+/g);
+
+                    if (!numbers?.length) {
+                        return true;
+                    }
+
+                    for (const num of numbers) {
+                        if (number(num).isValid) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                },
             });
     }
 

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-validator.ts
@@ -127,7 +127,14 @@ export default class HostedInputValidator {
     }
 
     private _getCardNameSchema(): StringSchema {
-        return string().max(200).required('Full name is required');
+        return string()
+            .max(200)
+            .required('Full name is required')
+            .test({
+                message: 'Credit card name must be valid',
+                name: 'invalid_card_name',
+                test: (value) => !number(value).isValid,
+            });
     }
 
     private _getNoteSchema(): StringSchema {


### PR DESCRIPTION
## What?
Payments team runs transaction journal audit job on a regular basis, which looks for possible PAN (Credit card numbers) stored in transaction journals. One of those reasons and one that we see quite commonly is where due to human mistake, shoppers are typing credit card number into Card holder name field. We want to add this validation BC hosted form fields.

## Why?
For more credit cards security.

## Testing / Proof
Unit tests
Screenshot
<img width="642" alt="Screenshot 2025-02-03 at 2 57 05 PM" src="https://github.com/user-attachments/assets/bcb7bf1d-799c-420f-b7a5-82242a2ae2cd" />


@bigcommerce/team-checkout @bigcommerce/team-payments
