### PR TITLE
refactor(payment): removed Braintree LPM fallback experiment and speed up related tests run

### DIFF
--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
@@ -76,6 +76,8 @@ describe('BraintreeLocalMethodsPaymentStrategy', () => {
             braintreeSdk,
             braintreeRequestSender,
             loadingIndicator,
+            1,
+            10,
         );
 
         lpmContainer = document.createElement('div');
@@ -312,7 +314,7 @@ describe('BraintreeLocalMethodsPaymentStrategy', () => {
                         email: 'foo@bar.com',
                         fallback: {
                             buttonText: 'Complete Payment',
-                            url: 'url-placeholder',
+                            url: storeConfigMock.links.checkoutLink,
                         },
                         givenName: 'Test',
                         surname: 'Tester',

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
@@ -222,16 +222,13 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
         const { currency, email, lineItems } = cart;
         const isShippingRequired = lineItems.physicalItems.length > 0;
         const grandTotal = state.getCheckoutOrThrow().outstandingBalance;
-        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
-        const isBraintreeFallbackUrlExperiment = features['PAYPAL-5187.braintree_lpm_fallback'];
-        const checkoutUrl = `${state.getConfig()?.storeConfig?.links?.siteLink ?? ''}/checkout`;
-        const fallbackUrl = isBraintreeFallbackUrlExperiment ? checkoutUrl : 'url-placeholder';
+        const checkoutUrl = state.getStoreConfigOrThrow().links.checkoutLink;
 
         return {
             paymentType: methodId,
             amount: grandTotal,
             fallback: {
-                url: fallbackUrl,
+                url: checkoutUrl,
                 buttonText: 'Complete Payment',
             },
             currencyCode: currency.code,


### PR DESCRIPTION
## What?
Removed Braintree LPM fallback experiment and speed up related tests run

## Why?
Experiment was turned on a while ago and feature works as expected, so to it could be removed as part of code cleanup

## Testing / Proof
Unit tests
CI