### PR TITLE
feat(checkout): Add worker-event-listener

### DIFF
--- a/packages/core/src/common/iframe/iframe-event-listener.ts
+++ b/packages/core/src/common/iframe/iframe-event-listener.ts
@@ -99,6 +99,6 @@ export default class IframeEventListener<
     }
 }
 
-type EventListeners<TEventMap, TContext = undefined> = {
+export type EventListeners<TEventMap, TContext = undefined> = {
     [key in keyof TEventMap]?: Array<(event: TEventMap[key], context?: TContext) => void>;
 };

--- a/packages/core/src/common/iframe/index.ts
+++ b/packages/core/src/common/iframe/index.ts
@@ -1,6 +1,6 @@
 export * from './iframe-resizer';
 
-export { default as IframeEventListener } from './iframe-event-listener';
+export { default as IframeEventListener, EventListeners } from './iframe-event-listener';
 export { default as IframeEventPoster } from './iframe-event-poster';
-export { default as IframeEvent } from './iframe-event';
+export { default as IframeEvent, IframeEventMap } from './iframe-event';
 export { default as isIframeEvent } from './is-iframe-event';

--- a/packages/core/src/common/worker/index.ts
+++ b/packages/core/src/common/worker/index.ts
@@ -1,0 +1,1 @@
+export { WorkerEventListener } from './worker-event-listener';

--- a/packages/core/src/common/worker/worker-event-listener.test.ts
+++ b/packages/core/src/common/worker/worker-event-listener.test.ts
@@ -1,0 +1,66 @@
+import { WorkerEventListener } from './worker-event-listener';
+
+describe('WorkerEventListener', () => {
+    let worker: Worker;
+    let workerEventListener: WorkerEventListener<any>;
+
+    const testMessage = {
+        type: 'dummyType',
+        payload: { data: 'test' },
+        context: { extensionId: '123' },
+    };
+
+    beforeEach(() => {
+        worker = {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            postMessage: jest.fn(),
+        } as unknown as Worker;
+
+        workerEventListener = new WorkerEventListener(worker);
+    });
+
+    it('should start listening to messages', () => {
+        workerEventListener.listen();
+
+        expect(worker.addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+    });
+
+    it('should stop listening to worker messages', () => {
+        workerEventListener.listen();
+        workerEventListener.stopListen();
+
+        expect(worker.removeEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+    });
+
+    it('should add a listener for a specific event type', () => {
+        const listener = jest.fn();
+
+        workerEventListener.addListener(testMessage.type, listener);
+        workerEventListener.trigger(testMessage);
+
+        expect(listener).toHaveBeenCalledWith(testMessage);
+    });
+
+    it('should remove a listener for a specific event type', () => {
+        const listener = jest.fn();
+
+        workerEventListener.addListener(testMessage.type, listener);
+        workerEventListener.removeListener(testMessage.type, listener);
+        workerEventListener.trigger(testMessage);
+
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should trigger all listeners for a specific event type', () => {
+        const listener1 = jest.fn();
+        const listener2 = jest.fn();
+
+        workerEventListener.addListener(testMessage.type, listener1);
+        workerEventListener.addListener(testMessage.type, listener2);
+        workerEventListener.trigger(testMessage);
+
+        expect(listener1).toHaveBeenCalledWith(testMessage);
+        expect(listener2).toHaveBeenCalledWith(testMessage);
+    });
+});

--- a/packages/core/src/common/worker/worker-event-listener.ts
+++ b/packages/core/src/common/worker/worker-event-listener.ts
@@ -1,0 +1,89 @@
+import { bindDecorator as bind } from '@bigcommerce/checkout-sdk/utility';
+
+import { IframeEventMap } from '../iframe/iframe-event';
+
+export class WorkerEventListener<
+    TEventMap extends IframeEventMap<keyof TEventMap>,
+    TContext = undefined,
+> {
+    private _isListening: boolean;
+    private _listeners: EventListeners<TEventMap, TContext>;
+
+    constructor(private _worker: Worker) {
+        this._isListening = false;
+        this._listeners = {};
+    }
+
+    listen(): void {
+        if (this._isListening) {
+            return;
+        }
+
+        this._isListening = true;
+
+        this._worker.addEventListener('message', this._handleMessage);
+    }
+
+    stopListen(): void {
+        if (!this._isListening) {
+            return;
+        }
+
+        this._isListening = false;
+
+        this._worker.removeEventListener('message', this._handleMessage);
+    }
+
+    addListener<TType extends keyof TEventMap>(
+        type: TType,
+        listener: (event: TEventMap[TType], context?: TContext) => void,
+    ): void {
+        let listeners = this._listeners[type];
+
+        if (!listeners) {
+            this._listeners[type] = listeners = [];
+        }
+
+        if (listeners.indexOf(listener) === -1) {
+            listeners.push(listener);
+        }
+    }
+
+    removeListener<TType extends keyof TEventMap>(
+        type: TType,
+        listener: (event: TEventMap[TType], context?: TContext) => void,
+    ): void {
+        const listeners = this._listeners[type];
+
+        if (!listeners) {
+            return;
+        }
+
+        const index = listeners.indexOf(listener);
+
+        if (index >= 0) {
+            listeners.splice(index, 1);
+        }
+    }
+
+    trigger<TType extends keyof TEventMap>(event: TEventMap[TType], context?: TContext): void {
+        const listeners = this._listeners[event.type];
+
+        if (!listeners) {
+            return;
+        }
+
+        listeners.forEach((listener) => (context ? listener(event, context) : listener(event)));
+    }
+
+    @bind
+    private _handleMessage(messageEvent: MessageEvent): void {
+        const { context, ...event } = messageEvent.data;
+
+        this.trigger(event, context);
+    }
+}
+
+type EventListeners<TEventMap, TContext = undefined> = {
+    [key in keyof TEventMap]?: Array<(event: TEventMap[key], context?: TContext) => void>;
+};

--- a/packages/core/src/common/worker/worker-event-listener.ts
+++ b/packages/core/src/common/worker/worker-event-listener.ts
@@ -1,6 +1,6 @@
 import { bindDecorator as bind } from '@bigcommerce/checkout-sdk/utility';
 
-import { IframeEventMap } from '../iframe/iframe-event';
+import { EventListeners, IframeEventMap } from '../iframe';
 
 export class WorkerEventListener<
     TEventMap extends IframeEventMap<keyof TEventMap>,
@@ -20,7 +20,6 @@ export class WorkerEventListener<
         }
 
         this._isListening = true;
-
         this._worker.addEventListener('message', this._handleMessage);
     }
 
@@ -30,7 +29,6 @@ export class WorkerEventListener<
         }
 
         this._isListening = false;
