### PR TITLE
feat(payment): PI-3064 fixed AmazonPay button for disabled ph4 flag

### DIFF
--- a/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
@@ -225,7 +225,7 @@ export default class AmazonPayV2PaymentProcessor {
             isButtonMicroTextDisabled,
         } = initializationData;
 
-        if (!merchantId || !ledgerCurrency || !createCheckoutSessionConfig) {
+        if (!merchantId || !ledgerCurrency) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
@@ -258,6 +258,10 @@ export default class AmazonPayV2PaymentProcessor {
         } = getStoreConfigOrThrow();
 
         if (this.isPh4Enabled(features, storeCountryCode)) {
+            if (!createCheckoutSessionConfig) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
             const amount = getCheckout()?.outstandingBalance.toString();
             const currencyCode = cart?.currency.code;
             const buttonOptions: AmazonPayV2NewButtonParams = { ...buttonBaseConfig };


### PR DESCRIPTION
## What?
fixed AmazonPay button for disabled ph4 flag

## Why?
Due to the error for some merchant that have disabled manually phase 4 feature flag

## Testing / Proof
before:
![Screenshot 2025-02-06 at 14 54 24](https://github.com/user-attachments/assets/e0d18ca4-24cf-4b8f-ab60-3cda514379ce)

After:
https://github.com/user-attachments/assets/b824fced-5a9a-40d2-9820-d898de750350



@bigcommerce/team-checkout @bigcommerce/team-payments
