### PR TITLE
feat(payment): PAYPAL-4324 Fixed creation of native button for apple pay

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -161,7 +161,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
     }
 
     private _createNativeButton(): HTMLElement {
-        const applePayButton = document.createElement('div');
+        const applePayButton = document.createElement('button');
 
         applePayButton.setAttribute('type', 'button');
         applePayButton.setAttribute('aria-label', 'Apple Pay');


### PR DESCRIPTION
## What?

Fixed creation of native button for apple pay

## Why?

To fix e2e test in checkout-js

## Testing / Proof

<img width="948" alt="Screenshot 2025-02-06 at 14 22 50" src="https://github.com/user-attachments/assets/3e2511ac-b583-4216-8357-8c3e656bb32a" />


@bigcommerce/team-checkout @bigcommerce/team-payments
