### PR TITLE
feat(payment): PAYPAL-5097 created Braintree Messages class and added Braintree BNPL Configurator implementation

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-button-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal-credit/braintree-paypal-credit-button-strategy.ts
@@ -5,10 +5,12 @@ import {
     BraintreeHostWindow,
     BraintreeInitializationData,
     BraintreeIntegrationService,
+    BraintreeMessages,
     BraintreePaypalCheckout,
     BraintreePaypalSdkCreatorConfig,
     BraintreeTokenizePayload,
     isBraintreeError,
+    MessagingPlacements,
     PaypalAuthorizeData,
     PaypalButtonStyleLabelOption,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
@@ -39,6 +41,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         private paymentIntegrationService: PaymentIntegrationService,
         private formPoster: FormPoster,
         private braintreeIntegrationService: BraintreeIntegrationService,
+        private braintreeMessages: BraintreeMessages,
         private braintreeHostWindow: BraintreeHostWindow,
     ) {}
 
@@ -99,7 +102,10 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         const paypalCheckoutSuccessCallback = (
             braintreePaypalCheckout: BraintreePaypalCheckout,
         ) => {
-            this.renderPayPalMessages(braintreepaypalcredit.messagingContainerId);
+            if (braintreepaypalcredit.messagingContainerId) {
+                this.renderPayPalMessages(methodId, braintreepaypalcredit.messagingContainerId);
+            }
+
             this.renderPayPalButton(
                 braintreePaypalCheckout,
                 braintreepaypalcredit,
@@ -123,24 +129,8 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         await this.braintreeIntegrationService.teardown();
     }
 
-    private renderPayPalMessages(messagingContainerId?: string): void {
-        const isMessageContainerAvailable =
-            messagingContainerId && Boolean(document.getElementById(messagingContainerId));
-        const { paypal } = this.braintreeHostWindow;
-
-        if (isMessageContainerAvailable && paypal) {
-            const state = this.paymentIntegrationService.getState();
-            const amount = state.getCartOrThrow().cartAmount;
-
-            const paypalMessagesRender = paypal.Messages({
-                amount,
-                placement: 'cart',
-            });
-
-            paypalMessagesRender.render(`#${messagingContainerId}`);
-        } else {
-            this.braintreeIntegrationService.removeElement(messagingContainerId);
-        }
+    private renderPayPalMessages(methodId: string, messagingContainerId: string): void {
+        this.braintreeMessages.render(methodId, messagingContainerId, MessagingPlacements.CART);
     }
 
     private renderPayPalButton(

--- a/packages/braintree-integration/src/braintree-paypal-credit/create-braintree-paypal-credit-button-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal-credit/create-braintree-paypal-credit-button-strategy.ts
@@ -4,6 +4,7 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 import {
     BraintreeHostWindow,
     BraintreeIntegrationService,
+    BraintreeMessages,
     BraintreeScriptLoader,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
@@ -21,11 +22,13 @@ const createBraintreePaypalCreditButtonStrategy: CheckoutButtonStrategyFactory<
         new BraintreeScriptLoader(getScriptLoader(), braintreeHostWindow),
         braintreeHostWindow,
     );
+    const braintreeMessages = new BraintreeMessages(paymentIntegrationService);
 
     return new BraintreePaypalCreditButtonStrategy(
         paymentIntegrationService,
         createFormPoster(),
         braintreeIntegrationService,
+        braintreeMessages,
         braintreeHostWindow,
     );
 };

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
@@ -7,6 +7,7 @@ import {
     BraintreeError,
     BraintreeHostWindow,
     BraintreeIntegrationService,
+    BraintreeMessages,
     BraintreeModuleCreator,
     BraintreePaypal,
     BraintreePaypalCheckout,
@@ -34,7 +35,6 @@ import {
     PaymentMethodFailedError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
-    getCart,
     getConfig,
     getOrderRequestBody,
     getShippingAddress,
@@ -51,13 +51,13 @@ describe('BraintreePaypalPaymentStrategy', () => {
     let strategy: BraintreePaypalPaymentStrategy;
     let paymentIntegrationService: PaymentIntegrationService;
     let braintreeScriptLoader: BraintreeScriptLoader;
+    let braintreeMessages: BraintreeMessages;
     let braintreeIntegrationService: BraintreeIntegrationService;
     let paymentMethodMock: PaymentMethod;
     let clientCreatorMock: BraintreeModuleCreator<BraintreeClient>;
     let braintreePaypalCreatorMock: BraintreeModuleCreator<BraintreePaypal>;
     let paypalCheckoutCreatorMock: BraintreeModuleCreator<BraintreePaypalCheckout>;
     let paypalSdkMock: PaypalSDK;
-    let paypalMessageElement: HTMLDivElement;
     let braintreePaypalCheckoutMock: BraintreePaypalCheckout;
 
     const storeConfig = getConfig().storeConfig;
@@ -87,14 +87,9 @@ describe('BraintreePaypalPaymentStrategy', () => {
 
     beforeEach(() => {
         eventEmitter = new EventEmitter();
-        paypalMessageElement = document.createElement('div');
-        paypalMessageElement.id = 'banner-container-id';
-        document.body.appendChild(paypalMessageElement);
 
         paypalSdkMock = getPaypalMock();
-
         paymentMethodMock = getBraintreePaypal();
-
         clientCreatorMock = getModuleCreatorMock(getClientMock());
         braintreePaypalCreatorMock = getModuleCreatorMock(getBraintreePaypalMock());
         braintreePaypalCheckoutMock = getPaypalCheckoutMock();
@@ -103,7 +98,21 @@ describe('BraintreePaypalPaymentStrategy', () => {
             false,
         );
 
+        (window as BraintreeHostWindow).paypal = paypalSdkMock;
+
         paymentIntegrationService = new PaymentIntegrationServiceMock();
+        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader(), window);
+        braintreeMessages = new BraintreeMessages(paymentIntegrationService);
+        braintreeIntegrationService = new BraintreeIntegrationService(
+            braintreeScriptLoader,
+            window,
+        );
+        strategy = new BraintreePaypalPaymentStrategy(
+            paymentIntegrationService,
+            braintreeIntegrationService,
+            braintreeMessages,
+            new LoadingIndicator(),
+        );
 
         const state = paymentIntegrationService.getState();
 
@@ -115,18 +124,12 @@ describe('BraintreePaypalPaymentStrategy', () => {
         ).mockImplementation((useStoreCredit) => (useStoreCredit ? 150 : 190));
         jest.spyOn(paymentIntegrationService, 'submitPayment').mockResolvedValue(state);
 
-        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader(), window);
         jest.spyOn(braintreeScriptLoader, 'loadClient').mockResolvedValue(clientCreatorMock);
         jest.spyOn(braintreeScriptLoader, 'loadPaypal').mockResolvedValue(
             braintreePaypalCreatorMock,
         );
         jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockResolvedValue(
             paypalCheckoutCreatorMock,
-        );
-
-        braintreeIntegrationService = new BraintreeIntegrationService(
-            braintreeScriptLoader,
-            window,
         );
 
         const getSDKPaypalCheckoutMock = (
@@ -171,17 +174,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
             details: { email: 'random@email.com' },
         });
 
-        strategy = new BraintreePaypalPaymentStrategy(
-            paymentIntegrationService,
-            braintreeIntegrationService,
-            new LoadingIndicator(),
-        );
-
-        (window as BraintreeHostWindow).paypal = paypalSdkMock;
-
-        jest.spyOn(paypalSdkMock, 'Messages').mockImplementation(() => ({
-            render: jest.fn(),
-        }));
+        jest.spyOn(braintreeMessages, 'render');
 
         jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation((options: PaypalButtonOptions) => {
             eventEmitter.on('approve', () => {
@@ -251,20 +244,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
             );
         });
 
-        it('renders PayPal checkout message', async () => {
-            paymentMethodMock.initializationData.enableCheckoutPaywallBanner = true;
-
-            const cartMock = getCart();
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue(paymentMethodMock);
-
-            jest.spyOn(paymentIntegrationService.getState(), 'getCartOrThrow').mockReturnValue(
-                cartMock,
-            );
-
+        it('renders Braintree PayPal message', async () => {
             const options = {
                 methodId: paymentMethodMock.id,
                 braintree: { bannerContainerId: 'banner-container-id' },
@@ -272,17 +252,11 @@ describe('BraintreePaypalPaymentStrategy', () => {
 
             await strategy.initialize(options);
 
-            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
-                amount: 190,
-                buyerCountry: 'US',
-                placement: 'payment',
-                style: {
-                    layout: 'text',
-                    logo: {
-                        type: 'inline',
-                    },
-                },
-            });
+            expect(braintreeMessages.render).toHaveBeenCalledWith(
+                paymentMethodMock.id,
+                'banner-container-id',
+                'payment',
+            );
         });
 
         it('throws error if unable to initialize', async () => {
@@ -452,7 +426,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
             );
         });
 
-        it('if paypal fails we do not submit an order', async () => {
+        it('does not submit order when paypal fails', async () => {
             paymentIntegrationService = new PaymentIntegrationServiceMock();
 
             jest.spyOn(
@@ -463,11 +437,6 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 paymentIntegrationService.getState(),
             );
 
-            strategy = new BraintreePaypalPaymentStrategy(
-                paymentIntegrationService,
-                braintreeIntegrationService,
-                new LoadingIndicator(),
-            );
             braintreeIntegrationService.paypal = () =>
                 Promise.reject({ name: 'BraintreeError', message: 'my_message' });
 
@@ -720,12 +689,6 @@ describe('BraintreePaypalPaymentStrategy', () => {
         describe('if paypal credit', () => {
             beforeEach(() => {
                 const state = paymentIntegrationService.getState();
-
-                strategy = new BraintreePaypalPaymentStrategy(
-                    paymentIntegrationService,
-                    braintreeIntegrationService,
-                    new LoadingIndicator(),
-                );
 
                 jest.spyOn(state, 'getPaymentMethodOrThrow').mockImplementation(() => ({
                     ...paymentMethodMock,

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -1,10 +1,13 @@
 import {
     BraintreeError,
     BraintreeHostWindow,
+    BraintreeInitializationData,
     BraintreeIntegrationService,
+    BraintreeMessages,
     BraintreePaypalCheckout,
     BraintreePaypalSdkCreatorConfig,
     BraintreeTokenizePayload,
+    MessagingPlacements,
     PaypalAuthorizeData,
     PaypalButtonRender,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
@@ -45,7 +48,7 @@ import {
 } from './braintree-paypal-payment-initialize-options';
 
 export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
-    private paymentMethod?: PaymentMethod;
+    private paymentMethod?: PaymentMethod<BraintreeInitializationData>;
     private braintreeHostWindow: BraintreeHostWindow = window;
     private braintree?: BraintreePaypalPaymentInitializeOptions;
     private braintreeTokenizePayload?: BraintreeTokenizePayload;
@@ -55,6 +58,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
         private braintreeIntegrationService: BraintreeIntegrationService,
+        private braintreeMessages: BraintreeMessages,
         private loadingIndicator: LoadingIndicator,
     ) {}
 
@@ -284,8 +288,11 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             await this.braintreeIntegrationService.getPaypalCheckout(
                 paypalCheckoutConfig,
                 (braintreePaypalCheckout) => {
-                    if (initializationData?.enableCheckoutPaywallBanner) {
-                        this.renderPayPalMessages();
+                    if (this.paymentMethod?.id && this.braintree?.bannerContainerId) {
+                        this.renderPayPalMessages(
+                            this.paymentMethod.id,
+                            this.braintree.bannerContainerId,
+                        );
                     }
 
                     this.renderPayPalButton(braintreePaypalCheckout);
@@ -295,6 +302,10 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
         } catch (error) {
             this.handleError(error);
         }
+    }
+
+    private renderPayPalMessages(methodId: string, containerId: string) {
+        this.braintreeMessages.render(methodId, containerId, MessagingPlacements.PAYMENT);
     }
 
     private renderPayPalButton(braintreePaypalCheckout: BraintreePaypalCheckout) {
@@ -415,38 +426,6 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             }
 
             throw error;
-        }
-    }
-
-    private renderPayPalMessages() {
-        const { bannerContainerId } = this.braintree || {};
-
-        if (
-            this.braintreeHostWindow.paypal &&
-            bannerContainerId &&
-            Boolean(document.getElementById(bannerContainerId))
-        ) {
-            const state = this.paymentIntegrationService.getState();
-            const checkout = state.getCheckout();
-            const billingAddress = state.getBillingAddressOrThrow();
-
-            if (!checkout) {
-                throw new MissingDataError(MissingDataErrorType.MissingCheckout);
-            }
-
-            this.braintreeHostWindow.paypal
-                .Messages({
-                    amount: checkout.subtotal,
-                    buyerCountry: billingAddress.countryCode,
-                    placement: 'payment',
-                    style: {
-                        layout: 'text',
-                        logo: {
-                            type: 'inline',
-                        },
-                    },
-                })
-                .render(`#${bannerContainerId}`);
         }
     }
 

--- a/packages/braintree-integration/src/braintree-paypal/create-braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/create-braintree-paypal-payment-strategy.ts
@@ -3,6 +3,7 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 import {
     BraintreeHostWindow,
     BraintreeIntegrationService,
+    BraintreeMessages,
     BraintreeScriptLoader,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
@@ -26,10 +27,12 @@ const createBraintreePaypalPaymentStrategy: PaymentStrategyFactory<
         braintreeHostWindow,
         overlay,
     );
+    const braintreeMessages = new BraintreeMessages(paymentIntegrationService);
 
     return new BraintreePaypalPaymentStrategy(
         paymentIntegrationService,
         braintreeIntegrationService,
+        braintreeMessages,
         new LoadingIndicator({
             containerStyles: LOADING_INDICATOR_STYLES,
         }),

--- a/packages/braintree-integration/src/mocks/paypal.mock.ts
+++ b/packages/braintree-integration/src/mocks/paypal.mock.ts
@@ -18,6 +18,8 @@ export function getPaypalSDKMock(): PaypalSDK {
             setup: jest.fn(),
         },
         Buttons: jest.fn(),
-        Messages: jest.fn(),
+        Messages: jest.fn().mockReturnValue({
+            render: jest.fn(),
+        }),
     };
 }

--- a/packages/braintree-utils/src/braintree-messages.spec.ts
+++ b/packages/braintree-utils/src/braintree-messages.spec.ts
@@ -1,0 +1,409 @@
+import {
+    PaymentIntegrationService,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { BraintreeHostWindow } from './braintree';
+import BraintreeMessages from './braintree-messages';
+import { getBraintree, getPaypalMock } from './mocks';
+import { MessagingPlacements, PaypalSDK } from './paypal';
+
+describe('BraintreeMessages', () => {
+    let braintreeMessages: BraintreeMessages;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let paymentMethod: PaymentMethod;
+    let paypalSdkMock: PaypalSDK;
+    let paypalMessageElement: HTMLDivElement;
+
+    const amount = 190;
+    const methodId = 'braintreepaypalcredit';
+    const defaultMessageContainerId = 'braintree-paypal-credit-message-mock-id';
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        braintreeMessages = new BraintreeMessages(paymentIntegrationService);
+
+        paypalSdkMock = getPaypalMock();
+        (window as BraintreeHostWindow).paypal = paypalSdkMock;
+
+        paymentMethod = {
+            ...getBraintree(),
+            clientToken: 'myToken',
+        };
+
+        paypalMessageElement = document.createElement('div');
+        paypalMessageElement.id = defaultMessageContainerId;
+        document.body.appendChild(paypalMessageElement);
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethod,
+        );
+    });
+
+    afterEach(() => {
+        delete (window as BraintreeHostWindow).paypal;
+
+        if (document.getElementById(defaultMessageContainerId)) {
+            document.body.removeChild(paypalMessageElement);
+        }
+    });
+
+    it('does not render paypal banner when paypal is not presented in window', () => {
+        delete (window as BraintreeHostWindow).paypal;
+
+        braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.PAYMENT);
+
+        expect(paypalSdkMock.Messages).not.toHaveBeenCalled();
+    });
+
+    it('does not render paypal banner when container is not presented in DOM', () => {
+        document.body.removeChild(paypalMessageElement);
+
+        braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.PAYMENT);
+
+        expect(paypalSdkMock.Messages).not.toHaveBeenCalled();
+    });
+
+    it('does not render paypal banner when payment initialization data was not returned from server', () => {
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            {
+                ...paymentMethod,
+                initializationData: null,
+            },
+        );
+
+        braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.PAYMENT);
+
+        expect(paypalSdkMock.Messages).not.toHaveBeenCalled();
+    });
+
+    it('does not render paypal banner on checkout page when it is disabled', () => {
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    enableCheckoutPaywallBanner: false,
+                    paypalBNPLConfiguration: null,
+                },
+            },
+        );
+
+        braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.PAYMENT);
+
+        expect(paypalSdkMock.Messages).not.toHaveBeenCalled();
+    });
+
+    describe('non BNPL implementation (old approach)', () => {
+        it('renders Braintree Message with provided configuration', () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    enableCheckoutPaywallBanner: true,
+                    paypalBNPLConfiguration: null,
+                },
+            });
+
+            braintreeMessages.render(
+                methodId,
+                defaultMessageContainerId,
+                MessagingPlacements.PAYMENT,
+            );
+
+            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
+                amount,
+                buyerCountry: 'US',
+                placement: 'payment',
+                style: {
+                    layout: 'text',
+                    logo: {
+                        type: 'inline',
+                    },
+                },
+            });
+        });
+    });
+
+    describe('BNPL implementation', () => {
+        it('does not render home page Braintree Message if banner status is false', () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: [
+                        {
+                            id: 'homepage',
+                            name: 'Home page',
+                            status: false,
+                            styles: {},
+                        },
+                    ],
+                },
+            });
+
+            braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.HOME);
+
+            expect(paypalSdkMock.Messages).not.toHaveBeenCalled();
+        });
+
+        it('renders Braintree Message on home page', () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: [
+                        {
+                            id: 'homepage',
+                            name: 'Home page',
+                            status: true,
+                            styles: {
+                                color: 'white-no-border',
+                                layout: 'flex',
+                                ratio: '8x1',
+                            },
+                        },
+                    ],
+                },
+            });
+
+            braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.HOME);
+
+            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
+                amount,
+                buyerCountry: 'US',
+                placement: 'homepage',
+                style: {
+                    color: 'white-no-border',
+                    layout: 'flex',
+                    ratio: '8x1',
+                },
+            });
+        });
+
+        it('does not render product page Braintree Message if banner status is false', () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: [
+                        {
+                            id: 'product',
+                            name: 'Product page',
+                            status: false,
+                            styles: {},
+                        },
+                    ],
+                },
+            });
+
+            braintreeMessages.render(
+                methodId,
+                defaultMessageContainerId,
+                MessagingPlacements.PRODUCT,
+            );
+
+            expect(paypalSdkMock.Messages).not.toHaveBeenCalled();
+        });
+
+        it('renders Braintree Message on product page', () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: [
+                        {
+                            id: 'product',
+                            name: 'Product page',
+                            status: true,
+                            styles: {
+                                layout: 'text',
+                                'logo-type': 'alternative',
+                                'text-color': 'black',
+                                'text-size': '12',
+                            },
+                        },
+                    ],
+                },
+            });
+
+            braintreeMessages.render(
+                methodId,
+                defaultMessageContainerId,
+                MessagingPlacements.PRODUCT,
+            );
+
+            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
+                amount,
+                buyerCountry: 'US',
+                placement: 'product',
+                style: {
+                    layout: 'text',
+                    logo: {
+                        type: 'alternative',
+                    },
+                    text: {
+                        color: 'black',
+                        size: 12,
+                    },
+                },
+            });
+        });
+
+        it('does not render cart page Braintree Message if banner status is false', () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: [
+                        {
+                            id: 'cart',
+                            name: 'Cart page',
+                            status: false,
+                            styles: {},
+                        },
+                    ],
+                },
+            });
+
+            braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.CART);
+
+            expect(paypalSdkMock.Messages).not.toHaveBeenCalled();
+        });
+
+        it('renders Braintree Message on cart page', () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: [
+                        {
+                            id: 'cart',
+                            name: 'Cart page',
+                            status: true,
+                            styles: {
+                                layout: 'text',
+                                'logo-type': 'alternative',
+                                'text-color': 'white',
+                                'text-size': '10',
+                                'logo-position': 'right',
+                            },
+                        },
+                    ],
+                },
+            });
+
+            braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.CART);
+
+            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
+                amount,
+                buyerCountry: 'US',
+                placement: 'cart',
+                style: {
+                    layout: 'text',
+                    logo: {
+                        position: 'right',
+                        type: 'alternative',
+                    },
+                    text: {
+                        color: 'white',
+                        size: 10,
+                    },
+                },
+            });
+        });
+
+        it('does not render checkout page Braintree Message if banner status is false', () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: [
+                        {
+                            id: 'checkout',
+                            name: 'Checkout page',
+                            status: false,
+                            styles: {},
+                        },
+                    ],
+                },
+            });
+
+            braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.CART);
+
+            expect(paypalSdkMock.Messages).not.toHaveBeenCalled();
+        });
+
+        it('renders Braintree Message on checkout page', () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: [
+                        {
+                            id: 'checkout',
+                            name: 'Checkout page',
+                            status: true,
+                            styles: {
+                                layout: 'text',
+                                'logo-type': 'inline',
+                                'text-color': 'black',
+                                'text-size': '12',
+                            },
+                        },
+                    ],
+                },
+            });
+
+            braintreeMessages.render(
+                methodId,
+                defaultMessageContainerId,
+                MessagingPlacements.PAYMENT,
+            );
+
+            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
+                amount,
+                buyerCountry: 'US',
+                placement: 'payment',
+                style: {
+                    layout: 'text',
+                    logo: {
+                        type: 'inline',
+                    },
+                    text: {
+                        color: 'black',
+                        size: 12,
+                    },
+                },
+            });
+        });
+    });
+});

