### PR TITLE
feat(payment): added canMakePayments method as additional verification of payment capability

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
@@ -13,7 +13,6 @@ import {
     InvalidArgumentError,
     MissingDataError,
     PaymentIntegrationService,
-    PaymentMethodFailedError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBuyNowCart,
@@ -156,11 +155,13 @@ describe('ApplePayButtonStrategy', () => {
         });
 
         it('throws error if canMakePayments returns false', async () => {
+            jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
             MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(false);
 
-            await expect(
-                strategy.initialize(getApplePayButtonInitializationOptions()),
-            ).rejects.toThrow(PaymentMethodFailedError);
+            await strategy.initialize(getApplePayButtonInitializationOptions());
+
+            expect(console.error).toHaveBeenCalled();
 
             MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(true);
         });

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
@@ -13,6 +13,7 @@ import {
     InvalidArgumentError,
     MissingDataError,
     PaymentIntegrationService,
+    PaymentMethodFailedError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBuyNowCart,
@@ -152,6 +153,16 @@ describe('ApplePayButtonStrategy', () => {
                     params: {},
                 }),
             ).rejects.toThrow(MissingDataError);
+        });
+
+        it('throws error if canMakePayments returns false', async () => {
+            MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(false);
+
+            await expect(
+                strategy.initialize(getApplePayButtonInitializationOptions()),
+            ).rejects.toThrow(PaymentMethodFailedError);
+
+            MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(true);
         });
 
         it('throws error when params object is empty', async () => {

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -16,7 +16,6 @@ import {
     PaymentIntegrationService,
     PaymentMethod,
     PaymentMethodCancelledError,
-    PaymentMethodFailedError,
     ShippingOption,
     StoreConfig,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -127,9 +126,9 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
         assertApplePayWindow(window);
 
         if (!this._sessionFactory.canMakePayment()) {
-            throw new PaymentMethodFailedError(
-                'This device is not capable of making Apple Pay payments',
-            );
+            console.error('This device is not capable of making Apple Pay payments');
+
+            return;
         }
 
         if (!methodId || !applepay) {

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -16,6 +16,7 @@ import {
     PaymentIntegrationService,
     PaymentMethod,
     PaymentMethodCancelledError,
+    PaymentMethodFailedError,
     ShippingOption,
     StoreConfig,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -124,6 +125,12 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
         }
 
         assertApplePayWindow(window);
+
+        if (!this._sessionFactory.canMakePayment()) {
+            throw new PaymentMethodFailedError(
+                'This device is not capable of making Apple Pay payments',
+            );
+        }
 
         if (!methodId || !applepay) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
@@ -14,7 +14,6 @@ import {
     InvalidArgumentError,
     MissingDataError,
     PaymentIntegrationService,
-    PaymentMethodFailedError,
     ShippingOption,
     StoreConfig,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -159,11 +158,13 @@ describe('ApplePayCustomerStrategy', () => {
         });
 
         it('throws error if canMakePayments returns false', async () => {
+            jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
             MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(false);
 
-            await expect(
-                strategy.initialize(getApplePayCustomerInitializationOptions()),
-            ).rejects.toThrow(PaymentMethodFailedError);
+            await strategy.initialize(getApplePayCustomerInitializationOptions());
+
+            expect(console.error).toHaveBeenCalled();
 
             MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(true);
         });

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
@@ -14,6 +14,7 @@ import {
     InvalidArgumentError,
     MissingDataError,
     PaymentIntegrationService,
+    PaymentMethodFailedError,
     ShippingOption,
     StoreConfig,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -155,6 +156,16 @@ describe('ApplePayCustomerStrategy', () => {
 
         it('throws error when payment data is empty', async () => {
             await expect(strategy.initialize({})).rejects.toThrow(MissingDataError);
+        });
+
+        it('throws error if canMakePayments returns false', async () => {
+            MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(false);
+
+            await expect(
+                strategy.initialize(getApplePayCustomerInitializationOptions()),
+            ).rejects.toThrow(PaymentMethodFailedError);
+
+            MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(true);
         });
 
         it('sets up request for digital items', async () => {

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -17,6 +17,7 @@ import {
     PaymentIntegrationService,
     PaymentMethod,
     PaymentMethodCancelledError,
+    PaymentMethodFailedError,
     ShippingOption,
     StoreConfig,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -91,6 +92,12 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         }
 
         assertApplePayWindow(window);
+
+        if (!this._sessionFactory.canMakePayment()) {
+            throw new PaymentMethodFailedError(
+                'This device is not capable of making Apple Pay payments',
+            );
+        }
 
         try {
             this._paymentMethod = state.getPaymentMethodOrThrow(methodId);

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -17,7 +17,6 @@ import {
     PaymentIntegrationService,
     PaymentMethod,
     PaymentMethodCancelledError,
-    PaymentMethodFailedError,
     ShippingOption,
     StoreConfig,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -94,9 +93,9 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         assertApplePayWindow(window);
 
         if (!this._sessionFactory.canMakePayment()) {
-            throw new PaymentMethodFailedError(
-                'This device is not capable of making Apple Pay payments',
-            );
+            console.error('This device is not capable of making Apple Pay payments');
+
+            return;
         }
 
         try {

--- a/packages/apple-pay-integration/src/apple-pay-session-factory.ts
+++ b/packages/apple-pay-integration/src/apple-pay-session-factory.ts
@@ -18,4 +18,10 @@ export default class ApplePaySessionFactory {
 
         return new ApplePaySession(1, request);
     }
+
+    canMakePayment(): boolean {
+        assertApplePayWindow(window);
+
+        return ApplePaySession.canMakePayments();
+    }
 }

--- a/packages/apple-pay-integration/src/mocks/apple-pay-payment.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-payment.mock.ts
@@ -1,6 +1,6 @@
 export class MockApplePaySession {
     static supportsVersion: () => boolean;
-    static canMakePayments: () => boolean;
+    static canMakePayments: () => boolean = jest.fn().mockReturnValue(true);
 
     addEventListener = jest.fn();
     dispatchEvent = jest.fn();


### PR DESCRIPTION
## What?

Added canMakePayments method as additional verification of payment capability

## Why?

For additional check of apple pay payment capability

## Testing / Proof

Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
