### PR TITLE
feat(payment): Stripe OCS accordion state on initialization

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.spec.ts
@@ -18,12 +18,8 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import StripeOCSPaymentStrategy from './stripe-ocs-payment-strategy';
-import {
-    StripeElementType,
-    StripePaymentMethodType,
-    StripeStringConstants,
-    StripeUPEClient,
-} from './stripe-upe';
+import { getStripeOCSInitializeOptionsMock } from './stripe-ocs.mock';
+import { StripeElementType, StripeStringConstants, StripeUPEClient } from './stripe-upe';
 import { WithStripeUPEPaymentInitializeOptions } from './stripe-upe-initialize-options';
 import StripeUPEIntegrationService from './stripe-upe-integration-service';
 import { getStripeUPEIntegrationServiceMock } from './stripe-upe-integration-service.mock';
@@ -31,7 +27,6 @@ import StripeUPEScriptLoader from './stripe-upe-script-loader';
 import {
     getStripeOCSOrderRequestBodyMock,
     getStripeUPE,
-    getStripeUPEInitializeOptionsMock,
     getStripeUPEJsMock,
     StripeEventMock,
 } from './stripe-upe.mock';
@@ -67,7 +62,7 @@ describe('StripeOCSPaymentStrategy', () => {
             stripeUPEIntegrationService,
         );
 
-        stripeOptions = getStripeUPEInitializeOptionsMock(StripePaymentMethodType.OCS, style);
+        stripeOptions = getStripeOCSInitializeOptionsMock();
         stripeUPEJsMock = getStripeUPEJsMock();
 
         jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
@@ -221,6 +216,7 @@ describe('StripeOCSPaymentStrategy', () => {
             await stripeOCSPaymentStrategy.initialize({
                 ...stripeOptions,
                 stripeupe: {
+                    ...stripeOptions.stripeupe,
                     containerId: 'containerId',
                     render: renderMock,
                     onError: onErrorMock,
@@ -281,6 +277,7 @@ describe('StripeOCSPaymentStrategy', () => {
             await stripeOCSPaymentStrategy.initialize({
                 ...stripeOptions,
                 stripeupe: {
+                    ...stripeOptions.stripeupe,
                     containerId: 'containerId',
                     render: renderMock,
                     onError: onErrorMock,
@@ -382,10 +379,7 @@ describe('StripeOCSPaymentStrategy', () => {
         describe('Stripe Element styling', () => {
             describe('RadioButton styling', () => {
                 it('should initialize with default style', async () => {
-                    stripeOptions = getStripeUPEInitializeOptionsMock(
-                        StripePaymentMethodType.OCS,
-                        style,
-                    );
+                    stripeOptions = getStripeOCSInitializeOptionsMock(style);
                     await stripeOCSPaymentStrategy.initialize(stripeOptions);
 
                     expect(stripeScriptLoader.getElements).toHaveBeenCalledWith(
@@ -414,7 +408,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 });
 
                 it('should initialize with custom style', async () => {
-                    stripeOptions = getStripeUPEInitializeOptionsMock(StripePaymentMethodType.OCS, {
+                    stripeOptions = getStripeOCSInitializeOptionsMock({
                         ...style,
                         radioIconOuterWidth: '52px',
                         radioIconOuterStrokeWidth: '4px',
@@ -1107,7 +1101,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 }),
             );
 
-            await stripeOCSPaymentStrategy.initialize(getStripeUPEInitializeOptionsMock());
+            await stripeOCSPaymentStrategy.initialize(getStripeOCSInitializeOptionsMock());
             await stripeOCSPaymentStrategy.deinitialize();
 
             expect(stripeUPEIntegrationService.deinitialize).toHaveBeenCalled();
@@ -1115,7 +1109,7 @@ describe('StripeOCSPaymentStrategy', () => {
         });
 
         it('when stripe element not initialized', async () => {
-            await stripeOCSPaymentStrategy.initialize(getStripeUPEInitializeOptionsMock());
+            await stripeOCSPaymentStrategy.initialize(getStripeOCSInitializeOptionsMock());
 
             jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
                 Promise.resolve({

--- a/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-ocs-payment-strategy.ts
@@ -157,8 +157,14 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
             stripeConnectedAccount,
         );
 
-        const { containerId, style, render, paymentMethodSelect, handleClosePaymentMethod } =
-            stripeupe;
+        const {
+            containerId,
+            style,
+            layout,
+            render,
+            paymentMethodSelect,
+            handleClosePaymentMethod,
+        } = stripeupe;
 
         this.stripeElements = await this.scriptLoader.getElements(this.stripeUPEClient, {
             clientSecret: clientToken,
@@ -189,13 +195,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
                     applePay: StripeStringConstants.NEVER,
                     googlePay: StripeStringConstants.NEVER,
                 },
-                layout: {
-                    type: 'accordion',
-                    defaultCollapsed: false,
-                    radios: true,
-                    spacedAccordionItems: false,
-                    visibleAccordionItemsCount: 0,
-                },
+                layout,
             });
 
         this.stripeUPEIntegrationService.mountElement(stripeElement, containerId);

--- a/packages/stripe-integration/src/stripe-upe/stripe-ocs.mock.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-ocs.mock.ts
@@ -1,0 +1,30 @@
+import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { WithStripeUPEPaymentInitializeOptions } from './stripe-upe-initialize-options';
+
+const gatewayId = 'stripeupe';
+const methodId = 'stripe_ocs';
+
+export const defaultAccordionLayout: Record<string, string | number | boolean> = {
+    defaultCollapsed: false,
+    radios: true,
+    spacedAccordionItems: false,
+    type: 'accordion',
+    visibleAccordionItemsCount: 0,
+};
+export const defaultAccordionStyles: Record<string, string | number> = { fieldText: '#ccc' };
+
+export function getStripeOCSInitializeOptionsMock(
+    style = defaultAccordionStyles,
+): PaymentInitializeOptions & WithStripeUPEPaymentInitializeOptions {
+    return {
+        methodId,
+        gatewayId,
+        [gatewayId]: {
+            containerId: `${gatewayId}-${methodId}-component-field`,
+            layout: defaultAccordionLayout,
+            style,
+            render: jest.fn(),
+        },
+    };
+}

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
@@ -29,6 +29,11 @@ export default interface StripeUPEPaymentInitializeOptions {
     containerId: string;
 
     /**
+     * Stripe OCS layout options
+     */
+    layout?: Record<string, string | number | boolean>;
+
+    /**
      * Checkout styles from store theme
      */
     style?: Record<string, StripeUPEAppearanceValues>;


### PR DESCRIPTION
## What?
Update Stripe OCS accordion state on initialization
Checkout-js PR: [https://github.com/bigcommerce/checkout-js/pull/2312](https://github.com/bigcommerce/checkout-js/pull/2312)

## Why?
To synchronize Stripe accordion selected method with native BC accordion on initialization
Move layout configuration to checkout-js side  

## Testing / Proof
OSC accordion on the last place

https://github.com/user-attachments/assets/2b8316b3-3eb5-44a5-a199-093e238e4c2e

OSC accordion on the first place

https://github.com/user-attachments/assets/79c5f1eb-7c58-4f57-b623-f66d81517ecd

<img width="723" alt="Screenshot 2025-05-22 at 15 15 04" src="https://github.com/user-attachments/assets/dc78b532-22cd-49fb-b11b-2a9cd924da5b" />



@bigcommerce/team-checkout @bigcommerce/team-payments
