### PR TITLE
feat(extension): CHECKOUT-8974 Introduce ReRenderShippingForm Command

### DIFF
--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -1468,7 +1468,7 @@ export default class CheckoutService {
     handleExtensionCommand<T extends keyof ExtensionCommandMap>(
         extensionId: string,
         command: T,
-        handler: (command: ExtensionCommandMap[T]) => void,
+        handler: (command: ExtensionCommandMap[T]) => Promise<void> | void,
     ): () => void {
         return this._extensionMessenger.listenForCommand(extensionId, command, handler);
     }
@@ -1485,7 +1485,7 @@ export default class CheckoutService {
     handleExtensionQuery<T extends keyof ExtensionQueryMap>(
         extensionId: string,
         query: T,
-        handler: (command: ExtensionQueryMap[T]) => void,
+        handler: (command: ExtensionQueryMap[T]) => Promise<void> | void,
     ): () => void {
         return this._extensionMessenger.listenForQuery(extensionId, query, handler);
     }

--- a/packages/core/src/extension/extension-commands.ts
+++ b/packages/core/src/extension/extension-commands.ts
@@ -1,12 +1,14 @@
 export type ExtensionCommand =
     | ReloadCheckoutCommand
     | ShowLoadingIndicatorCommand
-    | SetIframeStyleCommand;
+    | SetIframeStyleCommand
+    | ReRenderShippingForm;
 
 export enum ExtensionCommandType {
     ReloadCheckout = 'EXTENSION:RELOAD_CHECKOUT',
     ShowLoadingIndicator = 'EXTENSION:SHOW_LOADING_INDICATOR',
     SetIframeStyle = 'EXTENSION:SET_IFRAME_STYLE',
+    ReRenderShippingForm = 'EXTENSION:RE_RENDER_SHIPPING_FORM',
 }
 
 export interface ReloadCheckoutCommand {
@@ -29,8 +31,13 @@ export interface SetIframeStyleCommand {
     };
 }
 
+export interface ReRenderShippingForm {
+    type: ExtensionCommandType.ReRenderShippingForm;
+}
+
 export interface ExtensionCommandMap {
     [ExtensionCommandType.ReloadCheckout]: ReloadCheckoutCommand;
     [ExtensionCommandType.ShowLoadingIndicator]: ShowLoadingIndicatorCommand;
     [ExtensionCommandType.SetIframeStyle]: SetIframeStyleCommand;
+    [ExtensionCommandType.ReRenderShippingForm]: ReRenderShippingForm;
 }

--- a/packages/core/src/extension/extension-messenger.ts
+++ b/packages/core/src/extension/extension-messenger.ts
@@ -52,7 +52,7 @@ export class ExtensionMessenger {
         commandHandler: (
             command: ExtensionCommandMap[T],
             context?: ExtensionCommandOrQueryContext,
-        ) => void,
+        ) => Promise<void> | void,
     ): () => void {
         const extension = this._getExtensionById(extensionId);
 
@@ -88,7 +88,7 @@ export class ExtensionMessenger {
         queryHandler: (
             query: ExtensionQueryMap[T],
             context?: ExtensionCommandOrQueryContext,
-        ) => void,
+        ) => Promise<void> | void,
     ): () => void {
         const extension = this._getExtensionById(extensionId);
 


### PR DESCRIPTION
## What?
Introduce a new checkout extension command.

## Why?
To support the force re-rendering of the shipping form.

## Testing / Proof
CI.

@bigcommerce/team-checkout @bigcommerce/team-payments
