### PR TITLE
chore(common): update node to 22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ aliases:
   - &node_executor
       executor:
         name: node/node
-        node-version: "20.6.0"
+        node-version: "22.13.0"
 
 version: 2.1
 
@@ -66,7 +66,7 @@ jobs:
 
   build:
     <<: *node_executor
-    resource_class: medium+
+    resource_class: large
     steps:
       - ci/pre-setup
       - node/npm-install
@@ -132,7 +132,6 @@ workflows:
       - test-packages
       - lint
       - build
-      - ci/validate-commits
 
       # Only build and push CDN artifact when commits are merged to canonical repo
       - build_cdn:
@@ -145,7 +144,6 @@ workflows:
             - test-packages
             - lint
             - build
-            - ci/validate-commits
       - ci/build-js-artifact:
           context: "GCR + Artifact Bucket Access"
           dist_directory: dist-cdn
@@ -177,7 +175,6 @@ workflows:
             - test-packages
             - lint
             - build
-            - ci/validate-commits
       - npm_release:
           requires:
             - approve_npm_release

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,8 +86,8 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "20",
-        "npm": "9"
+        "node": "22",
+        "npm": "10"
       },
       "optionalDependencies": {
         "@swc/core-linux-x64-gnu": "^1.5.29"

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "url": "https://github.com/bigcommerce/checkout-sdk-js/issues"
   },
   "engines": {
-    "node": "20",
-    "npm": "9"
+    "node": "22",
+    "npm": "10"
   },
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-sdk-js",
   "scripts": {
-    "prepare": "check-node-version --node '>=20' --npm '>=9'",
+    "prepare": "check-node-version --node '>=22' --npm '>=10'",
     "build": "npm run bundle && npm run bundle-dts",
     "build:link": "rm -rf dist && npx nx run core:build --skip-nx-cache && npm run bundle-dts",
     "prebuild-cdn": "rm -rf dist-cdn",


### PR DESCRIPTION
## What?
- Update node to 22
- Drop validate commit CI step

## Why?
Update to latest node version.

## Testing / Proof
- CI

@bigcommerce/team-checkout @bigcommerce/team-payments