--- a/packages/braintree-utils/src/braintree-messages.ts
+++ b/packages/braintree-utils/src/braintree-messages.ts
@@ -1,0 +1,132 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import {
+    BraintreeHostWindow,
+    BraintreeInitializationData,
+    PayPalBNPLConfigurationItem,
+} from './braintree';
+import { MessagesStyleOptions, MessagingPlacements } from './paypal';
+
+export default class BraintreeMessages {
+    private braintreeHostWindow: BraintreeHostWindow = window;
+
+    constructor(private paymentIntegrationService: PaymentIntegrationService) {}
+
+    render(methodId: string, containerId: string, placement: MessagingPlacements): void {
+        const messagingContainer = containerId && document.getElementById(containerId);
+
+        if (this.braintreeHostWindow.paypal && messagingContainer) {
+            const state = this.paymentIntegrationService.getState();
+            const cart = state.getCartOrThrow();
+            const billingAddress = state.getBillingAddressOrThrow();
+            const paymentMethod =
+                state.getPaymentMethodOrThrow<BraintreeInitializationData>(methodId);
+
+            if (!paymentMethod.initializationData) {
+                return;
+            }
+
+            const { paypalBNPLConfiguration, enableCheckoutPaywallBanner } =
+                paymentMethod.initializationData;
+
+            // TODO: uncomment when PROJECT-7052.braintree_bnpl_configurator is rolled out to 100% for all tiers
+            // const { paypalBNPLConfiguration = [] } = paymentMethod.initializationData || {};
+
+            // TODO: this condition can be removed when PROJECT-7052.braintree_bnpl_configurator is rolled out to 100% for all tiers
+            // since banners enablement will be regulated by the paypalBNPLConfiguration via banner status state
+            // Explanation:
+            // - "enableCheckoutPaywallBanner" is an old approach to enable banner on checkout page
+            // - "paypalBNPLConfiguration" could not be provided from BE when PROJECT-7052.braintree_bnpl_configurator is enabled
+            // - "placement == 'payment'" means that banner should be rendered on checkout page
+            // So, when experiment is disabled we should not render banner on checkout page when enableCheckoutPaywallBanner is false
+            // However, when experiment is enabled, then we should ignore enableCheckoutPaywallBanner flag at all
+            if (
+                placement === MessagingPlacements.PAYMENT &&
+                !paypalBNPLConfiguration &&
+                !enableCheckoutPaywallBanner
+            ) {
+                return;
+            }
+
+            let style: MessagesStyleOptions = {
+                layout: 'text',
+                logo: {
+                    type: 'inline',
+                },
+            };
+
+            if (paypalBNPLConfiguration) {
+                const bannedId = placement === MessagingPlacements.PAYMENT ? 'checkout' : placement;
+                const bannerConfiguration = paypalBNPLConfiguration.find(
+                    ({ id }) => id === bannedId,
+                );
+
+                if (!bannerConfiguration || !bannerConfiguration.status) {
+                    return;
+                }
+
+                if (placement === MessagingPlacements.CART) {
+                    messagingContainer.removeAttribute('data-pp-style-logo-type');
+                    messagingContainer.removeAttribute('data-pp-style-logo-position');
+                    messagingContainer.removeAttribute('data-pp-style-text-color');
+                    messagingContainer.removeAttribute('data-pp-style-text-size');
+                }
+
+                style = this.getPaypalMessagesStylesFromBNPLConfig(bannerConfiguration);
+            }
+
+            this.braintreeHostWindow.paypal
+                .Messages({
+                    amount: cart.cartAmount,
+                    buyerCountry: billingAddress.countryCode,
+                    placement,
+                    style,
+                })
+                .render(`#${containerId}`);
+        }
+    }
+
+    private getPaypalMessagesStylesFromBNPLConfig({
+        styles,
+    }: PayPalBNPLConfigurationItem): MessagesStyleOptions {
+        const messagesStyles: MessagesStyleOptions = {};
+
+        if (styles.color) {
+            messagesStyles.color = styles.color;
+        }
+
+        if (styles.layout) {
+            messagesStyles.layout = styles.layout;
+        }
+
+        if (styles['logo-type'] || styles['logo-position']) {
+            messagesStyles.logo = {};
+
+            if (styles['logo-type']) {
+                messagesStyles.logo.type = styles['logo-type'];
+            }
+
+            if (styles['logo-position']) {
+                messagesStyles.logo.position = styles['logo-position'];
+            }
+        }
+
+        if (styles.ratio) {
+            messagesStyles.ratio = styles.ratio;
+        }
+
+        if (styles['text-color'] || styles['text-size']) {
+            messagesStyles.text = {};
+
+            if (styles['text-color']) {
+                messagesStyles.text.color = styles['text-color'];
+            }
+
+            if (styles['text-size']) {
+                messagesStyles.text.size = +styles['text-size'];
+            }
+        }
+
+        return messagesStyles;
+    }
+}

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -102,6 +102,7 @@ export interface BraintreeLocalPaymentCreateConfig extends BraintreeModuleCreato
 
 export interface BraintreeInitializationData {
     clientToken: string;
+    enableCheckoutPaywallBanner?: boolean;
     intent?: 'authorize' | 'order' | 'sale';
     isCreditEnabled?: boolean;
     isAcceleratedCheckoutEnabled?: boolean;
@@ -112,6 +113,7 @@ export interface BraintreeInitializationData {
     isBraintreeAnalyticsV2Enabled?: boolean;
     shouldRunAcceleratedCheckout?: boolean; // TODO: only for BT AXO A/B testing purposes, hence should be removed after testing
     paymentButtonStyles?: Record<string, PaypalStyleOptions>;
+    paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[];
 }
 
 export interface BraintreePaypalRequest {
@@ -481,6 +483,18 @@ export type BraintreeVisaCheckoutCreator = BraintreeModuleCreator<BraintreeVisaC
 export interface BraintreeVisaCheckout extends BraintreeModule {
     tokenize(payment: VisaCheckoutPaymentSuccessPayload): Promise<VisaCheckoutTokenizedPayload>;
     createInitOptions(options: Partial<VisaCheckoutInitOptions>): VisaCheckoutInitOptions;
+}
+
+/**
+ *
+ * Braintree BNPL Configurator related types
+ *
+ */
+export interface PayPalBNPLConfigurationItem {
+    id: string;
+    name: string;
+    status: boolean;
+    styles: Record<string, string>;
 }
 
 /**

--- a/packages/braintree-utils/src/index.ts
+++ b/packages/braintree-utils/src/index.ts
@@ -3,6 +3,7 @@ export * from './types';
 export * from './utils';
 
 export { default as BraintreeIntegrationService } from './braintree-integration-service';
+export { default as BraintreeMessages } from './braintree-messages';
 export { default as BraintreeScriptLoader } from './braintree-script-loader';
 export { default as BraintreeSdk } from './braintree-sdk';
 export { default as createBraintreeSdk } from './create-braintree-sdk';

--- a/packages/braintree-utils/src/map-to-legacy-billing-address.spec.ts
+++ b/packages/braintree-utils/src/map-to-legacy-billing-address.spec.ts
@@ -78,6 +78,7 @@ describe('mapToLegacyBillingAddress()', () => {
         };
 
         const result = mapToLegacyBillingAddress(details);
+
         expect(result).toEqual({
             email: 'noaddress@example.com',
             first_name: 'No',

--- a/packages/braintree-utils/src/map-to-legacy-shipping-address.spec.ts
+++ b/packages/braintree-utils/src/map-to-legacy-shipping-address.spec.ts
@@ -44,6 +44,7 @@ describe('mapToLegacyShippingAddress()', () => {
         };
 
         const result = mapToLegacyShippingAddress(details);
+
         expect(result).toEqual({
             email: 'noaddress@example.com',
             first_name: '',

--- a/packages/braintree-utils/src/mocks/paypal.mock.ts
+++ b/packages/braintree-utils/src/mocks/paypal.mock.ts
@@ -18,6 +18,8 @@ export function getPaypalMock(): PaypalSDK {
             setup: jest.fn(),
         },
         Buttons: jest.fn(),
-        Messages: jest.fn(),
+        Messages: jest.fn().mockReturnValue({
+            render: jest.fn(),
+        }),
     };
 }

--- a/packages/braintree-utils/src/paypal.ts
+++ b/packages/braintree-utils/src/paypal.ts
@@ -77,10 +77,25 @@ export interface MessagingOptions {
 }
 
 export interface MessagesStyleOptions {
-    layout?: 'text' | 'flex';
+    color?: string; // 'blue' | 'black' | 'white' | 'white-no-border' | 'gray' | 'monochrome' | 'grayscale'
+    layout?: string; // 'text' | 'flex'
     logo?: {
-        type: 'none' | 'inline' | 'primary';
+        type?: string; // 'primary' | 'alternative' | 'inline' | 'none'
+        position?: string; // 'left' | 'right' | 'top'
     };
+    ratio?: string; // '1x1' | '1x4' | '8x1' | '20x1'
+    text?: {
+        align?: string; // 'left' | 'right' | 'center'
+        color?: string; // 'black' | 'white' | 'monochrome' | 'grayscale'
+        size?: number; // from 10 to 16
+    };
+}
+
+export enum MessagingPlacements {
+    CART = 'cart',
+    HOME = 'homepage',
+    PAYMENT = 'payment',
+    PRODUCT = 'product',
 }
 
 export interface MessagingRender {

--- a/packages/braintree-utils/src/utils/get-fastlane-styles.spec.ts
+++ b/packages/braintree-utils/src/utils/get-fastlane-styles.spec.ts
@@ -71,6 +71,7 @@ describe('#getValidBraintreeFastlaneStyles()', () => {
         const uiStyles = {
             root: { backgroundColorPrimary: 'red' },
         };
+
         expect(getFastlaneStyles(undefined, uiStyles)).toEqual(uiStyles);
     });
 
@@ -78,6 +79,7 @@ describe('#getValidBraintreeFastlaneStyles()', () => {
         const styleSettings = {
             fastlaneRootSettingsBackgroundColor: 'blue',
         };
+
         expect(getFastlaneStyles(styleSettings)).toEqual({
             root: { backgroundColorPrimary: 'blue' },
         });
@@ -115,6 +117,7 @@ describe('#getValidBraintreeFastlaneStyles()', () => {
                 },
             },
         };
+
         expect(getFastlaneStyles(styleSettings, uiStyles)).toEqual({
             root: {
                 backgroundColorPrimary: 'blue',


### PR DESCRIPTION
## What?
Created Braintree Messages class and added Braintree BNPL Configurator implementation

## Why?
To be able to apply BNPL banner style changes on checkout payment paywall

## Testing / Proof
Unit tests
Manual tests

<img width="1017" alt="Screenshot 2025-03-13 at 17 51 36" src="https://github.com/user-attachments/assets/24c7542e-63e9-4b94-999c-f8f551a49983" />
<img width="744" alt="Screenshot 2025-03-13 at 16 47 10" src="https://github.com/user-attachments/assets/28254c8f-60bb-4a9d-9d0b-fe4b46b4dd06" />

