### PR TITLE
feat(payment): PAYPAL-5041 added phone to order

### DIFF
--- a/packages/paypal-commerce-integration/src/mocks/get-billing-address-from-order-details.mock.ts
+++ b/packages/paypal-commerce-integration/src/mocks/get-billing-address-from-order-details.mock.ts
@@ -9,7 +9,7 @@ export default function getBillingAddressFromOrderDetails(): BillingAddressReque
         firstName: payer.name.given_name,
         lastName: payer.name.surname,
         email: payer.email_address,
-        phone: '',
+        phone: payer.phone?.phone_number.national_number || '',
         company: '',
         address1: payer.address.address_line_1,
         address2: payer.address.address_line_2,

--- a/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-order-details.mock.ts
+++ b/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-order-details.mock.ts
@@ -33,6 +33,11 @@ export default function getPayPalCommerceOrderDetails(): PayPalOrderDetails {
                 postal_code: '95131',
                 country_code: 'US',
             },
+            phone: {
+                phone_number: {
+                    national_number: '123456789',
+                },
+            },
         },
     };
 }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
@@ -499,6 +499,43 @@ describe('PayPalCommerceIntegrationService', () => {
                 customFields: [],
             });
         });
+
+        it('successfully returns valid address with phone number filled in', () => {
+            const paypalOrderDetails = getPayPalCommerceOrderDetails();
+            const address = {
+                firstName: paypalOrderDetails.payer.name.given_name,
+                lastName: paypalOrderDetails.payer.name.surname,
+                email: paypalOrderDetails.payer.email_address,
+                phone: '555',
+                company: '',
+                address1: paypalOrderDetails.payer.address.address_line_1,
+                address2: '',
+                city: paypalOrderDetails.payer.address.admin_area_2,
+                countryCode: paypalOrderDetails.payer.address.country_code,
+                postalCode: paypalOrderDetails.payer.address.postal_code,
+                stateOrProvince: '',
+                stateOrProvinceCode: paypalOrderDetails.payer.address.admin_area_1,
+                customFields: [],
+            };
+
+            const output = subject.getAddress(address);
+
+            expect(output).toStrictEqual({
+                firstName: paypalOrderDetails.payer.name.given_name,
+                lastName: paypalOrderDetails.payer.name.surname,
+                email: paypalOrderDetails.payer.email_address,
+                phone: '555',
+                company: '',
+                address1: paypalOrderDetails.payer.address.address_line_1,
+                address2: '',
+                city: paypalOrderDetails.payer.address.admin_area_2,
+                countryCode: paypalOrderDetails.payer.address.country_code,
+                postalCode: paypalOrderDetails.payer.address.postal_code,
+                stateOrProvince: '',
+                stateOrProvinceCode: paypalOrderDetails.payer.address.admin_area_1,
+                customFields: [],
+            });
+        });
     });
 
     describe('#getBillingAddressFromOrderDetails', () => {
@@ -508,6 +545,42 @@ describe('PayPalCommerceIntegrationService', () => {
             const output = subject.getBillingAddressFromOrderDetails(paypalOrderDetails);
 
             expect(output).toStrictEqual(getBillingAddressFromOrderDetails());
+        });
+
+        it('successfully returns empty string in phone number', () => {
+            const paypalOrderDetails = {
+                ...getPayPalCommerceOrderDetails(),
+                payer: {
+                    ...getPayPalCommerceOrderDetails().payer,
+                    phone: {
+                        phone_number: {
+                            national_number: '',
+                        },
+                    },
+                },
+            };
+
+            const output = subject.getBillingAddressFromOrderDetails(paypalOrderDetails);
+
+            expect(output.phone).toBe('');
+        });
+
+        it('successfully returns correct phone number', () => {
+            const paypalOrderDetails = {
+                ...getPayPalCommerceOrderDetails(),
+                payer: {
+                    ...getPayPalCommerceOrderDetails().payer,
+                    phone: {
+                        phone_number: {
+                            national_number: '555333',
+                        },
+                    },
+                },
+            };
+
+            const output = subject.getBillingAddressFromOrderDetails(paypalOrderDetails);
+
+            expect(output.phone).toBe('555333');
         });
     });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -243,7 +243,7 @@ export default class PayPalCommerceIntegrationService {
             firstName: address?.firstName || '',
             lastName: address?.lastName || '',
             email: address?.email || '',
-            phone: '',
+            phone: address?.phone || '',
             company: '',
             address1: address?.address1 || '',
             address2: address?.address2 || '',
@@ -267,6 +267,7 @@ export default class PayPalCommerceIntegrationService {
             countryCode: payer.address.country_code,
             postalCode: payer.address.postal_code,
             stateOrProvinceCode: payer.address.admin_area_1,
+            phone: payer.phone?.phone_number?.national_number,
         });
     }
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -444,6 +444,11 @@ export interface PayPalOrderDetails {
         };
         email_address: string;
         address: PayPalOrderAddress;
+        phone?: {
+            phone_number: {
+                national_number: string;
+            };
+        };
     };
     purchase_units: Array<{
         shipping: {


### PR DESCRIPTION
## What?
Added phone number to be displayed on CP order section

## Why?
To give merchants ability to see phone number inside CP in orders section

## Testing / Proof
**Before**

<img width="1251" alt="Screenshot 2025-02-03 at 14 05 50" src="https://github.com/user-attachments/assets/4867a3ff-3ad6-4145-bf26-38e54212ec0a" />

**After**
<img width="1251" alt="Screenshot 2025-02-03 at 14 04 35" src="https://github.com/user-attachments/assets/caad1691-941a-469c-9d5e-822d563a3073" />

@bigcommerce/team-checkout @bigcommerce/team-payments
