### PR TITLE
feat(payment): PI-3505 Added Company Name fields to the Bluesnap Dire…

### DIFF
--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.spec.ts
@@ -101,6 +101,46 @@ describe('BlueSnapDirectAPMPaymentStrategy', () => {
             expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expectedPayment);
         });
 
+        it('should submit the ECP payment with company name', async () => {
+            await strategy.initialize();
+
+            const accountType = 'CORPORATE_CHECKING' as const;
+            const payload = {
+                payment: {
+                    gatewayId: 'bluesnapdirect',
+                    methodId: 'ecp',
+                    paymentData: {
+                        accountNumber: '223344556',
+                        companyName: 'BigCommerce',
+                        accountType,
+                        shopperPermission: true,
+                        routingNumber: '998877665',
+                    },
+                },
+            };
+
+            const expectedPayment = {
+                gatewayId: 'bluesnapdirect',
+                methodId: 'ecp',
+                paymentData: {
+                    formattedPayload: {
+                        ecp: {
+                            account_number: '223344556',
+                            account_type: 'CORPORATE_CHECKING',
+                            company_name: 'BigCommerce',
+                            routing_number: '998877665',
+                            shopper_permission: true,
+                        },
+                    },
+                },
+            };
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        });
+
         it('should submit the SEPA payment', async () => {
             await strategy.initialize();
 

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-apm/bluesnap-direct-apm-payment-strategy.ts
@@ -89,6 +89,9 @@ export default class BlueSnapDirectAPMPaymentStrategy implements PaymentStrategy
                             account_type: payment.paymentData.accountType,
                             shopper_permission: payment.paymentData.shopperPermission,
                             routing_number: payment.paymentData.routingNumber,
+                            ...(payment.paymentData.companyName
+                                ? { company_name: payment.paymentData.companyName }
+                                : {}),
                         },
                         vault_payment_instrument: payment.paymentData.shouldSaveInstrument,
                         set_as_default_stored_instrument:

--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -255,6 +255,7 @@ export interface WithEcpInstrument {
     accountType: BankAccountType | EcpAccountType;
     shopperPermission: boolean;
     routingNumber: string;
+    companyName?: string;
     shouldSaveInstrument?: boolean;
     shouldSetAsDefaultInstrument?: boolean;
     instrumentId?: string;


### PR DESCRIPTION
…ct ECP implementation

https://github.com/bigcommerce/checkout-js/pull/2206

## What?
Added Company Name fields to the Bluesnap Direct ECP implementation.

## Why?
Due to the non-required Company name, for Corporate account types 

## Testing / Proof

https://github.com/user-attachments/assets/eee03dac-5c4f-4cf0-9091-ca3ab5a235b0


@bigcommerce/team-checkout