### PR TITLE
fix(payment): PI-3102 removed error throwing on initialization for am…

### DIFF
--- a/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.spec.ts
@@ -248,6 +248,16 @@ describe('AmazonPayV2PaymentStrategy', () => {
 
                 expect(amazonPayV2PaymentProcessor.initialize).not.toHaveBeenCalled();
             });
+
+            test("payment button wasn't rendered is not provided", async () => {
+                jest.spyOn(amazonPayV2PaymentProcessor, 'renderAmazonPayButton').mockReturnValue(
+                    undefined,
+                );
+
+                await expect(strategy.initialize(initializeOptions)).rejects.toThrow(
+                    'Unable to render the Amazon Pay button to an invalid HTML container element.',
+                );
+            });
         });
     });
 

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.ts
@@ -78,6 +78,12 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
                 placement: AmazonPayV2Placement.Checkout,
                 isButtonMicroTextDisabled,
             });
+
+            if (!this._amazonPayButton) {
+                throw new InvalidArgumentError(
+                    'Unable to render the Amazon Pay button to an invalid HTML container element.',
+                );
+            }
         }
     }
 

--- a/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.spec.ts
@@ -1,7 +1,6 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import {
-    InvalidArgumentError,
     MissingDataError,
     MissingDataErrorType,
     NotInitializedError,
@@ -369,7 +368,7 @@ describe('AmazonPayV2PaymentProcessor', () => {
                 paymentMethods: { getPaymentMethodOrThrow: jest.fn(() => getAmazonPayV2()) },
             } as InternalCheckoutSelectors;
         };
-        // eslint-disable-next-line  @typescript-eslint/no-unsafe-member-access
+
         const stateMock = new PaymentIntegrationServiceMock().getState();
         const getPaymentIntegrationSelectorsMock = () =>
             ({
@@ -610,12 +609,12 @@ describe('AmazonPayV2PaymentProcessor', () => {
 
         describe('should fail...', () => {
             test('if an invalid containerId is provided', async () => {
-                const renderAmazonPayButtonToAnInvalidContainer = () =>
-                    renderAmazonPayButton('bar');
+                const renderResult = renderAmazonPayButton('bar');
 
                 await processor.initialize(amazonPayV2Mock);
 
-                expect(renderAmazonPayButtonToAnInvalidContainer).toThrow(InvalidArgumentError);
+                expect(renderResult).toBeUndefined();
+
                 expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
             });
 

--- a/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
@@ -2,7 +2,6 @@ import {
     CheckoutSettings,
     getShippableItemsCount,
     guard,
-    InvalidArgumentError,
     MissingDataError,
     MissingDataErrorType,
     NotInitializedError,
@@ -124,13 +123,11 @@ export default class AmazonPayV2PaymentProcessor {
         options,
         placement,
         isButtonMicroTextDisabled = false,
-    }: AmazonPayV2ButtonRenderingOptions): HTMLDivElement {
+    }: AmazonPayV2ButtonRenderingOptions): HTMLDivElement | undefined {
         const container = document.querySelector<HTMLElement>(`#${containerId}`);
 
         if (!container) {
-            throw new InvalidArgumentError(
-                'Unable to render the Amazon Pay button to an invalid HTML container element.',
-            );
+            return;
         }
 
         const { id: parentContainerId } = container.appendChild(this.getButtonParentContainer());

--- a/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
@@ -278,16 +278,13 @@ describe('GooglePayPaymentProcessor', () => {
             expect(container.appendChild).toHaveBeenCalledWith(clientMocks.button);
         });
 
-        describe('should fail if:', () => {
+        describe('should not mount button if:', () => {
             test('an invalid container is provided', async () => {
                 await processor.initialize(getGeneric);
 
-                const addPaymentButton = () =>
-                    processor.addPaymentButton('wrong_container_id', buttonOptions);
-
-                expect(addPaymentButton).toThrow(
-                    'Unable to render the Google Pay button to an invalid HTML container element.',
-                );
+                expect(
+                    processor.addPaymentButton('wrong_container_id', buttonOptions),
+                ).toBeUndefined();
             });
 
             test('not initialized', () => {

--- a/packages/google-pay-integration/src/google-pay-payment-processor.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.ts
@@ -5,7 +5,6 @@ import {
     AddressRequestBody,
     BillingAddressRequestBody,
     guard,
-    InvalidArgumentError,
     NotInitializedError,
     NotInitializedErrorType,
     PaymentMethod,
@@ -81,13 +80,11 @@ export default class GooglePayPaymentProcessor {
     addPaymentButton(
         containerId: string,
         options: Omit<GooglePayButtonOptions, 'allowedPaymentMethods'>,
-    ): HTMLElement {
+    ): HTMLElement | undefined {
         const container = document.querySelector<HTMLElement>(`#${containerId}`);
 
         if (!container) {
-            throw new InvalidArgumentError(
-                'Unable to render the Google Pay button to an invalid HTML container element.',
-            );
+            return;
         }
 
         const paymentButton = this._getPaymentsClient().createButton({


### PR DESCRIPTION
…azon-pay and google-pay customer step buttons

## What?
Removed error throwing on initialization for amazon-pay and google-pay customer step buttons.

## Why?
When customer step unmounts faster then payment button start to render, there appeared a modal with error "invalid html container element".
![image](https://github.com/user-attachments/assets/f615cc1f-2bd1-46fa-acc2-0a342656d485)
It's not blocker at all for further checkout  progress, so it's better to hide this error modal for such cases.

Modal will appear only when error happens on the Payment step, it could be real blocker for the further checkout when this button is only available payment option. We gonna show this modal only on payment step 


## Testing / Proof


https://github.com/user-attachments/assets/11bb6065-d920-4074-a77f-da3c69442dd4

https://github.com/user-attachments/assets/9a9725de-1a28-4444-bcff-cf2d163c3050

https://github.com/user-attachments/assets/85a6a8d9-eaab-43c3-81f4-8982fef8d3ee

https://github.com/user-attachments/assets/c9772807-0410-4d12-9af7-53fe4a0086f0





@bigcommerce/team-checkout @bigcommerce/team-payments
