### PR TITLE
refactor(payment): PAYPAL-5216 removed paypal messages implementation from Braintree PayPal button strategy

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-button-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-button-initialize-options.ts
@@ -19,11 +19,6 @@ export default interface BraintreePaypalButtonInitializeOptions {
     currencyCode?: string;
 
     /**
-     * The ID of a container which the messaging should be inserted.
-     */
-    messagingContainerId?: string;
-
-    /**
      * @internal
      * This is an internal property and therefore subject to change. DO NOT USE.
      */

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-button-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-button-strategy.spec.ts
@@ -57,15 +57,12 @@ describe('BraintreePaypalButtonStrategy', () => {
     let paymentIntegrationService: PaymentIntegrationService;
     let paymentMethod: PaymentMethod;
     let paypalButtonElement: HTMLDivElement;
-    let paypalMessageElement: HTMLDivElement;
     let paypalSdkMock: PaypalSDK;
     let strategy: BraintreePaypalButtonStrategy;
 
     const defaultButtonContainerId = 'braintree-paypal-button-mock-id';
-    const defaultMessageContainerId = 'braintree-paypal-message-mock-id';
 
     const braintreePaypalOptions: BraintreePaypalButtonInitializeOptions = {
-        messagingContainerId: defaultMessageContainerId, // only available on cart page
         shouldProcessPayment: false,
         style: { height: 45 },
         onAuthorizeError: jest.fn(),
@@ -157,10 +154,6 @@ describe('BraintreePaypalButtonStrategy', () => {
         paypalButtonElement.id = defaultButtonContainerId;
         document.body.appendChild(paypalButtonElement);
 
-        paypalMessageElement = document.createElement('div');
-        paypalMessageElement.id = defaultMessageContainerId;
-        document.body.appendChild(paypalMessageElement);
-
         formPoster = createFormPoster();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
         braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader(), window);
@@ -222,10 +215,6 @@ describe('BraintreePaypalButtonStrategy', () => {
                 render: jest.fn(),
             };
         });
-
-        jest.spyOn(paypalSdkMock, 'Messages').mockImplementation(() => ({
-            render: jest.fn(),
-        }));
     });
 
     afterEach(() => {
@@ -235,10 +224,6 @@ describe('BraintreePaypalButtonStrategy', () => {
 
         if (document.getElementById(defaultButtonContainerId)) {
             document.body.removeChild(paypalButtonElement);
-        }
-
-        if (document.getElementById(defaultMessageContainerId)) {
-            document.body.removeChild(paypalMessageElement);
         }
     });
 
@@ -436,15 +421,6 @@ describe('BraintreePaypalButtonStrategy', () => {
             );
         });
 
-        it('renders Braintree PayPal message', async () => {
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
-                amount: cart.cartAmount,
-                placement: 'cart',
-            });
-        });
-
         it('renders Braintree PayPal button', async () => {
             await strategy.initialize(initializationOptions);
 
@@ -460,14 +436,11 @@ describe('BraintreePaypalButtonStrategy', () => {
             });
         });
 
-        it('removes Braintree PayPal button and message containers when paypal is not available in window', async () => {
+        it('removes Braintree PayPal button container when paypal is not available in window', async () => {
             delete (window as BraintreeHostWindow).paypal;
 
             await strategy.initialize(initializationOptions);
 
-            expect(braintreeIntegrationService.removeElement).toHaveBeenCalledWith(
-                defaultMessageContainerId,
-            );
             expect(braintreeIntegrationService.removeElement).toHaveBeenCalledWith(
                 defaultButtonContainerId,
             );

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-button-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-button-strategy.ts
@@ -98,7 +98,6 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         const paypalCheckoutSuccessCallback = (
             braintreePaypalCheckout: BraintreePaypalCheckout,
         ) => {
-            this.renderPayPalMessages(braintreepaypal.messagingContainerId);
             this.renderPayPalButton(
                 braintreePaypalCheckout,
                 braintreepaypal,
@@ -120,26 +119,6 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
 
     async deinitialize(): Promise<void> {
         await this.braintreeIntegrationService.teardown();
-    }
-
-    private renderPayPalMessages(messagingContainerId?: string): void {
-        const isMessageContainerAvailable =
-            messagingContainerId && Boolean(document.getElementById(messagingContainerId));
-        const { paypal } = this.braintreeHostWindow;
-
-        if (isMessageContainerAvailable && paypal) {
-            const state = this.paymentIntegrationService.getState();
-            const amount = state.getCartOrThrow().cartAmount;
-
-            const paypalMessagesRender = paypal.Messages({
-                amount,
-                placement: 'cart',
-            });
-
-            paypalMessagesRender.render(`#${messagingContainerId}`);
-        } else {
-            this.braintreeIntegrationService.removeElement(messagingContainerId);
-        }
     }
 
     private renderPayPalButton(


### PR DESCRIPTION
## What?
Removed paypal messages implementation from Braintree PayPal button strategy

## Why?
Since implementation was moved to Braintree PayPal Credit button strategy where it is supposed to be

## Testing / Proof
Unit tests
CI
