### PR TITLE
fix(webpack-cdn): shell command built from environment values

### DIFF
--- a/webpack-cdn.config.js
+++ b/webpack-cdn.config.js
@@ -1,4 +1,4 @@
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
 const { major } = require('semver');
 const { DefinePlugin } = require('webpack');
@@ -75,7 +75,10 @@ async function getCdnLoaderConfig(options, argv) {
             {
                 apply(compiler) {
                     compiler.hooks.done.tap('DuplicateLoader', () => {
-                        execSync(`cp ${path.join(outputPath, `loader-v${version}.js`)} ${path.join(outputPath, `loader.js`)}`);
+                        execFileSync('cp', [
+                            path.join(outputPath, `loader-v${version}.js`),
+                            path.join(outputPath, `loader.js`)
+                        ]);
                     });
                 },
             },


### PR DESCRIPTION
https://github.com/bigcommerce/checkout-sdk-js/blob/b3cdb2de6a59f10f1c170a6c0c6ddd21dd401828/webpack-cdn.config.js#L1-L1

https://github.com/bigcommerce/checkout-sdk-js/blob/b3cdb2de6a59f10f1c170a6c0c6ddd21dd401828/webpack-cdn.config.js#L78-L78

Fix the issue the dynamically constructed shell command should be replaced with a safer alternative that avoids shell interpretation. Specifically, the `execSync` call should be replaced with `execFileSync`, which allows passing the command and its arguments separately. This ensures that the paths are treated as literal arguments and not interpreted by the shell.

The changes involve:
1. Replacing the `execSync` call on line 78 with `execFileSync`.
2. Splitting the `cp` command into the executable (`cp`) and its arguments (source and destination paths).

---


#### References
[Command Injection](https://www.owasp.org/index.php/Command_Injection)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)


@bigcommerce/team-checkout @bigcommerce/team-payments
