### PR TITLE
feat(payment): added canMakePayments method as additional verification of payment capability

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
@@ -154,6 +154,18 @@ describe('ApplePayButtonStrategy', () => {
             ).rejects.toThrow(MissingDataError);
         });
 
+        it('throws error if canMakePayments returns false', async () => {
+            jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+            MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(false);
+
+            await strategy.initialize(getApplePayButtonInitializationOptions());
+
+            expect(console.error).toHaveBeenCalled();
+
+            MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(true);
+        });
+
         it('throws error when params object is empty', async () => {
             await expect(
                 strategy.initialize({

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -125,6 +125,12 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
 
         assertApplePayWindow(window);
 
+        if (!this._sessionFactory.canMakePayment()) {
+            console.error('This device is not capable of making Apple Pay payments');
+
+            return;
+        }
+
         if (!methodId || !applepay) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
@@ -157,6 +157,18 @@ describe('ApplePayCustomerStrategy', () => {
             await expect(strategy.initialize({})).rejects.toThrow(MissingDataError);
         });
 
+        it('throws error if canMakePayments returns false', async () => {
+            jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+            MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(false);
+
+            await strategy.initialize(getApplePayCustomerInitializationOptions());
+
+            expect(console.error).toHaveBeenCalled();
+
+            MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(true);
+        });
+
         it('sets up request for digital items', async () => {
             const cart = getCart();
 

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -92,6 +92,12 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
 
         assertApplePayWindow(window);
 
+        if (!this._sessionFactory.canMakePayment()) {
+            console.error('This device is not capable of making Apple Pay payments');
+
+            return;
+        }
+
         try {
             this._paymentMethod = state.getPaymentMethodOrThrow(methodId);
         } catch (_e) {

--- a/packages/apple-pay-integration/src/apple-pay-session-factory.ts
+++ b/packages/apple-pay-integration/src/apple-pay-session-factory.ts
@@ -18,4 +18,10 @@ export default class ApplePaySessionFactory {
 
         return new ApplePaySession(1, request);
     }
+
+    canMakePayment(): boolean {
+        assertApplePayWindow(window);
+
+        return ApplePaySession.canMakePayments();
+    }
 }

--- a/packages/apple-pay-integration/src/mocks/apple-pay-payment.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-payment.mock.ts
@@ -1,6 +1,6 @@
 export class MockApplePaySession {
     static supportsVersion: () => boolean;
-    static canMakePayments: () => boolean;
+    static canMakePayments: () => boolean = jest.fn().mockReturnValue(true);
 
     addEventListener = jest.fn();
     dispatchEvent = jest.fn();


### PR DESCRIPTION
## What?

Added canMakePayments method as additional verification of payment capability

## Why?

For additional check of apple pay payment capability

## Testing / Proof

Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
