### PR TITLE
feat(payment): PI-3669 apply multiple coupons in the Google Pay modal

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
@@ -16,12 +16,7 @@ import {
 
 import getCardDataResponse from '../mocks/google-pay-card-data-response.mock';
 import { getAuthorizeNet, getGeneric } from '../mocks/google-pay-payment-method.mock';
-import {
-    CallbackIntentsType,
-    CallbackTriggerType,
-    ErrorReasonType,
-    GooglePayFullBillingAddress,
-} from '../types';
+import { CallbackIntentsType, CallbackTriggerType, GooglePayFullBillingAddress } from '../types';
 
 import GooglePayGateway from './google-pay-gateway';
 
@@ -385,53 +380,22 @@ describe('GooglePayGateway', () => {
     });
 
     describe('#handleCoupons', () => {
-        const removeCouponButton = {
-            ...document.createElement('a'),
-            click: jest.fn(),
-        };
-        const couponCodeInput = {
-            ...document.createElement('input'),
-        };
-
-        const form = {
-            ...document.createElement('form'),
-            dispatchEvent: jest.fn(),
-        };
-
         let applyCouponIntegrationService: SpyInstance<
+            Promise<PaymentIntegrationSelectors>,
+            [coupon: string, options?: RequestOptions<Record<string, unknown>> | undefined]
+        >;
+
+        let removeCouponIntegrationService: SpyInstance<
             Promise<PaymentIntegrationSelectors>,
             [coupon: string, options?: RequestOptions<Record<string, unknown>> | undefined]
         >;
 
         beforeEach(() => {
             applyCouponIntegrationService = jest.spyOn(paymentIntegrationService, 'applyCoupon');
-
-            jest.spyOn(document, 'getElementById').mockImplementation((selector: string) => {
-                switch (selector) {
-                    case 'couponcode':
-                        return couponCodeInput;
-
-                    default:
-                        return null;
-                }
-            });
-
-            jest.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
-                switch (selector) {
-                    case 'a[href*="/cart.php?action=removecoupon"]':
-                        return removeCouponButton;
-
-                    case '.coupon-form':
-                        return form;
-
-                    default:
-                        return null;
-                }
-            });
-            jest.spyOn(gateway, 'removeAllCoupons');
+            removeCouponIntegrationService = jest.spyOn(paymentIntegrationService, 'removeCoupon');
         });
 
-        it('should return applied coupon code', async () => {
+        it('should apply coupon codes', async () => {
             jest.spyOn(gateway, 'getAppliedCoupons')
                 .mockReturnValueOnce({ offers: [] })
                 .mockReturnValueOnce({
@@ -444,7 +408,8 @@ describe('GooglePayGateway', () => {
                 redemptionCodes: ['code1'],
             });
 
-            expect(applyCouponIntegrationService).toHaveBeenCalledWith('code1');
+            expect(removeCouponIntegrationService).not.toHaveBeenCalled();
+            expect(applyCouponIntegrationService).toHaveBeenCalledTimes(1);
             expect(result).toStrictEqual({
                 error: undefined,
                 newOfferInfo: {
@@ -458,82 +423,38 @@ describe('GooglePayGateway', () => {
             });
         });
 
-        it('should return a google pay error object if there is a coupon code already applied', async () => {
-            jest.spyOn(gateway, 'getAppliedCoupons').mockReturnValueOnce({
-                offers: [{ redemptionCode: 'code2', description: 'some description' }],
-            });
-
-            await gateway.initialize(getGeneric);
-
-            const result = await gateway.handleCoupons({
-                redemptionCodes: ['code1'],
-            });
-
-            expect(result).toStrictEqual({
-                error: {
-                    intent: CallbackTriggerType.OFFER,
-                    message: 'You can only apply one promo code per order.',
-                    reason: ErrorReasonType.OFFER_INVALID,
-                },
-                newOfferInfo: {
-                    offers: [
-                        {
-                            description: 'some description',
-                            redemptionCode: 'code2',
-                        },
-                    ],
-                },
-            });
-        });
-
-        it('should call removeAllCoupons if there is no coupon codes came in the arguments', async () => {
-            jest.spyOn(gateway, 'getAppliedCoupons').mockReturnValueOnce({
-                offers: [{ redemptionCode: 'code_123', description: 'some description' }],
-            });
-
-            await gateway.initialize(getGeneric);
-            await gateway.handleCoupons({
-                redemptionCodes: [],
-            });
-
-            expect(gateway.removeAllCoupons).toHaveBeenCalledWith({
-                offers: [
-                    {
-                        description: 'some description',
-                        redemptionCode: 'code_123',
-                    },
-                ],
-            });
-            expect(removeCouponButton.click).toHaveBeenCalled();
-        });
-
-        it('should return applied coupon code if there is cart page selectors (behaviour on the cart page)', async () => {
+        it('should remove coupon codes', async () => {
             jest.spyOn(gateway, 'getAppliedCoupons')
-                .mockReturnValueOnce({ offers: [] })
                 .mockReturnValueOnce({
-                    offers: [{ redemptionCode: 'code444', description: 'some description' }],
+                    offers: [
+                        { redemptionCode: 'code1', description: 'some description' },
+                        { redemptionCode: 'code2', description: 'some description 2' },
+                        { redemptionCode: 'code3', description: 'some description 3' },
+                    ],
+                })
+                .mockReturnValueOnce({
+                    offers: [{ redemptionCode: 'code2', description: 'some description 2' }],
                 });
 
             await gateway.initialize(getGeneric);
 
             const result = await gateway.handleCoupons({
-                redemptionCodes: ['code444'],
+                redemptionCodes: ['code2'],
             });
 
-            expect(applyCouponIntegrationService).toHaveBeenCalledWith('code444');
+            expect(applyCouponIntegrationService).not.toHaveBeenCalled();
+            expect(removeCouponIntegrationService).toHaveBeenCalledTimes(2);
             expect(result).toStrictEqual({
                 error: undefined,
                 newOfferInfo: {
                     offers: [
                         {
-                            description: 'some description',
-                            redemptionCode: 'code444',
+                            description: 'some description 2',
+                            redemptionCode: 'code2',
                         },
                     ],
                 },
             });
-            expect(couponCodeInput.value).toBe('code444');
-            expect(form.dispatchEvent).toHaveBeenCalled();
         });
 
         it('should return Google Pay error object if applyCoupon is failed', async () => {


### PR DESCRIPTION
## What?
Added possibility to apply multiple coupons in the Google Pay modal.

## Why?
Because we don't have the functionality to apply multiple coupons in the Google Pay modal.

## Testing / Proof
Manual testing.

https://github.com/user-attachments/assets/508f12a5-5f5d-4e3b-9ad9-57fa0ce8a94d



@bigcommerce/team-checkout @bigcommerce/team-payments
