### PR TITLE
feat(extension): CHECKOUT-8974 Introduce Extension Query

### DIFF
--- a/packages/core/src/bundles/checkout-sdk.ts
+++ b/packages/core/src/bundles/checkout-sdk.ts
@@ -13,4 +13,4 @@ export {
 } from '../analytics';
 export { createStoredCardHostedFormService } from '../hosted-form';
 export { createBodlService } from '../bodl';
-export { ExtensionCommandType } from '../extension';
+export { ExtensionCommandType, ExtensionQueryType, ExtensionQueryMap } from '../extension';

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -47,6 +47,7 @@ import {
     ExtensionEventBroadcaster,
     ExtensionMessageType,
     ExtensionMessenger,
+    ExtensionQueryType,
     ExtensionRegion,
     ExtensionRequestSender,
     getExtensions,
@@ -169,7 +170,7 @@ describe('CheckoutService', () => {
         store = createCheckoutStore(getCheckoutStoreState());
         storeProjection = createDataStoreProjection(store, createCheckoutSelectorsFactory());
 
-        extensionMessenger = new ExtensionMessenger(store, {}, {});
+        extensionMessenger = new ExtensionMessenger(store, {}, {}, {});
 
         const locale = 'en';
         const requestSender = createRequestSender();
@@ -1588,7 +1589,7 @@ describe('CheckoutService', () => {
             const extensions = getExtensions();
             const handler = jest.fn();
 
-            jest.spyOn(extensionMessenger, 'listen');
+            jest.spyOn(extensionMessenger, 'listenForCommand');
 
             checkoutService.handleExtensionCommand(
                 extensions[0].id,
@@ -1596,9 +1597,28 @@ describe('CheckoutService', () => {
                 handler,
             );
 
-            expect(extensionMessenger.listen).toHaveBeenCalledWith(
+            expect(extensionMessenger.listenForCommand).toHaveBeenCalledWith(
                 extensions[0].id,
                 ExtensionCommandType.ReloadCheckout,
+                handler,
+            );
+        });
+
+        it('handles extension queries', () => {
+            const extensions = getExtensions();
+            const handler = jest.fn();
+
+            jest.spyOn(extensionMessenger, 'listenForQuery');
+
+            checkoutService.handleExtensionQuery(
+                extensions[0].id,
+                ExtensionQueryType.GetConsignments,
+                handler,
+            );
+
+            expect(extensionMessenger.listenForQuery).toHaveBeenCalledWith(
+                extensions[0].id,
+                ExtensionQueryType.GetConsignments,
                 handler,
             );
         });

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -27,6 +27,7 @@ import {
     ExtensionEventBroadcaster,
     ExtensionMessage,
     ExtensionMessenger,
+    ExtensionQueryMap,
     ExtensionRegion,
 } from '../extension';
 import { FormFieldsActionCreator } from '../form';
@@ -1469,7 +1470,24 @@ export default class CheckoutService {
         command: T,
         handler: (command: ExtensionCommandMap[T]) => void,
     ): () => void {
-        return this._extensionMessenger.listen(extensionId, command, handler);
+        return this._extensionMessenger.listenForCommand(extensionId, command, handler);
+    }
+
+    /**
+     * Manages the query handler for an extension.
+     *
+     * @alpha
+     * @param extensionId - The ID of the extension sending the query.
+     * @param query - The query to be handled.
+     * @param handler - The handler function for the extension query.
+     * @returns A function that, when called, will deregister the query handler.
+     */
+    handleExtensionQuery<T extends keyof ExtensionQueryMap>(
+        extensionId: string,
+        query: T,
+        handler: (command: ExtensionQueryMap[T]) => void,
+    ): () => void {
+        return this._extensionMessenger.listenForQuery(extensionId, query, handler);
     }
 
     /**

--- a/packages/core/src/extension/errors/index.ts
+++ b/packages/core/src/extension/errors/index.ts
@@ -1,2 +1,4 @@
 export { ExtensionNotFoundError } from './extension-not-found-error';
 export { ExtensionNotLoadedError } from './extension-not-loaded-error';
+export { UnsupportedExtensionCommandError } from './unsupported-extension-command-error';
+export { UnsupportedExtensionQueryError } from './unsupported-extension-query-error';

--- a/packages/core/src/extension/errors/unsupported-extension-query-error.ts
+++ b/packages/core/src/extension/errors/unsupported-extension-query-error.ts
@@ -1,0 +1,10 @@
+import { StandardError } from '../../common/error/errors';
+
+export class UnsupportedExtensionQueryError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unable to proceed due to unsupported extension query.');
+
+        this.name = 'UnsupportedExtensionQueryError';
+        this.type = 'unsupported_extension_query_error';
+    }
+}

--- a/packages/core/src/extension/extension-commands.ts
+++ b/packages/core/src/extension/extension-commands.ts
@@ -4,6 +4,10 @@ export type ExtensionCommand =
     | SetIframeStyleCommand
     | GetConsignmentsCommand;
 
+export enum InstantDataCommandType {
+    Consignments = 'consignments',
+}
+
 export enum ExtensionCommandType {
     ReloadCheckout = 'EXTENSION:RELOAD_CHECKOUT',
     ShowLoadingIndicator = 'EXTENSION:SHOW_LOADING_INDICATOR',

--- a/packages/core/src/extension/extension-commands.ts
+++ b/packages/core/src/extension/extension-commands.ts
@@ -1,22 +1,12 @@
 export type ExtensionCommand =
     | ReloadCheckoutCommand
     | ShowLoadingIndicatorCommand
-    | SetIframeStyleCommand
-    | GetConsignmentsCommand;
-
-export enum InstantDataCommandType {
-    Consignments = 'consignments',
-}
+    | SetIframeStyleCommand;
 
 export enum ExtensionCommandType {
     ReloadCheckout = 'EXTENSION:RELOAD_CHECKOUT',
     ShowLoadingIndicator = 'EXTENSION:SHOW_LOADING_INDICATOR',
     SetIframeStyle = 'EXTENSION:SET_IFRAME_STYLE',
-    GetConsignments = 'EXTENSION:GET_CONSIGNMENTS',
-}
-
-export interface ExtensionCommandContext {
-    extensionId: string;
 }
 
 export interface ReloadCheckoutCommand {
@@ -39,13 +29,8 @@ export interface SetIframeStyleCommand {
     };
 }
 
-export interface GetConsignmentsCommand {
-    type: ExtensionCommandType.GetConsignments;
-}
-
 export interface ExtensionCommandMap {
     [ExtensionCommandType.ReloadCheckout]: ReloadCheckoutCommand;
     [ExtensionCommandType.ShowLoadingIndicator]: ShowLoadingIndicatorCommand;
     [ExtensionCommandType.SetIframeStyle]: SetIframeStyleCommand;
-    [ExtensionCommandType.GetConsignments]: GetConsignmentsCommand;
 }

--- a/packages/core/src/extension/extension-message.ts
+++ b/packages/core/src/extension/extension-message.ts
@@ -1,6 +1,8 @@
 import { Consignment } from '../shipping';
 
+import { ExtensionCommand } from './extension-commands';
 import { ExtensionEvent } from './extension-events';
+import { ExtensionQuery } from './extension-queries';
 
 export const enum ExtensionMessageType {
     GetConsignments = 'EXTENSION:GET_CONSIGNMENTS',
@@ -18,3 +20,9 @@ export type ExtensionMessage = ExtensionEvent | GetConsignmentsMessage;
 export interface ExtensionMessageMap {
     [ExtensionMessageType.GetConsignments]: GetConsignmentsMessage;
 }
+
+export interface ExtensionCommandOrQueryContext {
+    extensionId: string;
+}
+
+export type ExtensionCommandOrQuery = ExtensionCommand | ExtensionQuery;

--- a/packages/core/src/extension/extension-message.ts
+++ b/packages/core/src/extension/extension-message.ts
@@ -14,3 +14,7 @@ export interface GetConsignmentsMessage {
 }
 
 export type ExtensionMessage = ExtensionEvent | GetConsignmentsMessage;
+
+export interface ExtensionMessageMap {
+    [ExtensionMessageType.GetConsignments]: GetConsignmentsMessage;
+}

--- a/packages/core/src/extension/extension-messenger.spec.ts
+++ b/packages/core/src/extension/extension-messenger.spec.ts
@@ -4,16 +4,21 @@ import { createCheckoutStore, ReadableCheckoutStore } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 
-import { ExtensionNotFoundError } from './errors';
-import { UnsupportedExtensionCommandError } from './errors/unsupported-extension-command-error';
+import {
+    ExtensionNotFoundError,
+    UnsupportedExtensionCommandError,
+    UnsupportedExtensionQueryError,
+} from './errors';
 import { Extension } from './extension';
 import { ExtensionCommandMap, ExtensionCommandType } from './extension-commands';
 import { ExtensionEvent } from './extension-events';
 import { ExtensionMessenger } from './extension-messenger';
+import { ExtensionQueryMap, ExtensionQueryType } from './extension-queries';
 import { getExtensionEvent, getExtensions } from './extension.mock';
 
 describe('ExtensionMessenger', () => {
     let extensionCommandHandler: jest.Mock;
+    let extensionQueryHandler: jest.Mock;
     let extension: Extension;
     let extensionMessenger: ExtensionMessenger;
     let event: {
@@ -27,9 +32,10 @@ describe('ExtensionMessenger', () => {
         extension = getExtensions()[0];
         event = getExtensionEvent();
         extensionCommandHandler = jest.fn();
+        extensionQueryHandler = jest.fn();
     });
 
-    describe('#listen() and #stopListen()', () => {
+    describe('#listenForCommand', () => {
         let listener: IframeEventListener<ExtensionCommandMap>;
 
         beforeEach(() => {
@@ -39,12 +45,12 @@ describe('ExtensionMessenger', () => {
                 [extension.id]: listener,
             };
 
-            extensionMessenger = new ExtensionMessenger(store, listeners, {});
+            extensionMessenger = new ExtensionMessenger(store, listeners, {}, {});
         });
 
-        it('should throw if unable to find the extensiion', () => {
+        it('should throw if unable to find the extension', () => {
             expect(() =>
-                extensionMessenger.listen(
+                extensionMessenger.listenForCommand(
                     'xxx',
                     ExtensionCommandType.ReloadCheckout,
                     extensionCommandHandler,
@@ -54,7 +60,7 @@ describe('ExtensionMessenger', () => {
 
         it('should throw if trying to listen for an unsupported command', () => {
             expect(() =>
-                extensionMessenger.listen(
+                extensionMessenger.listenForCommand(
                     extension.id,
                     'INVALID_COMMAND' as ExtensionCommandType,
                     extensionCommandHandler,
@@ -73,7 +79,7 @@ describe('ExtensionMessenger', () => {
                 });
             });
 
-            extensionMessenger.listen(
+            extensionMessenger.listenForCommand(
                 extension.id,
                 ExtensionCommandType.ReloadCheckout,
                 extensionCommandHandler,
@@ -100,7 +106,7 @@ describe('ExtensionMessenger', () => {
                 });
             });
 
-            extensionMessenger.listen(
+            extensionMessenger.listenForCommand(
                 extension.id,
                 ExtensionCommandType.ReloadCheckout,
                 extensionCommandHandler,
@@ -132,7 +138,7 @@ describe('ExtensionMessenger', () => {
                 eventEmitter.removeAllListeners(type);
             });
 
-            const remover = extensionMessenger.listen(
+            const remover = extensionMessenger.listenForCommand(
                 extension.id,
                 ExtensionCommandType.ReloadCheckout,
                 extensionCommandHandler,
@@ -150,10 +156,144 @@ describe('ExtensionMessenger', () => {
         it('should stop listening', () => {
             jest.spyOn(listener, 'stopListen');
 
-            extensionMessenger.listen(
+            extensionMessenger.listenForCommand(
                 extension.id,
                 ExtensionCommandType.ReloadCheckout,
                 extensionCommandHandler,
+            );
+
+            extensionMessenger.stopListen(extension.id);
+
+            // FIXME
+            expect(listener.stopListen).toHaveBeenCalled();
+        });
+    });
+
+    describe('#listenForQuery', () => {
+        let listener: IframeEventListener<ExtensionQueryMap>;
+
+        beforeEach(() => {
+            listener = new IframeEventListener(extension.url);
+
+            const listeners = {
+                [extension.id]: listener,
+            };
+
+            extensionMessenger = new ExtensionMessenger(store, {}, listeners, {});
+        });
+
+        it('should throw if unable to find the extension', () => {
+            expect(() =>
+                extensionMessenger.listenForQuery(
+                    'xxx',
+                    ExtensionQueryType.GetConsignments,
+                    extensionQueryHandler,
+                ),
+            ).toThrow(ExtensionNotFoundError);
+        });
+
+        it('should throw if trying to listen for an unsupported command', () => {
+            expect(() =>
+                extensionMessenger.listenForQuery(
+                    extension.id,
+                    'INVALID_QUERY' as ExtensionQueryType,
+                    extensionQueryHandler,
+                ),
+            ).toThrow(UnsupportedExtensionQueryError);
+        });
+
+        it('should listen and add an event listener', () => {
+            const eventEmitter = new EventEmitter();
+
+            jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
+                eventEmitter.addListener(type, ({ context }) => {
+                    if (type === ExtensionQueryType.GetConsignments) {
+                        listener({ type }, context);
+                    }
+                });
+            });
+
+            extensionMessenger.listenForQuery(
+                extension.id,
+                ExtensionQueryType.GetConsignments,
+                extensionQueryHandler,
+            );
+
+            eventEmitter.emit(ExtensionQueryType.GetConsignments, {
+                context: { extensionId: extension.id },
+            });
+
+            expect(extensionQueryHandler).toHaveBeenCalledWith(
+                { type: ExtensionQueryType.GetConsignments },
+                { extensionId: extension.id },
+            );
+        });
+
+        it('should listen to commands emitted by same extension', () => {
+            const eventEmitter = new EventEmitter();
+
+            jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
+                eventEmitter.addListener(type, ({ context }) => {
+                    if (type === ExtensionQueryType.GetConsignments) {
+                        listener({ type }, context);
+                    }
+                });
+            });
+
+            extensionMessenger.listenForQuery(
+                extension.id,
+                ExtensionQueryType.GetConsignments,
+                extensionQueryHandler,
+            );
+
+            eventEmitter.emit(ExtensionQueryType.GetConsignments, {
+                context: { extensionId: extension.id },
+            });
+
+            eventEmitter.emit(ExtensionQueryType.GetConsignments, {
+                context: { extensionId: getExtensions()[1].id },
+            });
+
+            expect(extensionQueryHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it('should remove the event listener', () => {
+            const eventEmitter = new EventEmitter();
+
+            jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
+                eventEmitter.addListener(type, ({ context }) => {
+                    if (type === ExtensionQueryType.GetConsignments) {
+                        listener({ type }, context);
+                    }
+                });
+            });
+
+            jest.spyOn(listener, 'removeListener').mockImplementation((type) => {
+                eventEmitter.removeAllListeners(type);
+            });
+
+            const remover = extensionMessenger.listenForQuery(
+                extension.id,
+                ExtensionQueryType.GetConsignments,
+                extensionQueryHandler,
+            );
+
+            remover();
+
+            eventEmitter.emit(ExtensionQueryType.GetConsignments, {
+                context: { extensionId: extension.id },
+            });
+
+            expect(extensionQueryHandler).not.toHaveBeenCalled();
+        });
+
+        it('should stop listening', () => {
+            jest.spyOn(listener, 'stopListen');
+
+            extensionMessenger.listenForQuery(
+                extension.id,
+                ExtensionQueryType.GetConsignments,
+                extensionQueryHandler,
             );
 
             extensionMessenger.stopListen(extension.id);
@@ -167,7 +307,7 @@ describe('ExtensionMessenger', () => {
         it('should log out the error if an extension has not yet been rendered', () => {
             document.querySelector = jest.fn().mockReturnValue(undefined);
 
-            extensionMessenger = new ExtensionMessenger(store, {}, {});
+            extensionMessenger = new ExtensionMessenger(store, {}, {}, {});
 
             jest.spyOn(extensionMessenger, 'clearCacheById');
             jest.spyOn(console, 'log');
@@ -190,7 +330,7 @@ describe('ExtensionMessenger', () => {
                 [extension.id]: poster,
             };
 
-            extensionMessenger = new ExtensionMessenger(store, {}, posters);
+            extensionMessenger = new ExtensionMessenger(store, {}, {}, posters);
 
             document.querySelector = jest.fn().mockReturnValue(container);
 

--- a/packages/core/src/extension/extension-queries.ts
+++ b/packages/core/src/extension/extension-queries.ts
@@ -1,0 +1,16 @@
+export type ExtensionQuery = GetConsignmentsQuery;
+
+export enum ExtensionQueryType {
+    GetConsignments = 'EXTENSION:GET_CONSIGNMENTS',
+}
+
+export interface GetConsignmentsQuery {
+    type: ExtensionQueryType.GetConsignments;
+    payload?: {
+        useCache?: boolean;
+    };
+}
+
+export interface ExtensionQueryMap {
+    [ExtensionQueryType.GetConsignments]: GetConsignmentsQuery;
+}

--- a/packages/core/src/extension/extension-service.spec.ts
+++ b/packages/core/src/extension/extension-service.spec.ts
@@ -124,7 +124,7 @@ describe('ExtensionService', () => {
         );
     });
 
-    it('gets data instantly', async () => {
+    it('getConsignments()', async () => {
         const eventEmitter = new EventEmitter();
         const replyMessage: GetConsignmentsMessage = {
             type: ExtensionMessageType.GetConsignments,

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -9,6 +9,7 @@ export { createExtensionEventBroadcaster } from './create-extension-event-broadc
 export { ExtensionIframe } from './extension-iframe';
 export { ExtensionMessenger } from './extension-messenger';
 export { ExtensionCommand, ExtensionCommandType, ExtensionCommandMap } from './extension-commands';
+export { ExtensionQuery, ExtensionQueryType, ExtensionQueryMap } from './extension-queries';
 export { extensionReducer } from './extension-reducer';
 export { ExtensionRequestSender } from './extension-request-sender';
 export {

--- a/packages/core/src/extension/initialize-extension-service.ts
+++ b/packages/core/src/extension/initialize-extension-service.ts
@@ -4,10 +4,10 @@ import {
     setupContentWindowForIframeResizer,
 } from '../common/iframe';
 
-import { ExtensionCommand, ExtensionCommandContext } from './extension-commands';
+import { ExtensionCommand } from './extension-commands';
 import { ExtensionEventMap } from './extension-events';
 import { ExtensionInternalCommand } from './extension-internal-commands';
-import { ExtensionMessageMap } from './extension-message';
+import {ExtensionCommandOrQueryContext, ExtensionMessageMap} from './extension-message';
 import ExtensionService from './extension-service';
 import { iframeResizerSetup } from './iframe-resizer-setup';
 
@@ -28,7 +28,7 @@ export default async function initializeExtensionService(
     const extension = new ExtensionService(
         new IframeEventListener<ExtensionMessageMap>(parentOrigin),
         new IframeEventListener<ExtensionEventMap>(parentOrigin),
-        new IframeEventPoster<ExtensionCommand, ExtensionCommandContext>(parentOrigin),
+        new IframeEventPoster<ExtensionCommand, ExtensionCommandOrQueryContext>(parentOrigin),
         new IframeEventPoster<ExtensionInternalCommand>(parentOrigin),
     );
 

--- a/packages/core/src/extension/initialize-extension-service.ts
+++ b/packages/core/src/extension/initialize-extension-service.ts
@@ -7,6 +7,7 @@ import {
 import { ExtensionCommand, ExtensionCommandContext } from './extension-commands';
 import { ExtensionEventMap } from './extension-events';
 import { ExtensionInternalCommand } from './extension-internal-commands';
+import { ExtensionMessageMap } from './extension-message';
 import ExtensionService from './extension-service';
 import { iframeResizerSetup } from './iframe-resizer-setup';
 
@@ -25,6 +26,7 @@ export default async function initializeExtensionService(
     setupContentWindowForIframeResizer();
 
     const extension = new ExtensionService(
+        new IframeEventListener<ExtensionMessageMap>(parentOrigin),
         new IframeEventListener<ExtensionEventMap>(parentOrigin),
         new IframeEventPoster<ExtensionCommand, ExtensionCommandContext>(parentOrigin),
         new IframeEventPoster<ExtensionInternalCommand>(parentOrigin),

--- a/packages/core/src/extension/initialize-extension-service.ts
+++ b/packages/core/src/extension/initialize-extension-service.ts
@@ -7,7 +7,7 @@ import {
 import { ExtensionCommand } from './extension-commands';
 import { ExtensionEventMap } from './extension-events';
 import { ExtensionInternalCommand } from './extension-internal-commands';
-import {ExtensionCommandOrQueryContext, ExtensionMessageMap} from './extension-message';
+import { ExtensionCommandOrQueryContext, ExtensionMessageMap } from './extension-message';
 import ExtensionService from './extension-service';
 import { iframeResizerSetup } from './iframe-resizer-setup';
 


### PR DESCRIPTION
## What?
Introduce a new `query` concept that allows an extension to fetch any data from the checkout object by using a simple query key. 

## Why?
An extension can fetch checkout data immediately.

## Testing / Proof
After the extension service initialization, clicking the emoji will run:
```
console.log(await service.getConsignments(useCache));
```
`useCache` is set to `true` at first. On the second time of clicking the emoji, `useCache` will be `false`, therefore, a `GET` checkout call is made.

https://github.com/user-attachments/assets/8e87cdfb-103c-4338-bf1b-73bf2f1d2e28

@bigcommerce/team-checkout @bigcommerce/team-payments
