### PR TITLE
feat(payment): PI-2875 Google Pay coupons handling

### DIFF
--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -12,6 +12,8 @@ import {
     CheckoutValidator,
 } from '../checkout';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import CouponActionCreator from '../coupon/coupon-action-creator';
+import CouponRequestSender from '../coupon/coupon-request-sender';
 import { CustomerActionCreator, CustomerRequestSender } from '../customer';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { HostedFormFactory } from '../hosted-form';
@@ -112,6 +114,10 @@ export default function createPaymentIntegrationService(
         new StoreCreditRequestSender(requestSender),
     );
 
+    const applyCouponActionCreator = new CouponActionCreator(
+        new CouponRequestSender(requestSender),
+    );
+
     const spamProtection = createSpamProtection(createScriptLoader());
     const spamProtectionRequestSender = new SpamProtectionRequestSender(requestSender);
     const spamProtectionActionCreator = new SpamProtectionActionCreator(
@@ -150,6 +156,7 @@ export default function createPaymentIntegrationService(
         customerActionCreator,
         cartRequestSender,
         storeCreditActionCreator,
+        applyCouponActionCreator,
         spamProtectionActionCreator,
         paymentProviderCustomerActionCreator,
         shippingCountryActionCreator,

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -24,6 +24,7 @@ import {
 } from '../checkout';
 import { DataStoreProjection } from '../common/data-store';
 import { getResponse } from '../common/http-request/responses.mock';
+import { CouponActionCreator } from '../coupon';
 import { CustomerActionCreator } from '../customer';
 import { HostedForm, HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator } from '../order';
@@ -84,6 +85,7 @@ describe('DefaultPaymentIntegrationService', () => {
     let customerActionCreator: Pick<CustomerActionCreator, 'signInCustomer' | 'signOutCustomer'>;
     let cartRequestSender: CartRequestSender;
     let storeCreditActionCreator: Pick<StoreCreditActionCreator, 'applyStoreCredit'>;
+    let couponActionCreator: Pick<CouponActionCreator, 'applyCoupon' | 'removeCoupon'>;
     let paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator;
     let shippingCountryActionCreator: Pick<ShippingCountryActionCreator, 'loadCountries'>;
     let remoteCheckoutActionCreator: Pick<
@@ -226,6 +228,17 @@ describe('DefaultPaymentIntegrationService', () => {
             ),
         };
 
+        couponActionCreator = {
+            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            applyCoupon: jest.fn(async () => () => createAction('APPLY_COUPON_REQUESTED')),
+            // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            removeCoupon: jest.fn(async () => () => createAction('REMOVE_COUPON_REQUESTED')),
+        };
+
         spamProtectionActionCreator = {
             // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -295,6 +308,7 @@ describe('DefaultPaymentIntegrationService', () => {
             customerActionCreator as CustomerActionCreator,
             cartRequestSender,
             storeCreditActionCreator as StoreCreditActionCreator,
+            couponActionCreator as CouponActionCreator,
             spamProtectionActionCreator as SpamProtectionActionCreator,
             paymentProviderCustomerActionCreator,
             shippingCountryActionCreator as ShippingCountryActionCreator,
@@ -567,6 +581,44 @@ describe('DefaultPaymentIntegrationService', () => {
             });
             expect(store.dispatch).toHaveBeenCalledWith(
                 storeCreditActionCreator.applyStoreCredit(true, {
+                    params: {},
+                }),
+            );
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#applyCoupon', () => {
+        it('applies a coupon', async () => {
+            const coupon = 'some_coupon';
+            const output = await subject.applyCoupon(coupon, {
+                params: {},
+            });
+
+            expect(couponActionCreator.applyCoupon).toHaveBeenCalledWith(coupon, {
+                params: {},
+            });
+            expect(store.dispatch).toHaveBeenCalledWith(
+                couponActionCreator.applyCoupon(coupon, {
+                    params: {},
+                }),
+            );
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#removeCoupon', () => {
+        it('removes a coupon', async () => {
+            const coupon = 'some_coupon';
+            const output = await subject.removeCoupon(coupon, {
+                params: {},
+            });
+
+            expect(couponActionCreator.removeCoupon).toHaveBeenCalledWith(coupon, {
+                params: {},
+            });
+            expect(store.dispatch).toHaveBeenCalledWith(
+                couponActionCreator.removeCoupon(coupon, {
                     params: {},
                 }),
             );

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -17,6 +17,7 @@ import { BillingAddressActionCreator } from '../billing';
 import { CartRequestSender } from '../cart';
 import { Checkout, CheckoutActionCreator, CheckoutStore, CheckoutValidator } from '../checkout';
 import { DataStoreProjection } from '../common/data-store';
+import CouponActionCreator from '../coupon/coupon-action-creator';
 import { CustomerActionCreator, CustomerCredentials } from '../customer';
 import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator } from '../order';
@@ -54,6 +55,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _customerActionCreator: CustomerActionCreator,
         private _cartRequestSender: CartRequestSender,
         private _storeCreditActionCreator: StoreCreditActionCreator,
+        private _couponActionCreator: CouponActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator,
         private _paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator,
         private _shippingCountryActionCreator: ShippingCountryActionCreator,
@@ -211,6 +213,24 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         await this._store.dispatch(
             this._storeCreditActionCreator.applyStoreCredit(useStoreCredit, options),
         );
+
+        return this._storeProjection.getState();
+    }
+
+    async applyCoupon(
+        coupon: string,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(this._couponActionCreator.applyCoupon(coupon, options));
+
+        return this._storeProjection.getState();
+    }
+
+    async removeCoupon(
+        coupon: string,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(this._couponActionCreator.removeCoupon(coupon, options));
 
         return this._storeProjection.getState();
     }

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
@@ -2,10 +2,13 @@ import {
     InvalidArgumentError,
     MissingDataError,
     NotInitializedError,
+    PaymentIntegrationSelectors,
     PaymentIntegrationService,
+    RequestOptions,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBillingAddress,
+    getConfig,
     getConsignment,
     getShippingOption,
     PaymentIntegrationServiceMock,
@@ -13,13 +16,31 @@ import {
 
 import getCardDataResponse from '../mocks/google-pay-card-data-response.mock';
 import { getAuthorizeNet, getGeneric } from '../mocks/google-pay-payment-method.mock';
-import { CallbackIntentsType, CallbackTriggerType, GooglePayFullBillingAddress } from '../types';
+import {
+    CallbackIntentsType,
+    CallbackTriggerType,
+    ErrorReasonType,
+    GooglePayFullBillingAddress,
+} from '../types';
 
 import GooglePayGateway from './google-pay-gateway';
+
+import SpyInstance = jest.SpyInstance;
 
 describe('GooglePayGateway', () => {
     let gateway: GooglePayGateway;
     let paymentIntegrationService: PaymentIntegrationService;
+    const storeConfig = getConfig().storeConfig;
+    const storeConfigWithFeaturesOn = {
+        ...storeConfig,
+        checkoutSettings: {
+            ...storeConfig.checkoutSettings,
+            features: {
+                ...storeConfig.checkoutSettings.features,
+                'PI-2875.googlepay_coupons_handling': true,
+            },
+        },
+    };
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -27,6 +48,10 @@ describe('GooglePayGateway', () => {
 
         jest.spyOn(paymentIntegrationService, 'loadShippingCountries').mockResolvedValue(
             paymentIntegrationService.getState(),
+        );
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfigOrThrow').mockReturnValue(
+            storeConfigWithFeaturesOn,
         );
 
         gateway = new GooglePayGateway('example', paymentIntegrationService);
@@ -256,6 +281,7 @@ describe('GooglePayGateway', () => {
                     CallbackTriggerType.INITIALIZE,
                     CallbackTriggerType.SHIPPING_ADDRESS,
                     CallbackTriggerType.SHIPPING_OPTION,
+                    CallbackTriggerType.OFFER,
                 ],
                 initializationTrigger: [CallbackTriggerType.INITIALIZE],
                 addressChangeTriggers: [
@@ -263,6 +289,7 @@ describe('GooglePayGateway', () => {
                     CallbackTriggerType.SHIPPING_ADDRESS,
                 ],
                 shippingOptionsChangeTriggers: [CallbackTriggerType.SHIPPING_OPTION],
+                offerChangeTriggers: [CallbackTriggerType.OFFER],
             };
 
             await gateway.initialize(getGeneric);
@@ -354,6 +381,192 @@ describe('GooglePayGateway', () => {
             await gateway.initialize(initializeData);
 
             expect(await gateway.getNonce('methodId')).toBe('gpay-nonce');
+        });
+    });
+
+    describe('#handleCoupons', () => {
+        const removeCouponButton = {
+            ...document.createElement('a'),
+            click: jest.fn(),
+        };
+        const couponCodeInput = {
+            ...document.createElement('input'),
+        };
+
+        const form = {
+            ...document.createElement('form'),
+            dispatchEvent: jest.fn(),
+        };
+
+        let applyCouponIntegrationService: SpyInstance<
+            Promise<PaymentIntegrationSelectors>,
+            [coupon: string, options?: RequestOptions<Record<string, unknown>> | undefined]
+        >;
+
+        beforeEach(() => {
+            applyCouponIntegrationService = jest.spyOn(paymentIntegrationService, 'applyCoupon');
+
+            jest.spyOn(document, 'getElementById').mockImplementation((selector: string) => {
+                switch (selector) {
+                    case 'couponcode':
+                        return couponCodeInput;
+
+                    default:
+                        return null;
+                }
+            });
+
+            jest.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+                switch (selector) {
+                    case 'a[href*="/cart.php?action=removecoupon"]':
+                        return removeCouponButton;
+
+                    case '.coupon-form':
+                        return form;
+
+                    default:
+                        return null;
+                }
+            });
+            jest.spyOn(gateway, 'removeAllCoupons');
+        });
+
+        it('should return applied coupon code', async () => {
+            jest.spyOn(gateway, 'getAppliedCoupons')
+                .mockReturnValueOnce({ offers: [] })
+                .mockReturnValueOnce({
+                    offers: [{ redemptionCode: 'code1', description: 'some description' }],
+                });
+
+            await gateway.initialize(getGeneric);
+
+            const result = await gateway.handleCoupons({
+                redemptionCodes: ['code1'],
+            });
+
+            expect(applyCouponIntegrationService).toHaveBeenCalledWith('code1');
+            expect(result).toStrictEqual({
+                error: undefined,
+                newOfferInfo: {
+                    offers: [
+                        {
+                            description: 'some description',
+                            redemptionCode: 'code1',
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('should return a google pay error object if there is a coupon code already applied', async () => {
+            jest.spyOn(gateway, 'getAppliedCoupons').mockReturnValueOnce({
+                offers: [{ redemptionCode: 'code2', description: 'some description' }],
+            });
+
+            await gateway.initialize(getGeneric);
+
+            const result = await gateway.handleCoupons({
+                redemptionCodes: ['code1'],
+            });
+
+            expect(result).toStrictEqual({
+                error: {
+                    intent: CallbackTriggerType.OFFER,
+                    message: 'You can only apply one promo code per order.',
+                    reason: ErrorReasonType.OFFER_INVALID,
+                },
+                newOfferInfo: {
+                    offers: [
+                        {
+                            description: 'some description',
+                            redemptionCode: 'code2',
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('should call removeAllCoupons if there is no coupon codes came in the arguments', async () => {
+            jest.spyOn(gateway, 'getAppliedCoupons').mockReturnValueOnce({
+                offers: [{ redemptionCode: 'code_123', description: 'some description' }],
+            });
+
+            await gateway.initialize(getGeneric);
+            await gateway.handleCoupons({
+                redemptionCodes: [],
+            });
+
+            expect(gateway.removeAllCoupons).toHaveBeenCalledWith({
+                offers: [
+                    {
+                        description: 'some description',
+                        redemptionCode: 'code_123',
+                    },
+                ],
+            });
+            expect(removeCouponButton.click).toHaveBeenCalled();
+        });
+
+        it('should return applied coupon code if there is cart page selectors (behaviour on the cart page)', async () => {
+            jest.spyOn(gateway, 'getAppliedCoupons')
+                .mockReturnValueOnce({ offers: [] })
+                .mockReturnValueOnce({
+                    offers: [{ redemptionCode: 'code444', description: 'some description' }],
+                });
+
+            await gateway.initialize(getGeneric);
+
+            const result = await gateway.handleCoupons({
+                redemptionCodes: ['code444'],
+            });
+
+            expect(applyCouponIntegrationService).toHaveBeenCalledWith('code444');
+            expect(result).toStrictEqual({
+                error: undefined,
+                newOfferInfo: {
+                    offers: [
+                        {
+                            description: 'some description',
+                            redemptionCode: 'code444',
+                        },
+                    ],
+                },
+            });
+            expect(couponCodeInput.value).toBe('code444');
+            expect(form.dispatchEvent).toHaveBeenCalled();
+        });
+
+        it('should return Google Pay error object if applyCoupon is failed', async () => {
+            jest.spyOn(gateway, 'getAppliedCoupons')
+                .mockReturnValueOnce({ offers: [] })
+                .mockReturnValueOnce({
+                    offers: [{ redemptionCode: 'code444', description: 'some description' }],
+                });
+            jest.spyOn(paymentIntegrationService, 'applyCoupon').mockRejectedValueOnce(
+                new Error('Coupon error'),
+            );
+
+            await gateway.initialize(getGeneric);
+
+            const result = await gateway.handleCoupons({
+                redemptionCodes: ['code444'],
+            });
+
+            expect(result).toStrictEqual({
+                error: {
+                    intent: 'OFFER',
+                    message: 'Coupon error',
+                    reason: 'OFFER_INVALID',
+                },
+                newOfferInfo: {
+                    offers: [
+                        {
+                            description: 'some description',
+                            redemptionCode: 'code444',
+                        },
+                    ],
+                },
+            });
         });
     });
 

--- a/packages/google-pay-integration/src/google-pay-button-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.ts
@@ -21,10 +21,10 @@ import isGooglePayErrorObject from './guards/is-google-pay-error-object';
 import isGooglePayKey from './guards/is-google-pay-key';
 import {
     GooglePayBuyNowInitializeOptions,
+    GooglePayError,
     GooglePayInitializationData,
+    GooglePayPaymentDataRequest,
     GooglePayPaymentOptions,
-    IntermediatePaymentData,
-    NewTransactionInfo,
     ShippingOptionParameters,
     TotalPriceStatusType,
 } from './types';
@@ -193,11 +193,13 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
                     callbackTrigger,
                     shippingAddress,
                     shippingOptionData,
-                }: IntermediatePaymentData): Promise<NewTransactionInfo | void> => {
+                    offerData,
+                }) => {
                     const {
                         availableTriggers,
                         addressChangeTriggers,
                         shippingOptionsChangeTriggers,
+                        offerChangeTriggers,
                     } = this._googlePayPaymentProcessor.getCallbackTriggers();
 
                     if (!availableTriggers.includes(callbackTrigger)) {
@@ -216,11 +218,23 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
                         );
                     }
 
+                    const { newOfferInfo = undefined, error: couponsError = undefined } =
+                        offerChangeTriggers.includes(callbackTrigger)
+                            ? await this._googlePayPaymentProcessor.handleCoupons(offerData)
+                            : {};
+
+                    // We can add another errors if needed 'couponsError || shippingError || anotherError'
+                    const error: GooglePayError | undefined = couponsError;
+
                     if (this._buyNowInitializeOptions) {
-                        return this._getBuyNowTransactionInfo(availableShippingOptions);
+                        return this._getBuyNowTransactionInfo(
+                            availableShippingOptions,
+                            newOfferInfo,
+                            error,
+                        );
                     }
 
-                    return this._getTransactionInfo(availableShippingOptions);
+                    return this._getTransactionInfo(availableShippingOptions, newOfferInfo, error);
                 },
             },
         };
@@ -248,7 +262,11 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
         }
     }
 
-    private _getBuyNowTransactionInfo(availableShippingOptions?: ShippingOptionParameters) {
+    private _getBuyNowTransactionInfo(
+        availableShippingOptions?: ShippingOptionParameters,
+        newOfferInfo?: GooglePayPaymentDataRequest['offerInfo'],
+        error?: GooglePayError,
+    ) {
         if (!this._buyNowCart) {
             return;
         }
@@ -267,10 +285,20 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             ...(availableShippingOptions && {
                 newShippingOptionParameters: availableShippingOptions,
             }),
+            ...(newOfferInfo && {
+                newOfferInfo,
+            }),
+            ...(error && {
+                error,
+            }),
         };
     }
 
-    private async _getTransactionInfo(availableShippingOptions?: ShippingOptionParameters) {
+    private async _getTransactionInfo(
+        availableShippingOptions?: ShippingOptionParameters,
+        newOfferInfo?: GooglePayPaymentDataRequest['offerInfo'],
+        error?: GooglePayError,
+    ) {
         await this._paymentIntegrationService.loadCheckout();
 
         const totalPrice = this._googlePayPaymentProcessor.getTotalPrice();
@@ -287,6 +315,12 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             },
             ...(availableShippingOptions && {
                 newShippingOptionParameters: availableShippingOptions,
+            }),
+            ...(newOfferInfo && {
+                newOfferInfo,
+            }),
+            ...(error && {
+                error,
             }),
         };
     }

--- a/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
@@ -160,6 +160,9 @@ describe('GooglePayPaymentProcessor', () => {
                     totalPrice: '0',
                     totalPriceStatus: 'ESTIMATED',
                 },
+                offerInfo: {
+                    offers: [],
+                },
                 callbackIntents: ['OFFER'],
             };
 
@@ -331,6 +334,9 @@ describe('GooglePayPaymentProcessor', () => {
                     authJwt: 'foo.bar.baz',
                     merchantId: '12345678901234567890',
                     merchantName: 'Example Merchant',
+                },
+                offerInfo: {
+                    offers: [],
                 },
                 transactionInfo: {
                     countryCode: 'US',

--- a/packages/google-pay-integration/src/google-pay-payment-processor.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.ts
@@ -27,6 +27,8 @@ import {
     GooglePaymentsClient,
     GooglePayPaymentDataRequest,
     GooglePayPaymentOptions,
+    HandleCouponsOut,
+    IntermediatePaymentData,
     ShippingOptionParameters,
 } from './types';
 
@@ -152,6 +154,12 @@ export default class GooglePayPaymentProcessor {
         await this._gateway.handleShippingOptionChange(optionId);
     }
 
+    async handleCoupons(
+        offerData: IntermediatePaymentData['offerData'],
+    ): Promise<HandleCouponsOut> {
+        return this._gateway.handleCoupons(offerData);
+    }
+
     getTotalPrice(): string {
         return this._gateway.getTotalPrice();
     }
@@ -244,6 +252,7 @@ export default class GooglePayPaymentProcessor {
             merchantInfo: this._gateway.getMerchantInfo(),
             ...(await this._gateway.getRequiredData()),
             callbackIntents: this._gateway.getCallbackIntents(),
+            offerInfo: this._gateway.getAppliedCoupons(),
         };
         this._isReadyToPayRequest = {
             ...this._baseRequest,

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'events';
 import {
     InvalidArgumentError,
     MissingDataError,
+    MissingDataErrorType,
     OrderFinalizationNotRequiredError,
     OrderRequestBody,
     PaymentArgumentInvalidError,
@@ -13,7 +14,10 @@ import {
     PaymentIntegrationService,
     PaymentMethod,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    getConfig,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import GooglePayGateway from './gateways/google-pay-gateway';
 import { WithGooglePayPaymentInitializeOptions } from './google-pay-payment-initialize-options';
@@ -26,6 +30,7 @@ import getGooglePaymentsClientMocks from './mocks/google-pay-payments-client.moc
 import { createInitializeImplementationMock } from './mocks/google-pay-processor-initialize.mock';
 import {
     CallbackTriggerType,
+    ErrorReasonType,
     GooglePayInitializationData,
     GooglePaymentsClient,
     NewTransactionInfo,
@@ -43,6 +48,17 @@ describe('GooglePayPaymentStrategy', () => {
     let options: PaymentInitializeOptions & WithGooglePayPaymentInitializeOptions;
     let button: HTMLDivElement;
     let eventEmitter: EventEmitter;
+    const storeConfig = getConfig().storeConfig;
+    const storeConfigWithFeaturesOn = {
+        ...storeConfig,
+        checkoutSettings: {
+            ...storeConfig.checkoutSettings,
+            features: {
+                ...storeConfig.checkoutSettings.features,
+                'PI-2875.googlepay_coupons_handling': true,
+            },
+        },
+    };
 
     beforeEach(() => {
         paymentIntegrationService = new PaymentIntegrationServiceMock();
@@ -50,6 +66,10 @@ describe('GooglePayPaymentStrategy', () => {
 
         jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
             getGeneric(),
+        );
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfigOrThrow').mockReturnValue(
+            storeConfigWithFeaturesOn,
         );
 
         clientMocks = getGooglePaymentsClientMocks();
@@ -68,6 +88,12 @@ describe('GooglePayPaymentStrategy', () => {
         jest.spyOn(processor, 'processAdditionalAction').mockResolvedValue(undefined);
         jest.spyOn(processor, 'showPaymentSheet').mockResolvedValue(getCardDataResponse());
         jest.spyOn(processor, 'setExternalCheckoutXhr').mockResolvedValue(undefined);
+        jest.spyOn(processor, 'getNonce').mockResolvedValue('abc.123.xyz');
+        jest.spyOn(processor, 'handleCoupons').mockResolvedValue({
+            newOfferInfo: {
+                offers: [{ description: 'Coupon description', redemptionCode: 'code' }],
+            },
+        });
         strategy = new GooglePayPaymentStrategy(paymentIntegrationService, processor);
 
         options = {
@@ -266,6 +292,10 @@ describe('GooglePayPaymentStrategy', () => {
             });
 
             test('nonce is missing', async () => {
+                jest.spyOn(processor, 'getNonce').mockRejectedValue(
+                    new MissingDataError(MissingDataErrorType.MissingConsignments),
+                );
+
                 const execute = () => strategy.execute(payload);
 
                 jest.spyOn(
@@ -357,6 +387,167 @@ describe('GooglePayPaymentStrategy', () => {
                         totalPriceStatus: 'FINAL',
                         totalPrice: '190.00',
                     },
+                });
+            });
+
+            describe('Coupons', () => {
+                it('should call handleCoupons on initialize', async () => {
+                    const initializeMock = createInitializeImplementationMock(
+                        eventEmitter,
+                        CallbackTriggerType.OFFER,
+                        (res) => {
+                            if (res) {
+                                mockReturnedPaymentDataChangedValue = res;
+                            }
+                        },
+                    );
+
+                    jest.spyOn(processor, 'initialize').mockImplementation(initializeMock);
+
+                    jest.spyOn(processor, 'showPaymentSheet').mockImplementation(() => {
+                        eventEmitter.emit('onPaymentDataChanged');
+
+                        return Promise.resolve(getCardDataResponse());
+                    });
+
+                    await strategy.initialize(options);
+
+                    button.click();
+
+                    await new Promise((resolve) => process.nextTick(resolve));
+
+                    expect(processor.handleCoupons).toHaveBeenCalledWith({
+                        redemptionCodes: ['coupon_code'],
+                    });
+                });
+
+                it('should update offers data', async () => {
+                    const initializeMock = createInitializeImplementationMock(
+                        eventEmitter,
+                        CallbackTriggerType.OFFER,
+                        (res) => {
+                            if (res) {
+                                mockReturnedPaymentDataChangedValue = res;
+                            }
+                        },
+                    );
+
+                    jest.spyOn(processor, 'initialize').mockImplementation(initializeMock);
+
+                    jest.spyOn(processor, 'showPaymentSheet').mockImplementation(() => {
+                        eventEmitter.emit('onPaymentDataChanged');
+
+                        return Promise.resolve(getCardDataResponse());
+                    });
+
+                    await strategy.initialize(options);
+
+                    button.click();
+
+                    await new Promise((resolve) => process.nextTick(resolve));
+
+                    expect(mockReturnedPaymentDataChangedValue).toStrictEqual({
+                        newTransactionInfo: {
+                            countryCode: 'US',
+                            currencyCode: 'USD',
+                            totalPriceStatus: 'FINAL',
+                            totalPrice: '190.00',
+                        },
+                        newOfferInfo: {
+                            offers: [
+                                {
+                                    description: 'Coupon description',
+                                    redemptionCode: 'code',
+                                },
+                            ],
+                        },
+                    });
+                });
+
+                it('should return a Google Pay error', async () => {
+                    jest.spyOn(processor, 'handleCoupons').mockResolvedValue({
+                        error: {
+                            message: 'Error message',
+                            reason: ErrorReasonType.OFFER_INVALID,
+                            intent: CallbackTriggerType.OFFER,
+                        },
+                        newOfferInfo: {
+                            offers: [],
+                        },
+                    });
+
+                    const initializeMock = createInitializeImplementationMock(
+                        eventEmitter,
+                        CallbackTriggerType.OFFER,
+                        (res) => {
+                            if (res) {
+                                mockReturnedPaymentDataChangedValue = res;
+                            }
+                        },
+                    );
+
+                    jest.spyOn(processor, 'initialize').mockImplementation(initializeMock);
+
+                    jest.spyOn(processor, 'showPaymentSheet').mockImplementation(() => {
+                        eventEmitter.emit('onPaymentDataChanged');
+
+                        return Promise.resolve(getCardDataResponse());
+                    });
+
+                    await strategy.initialize(options);
+
+                    button.click();
+
+                    await new Promise((resolve) => process.nextTick(resolve));
+
+                    expect(mockReturnedPaymentDataChangedValue).toStrictEqual({
+                        newTransactionInfo: {
+                            countryCode: 'US',
+                            currencyCode: 'USD',
+                            totalPriceStatus: 'FINAL',
+                            totalPrice: '190.00',
+                        },
+                        error: {
+                            message: 'Error message',
+                            reason: ErrorReasonType.OFFER_INVALID,
+                            intent: CallbackTriggerType.OFFER,
+                        },
+                        newOfferInfo: {
+                            offers: [],
+                        },
+                    });
+                });
+
+                it('should not call handleCoupons if user not signed it to google pay', async () => {
+                    jest.spyOn(processor, 'getNonce').mockRejectedValue(
+                        new MissingDataError(MissingDataErrorType.MissingConsignments),
+                    );
+
+                    const initializeMock = createInitializeImplementationMock(
+                        eventEmitter,
+                        CallbackTriggerType.OFFER,
+                        (res) => {
+                            if (res) {
+                                mockReturnedPaymentDataChangedValue = res;
+                            }
+                        },
+                    );
+
+                    jest.spyOn(processor, 'initialize').mockImplementation(initializeMock);
+
+                    jest.spyOn(processor, 'showPaymentSheet').mockImplementation(() => {
+                        eventEmitter.emit('onPaymentDataChanged');
+
+                        return Promise.resolve(getCardDataResponse());
+                    });
+
+                    await strategy.initialize(options);
+
+                    button.click();
+
+                    await new Promise((resolve) => process.nextTick(resolve));
+
+                    expect(processor.handleCoupons).not.toHaveBeenCalled();
                 });
             });
         });

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -3,6 +3,8 @@ import { round } from 'lodash';
 import {
     guard,
     InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
     NotInitializedError,
     NotInitializedErrorType,
     OrderFinalizationNotRequiredError,
@@ -23,10 +25,12 @@ import isGooglePayErrorObject from './guards/is-google-pay-error-object';
 import isGooglePayKey from './guards/is-google-pay-key';
 import {
     CallbackTriggerType,
+    ErrorReasonType,
+    GooglePayError,
     GooglePayInitializationData,
     GooglePayPaymentOptions,
+    HandleCouponsOut,
     IntermediatePaymentData,
-    NewTransactionInfo,
     TotalPriceStatusType,
 } from './types';
 
@@ -186,15 +190,85 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         );
     }
 
+    protected async _getIsSignedInOrThrow(): Promise<boolean> {
+        try {
+            return !!(await this._googlePayPaymentProcessor.getNonce(this._getMethodId()));
+        } catch (e) {
+            if (
+                e instanceof MissingDataError &&
+                e.subtype === MissingDataErrorType.MissingPaymentToken
+            ) {
+                return false;
+            }
+
+            throw e;
+        }
+    }
+
+    protected async _handleOfferTrigger(
+        offerData: IntermediatePaymentData['offerData'],
+    ): Promise<Partial<HandleCouponsOut>> {
+        let isSignedIn = false;
+        let errorMessage = 'Sign in to Google Pay first to apply or remove promo codes.';
+
+        try {
+            isSignedIn = await this._getIsSignedInOrThrow();
+        } catch (error) {
+            if (error instanceof MissingDataError) {
+                errorMessage = error.message;
+            }
+        }
+
+        // We can only apply/remove coupons on the payment step only if we are logged into Google Pay, otherwise we will get an error
+        if (isSignedIn) {
+            const { newOfferInfo, error } = await this._googlePayPaymentProcessor.handleCoupons(
+                offerData,
+            );
+
+            return {
+                newOfferInfo,
+                error,
+            };
+        }
+
+        return {
+            error: {
+                reason: ErrorReasonType.OFFER_INVALID,
+                message: errorMessage,
+                intent: CallbackTriggerType.OFFER,
+            },
+        };
+    }
+
     protected _getGooglePayClientOptions(countryCode?: string): GooglePayPaymentOptions {
         return {
             paymentDataCallbacks: {
-                onPaymentDataChanged: async ({
-                    callbackTrigger,
-                }: IntermediatePaymentData): Promise<NewTransactionInfo | void> => {
-                    if (callbackTrigger !== CallbackTriggerType.INITIALIZE) {
+                onPaymentDataChanged: async ({ callbackTrigger, offerData }) => {
+                    const state = this._paymentIntegrationService.getState();
+                    // TODO remove this experiment usage after we make sure that coupons handling works fine
+                    const isGooglePayCouponsExperimentOn =
+                        state.getStoreConfigOrThrow().checkoutSettings.features[
+                            'PI-2875.googlepay_coupons_handling'
+                        ] || false;
+
+                    if (
+                        callbackTrigger !== CallbackTriggerType.INITIALIZE &&
+                        (!isGooglePayCouponsExperimentOn ||
+                            callbackTrigger !== CallbackTriggerType.OFFER)
+                    ) {
                         return;
                     }
+
+                    const { offerChangeTriggers } =
+                        this._googlePayPaymentProcessor.getCallbackTriggers();
+
+                    const { newOfferInfo = undefined, error: couponsError = undefined } =
+                        offerChangeTriggers.includes(callbackTrigger)
+                            ? await this._handleOfferTrigger(offerData)
+                            : {};
+
+                    // We can add another errors if needed 'couponsError || shippingError || anotherError'
+                    const error: GooglePayError | undefined = couponsError;
 
                     await this._paymentIntegrationService.loadCheckout();
 
@@ -213,6 +287,12 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                             totalPriceStatus: TotalPriceStatusType.FINAL,
                             totalPrice,
                         },
+                        ...(newOfferInfo && {
+                            newOfferInfo,
+                        }),
+                        ...(error && {
+                            error,
+                        }),
                     };
                 },
             },

--- a/packages/google-pay-integration/src/mocks/google-pay-processor-initialize.mock.ts
+++ b/packages/google-pay-integration/src/mocks/google-pay-processor-initialize.mock.ts
@@ -46,6 +46,9 @@ export const createInitializeImplementationMock = (
                                 ? consignment.selectedShippingOption.id
                                 : '',
                         },
+                        offerData: {
+                            redemptionCodes: ['coupon_code'],
+                        },
                     })
                     .then((res) => {
                         if (cb) {

--- a/packages/google-pay-integration/src/types.ts
+++ b/packages/google-pay-integration/src/types.ts
@@ -155,6 +155,7 @@ export interface GooglePayPaymentDataRequest extends GooglePayGatewayBaseRequest
         allowedCountryCodes?: string[];
         phoneNumberRequired?: boolean;
     };
+    offerInfo: Offers;
     shippingOptionRequired?: boolean;
     callbackIntents?: CallbackIntentsType[];
 }
@@ -176,6 +177,39 @@ export interface NewShippingOptionParameters {
     newShippingOptionParameters?: ShippingOptionParameters;
 }
 
+export interface NewOfferInfo {
+    newOfferInfo?: Offers;
+}
+
+export interface Offers {
+    offers: OfferInfoItem[];
+}
+
+export interface GooglePayError {
+    message: string;
+    reason: ErrorReasonType;
+    intent: CallbackTriggerType;
+}
+
+export enum ErrorReasonType {
+    OFFER_INVALID = 'OFFER_INVALID',
+    PAYMENT_DATA_INVALID = 'PAYMENT_DATA_INVALID',
+    SHIPPING_ADDRESS_INVALID = 'SHIPPING_ADDRESS_INVALID',
+    SHIPPING_ADDRESS_UNSERVICEABLE = 'SHIPPING_ADDRESS_UNSERVICEABLE',
+    SHIPPING_OPTION_INVALID = 'SHIPPING_OPTION_INVALID',
+    OTHER_ERROR = 'OTHER_ERROR',
+}
+
+export interface OfferInfoItem {
+    redemptionCode: string;
+    description: string;
+}
+
+export interface HandleCouponsOut {
+    newOfferInfo: GooglePayPaymentDataRequest['offerInfo'];
+    error?: GooglePayError;
+}
+
 export interface GoogleShippingOption {
     id: string;
     label?: string;
@@ -192,15 +226,23 @@ export interface IntermediatePaymentData {
     callbackTrigger: CallbackTriggerType;
     shippingAddress: GooglePayFullBillingAddress;
     shippingOptionData: GoogleShippingOption;
+    offerData: {
+        redemptionCodes: string[];
+    };
 }
 
 export interface GooglePayPaymentOptions {
     paymentDataCallbacks?: {
         onPaymentDataChanged(
             intermediatePaymentData: IntermediatePaymentData,
-        ): Promise<(NewTransactionInfo & NewShippingOptionParameters) | void>;
+        ): onPaymentDataChangedOut;
     };
 }
+
+export type onPaymentDataChangedOut = Promise<
+    | (NewTransactionInfo & NewShippingOptionParameters & NewOfferInfo & { error?: GooglePayError })
+    | void
+>;
 
 export type GooglePayRequiredPaymentData = Pick<
     GooglePayPaymentDataRequest,

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -77,6 +77,10 @@ export default interface PaymentIntegrationService {
         options?: RequestOptions,
     ): Promise<PaymentIntegrationSelectors>;
 
+    applyCoupon(coupon: string, options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
+
+    removeCoupon(couponId: string, options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
+
     createBuyNowCart(body: BuyNowCartRequestBody, options?: RequestOptions): Promise<Cart>;
 
     updatePaymentProviderCustomer(

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -59,6 +59,7 @@ const state = {
     getPaymentRedirectUrl: jest.fn(),
     getPaymentRedirectUrlOrThrow: jest.fn(),
     isPaymentDataRequired: jest.fn(),
+    applyCoupon: jest.fn(),
 };
 
 const createBuyNowCart = jest.fn(() => Promise.resolve(getCart()));
@@ -92,6 +93,8 @@ const initializePayment = jest.fn();
 const validateCheckout = jest.fn();
 const widgetInteraction = jest.fn();
 const handle = jest.fn();
+const applyCoupon = jest.fn();
+const removeCoupon = jest.fn();
 
 const PaymentIntegrationServiceMock = jest
     .fn<PaymentIntegrationService, []>()
@@ -123,6 +126,8 @@ const PaymentIntegrationServiceMock = jest
             signOutCustomer,
             selectShippingOption,
             applyStoreCredit,
+            applyCoupon,
+            removeCoupon,
             verifyCheckoutSpamProtection,
             updatePaymentProviderCustomer,
             initializePayment,


### PR DESCRIPTION
## What?
Added coupons handling on the Google Pay payment sheet.

Cart flow:

https://github.com/user-attachments/assets/2419842b-0807-4f87-9eec-c09add1ebc0f


Mini cart flow:

https://github.com/user-attachments/assets/8cd5c30d-c58c-4f96-b6a3-a7eeb0739985


PDP flow:

https://github.com/user-attachments/assets/78046f5f-c557-44b7-8a8e-5923780553d3


Customer step flow:

https://github.com/user-attachments/assets/20e16cb0-b400-4197-bf3e-69710c9907a4


Payment step flow:

https://github.com/user-attachments/assets/9e6ec42e-ff93-408e-9d6d-2b7ec834650e


Error showing:

https://github.com/user-attachments/assets/3a1bf300-8d5a-4221-83cc-9e1b29359a76

Removing Coupon:

https://github.com/user-attachments/assets/af332f2c-8f8e-4be9-b68f-c2ec320bd149



## Why?
Because we don't handle coupons adding through the Google Pay payment pop up.

## Testing / Proof
All tests have been passed / manual testing.

## Rollout/Rollback
Covered by experiment:
`PI-2875.googlepay_coupons_handling
`

@bigcommerce/team-checkout @bigcommerce/team-payments
