### PR TITLE
feat(payment): PAYPAL-5213 added messages implementation to Braintree PayPal Credit button strategy

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-button-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-button-initialize-options.ts
@@ -19,6 +19,11 @@ export default interface BraintreePaypalCreditButtonInitializeOptions {
     currencyCode?: string;
 
     /**
+     * The ID of a container where the messaging component should be inserted.
+     */
+    messagingContainerId?: string;
+
+    /**
      * @internal
      * This is an internal property and therefore subject to change. DO NOT USE.
      */

--- a/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-button-strategy.spec.ts
@@ -57,11 +57,15 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
     let paymentIntegrationService: PaymentIntegrationService;
     let paymentMethod: PaymentMethod;
     let paypalSdkMock: PaypalSDK;
-    let strategy: BraintreePaypalCreditButtonStrategy;
     let paypalButtonElement: HTMLDivElement;
+    let paypalMessageElement: HTMLDivElement;
+    let strategy: BraintreePaypalCreditButtonStrategy;
 
     const defaultButtonContainerId = 'braintree-paypal-credit-button-mock-id';
+    const defaultMessageContainerId = 'braintree-paypal-credit-message-mock-id';
+
     const braintreePaypalCreditOptions: BraintreePaypalCreditButtonInitializeOptions = {
+        messagingContainerId: defaultMessageContainerId, // only available on cart page
         shouldProcessPayment: false,
         style: { height: 45 },
         onAuthorizeError: jest.fn(),
@@ -153,6 +157,10 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
         paypalButtonElement.id = defaultButtonContainerId;
         document.body.appendChild(paypalButtonElement);
 
+        paypalMessageElement = document.createElement('div');
+        paypalMessageElement.id = defaultMessageContainerId;
+        document.body.appendChild(paypalMessageElement);
+
         formPoster = createFormPoster();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
         braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader(), window);
@@ -214,6 +222,10 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
                 render: jest.fn(),
             };
         });
+
+        jest.spyOn(paypalSdkMock, 'Messages').mockImplementation(() => ({
+            render: jest.fn(),
+        }));
     });
 
     afterEach(() => {
@@ -223,6 +235,10 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
 
         if (document.getElementById(defaultButtonContainerId)) {
             document.body.removeChild(paypalButtonElement);
+        }
+
+        if (document.getElementById(defaultMessageContainerId)) {
+            document.body.removeChild(paypalMessageElement);
         }
     });
 
@@ -420,6 +436,15 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
             );
         });
 
+        it('renders Braintree PayPal message', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
+                amount: cart.cartAmount,
+                placement: 'cart',
+            });
+        });
+
         it('renders braintree paylater button', async () => {
             await strategy.initialize(initializationOptions);
 
@@ -482,6 +507,19 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
                     height: 45,
                 },
             });
+        });
+
+        it('removes Braintree PayPal Credit button and message containers when paypal is not available in window', async () => {
+            delete (window as BraintreeHostWindow).paypal;
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeIntegrationService.removeElement).toHaveBeenCalledWith(
+                defaultMessageContainerId,
+            );
+            expect(braintreeIntegrationService.removeElement).toHaveBeenCalledWith(
+                defaultButtonContainerId,
+            );
         });
 
         it('does not render PayPal checkout button and calls onEligibilityFailure callback', async () => {

--- a/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-button-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-button-strategy.ts
@@ -99,6 +99,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         const paypalCheckoutSuccessCallback = (
             braintreePaypalCheckout: BraintreePaypalCheckout,
         ) => {
+            this.renderPayPalMessages(braintreepaypalcredit.messagingContainerId);
             this.renderPayPalButton(
                 braintreePaypalCheckout,
                 braintreepaypalcredit,
@@ -120,6 +121,26 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
 
     async deinitialize(): Promise<void> {
         await this.braintreeIntegrationService.teardown();
+    }
+
+    private renderPayPalMessages(messagingContainerId?: string): void {
+        const isMessageContainerAvailable =
+            messagingContainerId && Boolean(document.getElementById(messagingContainerId));
+        const { paypal } = this.braintreeHostWindow;
+
+        if (isMessageContainerAvailable && paypal) {
+            const state = this.paymentIntegrationService.getState();
+            const amount = state.getCartOrThrow().cartAmount;
+
+            const paypalMessagesRender = paypal.Messages({
+                amount,
+                placement: 'cart',
+            });
+
+            paypalMessagesRender.render(`#${messagingContainerId}`);
+        } else {
+            this.braintreeIntegrationService.removeElement(messagingContainerId);
+        }
     }
 
     private renderPayPalButton(


### PR DESCRIPTION
## What?
Added messages implementation to Braintree PayPal Credit button strategy

## Why?
Braintree Messaging is available only when Braintree PayPal Credit is enabled, so the best place to hold this implementation is in Braintree PayPal Credit Button strategy to render banner on cart page. So as part one of messages implementation migration the implementation was duplicated from Braintree PayPal to Braintree PayPal Credit button strategy

## Testing / Proof
Unit tests
Manual tests
CI

US VPN location:
<img width="522" alt="Screenshot 2025-03-06 at 10 32 18" src="https://github.com/user-attachments/assets/67f0d603-9d2d-422e-9415-ad231b0ada3d" />

Non US VPN location:
<img width="549" alt="Screenshot 2025-03-06 at 10 32 34" src="https://github.com/user-attachments/assets/bd693818-ea52-4291-ba83-677d948bad15" />
