### PR TITLE
chore(shipping): CHECKOUT-9114 Map invalid shipping address error type to a custom error

### DIFF
--- a/packages/core/src/order/errors/invalid-shipping-address-error.spec.ts
+++ b/packages/core/src/order/errors/invalid-shipping-address-error.spec.ts
@@ -1,0 +1,9 @@
+import InvalidShippingAddressError from './invalid-shipping-address-error';
+
+describe('InvalidShippingAddressError', () => {
+    it('returns error name', () => {
+        const error = new InvalidShippingAddressError('error');
+
+        expect(error.name).toBe('InvalidShippingAddressError');
+    });
+});

--- a/packages/core/src/order/errors/invalid-shipping-address-error.ts
+++ b/packages/core/src/order/errors/invalid-shipping-address-error.ts
@@ -1,0 +1,10 @@
+import { StandardError } from '../../common/error/errors';
+
+export default class InvalidShippingAddressError extends StandardError {
+    constructor(message: string) {
+        super(message);
+
+        this.name = 'InvalidShippingAddressError';
+        this.type = 'invalid_shipping_address';
+    }
+}

--- a/packages/core/src/order/order-request-sender.spec.ts
+++ b/packages/core/src/order/order-request-sender.spec.ts
@@ -169,16 +169,14 @@ describe('OrderRequestSender', () => {
 
             jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
 
-            try {
-                const payload = {
-                    cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
-                    useStoreCredit: false,
-                };
+            const payload = {
+                cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                useStoreCredit: false,
+            };
 
-                await orderRequestSender.submitOrder(payload);
-            } catch (error) {
-                expect(error).toBeInstanceOf(MissingShippingMethodError);
-            }
+            await expect(orderRequestSender.submitOrder(payload)).rejects.toThrow(
+                MissingShippingMethodError,
+            );
         });
 
         it('throws `InvalidShippingAddressError` if error type is `invalid_shipping_address`', async () => {
@@ -194,16 +192,14 @@ describe('OrderRequestSender', () => {
 
             jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
 
-            try {
-                const payload = {
-                    cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
-                    useStoreCredit: false,
-                };
+            const payload = {
+                cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                useStoreCredit: false,
+            };
 
-                await orderRequestSender.submitOrder(payload);
-            } catch (error) {
-                expect(error).toBeInstanceOf(InvalidShippingAddressError);
-            }
+            await expect(orderRequestSender.submitOrder(payload)).rejects.toThrow(
+                InvalidShippingAddressError,
+            );
         });
 
         it('submits order and returns response with timeout', async () => {

--- a/packages/core/src/order/order-request-sender.spec.ts
+++ b/packages/core/src/order/order-request-sender.spec.ts
@@ -5,6 +5,7 @@ import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import { MissingShippingMethodError, OrderTaxProviderUnavailableError } from './errors';
+import InvalidShippingAddressError from './errors/invalid-shipping-address-error';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import { getCompleteOrderResponseBody } from './internal-orders.mock';
 import Order from './order';
@@ -177,6 +178,31 @@ describe('OrderRequestSender', () => {
                 await orderRequestSender.submitOrder(payload);
             } catch (error) {
                 expect(error).toBeInstanceOf(MissingShippingMethodError);
+            }
+        });
+
+        it('throws `InvalidShippingAddressError` if error type is `invalid_shipping_address`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 400,
+                    title: 'Invalid shipping address',
+                    type: 'invalid_shipping_address',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
+
+            try {
+                const payload = {
+                    cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                    useStoreCredit: false,
+                };
+
+                await orderRequestSender.submitOrder(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidShippingAddressError);
             }
         });
 

--- a/packages/core/src/order/order-request-sender.ts
+++ b/packages/core/src/order/order-request-sender.ts
@@ -10,6 +10,7 @@ import {
 } from '../common/http-request';
 
 import { MissingShippingMethodError, OrderTaxProviderUnavailableError } from './errors';
+import InvalidShippingAddressError from './errors/invalid-shipping-address-error';
 import InternalOrderRequestBody from './internal-order-request-body';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import Order from './order';
@@ -77,6 +78,10 @@ export default class OrderRequestSender {
 
                 if (error.body.type === 'missing_shipping_method') {
                     throw new MissingShippingMethodError(error.body.detail);
+                }
+
+                if (error.body.type === 'invalid_shipping_address') {
+                    throw new InvalidShippingAddressError(error.body.detail);
                 }
 
                 throw error;


### PR DESCRIPTION
## What?
Map invalid shipping address error type to a custom error

## Why?
To display a better and more informed error heading to shopper map api error to custom error

## Testing / Proof
- CI
- Screenshot

![Screenshot 2025-04-02 at 10 40 40 pm](https://github.com/user-attachments/assets/9d2d9120-bdbd-4e6c-9cda-cfe53cc7d88c)



@bigcommerce/team-checkout @bigcommerce/team-payments
