### PR TITLE
feat(payment): remove Sofort and Giropay enums from StripeUPE

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.ts
@@ -527,12 +527,10 @@ export interface StripeHostWindow extends Window {
 export enum StripePaymentMethodType {
     CreditCard = 'card',
     Link = 'link',
-    SOFORT = 'sofort',
     EPS = 'eps',
     GRABPAY = 'grabpay',
     BANCONTACT = 'bancontact',
     IDEAL = 'ideal',
-    GIROPAY = 'giropay',
     ALIPAY = 'alipay',
     KLARNA = 'klarna',
     OCS = 'stripe_ocs',


### PR DESCRIPTION
## What?
Sofort and Giropay constants removed

## Why?
Because it is not supported by Stripe anymore

## Testing / Proof
Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
