### PR TITLE
feat(payment): PI-3099 update Adyen SDK to Remove iDEAL bank selection dropdown

### DIFF
--- a/packages/adyen-utils/src/adyenv3/adyenv3-script-loader.spec.ts
+++ b/packages/adyen-utils/src/adyenv3/adyenv3-script-loader.spec.ts
@@ -24,14 +24,14 @@ describe('AdyenV3ScriptLoader', () => {
         const adyenClient = getAdyenClient();
         const configuration = getAdyenConfiguration();
         const configurationWithClientKey = getAdyenConfiguration();
-        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.58.0/adyen.js';
+        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.71.1/adyen.js';
         const cssUrl =
-            'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.58.0/adyen.css';
+            'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.71.1/adyen.css';
         const cssOptions = {
             prepend: false,
             attributes: {
                 integrity:
-                    'sha384-zgFNrGzbwuX5qJLys75cOUIGru/BoEzhGMyC07I3OSdHqXuhUfoDPVG03G+61oF4',
+                    'sha384-5MvB4RnzvviA3VBT4KYABZ4HXNZG5LRqREEgd41xt/pf/QvKmsj2O9GuNuywRXx9',
                 crossorigin: 'anonymous',
             },
         };
@@ -39,7 +39,7 @@ describe('AdyenV3ScriptLoader', () => {
             async: true,
             attributes: {
                 integrity:
-                    'sha384-e0EBlzLdOXxOJimp2uut2z1m98HS2cdhQw+OmeJDp7MRCPRNrQhjIWZiWiIscJvf',
+                    'sha384-yvY2yFNR4WqIjPqP9MzjI+gJimmaJnAvj4rLHKvgJbgFD5fMuf8zIJrFJOW8Lhhf',
                 crossorigin: 'anonymous',
             },
         };

--- a/packages/adyen-utils/src/adyenv3/adyenv3-script-loader.ts
+++ b/packages/adyen-utils/src/adyenv3/adyenv3-script-loader.ts
@@ -16,12 +16,12 @@ export default class AdyenV3ScriptLoader {
             this._stylesheetLoader.loadStylesheet(
                 `https://checkoutshopper-${
                     configuration.environment ?? ''
-                }.adyen.com/checkoutshopper/sdk/5.58.0/adyen.css`,
+                }.adyen.com/checkoutshopper/sdk/5.71.1/adyen.css`,
                 {
                     prepend: false,
                     attributes: {
                         integrity:
-                            'sha384-zgFNrGzbwuX5qJLys75cOUIGru/BoEzhGMyC07I3OSdHqXuhUfoDPVG03G+61oF4',
+                            'sha384-5MvB4RnzvviA3VBT4KYABZ4HXNZG5LRqREEgd41xt/pf/QvKmsj2O9GuNuywRXx9',
                         crossorigin: 'anonymous',
                     },
                 },
@@ -29,12 +29,12 @@ export default class AdyenV3ScriptLoader {
             this._scriptLoader.loadScript(
                 `https://checkoutshopper-${
                     configuration.environment ?? ''
-                }.adyen.com/checkoutshopper/sdk/5.58.0/adyen.js`,
+                }.adyen.com/checkoutshopper/sdk/5.71.1/adyen.js`,
                 {
                     async: true,
                     attributes: {
                         integrity:
-                            'sha384-e0EBlzLdOXxOJimp2uut2z1m98HS2cdhQw+OmeJDp7MRCPRNrQhjIWZiWiIscJvf',
+                            'sha384-yvY2yFNR4WqIjPqP9MzjI+gJimmaJnAvj4rLHKvgJbgFD5fMuf8zIJrFJOW8Lhhf',
                         crossorigin: 'anonymous',
                     },
                 },


### PR DESCRIPTION
## What?
Update Adyen SDK to remove iDEAL bank selection dropdown for Adyen

## Why?
iDEAL have updated their central technical infrastructure.
[according to official documentation](https://docs.adyen.com/payment-methods/ideal/).

## Testing / Proof
https://github.com/user-attachments/assets/30b901f6-dd8c-4cef-aa16-9cbb8b2ebd63

<img width="550" alt="Screenshot 2025-01-27 at 12 36 24" src="https://github.com/user-attachments/assets/428a8d29-afab-40b7-ad25-090e9bcc2187" />

![image](https://github.com/user-attachments/assets/d4bd0c25-8056-4a1c-9aa1-57fd8aa1de08)
