### PR TITLE
feat(checkout): Add worker extension messenger and worker-event-poster

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -51,6 +51,7 @@ import {
     ExtensionRegion,
     ExtensionRequestSender,
     getExtensions,
+    WorkerExtensionMessenger,
 } from '../extension';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { getAddressFormFields, getFormFields } from '../form/form.mock';
@@ -164,13 +165,15 @@ describe('CheckoutService', () => {
     let storeProjection: DataStoreProjection<CheckoutSelectors>;
     let storeCreditRequestSender: StoreCreditRequestSender;
     let extensionMessenger: ExtensionMessenger;
+    let workerExtensionMessenger: WorkerExtensionMessenger;
     let extensionEventBroadcaster: ExtensionEventBroadcaster;
 
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreState());
         storeProjection = createDataStoreProjection(store, createCheckoutSelectorsFactory());
 
-        extensionMessenger = new ExtensionMessenger(store, {}, {}, {});
+        workerExtensionMessenger = new WorkerExtensionMessenger();
+        extensionMessenger = new ExtensionMessenger(store, workerExtensionMessenger, {}, {}, {});
 
         const locale = 'en';
         const requestSender = createRequestSender();
@@ -442,6 +445,7 @@ describe('CheckoutService', () => {
             subscriptionsActionCreator,
             formFieldsActionCreator,
             extensionActionCreator,
+            workerExtensionMessenger,
         );
     });
 

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -1557,10 +1557,15 @@ describe('CheckoutService', () => {
 
             const container = 'checkout.extension';
             const region = ExtensionRegion.ShippingShippingAddressFormBefore;
+            const workerExtensionMessenger = new WorkerExtensionMessenger();
 
             await checkoutService.renderExtension(container, region);
 
-            expect(extensionActionCreator.renderExtension).toHaveBeenCalledWith(container, region);
+            expect(extensionActionCreator.renderExtension).toHaveBeenCalledWith(
+                container,
+                region,
+                workerExtensionMessenger,
+            );
             expect(extensionEventBroadcaster.listen).toHaveBeenCalled();
         });
 

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -29,6 +29,7 @@ import {
     ExtensionMessenger,
     ExtensionQueryMap,
     ExtensionRegion,
+    WorkerExtensionMessenger,
 } from '../extension';
 import { FormFieldsActionCreator } from '../form';
 import { CountryActionCreator } from '../geography';
@@ -106,6 +107,7 @@ export default class CheckoutService {
         private _subscriptionsActionCreator: SubscriptionsActionCreator,
         private _formFieldsActionCreator: FormFieldsActionCreator,
         private _extensionActionCreator: ExtensionActionCreator,
+        private _workerExtensionMessenger: WorkerExtensionMessenger,
     ) {
         this._errorTransformer = createCheckoutServiceErrorTransformer();
     }
