### PR TITLE
feature(payment): create blank package bcpay-utils

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,6 +80,7 @@
 
 /packages/braintree-integration @bigcommerce/team-paypal
 /packages/braintree-utils @bigcommerce/team-paypal
+/packages/bcpay-utils @bigcommerce/team-paypal
 /packages/paypal-express-integration @bigcommerce/team-paypal
 /packages/paypal-commerce-integration @bigcommerce/team-paypal
 /packages/paypal-commerce-utils @bigcommerce/team-paypal

--- a/packages/bcpay-utils/.eslintrc.json
+++ b/packages/bcpay-utils/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.js", "*.jsx"],
+            "rules": {}
+        }
+    ]
+}

--- a/packages/bcpay-utils/README.md
+++ b/packages/bcpay-utils/README.md
@@ -1,0 +1,11 @@
+# bcpay-utils
+
+This package contains utils cloned from paypal-commerce-utils for the integration layer of the BigCommerce provider (bcpay-integration).
+
+## Running unit tests
+
+Run `npx nx test bcpay-utils` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `npx nx lint bcpay-utils` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/bcpay-utils/jest.config.js
+++ b/packages/bcpay-utils/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+    displayName: 'bcpay-utils',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+        },
+    },
+    transform: {
+        '^.+\\.[tj]sx?$': 'ts-jest',
+    },
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    coverageDirectory: '../../coverage/packages/bcpay-utils',
+};

--- a/packages/bcpay-utils/project.json
+++ b/packages/bcpay-utils/project.json
@@ -1,0 +1,23 @@
+{
+    "root": "packages/bcpay-utils",
+    "sourceRoot": "packages/bcpay-utils/src",
+    "projectType": "library",
+    "targets": {
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/bcpay-utils/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["coverage/packages/bcpay-utils"],
+            "options": {
+                "jestConfig": "packages/bcpay-utils/jest.config.js",
+                "passWithNoTests": true
+            }
+        }
+    },
+    "tags": ["scope:shared"]
+}

--- a/packages/bcpay-utils/tsconfig.json
+++ b/packages/bcpay-utils/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ],
+    "compilerOptions": {
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    }
+}

--- a/packages/bcpay-utils/tsconfig.lib.json
+++ b/packages/bcpay-utils/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": []
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.spec.ts"]
+}

--- a/packages/bcpay-utils/tsconfig.spec.json
+++ b/packages/bcpay-utils/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.d.ts"
+    ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -41,6 +41,7 @@
             "@bigcommerce/checkout-sdk/apple-pay-integration": [
                 "packages/apple-pay-integration/src/index.ts"
             ],
+            "@bigcommerce/checkout-sdk/bcpay-utils": ["packages/bcpay-utils/src/index.ts"],
             "@bigcommerce/checkout-sdk/bluesnap-direct-integration": [
                 "packages/bluesnap-direct-integration/src/index.ts"
             ],

--- a/workspace.json
+++ b/workspace.json
@@ -9,6 +9,7 @@
         "amazon-pay-utils": "packages/amazon-pay-utils",
         "analytics": "packages/analytics",
         "apple-pay-integration": "packages/apple-pay-integration",
+        "bcpay-utils": "packages/bcpay-utils",
         "bluesnap-direct-integration": "packages/bluesnap-direct-integration",
         "bolt-integration": "packages/bolt-integration",
         "braintree-integration": "packages/braintree-integration",


### PR DESCRIPTION
## What?
Created blank package for bcpay-utils and added package

## Why?
To create separate package as clone of paypal-commerce-integration

## Testing / Proof


@bigcommerce/team-checkout @bigcommerce/team-payments
