### PR TITLE
feat(payment): PI-3539 added additionalDescription to the shipping options in Google Pay popup

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -418,8 +418,21 @@ export default class GooglePayGateway {
         );
     }
 
-    private _getGooglePayShippingOption({ id, cost, description }: ShippingOption) {
+    private _getGooglePayShippingOption({ id, cost, description, additionalDescription }: ShippingOption) {
         const formattedCost = this._currencyService?.toCustomerCurrency(cost);
+        const state = this._paymentIntegrationService.getState();
+        const isNewShippingOptionsExperimentOn = state.getStoreConfigOrThrow().checkoutSettings.features[
+            // TODO add experiment
+            'experiment_name'
+            ];
+
+        if (isNewShippingOptionsExperimentOn) {
+            return {
+                id,
+                label: `${formattedCost || cost} ${description}`,
+                description: additionalDescription,
+            };
+        }
 
         return {
             id,


### PR DESCRIPTION
## What?
Before chages:
<img width="658" alt="Before" src="https://github.com/user-attachments/assets/349045f2-00ad-4e36-8f53-5b6ca7e3486a" />

After changes with `additionalDescription`:
<img width="659" alt="Screenshot 2025-03-20 at 11 39 35" src="https://github.com/user-attachments/assets/bcfe2b3f-d14f-4d9b-97cd-07d409bff417" />

After changes with `additionalDescription` empty:
<img width="635" alt="After without description" src="https://github.com/user-attachments/assets/8d845405-f928-411b-83f9-e1e257c00cba" />


## Why?
Because we don't display carrier quote description in the Google Pay popup window

## Testing / Proof
In progress

@bigcommerce/team-checkout @bigcommerce/team-payments
