### PR TITLE
feat(checkout): CHECKOUt-8521 Mark discounts field as optional

### DIFF
--- a/packages/core/src/order/order.ts
+++ b/packages/core/src/order/order.ts
@@ -126,5 +126,5 @@ export interface OrderShippingConsignment {
         name: string;
         value: string | null;
     }>;
-    discounts: OrderShippingConsignmentDiscount[];
+    discounts?: OrderShippingConsignmentDiscount[];
 }

--- a/packages/payment-integration-api/src/order/order.ts
+++ b/packages/payment-integration-api/src/order/order.ts
@@ -113,5 +113,5 @@ export interface OrderShippingConsignment {
         name: string;
         value: string | null;
     }>;
-    discounts: OrderShippingConsignmentDiscount[];
+    discounts?: OrderShippingConsignmentDiscount[];
 }


### PR DESCRIPTION
## What?
Mark discounts field as optional

## Why?
The `discounts` field is not consistently returned yet, as the related API experiment hasn't fully rolled out.

## Testing / Proof
CI

@bigcommerce/team-checkout @bigcommerce/team-payments
