### PR TITLE
feat(payment): PAYPAL-4936 Update PayPalCommerceIntegrationService by adding a proxy request functionality for order creation process

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -1,6 +1,7 @@
 import {
     BuyNowCartRequestBody,
     HostedInstrument,
+    RequestOptions,
     ShippingOption,
     VaultedInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -615,4 +616,36 @@ export interface PayPalOrderStatusData {
 export interface PayPalCreateOrderCardFieldsResponse {
     orderId: string;
     setupToken?: string;
+}
+
+export interface CreatePaymentOrderIntentOptions extends RequestOptions {
+    body?: { walletEntityId: string; cartId: string };
+}
+
+export interface CreatePaymentOrderIntentResponse {
+    data: {
+        payment: {
+            paymentWallet: {
+                createPaymentWalletIntent: {
+                    errors: Array<{
+                        location: Array<{ line: string; column: string }>;
+                        message: string;
+                    }>;
+                    paymentWalletIntentData: {
+                        __typename: string;
+                        approvalUrl: string;
+                        orderId: string;
+                    };
+                };
+            };
+        };
+    };
+}
+
+export interface CreateRedirectToCheckoutResponse {
+    data: {
+        cart: {
+            createCartRedirectUrls: { redirectUrls: { redirectedCheckoutUrl: string } | null };
+        };
+    };
 }


### PR DESCRIPTION
## What?

Update PayPalCommerceIntegrationService by adding a proxy request functionality for order creation process

## Why?

As part of the implementation of Headless Wallet Buttons (https://github.com/bigcommerce/checkout-sdk-js/pull/2742)

## Testing / Proof

Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
