### PR TITLE
fix(payment): PI-77 added Adyen es locale mapping

### DIFF
--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -167,6 +167,28 @@ describe('AdyenV3PaymentStrategy', () => {
                 expect(strategy.initialize(options));
                 expect(adyenComponent.mount).not.toHaveBeenCalled();
             });
+
+            it('set ES locale for es locales', () => {
+                jest.spyOn(paymentIntegrationService.getState(), 'getLocale').mockReturnValue(
+                    'es-419',
+                );
+
+                expect(strategy.initialize(options));
+                expect(adyenV3ScriptLoader.load).toHaveBeenCalledWith(
+                    expect.objectContaining({ locale: 'es' }),
+                );
+            });
+
+            it('set correct locale', () => {
+                jest.spyOn(paymentIntegrationService.getState(), 'getLocale').mockReturnValue(
+                    'en_US',
+                );
+
+                expect(strategy.initialize(options));
+                expect(adyenV3ScriptLoader.load).toHaveBeenCalledWith(
+                    expect.objectContaining({ locale: 'en_US' }),
+                );
+            });
         });
 
         describe('#execute', () => {

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -98,7 +98,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
                     : {}),
             },
             environment,
-            locale: this._paymentIntegrationService.getState().getLocale(),
+            locale: this._getLocale(),
             clientKey,
             paymentMethodsResponse,
             showPayButton: false,
@@ -271,6 +271,16 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
 
     private _updateComponentState(componentState: AdyenComponentEventState) {
         this._componentState = componentState;
+    }
+
+    private _getLocale(): string | undefined {
+        const locale = this._paymentIntegrationService.getState().getLocale();
+
+        if (locale && locale.substring(0, 2) === 'es') {
+            return 'es';
+        }
+
+        return locale;
     }
 
     private _getAdyenClient(): AdyenClient {


### PR DESCRIPTION
## What?
Added Adyen es locale mapping

## Why?
To make es-419 withing Adyen components

## Testing / Proof
Before fix Adyen component renders en locale due to the absence of  the es-419 on the Adyen side:
![Screenshot 2025-01-29 at 13 52 20](https://github.com/user-attachments/assets/32932945-328c-41de-a36d-7bd492ec1689)
After fix Adyen component have a correct locale:
![Screenshot 2025-01-29 at 13 49 44](https://github.com/user-attachments/assets/704714b3-b885-4ac6-8e39-567c09036b61)


@bigcommerce/team-checkout @bigcommerce/team-payments
