### PR TITLE
feat(payment): STRIPE-667 remove experiment for Stripe Link Spain state mapping

### DIFF
--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
@@ -41,7 +41,6 @@ import { getFlatRateOption } from '../../internal-shipping-options.mock';
 import { getShippingAddress } from '../../shipping-addresses.mock';
 import { ShippingInitializeOptions } from '../../shipping-request-options';
 
-import StripeUPEShippingInitializeOptions from './stripe-upe-shipping-initialize-options';
 import StripeUPEShippingStrategy from './stripe-upe-shipping-strategy';
 
 // TODO: CHECKOUT-7766
@@ -408,42 +407,6 @@ describe('StripeUPEShippingStrategy', () => {
             const promise = strategy.initialize(shippingInitialization);
 
             await expect(promise).rejects.toBeInstanceOf(MissingDataError);
-        });
-
-        it('Set experiments from initialization data and get state mapping with experiment', async () => {
-            const setStripeExperimentsMock = jest.fn();
-            const stripeUPEMock = getStripeUPE();
-            const shippingAddressMock = getShippingAddress();
-
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
-                ...stripeUPEMock,
-                initializationData: {
-                    ...stripeUPEMock.initializationData,
-                    isStripeStateMappingDisabledForES: true,
-                },
-            });
-            jest.spyOn(store.getState().shippingAddress, 'getShippingAddress').mockReturnValue(
-                shippingAddressMock,
-            );
-
-            await expect(
-                strategy.initialize({
-                    ...shippingInitialization,
-                    stripeupe: {
-                        ...shippingInitialization.stripeupe,
-                        setStripeExperiments: setStripeExperimentsMock,
-                    } as StripeUPEShippingInitializeOptions,
-                }),
-            ).resolves.toBe(store.getState());
-
-            expect(setStripeExperimentsMock).toHaveBeenCalledWith({
-                isStripeStateMappingDisabledForES: true,
-            });
-            expect(shippingInitialization.stripeupe?.getStripeState).toHaveBeenCalledWith(
-                shippingAddressMock.countryCode,
-                shippingAddressMock.stateOrProvinceCode,
-                true,
-            );
         });
     });
 

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -64,7 +64,6 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
             getStyles,
             availableCountries,
             getStripeState,
-            setStripeExperiments,
         } = options.stripeupe;
 
         Object.entries(options.stripeupe).forEach(([key, value]) => {
@@ -82,11 +81,7 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
         );
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId, gatewayId);
         const {
-            initializationData: {
-                stripePublishableKey,
-                stripeConnectedAccount,
-                isStripeStateMappingDisabledForES,
-            },
+            initializationData: { stripePublishableKey, stripeConnectedAccount },
         } = paymentMethod;
 
         if (
@@ -96,10 +91,6 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
         ) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
-
-        setStripeExperiments?.({
-            isStripeStateMappingDisabledForES,
-        });
 
         this._stripeUPEClient = await this._stripeUPEScriptLoader.getStripeClient(
             stripePublishableKey,
@@ -183,11 +174,7 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
             } = shipping;
             const stripeState =
                 stateOrProvinceCode && countryCode
-                    ? getStripeState(
-                          countryCode,
-                          stateOrProvinceCode,
-                          isStripeStateMappingDisabledForES,
-                      )
+                    ? getStripeState(countryCode, stateOrProvinceCode)
                     : stateOrProvinceCode;
 
             option = {

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
@@ -464,7 +464,6 @@ export interface StripeUPEInitializationData {
     stripePublishableKey: string;
     stripeConnectedAccount: string;
     shopperLanguage: string;
-    isStripeStateMappingDisabledForES?: boolean;
 }
 
 export interface StripeElementUpdateOptions {


### PR DESCRIPTION
## What?
Remove experiment for Stripe Link Spain state mapping
Prs:
checkout-js: [https://github.com/bigcommerce/checkout-js/pull/2253](https://github.com/bigcommerce/checkout-js/pull/2253)

## Why?
Fix was successfully rolled out and experiment can be removed

## Rollout/Rollback
Rollback this PR

## Testing
<img width="2106" alt="Screenshot 2025-04-10 at 16 46 46" src="https://github.com/user-attachments/assets/ea3e2c4e-3e45-41d9-8db3-8762d03964c9" />

Stripe Link add new address

https://github.com/user-attachments/assets/daef8aac-e8d5-4c1e-942a-5a03b63778c2

Stripe Link change existing address

https://github.com/user-attachments/assets/bcb6f646-b9a3-4e4a-a408-4a003e252544

Stripe Link pay with existing address

https://github.com/user-attachments/assets/79fc8fe8-82ec-49a6-85bb-c153a107b92f

@bigcommerce/team-checkout @bigcommerce/team-payments
