### PR TITLE
feat(payment): PI-3225 added loadingIndicator to the google-pay-payment-strategy

### DIFF
--- a/packages/google-pay-integration/src/google-pay-payment-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-initialize-options.ts
@@ -39,6 +39,11 @@
  */
 export default interface GooglePayPaymentInitializeOptions {
     /**
+     * A container for loading spinner.
+     */
+    loadingContainerId?: string;
+
+    /**
      * This walletButton is used to set an event listener, provide an element ID if you want
      * users to be able to launch the GooglePay wallet modal by clicking on a button.
      * It should be an HTML element.

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -36,6 +36,16 @@ import {
     NewTransactionInfo,
 } from './types';
 
+const LoadingShow = jest.fn();
+const LoadingHide = jest.fn();
+
+jest.mock('@bigcommerce/checkout-sdk/ui', () => ({
+    LoadingIndicator: jest.fn().mockImplementation(() => ({
+        show: LoadingShow,
+        hide: LoadingHide,
+    })),
+}));
+
 describe('GooglePayPaymentStrategy', () => {
     const BUTTON_ID = 'my_awesome_google_pay_button';
 
@@ -99,6 +109,7 @@ describe('GooglePayPaymentStrategy', () => {
         options = {
             methodId: 'googlepayworldpayaccess',
             googlepayworldpayaccess: {
+                loadingContainerId: 'id',
                 walletButton: BUTTON_ID,
                 onError: jest.fn(),
                 onPaymentSelect: jest.fn(),
@@ -333,6 +344,7 @@ describe('GooglePayPaymentStrategy', () => {
 
             await new Promise((resolve) => process.nextTick(resolve));
 
+            expect(LoadingHide).toHaveBeenCalled();
             expect(rejectedInitializeWidgetMock).toHaveBeenCalledTimes(1);
             expect(options.googlepayworldpayaccess?.onError).toHaveBeenCalled();
         });
@@ -371,6 +383,7 @@ describe('GooglePayPaymentStrategy', () => {
 
                 expect(paymentIntegrationService.loadCheckout).toHaveBeenCalled();
                 expect(initializeWidgetMock).toHaveBeenCalledTimes(1);
+                expect(LoadingShow).toHaveBeenCalled();
             });
 
             it('should return updated transactionInfo', async () => {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,6 @@
 export { Overlay } from './overlay';
-export { LoadingIndicator, LoadingIndicatorStyles } from './loading-indicator';
+export {
+    LoadingIndicator,
+    LoadingIndicatorStyles,
+    DEFAULT_CONTAINER_STYLES,
+} from './loading-indicator';

--- a/packages/ui/src/loading-indicator/index.ts
+++ b/packages/ui/src/loading-indicator/index.ts
@@ -1,2 +1,3 @@
 export { default as LoadingIndicator } from './loading-indicator';
+export { DEFAULT_CONTAINER_STYLES } from './loading-indicator';
 export { LoadingIndicatorStyles } from './loading-indicator-styles';

--- a/packages/ui/src/loading-indicator/loading-indicator.ts
+++ b/packages/ui/src/loading-indicator/loading-indicator.ts
@@ -9,6 +9,12 @@ const DEFAULT_STYLES: LoadingIndicatorStyles = {
     backgroundColor: '#ffffff',
 };
 
+export const DEFAULT_CONTAINER_STYLES = {
+    position: 'fixed',
+    'background-color': 'rgba(0, 0, 0, 0.4)',
+    'z-index': '1000',
+};
+
 const ROTATION_ANIMATION = 'embedded-checkout-loading-indicator-rotation';
 
 interface LoadingIndicatorOptions {


### PR DESCRIPTION
## What?
Added Loading Indicator to the google-pay-payment-strategy

## Why?
Because of the Sentry issue. 
User clicks on the Place order button before our requests are done, so we have to show loader in this case.

## Testing / Proof
Manual tests

https://github.com/user-attachments/assets/654d9c8b-91cb-4e2f-a2e2-7e1f98cba21a



@bigcommerce/team-checkout @bigcommerce/team-payments
