### PR TITLE
chore(common): updated bigpay-client dependency to 5.28.0 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.732.0",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.27.4",
+        "@bigcommerce/bigpay-client": "^5.28.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.5.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1335,9 +1335,10 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.27.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.27.4.tgz",
-      "integrity": "sha512-6LMxs/DxF+WYP5gMtsDuRQCdv2klMiUvDlE1b22AJWT0Ovsf/+7X/g5eGd5Aaje6FJ4WydwxstW23BXyLnPpjA==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.28.0.tgz",
+      "integrity": "sha512-sRxNRtAJ90zCT+4O00V0p11Kg+TqAXvCF977yqb3GMRXFo2hm+UVSAUbF/baSo+s9KZGoI6OsuNoSEgO/nB7Tw==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.2",
         "babel-jest": "^29.7.0",
@@ -26872,9 +26873,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.27.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.27.4.tgz",
-      "integrity": "sha512-6LMxs/DxF+WYP5gMtsDuRQCdv2klMiUvDlE1b22AJWT0Ovsf/+7X/g5eGd5Aaje6FJ4WydwxstW23BXyLnPpjA==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.28.0.tgz",
+      "integrity": "sha512-sRxNRtAJ90zCT+4O00V0p11Kg+TqAXvCF977yqb3GMRXFo2hm+UVSAUbF/baSo+s9KZGoI6OsuNoSEgO/nB7Tw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.2",
         "babel-jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "addFileAttribute": "true"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^5.27.4",
+    "@bigcommerce/bigpay-client": "^5.28.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.5.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
updated bigpay-client dependency to 5.28.0 version

## Why?
So we can use proper mapping for bigcommerce payments while sending data via payment payload

## Testing / Proof
CI
