### PR TITLE
feat(payment): PAYPAL-5354 Cannot read properties of undefined (reading 'customFields')

### DIFF
--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
@@ -369,7 +369,7 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
                 selectedAddress,
                 countries,
                 selectedAddress.phoneNumber,
-                shipping[0].customFields,
+                shipping[0]?.customFields,
             );
 
             if (shippingAddress) {

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
@@ -246,7 +246,7 @@ export default class PayPalCommerceFastlaneShippingStrategy implements ShippingS
                 selectedAddress.address,
                 selectedAddress.name,
                 selectedAddress.phoneNumber,
-                shipping[0].customFields,
+                shipping[0]?.customFields,
             );
 
             const paymentProviderCustomerAddresses =


### PR DESCRIPTION
## What?

`Consignments` can be an empty array, so in this case we get an error when trying to get `customFields`

## Why?

To fix `undefined` properties cannot be read error

## Testing / Proof

Can not be able to reproduce it via integration/local store. But the problem should be fixed after these changes. I will take a look at the Sentry logs after deployment.

@bigcommerce/team-checkout @bigcommerce/team-payments


[PAYPAL-5354]: https://bigcommercecloud.atlassian.net/browse/PAYPAL-5354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