### PR TITLE
fix(payment): PAYPAL-4585 updated Braintree Button height validation with null and undefined coverage

### DIFF
--- a/packages/braintree-integration/src/get-valid-button-style.spec.ts
+++ b/packages/braintree-integration/src/get-valid-button-style.spec.ts
@@ -102,6 +102,25 @@ describe('#getValidButtonStyle()', () => {
         expect(getValidButtonStyle(stylesMock)).toEqual(expects);
     });
 
+    it('returns styles with default height if height value is null', () => {
+        const stylesMock = {
+            color: PaypalButtonStyleColorOption.SIlVER,
+            fundingicons: true,
+            height: undefined,
+            layout: PaypalButtonStyleLayoutOption.HORIZONTAL,
+            shape: PaypalButtonStyleShapeOption.RECT,
+            size: PaypalButtonStyleSizeOption.SMALL,
+            tagline: true,
+        };
+
+        const expects = {
+            ...stylesMock,
+            height: 40,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
     it('returns styles with valid height even if number inside a string was received', () => {
         const stylesMock = {
             color: PaypalButtonStyleColorOption.SIlVER,

--- a/packages/braintree-integration/src/get-valid-button-style.ts
+++ b/packages/braintree-integration/src/get-valid-button-style.ts
@@ -25,7 +25,7 @@ function getValidHeight(height: number | string): number {
 
     const currentHeight = Number(height);
 
-    if (Number.isNaN(currentHeight)) {
+    if (!currentHeight || Number.isNaN(currentHeight)) {
         return defaultHeight;
     }
 


### PR DESCRIPTION
## What?
Updated Braintree Button height validation with null and undefined coverage

## Why?
Because when BE provides height as null, then current implementation returns minHeight (25px) instead of default

## Testing / Proof
Unit tests
Manual tests