@@ -1426,7 +1428,11 @@ export default class CheckoutService {
      * @returns A promise that resolves to the current state.
      */
     async renderExtension(container: string, region: ExtensionRegion): Promise<CheckoutSelectors> {
-        const action = this._extensionActionCreator.renderExtension(container, region);
+        const action = this._extensionActionCreator.renderExtension(
+            container,
+            region,
+            this._workerExtensionMessenger,
+        );
         const state = await this._dispatch(action, { queueId: 'extensions' });
 
         this._extensionEventBroadcaster.listen();

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -25,6 +25,7 @@ import {
     ExtensionActionCreator,
     ExtensionMessenger,
     ExtensionRequestSender,
+    WorkerExtensionMessenger,
 } from '../extension';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import * as defaultPaymentStrategyFactories from '../generated/payment-strategies';
@@ -144,7 +145,8 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     const extensionActionCreator = new ExtensionActionCreator(
         new ExtensionRequestSender(requestSender),
     );
-    const extensionMessenger = new ExtensionMessenger(store);
+    const workerExtensionMessenger = new WorkerExtensionMessenger();
+    const extensionMessenger = new ExtensionMessenger(store, workerExtensionMessenger);
     const storeProjection = createDataStoreProjection(store, createCheckoutSelectorsFactory());
 
     return new CheckoutService(
@@ -202,6 +204,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         subscriptionsActionCreator,
         formFieldsActionCreator,
         extensionActionCreator,
+        workerExtensionMessenger,
     );
 }
 

--- a/packages/core/src/common/worker/index.ts
+++ b/packages/core/src/common/worker/index.ts
@@ -1,1 +1,2 @@
 export { WorkerEventListener } from './worker-event-listener';
+export { WorkerEventPoster } from './worker-event-poster';

--- a/packages/core/src/common/worker/worker-event-poster.spec.ts
+++ b/packages/core/src/common/worker/worker-event-poster.spec.ts
@@ -1,0 +1,63 @@
+import { MockWorker } from '../../extension/extension.mock';
+
+import { WorkerEventPoster } from './worker-event-poster';
+
+describe('WorkerEventPoster', () => {
+    let mockWorker: MockWorker;
+
+    beforeEach(() => {
+        mockWorker = new MockWorker('https://worker.extension.com/worker.js');
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('constructor', () => {
+        it('should initialize with a worker and context', () => {
+            const poster = new WorkerEventPoster(mockWorker as any as Worker, 'testContext');
+
+            expect(poster).toBeDefined();
+        });
+    });
+
+    describe('post', () => {
+        it('should call worker.postMessage with the event and the provided context', () => {
+            const poster = new WorkerEventPoster(mockWorker as any as Worker, 'testContext');
+            const event = { id: 'dynamic-translatable-123', text: 'dynamic text', locale: 'en-US' };
+
+            poster.post(event);
+
+            expect(mockWorker.postMessage).toHaveBeenCalledTimes(1);
+            expect(mockWorker.postMessage).toHaveBeenCalledWith({
+                ...event,
+                context: 'testContext',
+            });
+        });
+
+        it('should spread the event properties into the message object', () => {
+            const poster = new WorkerEventPoster(mockWorker as any as Worker, 'testContext');
+            const event = { id: 'dynamic-translatable-123', text: 'dynamic text', locale: 'en-US' };
+
+            poster.post(event);
+
+            expect(mockWorker.postMessage).toHaveBeenCalledWith({
+                id: 'dynamic-translatable-123',
+                text: 'dynamic text',
+                locale: 'en-US',
+                context: 'testContext',
+            });
+        });
+
+        it('should throw an error if post is called when _worker is null (defensive check)', () => {
+            const poster = new WorkerEventPoster(null as any as Worker, 'testContext');
+
+            const event = { type: 'FAIL_EVENT' };
+
+            expect(() => poster.post(event)).toThrow(
+                'WorkerPoster: Worker is not initialized or creation failed. Cannot post message.',
+            );
+            expect(mockWorker.postMessage).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/common/worker/worker-event-poster.ts
+++ b/packages/core/src/common/worker/worker-event-poster.ts
@@ -1,0 +1,23 @@
+import { IframeEvent } from '../iframe';
+
+export interface IframeEventPostOptions<
+    TSuccessEvent extends IframeEvent,
+    TErrorEvent extends IframeEvent,
+> {
+    errorType?: TErrorEvent['type'];
+    successType?: TSuccessEvent['type'];
+}
+
+export class WorkerEventPoster<TEvent, TContext = undefined> {
+    constructor(private _worker: Worker, private _context?: TContext) {}
+
+    post(event: TEvent): void {
+        if (!this._worker) {
+            throw new Error(
+                'WorkerPoster: Worker is not initialized or creation failed. Cannot post message.',
+            );
+        }
+
+        this._worker.postMessage({ ...event, context: this._context });
+    }
+}

--- a/packages/core/src/common/worker/worker-event-poster.ts
+++ b/packages/core/src/common/worker/worker-event-poster.ts
@@ -1,13 +1,3 @@
-import { IframeEvent } from '../iframe';
-
-export interface IframeEventPostOptions<
-    TSuccessEvent extends IframeEvent,
-    TErrorEvent extends IframeEvent,
-> {
-    errorType?: TErrorEvent['type'];
-    successType?: TSuccessEvent['type'];
-}
-
 export class WorkerEventPoster<TEvent, TContext = undefined> {
     constructor(private _worker: Worker, private _context: TContext) {}
 

--- a/packages/core/src/common/worker/worker-event-poster.ts
+++ b/packages/core/src/common/worker/worker-event-poster.ts
@@ -9,7 +9,7 @@ export interface IframeEventPostOptions<
 }
 
 export class WorkerEventPoster<TEvent, TContext = undefined> {
-    constructor(private _worker: Worker, private _context?: TContext) {}
+    constructor(private _worker: Worker, private _context: TContext) {}
 
     post(event: TEvent): void {
         if (!this._worker) {

--- a/packages/core/src/extension/create-extension-web-worker.spec.ts
+++ b/packages/core/src/extension/create-extension-web-worker.spec.ts
@@ -1,34 +1,10 @@
 import { createExtensionWebWorker } from './create-extension-web-worker';
+import { MockWorker } from './extension.mock';
 
 // Store original window properties
 const originalWorker = window.Worker;
 const originalCreateObjectURL = URL.createObjectURL;
 const originalBlob = window.Blob;
-
-// Mock Worker class
-class MockWorker {
-    url: string;
-    onmessage: ((this: Worker, ev: MessageEvent) => any) | null = null;
-    onerror: ((this: Worker, ev: ErrorEvent) => any) | null = null;
-    constructor(url: string) {
-        this.url = url;
-    }
-    postMessage(): void {
-        /* mock */
-    }
-    terminate(): void {
-        /* mock */
-    }
-    addEventListener(): void {
-        /* mock */
-    }
-    removeEventListener(): void {
-        /* mock */
-    }
-    dispatchEvent(): boolean {
-        return true; /* mock */
-    }
-}
 
 describe('createExtensionWebWorker', () => {
     let mockCreateObjectURL: jest.Mock;

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -7,7 +7,7 @@ import { parseUrl } from '../common/url';
 
 import { createExtensionWebWorker } from './create-extension-web-worker';
 import { ExtensionNotFoundError } from './errors';
-import { ExtensionRegion } from './extension';
+import { ExtensionRegion, ExtensionType } from './extension';
 import { ExtensionAction, ExtensionActionType } from './extension-actions';
 import { ExtensionIframe } from './extension-iframe';
 import { ExtensionRequestSender } from './extension-request-sender';
@@ -70,7 +70,7 @@ export class ExtensionActionCreator {
 
                     observer.next(createAction(ExtensionActionType.RenderExtensionRequested));
 
-                    if (extension.type === 'worker') {
+                    if (extension.type === ExtensionType.Worker) {
                         const worker = createExtensionWebWorker(extension.url);
 
                         workerExtensionMessenger.add(extension.id, worker);

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -11,6 +11,7 @@ import { ExtensionRegion } from './extension';
 import { ExtensionAction, ExtensionActionType } from './extension-actions';
 import { ExtensionIframe } from './extension-iframe';
 import { ExtensionRequestSender } from './extension-request-sender';
+import { WorkerExtensionMessenger } from './worker-extension-messenger';
 
 export class ExtensionActionCreator {
     constructor(private _requestSender: ExtensionRequestSender) {}
@@ -43,6 +44,7 @@ export class ExtensionActionCreator {
     renderExtension(
         container: string,
         region: ExtensionRegion,
+        workerExtensionMessenger: WorkerExtensionMessenger,
     ): ThunkAction<ExtensionAction, InternalCheckoutSelectors> {
         return (store) =>
             Observable.create(async (observer: Observer<ExtensionAction>) => {
@@ -70,6 +72,8 @@ export class ExtensionActionCreator {
 
                     if (extension.type === 'worker') {
                         const worker = createExtensionWebWorker(extension.url);
+
+                        workerExtensionMessenger.add(extension.id, worker);
 
                         // TODO: CHECKOUT-9248 Add the web worker reference to the checkout SDK internal state for consistent access and management.
                         // eslint-disable-next-line no-console

--- a/packages/core/src/extension/extension-messenger.spec.ts
+++ b/packages/core/src/extension/extension-messenger.spec.ts
@@ -15,12 +15,14 @@ import { ExtensionEvent } from './extension-events';
 import { ExtensionMessenger } from './extension-messenger';
 import { ExtensionQueryMap, ExtensionQueryType } from './extension-queries';
 import { getExtensionEvent, getExtensions } from './extension.mock';
+import { WorkerExtensionMessenger } from './worker-extension-messenger';
 
 describe('ExtensionMessenger', () => {
     let extensionCommandHandler: jest.Mock;
     let extensionQueryHandler: jest.Mock;
     let extension: Extension;
     let extensionMessenger: ExtensionMessenger;
+    let workerExtensionMessenger: WorkerExtensionMessenger;
     let event: {
         origin: string;
         data: ExtensionEvent;
@@ -33,6 +35,7 @@ describe('ExtensionMessenger', () => {
         event = getExtensionEvent();
         extensionCommandHandler = jest.fn();
         extensionQueryHandler = jest.fn();
+        workerExtensionMessenger = new WorkerExtensionMessenger();
     });
 
     describe('#listenForCommand', () => {
@@ -45,7 +48,13 @@ describe('ExtensionMessenger', () => {
                 [extension.id]: listener,
             };
 
-            extensionMessenger = new ExtensionMessenger(store, listeners, {}, {});
+            extensionMessenger = new ExtensionMessenger(
+                store,
+                workerExtensionMessenger,
+                listeners,
+                {},
+                {},
+            );
         });
 
         it('should throw if unable to find the extension', () => {
@@ -179,7 +188,13 @@ describe('ExtensionMessenger', () => {
                 [extension.id]: listener,
             };
 
-            extensionMessenger = new ExtensionMessenger(store, {}, listeners, {});
+            extensionMessenger = new ExtensionMessenger(
+                store,
+                workerExtensionMessenger,
+                {},
+                listeners,
+                {},
+            );
         });
 
         it('should throw if unable to find the extension', () => {
@@ -307,7 +322,13 @@ describe('ExtensionMessenger', () => {
         it('should log out the error if an extension has not yet been rendered', () => {
             document.querySelector = jest.fn().mockReturnValue(undefined);
 
-            extensionMessenger = new ExtensionMessenger(store, {}, {}, {});
+            extensionMessenger = new ExtensionMessenger(
+                store,
+                workerExtensionMessenger,
+                {},
+                {},
+                {},
+            );
 
             jest.spyOn(extensionMessenger, 'clearCacheById');
             jest.spyOn(console, 'log');
@@ -330,7 +351,13 @@ describe('ExtensionMessenger', () => {
                 [extension.id]: poster,
             };
 
-            extensionMessenger = new ExtensionMessenger(store, {}, {}, posters);
+            extensionMessenger = new ExtensionMessenger(
+                store,
+                workerExtensionMessenger,
+                {},
+                {},
+                posters,
+            );
 
             document.querySelector = jest.fn().mockReturnValue(container);
 

--- a/packages/core/src/extension/extension-messenger.ts
+++ b/packages/core/src/extension/extension-messenger.ts
@@ -7,7 +7,7 @@ import {
     UnsupportedExtensionCommandError,
     UnsupportedExtensionQueryError,
 } from './errors';
-import { Extension } from './extension';
+import { Extension, ExtensionType } from './extension';
 import { ExtensionCommandMap, ExtensionCommandType } from './extension-commands';
 import { ExtensionCommandOrQueryContext, ExtensionMessage } from './extension-message';
 import { ExtensionQueryMap, ExtensionQueryType } from './extension-queries';
@@ -31,7 +31,7 @@ export class ExtensionMessenger {
     clearCacheByRegion(region: string): void {
         const extension = this._getExtensionByRegion(region);
 
-        if (extension.type === 'worker') {
+        if (extension.type === ExtensionType.Worker) {
             this._workerExtensionMessenger.clearCacheById(extension.id);
 
             return;
@@ -140,7 +140,7 @@ export class ExtensionMessenger {
         try {
             const extension = this._getExtensionById(extensionId);
 
-            if (extension.type === 'worker') {
+            if (extension.type === ExtensionType.Worker) {
                 this._workerExtensionMessenger.post(extensionId, message);
 
                 return;

--- a/packages/core/src/extension/extension.mock.ts
+++ b/packages/core/src/extension/extension.mock.ts
@@ -22,6 +22,16 @@ export function getExtensions(): Extension[] {
     ];
 }
 
+export function getWorkerExtension(): Extension {
+    return {
+        id: '789',
+        name: 'Worker Extension',
+        region: ExtensionRegion.GlobalWebWorker,
+        url: 'https://worker.extension.com/worker.js',
+        type: 'worker',
+    };
+}
+
 export function getExtensionState(): ExtensionState {
     return {
         data: getExtensions(),
@@ -56,4 +66,29 @@ export function getExtensionEvent(): {
             },
         },
     };
+}
+
+// Mock Worker implementation for testing purposes
+export class MockWorker {
+    url: string;
+    onmessage: ((this: Worker, ev: MessageEvent) => any) | null = null;
+    onerror: ((this: Worker, ev: ErrorEvent) => any) | null = null;
+    constructor(url: string) {
+        this.url = url;
+    }
+    postMessage(): void {
+        /* mock */
+    }
+    terminate(): void {
+        /* mock */
+    }
+    addEventListener(): void {
+        /* mock */
+    }
+    removeEventListener(): void {
+        /* mock */
+    }
+    dispatchEvent(): boolean {
+        return true; /* mock */
+    }
 }

--- a/packages/core/src/extension/extension.mock.ts
+++ b/packages/core/src/extension/extension.mock.ts
@@ -1,6 +1,6 @@
 import { getConsignments } from '../shipping/consignments.mock';
 
-import { Extension, ExtensionRegion } from './extension';
+import { Extension, ExtensionRegion, ExtensionType } from './extension';
 import { ExtensionCommand, ExtensionCommandType } from './extension-commands';
 import { ExtensionEvent, ExtensionEventType } from './extension-events';
 import { ExtensionState } from './extension-state';
@@ -28,7 +28,7 @@ export function getWorkerExtension(): Extension {
         name: 'Worker Extension',
         region: ExtensionRegion.GlobalWebWorker,
         url: 'https://worker.extension.com/worker.js',
-        type: 'worker',
+        type: ExtensionType.Worker,
     };
 }
 

--- a/packages/core/src/extension/extension.mock.ts
+++ b/packages/core/src/extension/extension.mock.ts
@@ -12,12 +12,14 @@ export function getExtensions(): Extension[] {
             name: 'Foo',
             region: ExtensionRegion.ShippingShippingAddressFormBefore,
             url: 'https://widget.foo.com/',
+            type: ExtensionType.Iframe,
         },
         {
             id: '456',
             name: 'Bar',
             region: ExtensionRegion.ShippingShippingAddressFormAfter,
             url: 'https://widget.bar.com/',
+            type: ExtensionType.Iframe,
         },
     ];
 }

--- a/packages/core/src/extension/extension.mock.ts
+++ b/packages/core/src/extension/extension.mock.ts
@@ -73,11 +73,11 @@ export class MockWorker {
     url: string;
     onmessage: ((this: Worker, ev: MessageEvent) => any) | null = null;
     onerror: ((this: Worker, ev: ErrorEvent) => any) | null = null;
+    // Using jest.Mock for postMessage to spy on its calls
+    postMessage: jest.Mock;
     constructor(url: string) {
         this.url = url;
-    }
-    postMessage(): void {
-        /* mock */
+        this.postMessage = jest.fn();
     }
     terminate(): void {
         /* mock */

--- a/packages/core/src/extension/extension.ts
+++ b/packages/core/src/extension/extension.ts
@@ -3,7 +3,7 @@ export interface Extension {
     name: string;
     region: ExtensionRegion;
     url: string;
-    type?: 'iframe' | 'worker';
+    type?: ExtensionType;
 }
 
 export interface ExtensionIframeConfig {
@@ -18,4 +18,9 @@ export const enum ExtensionRegion {
     SummaryAfter = 'summary.after',
     SummaryLastItemAfter = 'summary.lastItem.after',
     GlobalWebWorker = 'global',
+}
+
+export const enum ExtensionType {
+    Iframe = 'iframe',
+    Worker = 'worker',
 }

--- a/packages/core/src/extension/extension.ts
+++ b/packages/core/src/extension/extension.ts
@@ -3,7 +3,7 @@ export interface Extension {
     name: string;
     region: ExtensionRegion;
     url: string;
-    type?: ExtensionType;
+    type: ExtensionType;
 }
 
 export interface ExtensionIframeConfig {

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -19,3 +19,4 @@ export {
 } from './extension-selector';
 export { default as initializeExtensionService } from './initialize-extension-service';
 export { ExtensionState } from './extension-state';
+export { WorkerExtensionMessenger } from './worker-extension-messenger';

--- a/packages/core/src/extension/worker-extension-messenger.ts
+++ b/packages/core/src/extension/worker-extension-messenger.ts
@@ -1,0 +1,29 @@
+import { WorkerEventPoster } from '../common/worker';
+
+import { ExtensionMessage } from './extension-message';
+
+export class WorkerExtensionMessenger {
+    private _workers: { [extensionId: string]: Worker };
+
+    constructor() {
+        this._workers = {};
+    }
+
+    add(extensionId: string, worker: Worker): void {
+        this._workers[extensionId] = worker;
+    }
+
+    post(extensionId: string, message: ExtensionMessage): void {
+        if (!this._workers[extensionId]) {
+            throw new Error(`Worker with extensionId ${extensionId} not found`);
+        }
+
+        const workerPoster = new WorkerEventPoster(this._workers[extensionId], extensionId);
+
+        workerPoster.post(message);
+    }
+
+    clearCacheById(extensionId: string): void {
+        delete this._workers[extensionId];
+    }
+}


### PR DESCRIPTION
## What?
Add worker-extension-messenger and worker-event-poster.

## Why?
To support handling life cycle of worker event poster.

## Testing / Proof

Added unit tests.

**Manually testing**


https://github.com/user-attachments/assets/2d7c5b20-ddb0-4047-805b-f65eaaa4ec6d



@bigcommerce/team-checkout @bigcommerce/team-payments
