### PR TITLE
WIP chore(checkout): CHECKOUT-8264 Reset recaptcha if initialize is called twice

### DIFF
--- a/packages/core/src/spam-protection/google-recaptcha.ts
+++ b/packages/core/src/spam-protection/google-recaptcha.ts
@@ -83,7 +83,7 @@ export default class GoogleRecaptcha {
             });
     }
 
-    reset(containerId: string): any {
+    reset(containerId: string): void {
         const element = document.getElementById(containerId);
 
         element?.remove();

--- a/packages/core/src/spam-protection/google-recaptcha.ts
+++ b/packages/core/src/spam-protection/google-recaptcha.ts
@@ -66,16 +66,28 @@ export default class GoogleRecaptcha {
     }
 
     load(containerId: string, sitekey: string): Promise<void> {
-        return this.googleRecaptchaScriptLoader.load().then((recaptcha) => {
-            if (recaptcha) {
-                this._event$ = this._memoized(
-                    recaptcha,
-                    sitekey,
-                    document.getElementById(containerId),
-                );
-                this._recaptcha = recaptcha;
-            }
-        });
+        return this.googleRecaptchaScriptLoader
+            .load()
+            .then((recaptcha) => {
+                if (recaptcha) {
+                    this._event$ = this._memoized(
+                        recaptcha,
+                        sitekey,
+                        document.getElementById(containerId),
+                    );
+                    this._recaptcha = recaptcha;
+                }
+            })
+            .catch((err) => {
+                throw err;
+            });
+    }
+
+    reset(containerId: string): any {
+        const element = document.getElementById(containerId);
+
+        element?.remove();
+        this._recaptcha?.reset(this._widgetId);
     }
 
     execute(): Observable<RecaptchaResult> {

--- a/packages/core/src/spam-protection/spam-protection-action-creator.ts
+++ b/packages/core/src/spam-protection/spam-protection-action-creator.ts
@@ -27,7 +27,7 @@ export default class SpamProtectionActionCreator {
             const isRecaptchaResetExperimentEnabled =
                 state.config.getConfig()?.storeConfig.checkoutSettings.features[
                     'CHECKOUT-8264.recaptcha_error_fix'
-                ] ?? true;
+                ] ?? false;
 
             return concat(
                 of(createAction(SpamProtectionActionType.InitializeRequested, undefined)),


### PR DESCRIPTION
## What?
Reset recaptcha if recaptcha is instantiated twice instead of throwing an error.

## Why?
If we validate recaptcha for apple pay button and if a shopper tries to create a new account, then an error is thrown regarding recaptcha client already created.
In order to fix this, reset recaptcha client and remove the element so recaptcha can be triggered again.

## Testing / Proof
- CI 

#### Experiment off

https://github.com/user-attachments/assets/4a07fee8-d019-4c99-95ce-0220e61c3a78


#### Experiment on

https://github.com/user-attachments/assets/ace96df5-dc89-4317-bcd9-9a42b1e027d2



@bigcommerce/team-checkout @bigcommerce/team-payments