-
         this._worker.removeEventListener('message', this._handleMessage);
     }
 
@@ -83,7 +81,3 @@ export class WorkerEventListener<
         this.trigger(event, context);
     }
 }
-
-type EventListeners<TEventMap, TContext = undefined> = {
-    [key in keyof TEventMap]?: Array<(event: TEventMap[key], context?: TContext) => void>;
-};

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -4,14 +4,12 @@ import { Observable, Observer } from 'rxjs';
 import { InternalCheckoutSelectors } from '../checkout';
 import { RequestOptions } from '../common/http-request';
 import { parseUrl } from '../common/url';
-import { WorkerEventListener } from '../common/worker';
 
 import { createExtensionWebWorker } from './create-extension-web-worker';
 import { ExtensionNotFoundError } from './errors';
 import { ExtensionRegion } from './extension';
 import { ExtensionAction, ExtensionActionType } from './extension-actions';
 import { ExtensionIframe } from './extension-iframe';
-import { ExtensionMessageMap, ExtensionMessageType } from './extension-message';
 import { ExtensionRequestSender } from './extension-request-sender';
 
 export class ExtensionActionCreator {

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -4,12 +4,14 @@ import { Observable, Observer } from 'rxjs';
 import { InternalCheckoutSelectors } from '../checkout';
 import { RequestOptions } from '../common/http-request';
 import { parseUrl } from '../common/url';
+import { WorkerEventListener } from '../common/worker';
 
 import { createExtensionWebWorker } from './create-extension-web-worker';
 import { ExtensionNotFoundError } from './errors';
 import { ExtensionRegion } from './extension';
 import { ExtensionAction, ExtensionActionType } from './extension-actions';
 import { ExtensionIframe } from './extension-iframe';
+import { ExtensionMessageMap, ExtensionMessageType } from './extension-message';
 import { ExtensionRequestSender } from './extension-request-sender';
 
 export class ExtensionActionCreator {


### PR DESCRIPTION
## What?
Add worker-event-listner.

## Why?
To support handling life cycle of worker event listener.

## Testing / Proof
### CI checks
Added unit tests.
### Manually testing
- Two messages sent from a worker.
- The first message triggers the removal of one listener.
- Both messages trigger the message logger to show message in the console.

![Screenshot 2025-05-20 at 14 48 01](https://github.com/user-attachments/assets/553d0167-0fab-42d1-af0f-13a25be2d526)


@bigcommerce/team-checkout @bigcommerce/team-payments
