### PR TITLE
fix(shipping): CHECKOUT-8999 Remove duplicate call for shipping option

### DIFF
--- a/packages/core/src/shipping/consignment-action-creator.ts
+++ b/packages/core/src/shipping/consignment-action-creator.ts
@@ -366,7 +366,7 @@ export default class ConsignmentActionCreator {
                 const checkout = store.getState().checkout.getCheckout();
                 const { checkoutSettings } = store.getState().config.getStoreConfigOrThrow();
 
-                if (isExperimentEnabled(checkoutSettings, 'CHECKOUT-8999.remove_duplicate_shipping_option_call')) {
+                if (isExperimentEnabled(checkoutSettings.features, 'CHECKOUT-8999.remove_duplicate_shipping_option_call')) {
                     const consignmentInMemory = store.getState().consignments.getConsignmentById(consignment.id);
                     const alreadySelectedOptionId = consignmentInMemory?.selectedShippingOption?.id;
 

--- a/packages/core/src/shipping/consignment.ts
+++ b/packages/core/src/shipping/consignment.ts
@@ -49,6 +49,7 @@ export interface ConsignmentUpdateRequestBody {
     shippingAddress?: AddressRequestBody;
     lineItems?: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;
+    shippingOptionId?: string;
 }
 
 export interface ConsignmentMeta {

--- a/packages/utility/src/index.ts
+++ b/packages/utility/src/index.ts
@@ -1,1 +1,2 @@
 export { bindDecorator } from './bind-decorator';
+export { isExperimentEnabled } from './is-experiment-enabled';

--- a/packages/utility/src/is-experiment-enabled/index.ts
+++ b/packages/utility/src/is-experiment-enabled/index.ts
@@ -1,0 +1,1 @@
+export { default as isExperimentEnabled } from './is-experiment-enabled';

--- a/packages/utility/src/is-experiment-enabled/is-experiment-enabled.spec.ts
+++ b/packages/utility/src/is-experiment-enabled/is-experiment-enabled.spec.ts
@@ -1,0 +1,33 @@
+import isExperimentEnabled, { Features } from './is-experiment-enabled';
+
+describe('isExperimentEnabled', () => {
+    it('returns true if experiment is not present', () => {
+        const features: Features = {
+            test: true,
+        };
+
+        const experimentStatus = isExperimentEnabled(features, 'someexperiment');
+
+        expect(experimentStatus).toBe(true);
+    });
+
+    it('returns false if experiment value is false', () => {
+        const features: Features = {
+            test: false,
+        };
+
+        const experimentStatus = isExperimentEnabled(features, 'test');
+
+        expect(experimentStatus).toBe(false);
+    });
+
+    it('returns true if experiment value is true', () => {
+        const features: Features = {
+            test: true,
+        };
+
+        const experimentStatus = isExperimentEnabled(features, 'test');
+
+        expect(experimentStatus).toBe(true);
+    });
+});

--- a/packages/utility/src/is-experiment-enabled/is-experiment-enabled.ts
+++ b/packages/utility/src/is-experiment-enabled/is-experiment-enabled.ts
@@ -1,8 +1,7 @@
-import { CheckoutSettings } from '@bigcommerce/checkout-sdk/payment-integration-api';
+export interface Features {
+    [featureName: string]: boolean | undefined;
+}
 
-export default function isExperimentEnabled(
-    checkoutSettings: CheckoutSettings | undefined,
-    experimentName: string,
-): boolean {
-    return Boolean(checkoutSettings?.features[experimentName] ?? true);
+export default function isExperimentEnabled(features: Features, experimentName: string): boolean {
+    return features[experimentName] ?? true;
 }

--- a/packages/utility/src/is-experiment-enabled/is-experiment-enabled.ts
+++ b/packages/utility/src/is-experiment-enabled/is-experiment-enabled.ts
@@ -1,0 +1,8 @@
+import { CheckoutSettings } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default function isExperimentEnabled(
+    checkoutSettings: CheckoutSettings | undefined,
+    experimentName: string,
+): boolean {
+    return Boolean(checkoutSettings?.features[experimentName] ?? true);
+}


### PR DESCRIPTION
## What?
Avoid duplicate call for shipping option if shipping option id passed is same.

## Why?
Avoid duplicate call for shipping option if shipping option id that is passed same as the one that is already selected. This can happen sometimes with various subscriptions on clients from SDK that watch for consignment changes.

## Testing / Proof
- CI
- Screencast

#### Experiment off

https://github.com/user-attachments/assets/b651844d-8a1f-440c-b9f1-838933ad2900



#### Experiment on

https://github.com/user-attachments/assets/275fc799-e0b6-43bc-a0e1-0bad80980089




@bigcommerce/team-checkout @bigcommerce/team-payments
