### PR TITLE
fix(payment): PAYPAL-5020 added extra check for Buttons implementation in PayPal SDK and added silent log instead of throwing an error to our customer in PPCP customer strategies

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -379,6 +379,20 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                 defaultContainerId,
             );
         });
+
+        it('logs an error when PayPalSDK Buttons implementation is not available for some reasons', async () => {
+            jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(
+                Promise.resolve(undefined),
+            );
+
+            const log = jest.fn();
+
+            jest.spyOn(console, 'error').mockImplementation(log);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(log).toHaveBeenCalled();
+        });
     });
 
     describe('#createOrder button callback', () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -73,7 +73,15 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
             await this.paymentIntegrationService.loadPaymentMethod(methodId);
         }
 
-        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+        const paypalSdk = await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+
+        if (!paypalSdk || !paypalSdk.Buttons || typeof paypalSdk.Buttons !== 'function') {
+            console.error(
+                '[BC PayPal]: PayPal Button could not be rendered, due to issues with loading PayPal SDK',
+            );
+
+            return;
+        }
 
         this.renderButton(methodId, paypalcommercecredit);
     }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -51,7 +51,7 @@ export default class PayPalCommerceIntegrationService {
         providedCurrencyCode?: string,
         initializesOnCheckoutPage?: boolean,
         forceLoad?: boolean,
-    ): Promise<PayPalSDK> {
+    ): Promise<PayPalSDK | undefined> {
         const state = this.paymentIntegrationService.getState();
         const currencyCode = providedCurrencyCode || state.getCartOrThrow().currency.code;
         const paymentMethod =

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
@@ -215,6 +215,20 @@ describe('PayPalCommerceVenmoCustomerStrategy', () => {
                 defaultMethodId,
             );
         });
+
+        it('logs an error when PayPalSDK Buttons implementation is not available for some reasons', async () => {
+            jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(
+                Promise.resolve(undefined),
+            );
+
+            const log = jest.fn();
+
+            jest.spyOn(console, 'error').mockImplementation(log);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(log).toHaveBeenCalled();
+        });
     });
 
     describe('#renderButton', () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
@@ -62,7 +62,15 @@ export default class PayPalCommerceVenmoCustomerStrategy implements CustomerStra
             await this.paymentIntegrationService.loadPaymentMethod(methodId);
         }
 
-        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+        const paypalSdk = await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+
+        if (!paypalSdk || !paypalSdk.Buttons || typeof paypalSdk.Buttons !== 'function') {
+            console.error(
+                '[BC PayPal]: PayPal Button could not be rendered, due to issues with loading PayPal SDK',
+            );
+
+            return;
+        }
 
         this.renderButton(methodId, paypalcommercevenmo);
     }

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -347,6 +347,20 @@ describe('PayPalCommerceCustomerStrategy', () => {
                 defaultContainerId,
             );
         });
+
+        it('logs an error when PayPalSDK Buttons implementation is not available for some reasons', async () => {
+            jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(
+                Promise.resolve(undefined),
+            );
+
+            const log = jest.fn();
+
+            jest.spyOn(console, 'error').mockImplementation(log);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(log).toHaveBeenCalled();
+        });
     });
 
     describe('#createOrder button callback', () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -73,7 +73,15 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
             await this.paymentIntegrationService.loadPaymentMethod(methodId);
         }
 
-        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+        const paypalSdk = await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+
+        if (!paypalSdk || !paypalSdk.Buttons || typeof paypalSdk.Buttons !== 'function') {
+            console.error(
+                '[BC PayPal]: PayPal Button could not be rendered, due to issues with loading PayPal SDK',
+            );
+
+            return;
+        }
 
         this.renderButton(methodId, paypalcommerce);
     }


### PR DESCRIPTION
## What?
Added extra check for Buttons implementation in PayPal SDK and added silent log instead of throwing an error to our customer in PPCP customer strategies.

## Why?
To fix related Sentry issue and do not scare customer with an error when this could be avoided

## Testing / Proof
Unit tests
