### PR TITLE
fix(payment): PI-3028 take fresh data from state on the amazonpay cus…

### DIFF
--- a/packages/amazon-pay-integration/src/amazon-pay-v2-customer-strategy.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-customer-strategy.ts
@@ -33,14 +33,17 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
             );
         }
 
-        const state = this.paymentIntegrationService.getState();
         let paymentMethod: PaymentMethod<AmazonPayV2InitializeOptions>;
 
         try {
-            paymentMethod = state.getPaymentMethodOrThrow(methodId);
+            paymentMethod = this.paymentIntegrationService
+                .getState()
+                .getPaymentMethodOrThrow(methodId);
         } catch (_e) {
             await this.paymentIntegrationService.loadPaymentMethod(methodId);
-            paymentMethod = state.getPaymentMethodOrThrow(methodId);
+            paymentMethod = this.paymentIntegrationService
+                .getState()
+                .getPaymentMethodOrThrow(methodId);
         }
 
         await this.amazonPayV2PaymentProcessor.initialize(paymentMethod);


### PR DESCRIPTION
…tomer strategy initialization

## What?
Take fresh data from state on the AmazonPay customer strategy initialization

## Why?
When AmazonPay initialize request doesn't return AmazonPay data we need to re-fetch data again.
The problem occurs because for this cases we take data from state that was before an update.
We need to take fresh data from state.

## Testing / Proof

https://github.com/user-attachments/assets/e05d9eb3-f610-4de9-af12-c796c96803e7



@bigcommerce/team-checkout @bigcommerce/team-payments
