### PR TITLE
feat(payment): Stripe OCS accordion element styling

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
@@ -1,4 +1,4 @@
-import { StripeElementUpdateOptions } from './stripe-upe';
+import { StripeElementUpdateOptions, StripeUPEAppearanceValues } from './stripe-upe';
 
 /**
  * A set of options that are required to initialize the Stripe payment method.
@@ -31,9 +31,7 @@ export default interface StripeUPEPaymentInitializeOptions {
     /**
      * Checkout styles from store theme
      */
-    style?: {
-        [key: string]: string;
-    };
+    style?: Record<string, StripeUPEAppearanceValues>;
 
     onError?(error?: Error): void;
 

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
@@ -429,27 +429,12 @@ export interface StripeElements {
  * All available options are here https://stripe.com/docs/stripe-js/appearance-api#supported-css-properties
  */
 export interface StripeUPEAppearanceOptions {
-    variables?: {
-        colorPrimary?: string;
-        colorBackground?: string;
-        colorText?: string;
-        colorDanger?: string;
-        colorTextSecondary?: string;
-        colorTextPlaceholder?: string;
-        colorIcon?: string;
-        colorIconCardError?: string;
-        colorIconRedirect?: string;
-        spacingUnit?: string;
-        borderRadius?: string;
-        fontFamily?: string;
-    };
+    variables?: Record<string, StripeUPEAppearanceValues>;
 
-    rules?: {
-        [key: string]: {
-            [key: string]: string | number;
-        };
-    };
+    rules?: Record<string, Record<string, StripeUPEAppearanceValues>>;
 }
+
+export type StripeUPEAppearanceValues = string | string[] | number | undefined;
 
 export interface StripeElementsOptions {
     /**


### PR DESCRIPTION
## What?
Add basic customization options for Stripe OCS accordion
checkout-js PR: [https://github.com/bigcommerce/checkout-js/pull/2289](https://github.com/bigcommerce/checkout-js/pull/2289)

## Why?
To get ability for customization new Stripe accordion elememnt

## Testing / Proof

https://github.com/user-attachments/assets/394a94bd-9d99-4239-b596-64f3190cf0e4

<img width="1281" alt="Screenshot 2025-05-06 at 14 43 58" src="https://github.com/user-attachments/assets/9b4c3c3d-db54-4328-abe1-a4510f57e0f2" />


@bigcommerce/team-checkout @bigcommerce/team-payments
