### PR TITLE
feat(checkout): Add listening methods to worker extension messenger

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -1580,7 +1580,7 @@ describe('CheckoutService', () => {
         });
 
         it('posts a message to an extension', async () => {
-            jest.spyOn(extensionMessenger, 'post');
+            jest.spyOn(extensionMessenger, 'post').mockImplementation(() => Promise.resolve());
 
             const message = {
                 type: ExtensionMessageType.GetConsignments,

--- a/packages/core/src/common/worker/WorkerEvent.ts
+++ b/packages/core/src/common/worker/WorkerEvent.ts
@@ -1,0 +1,12 @@
+export default interface WorkerEvent<TType = string, TPayload = any> {
+    type: TType;
+    payload?: TPayload;
+}
+
+export type WorkerEventMap<TType extends string | number | symbol = string> = {
+    [key in TType]: WorkerEvent<TType>;
+};
+
+export type WorkerEventListeners<TEventMap, TContext = undefined> = {
+    [key in keyof TEventMap]?: Array<(event: TEventMap[key], context?: TContext) => void>;
+};

--- a/packages/core/src/common/worker/worker-event-listener.ts
+++ b/packages/core/src/common/worker/worker-event-listener.ts
@@ -1,13 +1,13 @@
 import { bindDecorator as bind } from '@bigcommerce/checkout-sdk/utility';
 
-import { EventListeners, IframeEventMap } from '../iframe';
+import { WorkerEventListeners, WorkerEventMap } from './WorkerEvent';
 
 export class WorkerEventListener<
-    TEventMap extends IframeEventMap<keyof TEventMap>,
+    TEventMap extends WorkerEventMap<keyof TEventMap>,
     TContext = undefined,
 > {
     private _isListening: boolean;
-    private _listeners: EventListeners<TEventMap, TContext>;
+    private _listeners: WorkerEventListeners<TEventMap, TContext>;
 
     constructor(private _worker: Worker) {
         this._isListening = false;

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -74,10 +74,6 @@ export class ExtensionActionCreator {
                         const worker = createExtensionWebWorker(extension.url);
 
                         workerExtensionMessenger.add(extension.id, worker);
-
-                        // TODO: CHECKOUT-9248 Add the web worker reference to the checkout SDK internal state for consistent access and management.
-                        // eslint-disable-next-line no-console
-                        console.log('Worker created:', worker);
                     } else {
                         const iframe = new ExtensionIframe(container, extension, {
                             cartId,

--- a/packages/core/src/extension/extension-messenger.ts
+++ b/packages/core/src/extension/extension-messenger.ts
@@ -41,6 +41,14 @@ export class ExtensionMessenger {
     }
 
     clearCacheById(extensionId: string): void {
+        const extension = this._getExtensionById(extensionId);
+
+        if (extension.type === ExtensionType.Worker) {
+            this._workerExtensionMessenger.clearCacheById(extension.id);
+
+            return;
+        }
+
         if (this._commandListeners[extensionId]) {
             delete this._commandListeners[extensionId];
         }
@@ -63,6 +71,14 @@ export class ExtensionMessenger {
         ) => Promise<void> | void,
     ): () => void {
         const extension = this._getExtensionById(extensionId);
+
+        if (extension.type === ExtensionType.Worker) {
+            return this._workerExtensionMessenger.listenForCommand(
+                extensionId,
+                command,
+                commandHandler,
+            );
+        }
 
         if (!this._commandListeners[extensionId]) {
             this._commandListeners[extensionId] = new IframeEventListener(extension.url);
@@ -100,6 +116,10 @@ export class ExtensionMessenger {
     ): () => void {
         const extension = this._getExtensionById(extensionId);
 
+        if (extension.type === ExtensionType.Worker) {
+            return this._workerExtensionMessenger.listenForQuery(extensionId, query, queryHandler);
+        }
+
         if (!this._queryListeners[extensionId]) {
             this._queryListeners[extensionId] = new IframeEventListener(extension.url);
         }
@@ -127,6 +147,14 @@ export class ExtensionMessenger {
     }
 
     stopListen(extensionId: string): void {
+        const extension = this._getExtensionById(extensionId);
+
+        if (extension.type === ExtensionType.Worker) {
+            this._workerExtensionMessenger.stopListen(extensionId);
+
+            return;
+        }
+
         if (this._commandListeners[extensionId]) {
             this._commandListeners[extensionId].stopListen();
         }

--- a/packages/core/src/extension/worker-extension-messenger.spec.ts
+++ b/packages/core/src/extension/worker-extension-messenger.spec.ts
@@ -97,7 +97,7 @@ describe('WorkerExtensionMessenger', () => {
             );
         });
 
-        it('should listen to commands emitted by same extension', () => {
+        it('should listen to commands emitted by the same extension', () => {
             const eventEmitter = new EventEmitter();
 
             jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
@@ -230,7 +230,7 @@ describe('WorkerExtensionMessenger', () => {
             );
         });
 
-        it('should listen to queries emitted by same extension', () => {
+        it('should listen to queries emitted by the same extension', () => {
             const eventEmitter = new EventEmitter();
 
             jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {

--- a/packages/core/src/extension/worker-extension-messenger.spec.ts
+++ b/packages/core/src/extension/worker-extension-messenger.spec.ts
@@ -1,0 +1,305 @@
+import EventEmitter from 'events';
+
+import { WorkerEventListener } from '../common/worker';
+
+import {
+    ExtensionNotFoundError,
+    UnsupportedExtensionCommandError,
+    UnsupportedExtensionQueryError,
+} from './errors';
+import { ExtensionCommandMap, ExtensionCommandType } from './extension-commands';
+import { ExtensionQueryMap, ExtensionQueryType } from './extension-queries';
+import { WorkerExtensionMessenger } from './worker-extension-messenger';
+
+jest.mock('../common/worker', () => ({
+    WorkerEventListener: jest.fn().mockImplementation(() => ({
+        listen: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        stopListen: jest.fn(),
+    })),
+    WorkerEventPoster: jest.fn().mockImplementation(() => ({
+        post: jest.fn(),
+    })),
+}));
+
+describe('WorkerExtensionMessenger', () => {
+    let extensionCommandHandler: jest.Mock;
+    let extensionQueryHandler: jest.Mock;
+    let messenger: WorkerExtensionMessenger;
+    let worker: Worker;
+
+    const extensionId = '12345678-1234-1234-1234-123456789012';
+
+    beforeEach(() => {
+        extensionCommandHandler = jest.fn();
+        extensionQueryHandler = jest.fn();
+        worker = {} as Worker;
+    });
+
+    describe('#listenForCommand', () => {
+        let listener: WorkerEventListener<ExtensionCommandMap>;
+
+        beforeEach(() => {
+            listener = new WorkerEventListener(worker);
+
+            const listeners = {
+                [extensionId]: listener,
+            };
+
+            messenger = new WorkerExtensionMessenger({ [extensionId]: worker }, listeners, {});
+        });
+
+        it('should throw if unable to find the extension', () => {
+            expect(() =>
+                messenger.listenForCommand(
+                    '404',
+                    ExtensionCommandType.ReloadCheckout,
+                    extensionCommandHandler,
+                ),
+            ).toThrow(ExtensionNotFoundError);
+        });
+
+        it('should throw if trying to listen for an unsupported command', () => {
+            expect(() =>
+                messenger.listenForCommand(
+                    extensionId,
+                    'INVALID_COMMAND' as ExtensionCommandType,
+                    extensionCommandHandler,
+                ),
+            ).toThrow(UnsupportedExtensionCommandError);
+        });
+
+        it('should listen and add an event listener', () => {
+            const eventEmitter = new EventEmitter();
+
+            jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
+                eventEmitter.addListener(type, ({ context }) => {
+                    if (type === ExtensionCommandType.ReloadCheckout) {
+                        listener({ type }, context);
+                    }
+                });
+            });
+
+            messenger.listenForCommand(
+                extensionId,
+                ExtensionCommandType.ReloadCheckout,
+                extensionCommandHandler,
+            );
+
+            eventEmitter.emit(ExtensionCommandType.ReloadCheckout, {
+                context: { extensionId },
+            });
+
+            expect(extensionCommandHandler).toHaveBeenCalledWith(
+                { type: ExtensionCommandType.ReloadCheckout },
+                { extensionId },
+            );
+        });
+
+        it('should listen to commands emitted by same extension', () => {
+            const eventEmitter = new EventEmitter();
+
+            jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
+                eventEmitter.addListener(type, ({ context }) => {
+                    if (type === ExtensionCommandType.ReloadCheckout) {
+                        listener({ type }, context);
+                    }
+                });
+            });
+
+            messenger.listenForCommand(
+                extensionId,
+                ExtensionCommandType.ReloadCheckout,
+                extensionCommandHandler,
+            );
+
+            eventEmitter.emit(ExtensionCommandType.ReloadCheckout, {
+                context: { extensionId },
+            });
+
+            eventEmitter.emit(ExtensionCommandType.ReloadCheckout, {
+                context: { extensionId: '404' },
+            });
+
+            expect(extensionCommandHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it('should remove the event listener', () => {
+            const eventEmitter = new EventEmitter();
+
+            jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
+                eventEmitter.addListener(type, ({ context }) => {
+                    if (type === ExtensionCommandType.ReloadCheckout) {
+                        listener({ type }, context);
+                    }
+                });
+            });
+
+            jest.spyOn(listener, 'removeListener').mockImplementation((type) => {
+                eventEmitter.removeAllListeners(type);
+            });
+
+            const remover = messenger.listenForCommand(
+                extensionId,
+                ExtensionCommandType.ReloadCheckout,
+                extensionCommandHandler,
+            );
+
+            remover();
+
+            eventEmitter.emit(ExtensionCommandType.ReloadCheckout, {
+                context: { extensionId },
+            });
+
+            expect(extensionCommandHandler).not.toHaveBeenCalled();
+        });
+
+        it('should stop listening', () => {
+            jest.spyOn(listener, 'stopListen');
+
+            messenger.listenForCommand(
+                extensionId,
+                ExtensionCommandType.ReloadCheckout,
+                extensionCommandHandler,
+            );
+
+            messenger.stopListen(extensionId);
+
+            expect(listener.stopListen).toHaveBeenCalled();
+        });
+    });
+
+    describe('#listenForQuery', () => {
+        let listener: WorkerEventListener<ExtensionQueryMap>;
+
+        beforeEach(() => {
+            listener = new WorkerEventListener(worker);
+
+            const listeners = {
+                [extensionId]: listener,
+            };
+
+            messenger = new WorkerExtensionMessenger({ [extensionId]: worker }, {}, listeners);
+        });
+
+        it('should throw if unable to find the extension', () => {
+            expect(() =>
+                messenger.listenForQuery(
+                    'xxx',
+                    ExtensionQueryType.GetConsignments,
+                    extensionQueryHandler,
+                ),
+            ).toThrow(ExtensionNotFoundError);
+        });
+
+        it('should throw if trying to listen for an unsupported command', () => {
+            expect(() =>
+                messenger.listenForQuery(
+                    extensionId,
+                    'INVALID_QUERY' as ExtensionQueryType,
+                    extensionQueryHandler,
+                ),
+            ).toThrow(UnsupportedExtensionQueryError);
+        });
+
+        it('should listen and add an event listener', () => {
+            const eventEmitter = new EventEmitter();
+
+            jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
+                eventEmitter.addListener(type, ({ context }) => {
+                    if (type === ExtensionQueryType.GetConsignments) {
+                        listener({ type }, context);
+                    }
+                });
+            });
+
+            messenger.listenForQuery(
+                extensionId,
+                ExtensionQueryType.GetConsignments,
+                extensionQueryHandler,
+            );
+
+            eventEmitter.emit(ExtensionQueryType.GetConsignments, {
+                context: { extensionId },
+            });
+
+            expect(extensionQueryHandler).toHaveBeenCalledWith(
+                { type: ExtensionQueryType.GetConsignments },
+                { extensionId },
+            );
+        });
+
+        it('should listen to queries emitted by same extension', () => {
+            const eventEmitter = new EventEmitter();
+
+            jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
+                eventEmitter.addListener(type, ({ context }) => {
+                    if (type === ExtensionQueryType.GetConsignments) {
+                        listener({ type }, context);
+                    }
+                });
+            });
+
+            messenger.listenForQuery(
+                extensionId,
+                ExtensionQueryType.GetConsignments,
+                extensionQueryHandler,
+            );
+
+            eventEmitter.emit(ExtensionQueryType.GetConsignments, {
+                context: { extensionId },
+            });
+
+            eventEmitter.emit(ExtensionQueryType.GetConsignments, {
+                context: { extensionId: '404' },
+            });
+
+            expect(extensionQueryHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it('should remove the event listener', () => {
+            const eventEmitter = new EventEmitter();
+
+            jest.spyOn(listener, 'addListener').mockImplementation((type, listener) => {
+                eventEmitter.addListener(type, ({ context }) => {
+                    if (type === ExtensionQueryType.GetConsignments) {
+                        listener({ type }, context);
+                    }
+                });
+            });
+
+            jest.spyOn(listener, 'removeListener').mockImplementation((type) => {
+                eventEmitter.removeAllListeners(type);
+            });
+
+            const remover = messenger.listenForQuery(
+                extensionId,
+                ExtensionQueryType.GetConsignments,
+                extensionQueryHandler,
+            );
+
+            remover();
+
+            eventEmitter.emit(ExtensionQueryType.GetConsignments, {
+                context: { [extensionId]: extensionId },
+            });
+
+            expect(extensionQueryHandler).not.toHaveBeenCalled();
+        });
+
+        it('should stop listening', () => {
+            jest.spyOn(listener, 'stopListen');
+
+            messenger.listenForQuery(
+                extensionId,
+                ExtensionQueryType.GetConsignments,
+                extensionQueryHandler,
+            );
+
+            messenger.stopListen(extensionId);
+
+            expect(listener.stopListen).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/extension/worker-extension-messenger.ts
+++ b/packages/core/src/extension/worker-extension-messenger.ts
@@ -1,16 +1,109 @@
-import { WorkerEventPoster } from '../common/worker';
+import { WorkerEventListener, WorkerEventPoster } from '../common/worker';
 
-import { ExtensionMessage } from './extension-message';
+import {
+    ExtensionNotFoundError,
+    UnsupportedExtensionCommandError,
+    UnsupportedExtensionQueryError,
+} from './errors';
+import { ExtensionCommandMap, ExtensionCommandType } from './extension-commands';
+import { ExtensionCommandOrQueryContext, ExtensionMessage } from './extension-message';
+import { ExtensionQueryMap, ExtensionQueryType } from './extension-queries';
 
 export class WorkerExtensionMessenger {
-    private _workers: { [extensionId: string]: Worker };
-
-    constructor() {
-        this._workers = {};
-    }
+    constructor(
+        private _workers: { [extensionId: string]: Worker } = {},
+        private _commandListeners: {
+            [extensionId: string]: WorkerEventListener<ExtensionCommandMap>;
+        } = {},
+        private _queryListeners: {
+            [extensionId: string]: WorkerEventListener<ExtensionQueryMap>;
+        } = {},
+    ) {}
 
     add(extensionId: string, worker: Worker): void {
         this._workers[extensionId] = worker;
+    }
+
+    listenForCommand<T extends keyof ExtensionCommandMap>(
+        extensionId: string,
+        command: T,
+        commandHandler: (
+            command: ExtensionCommandMap[T],
+            context?: ExtensionCommandOrQueryContext,
+        ) => Promise<void> | void,
+    ): () => void {
+        const worker = this._getWorkerById(extensionId);
+
+        if (!this._commandListeners[extensionId]) {
+            this._commandListeners[extensionId] = new WorkerEventListener(worker);
+        }
+
+        const listener = this._commandListeners[extensionId];
+
+        listener.listen();
+
+        const validCommandType = this._validateCommand<T>(command);
+
+        const commandHandlerProxy = (
+            command: ExtensionCommandMap[T],
+            context?: ExtensionCommandOrQueryContext,
+        ) => {
+            if (context?.extensionId === extensionId) {
+                commandHandler(command, context);
+            }
+        };
+
+        listener.addListener(validCommandType, commandHandlerProxy);
+
+        return () => {
+            listener.removeListener(validCommandType, commandHandlerProxy);
+        };
+    }
+
+    listenForQuery<T extends keyof ExtensionQueryMap>(
+        extensionId: string,
+        query: T,
+        queryHandler: (
+            query: ExtensionQueryMap[T],
+            context?: ExtensionCommandOrQueryContext,
+        ) => Promise<void> | void,
+    ): () => void {
+        const worker = this._getWorkerById(extensionId);
+
+        if (!this._queryListeners[extensionId]) {
+            this._queryListeners[extensionId] = new WorkerEventListener(worker);
+        }
+
+        const listener = this._queryListeners[extensionId];
+
+        listener.listen();
+
+        const validQueryType = this._validateQuery<T>(query);
+
+        const queryHandlerProxy = (
+            query: ExtensionQueryMap[T],
+            context?: ExtensionCommandOrQueryContext,
+        ) => {
+            if (context?.extensionId === extensionId) {
+                queryHandler(query, context);
+            }
+        };
+
+        listener.addListener(validQueryType, queryHandlerProxy);
+
+        return () => {
+            listener.removeListener(validQueryType, queryHandlerProxy);
+        };
+    }
+
+    stopListen(extensionId: string): void {
+        if (this._commandListeners[extensionId]) {
+            this._commandListeners[extensionId].stopListen();
+        }
+
+        if (this._queryListeners[extensionId]) {
+            this._queryListeners[extensionId].stopListen();
+        }
     }
 
     post(extensionId: string, message: ExtensionMessage): void {
@@ -25,5 +118,31 @@ export class WorkerExtensionMessenger {
 
     clearCacheById(extensionId: string): void {
         delete this._workers[extensionId];
+    }
+
+    private _getWorkerById(extensionId: string): Worker {
+        const worker = this._workers[extensionId];
+
+        if (!worker) {
+            throw new ExtensionNotFoundError(`Worker with extensionId ${extensionId} not found`);
+        }
+
+        return worker;
+    }
+
+    private _validateCommand<T extends keyof ExtensionCommandMap>(command: T): T {
+        if (Object.values(ExtensionCommandType).includes(command)) {
+            return command;
+        }
+
+        throw new UnsupportedExtensionCommandError();
+    }
+
+    private _validateQuery<T extends keyof ExtensionQueryMap>(query: T): T {
+        if (Object.values(ExtensionQueryType).includes(query)) {
+            return query;
+        }
+
+        throw new UnsupportedExtensionQueryError();
     }
 }


### PR DESCRIPTION
## What?
Implement listening methods for the worker extension messenger.

## Why?
Enable worker extension to use command and query.

## Testing / Proof
### Manual testing
- The sample worker extension commands `checkout-js` to toggle the loading indication every second.
- The sample worker retrieves the current consignment details.

https://github.com/user-attachments/assets/345e312f-001b-44b5-be56-2f7291d32eb0



@bigcommerce/team-checkout @bigcommerce/team-payments
