### PR TITLE
feat(payment): Move all Stripe OCS styling configs to checkout-js side

### DIFF
--- a/packages/stripe-integration/jest.config.js
+++ b/packages/stripe-integration/jest.config.js
@@ -13,4 +13,5 @@ module.exports = {
     setupFilesAfterEnv: ['../../jest-setup.js'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
     coverageDirectory: '../../coverage/packages/stripe-integration',
+    coveragePathIgnorePatterns: ['<rootDir>/src/index.ts'],
 };

--- a/packages/stripe-integration/src/index.ts
+++ b/packages/stripe-integration/src/index.ts
@@ -27,3 +27,5 @@ export {
     default as StripeOCSPaymentInitializeOption,
     WithStripeOCSPaymentInitializeOptions,
 } from './stripe-ocs/stripe-ocs-initialize-options';
+
+export { StripeAppearanceOptions, StripeCustomFont } from './stripe-utils';

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
@@ -1,4 +1,8 @@
-import { StripeElementUpdateOptions, StripeUPEAppearanceValues } from '../stripe-utils';
+import {
+    StripeAppearanceOptions,
+    StripeCustomFont,
+    StripeElementUpdateOptions,
+} from '../stripe-utils';
 
 /**
  * A set of options that are required to initialize the Stripe payment method.
@@ -35,9 +39,14 @@ export default interface StripeOCSPaymentInitializeOptions {
     layout?: Record<string, string | number | boolean>;
 
     /**
-     * Checkout styles from store theme
+     * Stripe OCS appearance options for styling the accordion.
      */
-    style?: Record<string, StripeUPEAppearanceValues>;
+    appearance?: StripeAppearanceOptions;
+
+    /**
+     * Stripe OCS fonts options for styling the accordion.
+     */
+    fonts?: StripeCustomFont[];
 
     onError?(error?: Error): void;
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -47,17 +47,6 @@ describe('StripeOCSPaymentStrategy', () => {
     const methodId = 'optymized_checkout';
     const gatewayId = 'stripeocs';
 
-    const testColor = '#123456';
-    const style = {
-        labelText: testColor,
-        fieldText: testColor,
-        fieldPlaceholderText: testColor,
-        fieldErrorText: testColor,
-        fieldBackground: testColor,
-        fieldInnerShadow: testColor,
-        fieldBorder: testColor,
-    };
-
     beforeEach(() => {
         const scriptLoader = createScriptLoader();
 
@@ -376,73 +365,6 @@ describe('StripeOCSPaymentStrategy', () => {
             await stripeOCSPaymentStrategy.initialize(stripeOptions);
 
             expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
-        });
-
-        describe('Stripe Element styling', () => {
-            describe('RadioButton styling', () => {
-                it('should initialize with default style', async () => {
-                    stripeOptions = getStripeOCSInitializeOptionsMock(style);
-                    await stripeOCSPaymentStrategy.initialize(stripeOptions);
-
-                    expect(stripeScriptLoader.getElements).toHaveBeenCalledWith(
-                        stripeUPEJsMock,
-                        expect.objectContaining({
-                            appearance: expect.objectContaining({
-                                rules: expect.objectContaining({
-                                    '.RadioIcon': {
-                                        width: '29.55px',
-                                    },
-                                    '.RadioIconOuter': {
-                                        strokeWidth: '3.38px',
-                                        stroke: '#ddd',
-                                    },
-                                    '.RadioIconOuter--checked': {
-                                        stroke: '#4496f6',
-                                    },
-                                    '.RadioIconInner': {
-                                        r: '28.77px',
-                                        fill: '#4496f6',
-                                    },
-                                }),
-                            }),
-                        }),
-                    );
-                });
-
-                it('should initialize with custom style', async () => {
-                    stripeOptions = getStripeOCSInitializeOptionsMock({
-                        ...style,
-                        radioIconOuterWidth: '52px',
-                        radioIconOuterStrokeWidth: '4px',
-                        radioIconInnerWidth: '25px',
-                    });
-                    await stripeOCSPaymentStrategy.initialize(stripeOptions);
-
-                    expect(stripeScriptLoader.getElements).toHaveBeenCalledWith(
-                        stripeUPEJsMock,
-                        expect.objectContaining({
-                            appearance: expect.objectContaining({
-                                rules: expect.objectContaining({
-                                    '.RadioIcon': {
-                                        width: '59.09px',
-                                    },
-                                    '.RadioIconOuter': {
-                                        strokeWidth: '6.77px',
-                                        stroke: '#ddd',
-                                    },
-                                    '.RadioIconOuter--checked': {
-                                        stroke: '#4496f6',
-                                    },
-                                    '.RadioIconInner': {
-                                        r: '21.15px',
-                                        fill: '#4496f6',
-                                    },
-                                }),
-                            }),
-                        }),
-                    );
-                });
-            });
         });
     });
 

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-initialize-options.ts
@@ -1,4 +1,4 @@
-import { StripeElementUpdateOptions, StripeUPEAppearanceValues } from '../stripe-utils';
+import { StripeAppearanceValues, StripeElementUpdateOptions } from '../stripe-utils';
 
 /**
  * A set of options that are required to initialize the Stripe payment method.
@@ -31,7 +31,7 @@ export default interface StripeUPEPaymentInitializeOptions {
     /**
      * Checkout styles from store theme
      */
-    style?: Record<string, StripeUPEAppearanceValues>;
+    style?: Record<string, StripeAppearanceValues>;
 
     onError?(error?: Error): void;
 

--- a/packages/stripe-integration/src/stripe-utils/stripe.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe.ts
@@ -113,7 +113,7 @@ export interface CustomFontSource {
     weight?: string;
 }
 
-export type CustomFont = CssFontSource | CustomFontSource;
+export type StripeCustomFont = CssFontSource | CustomFontSource;
 
 export interface StripeError {
     /**
@@ -415,12 +415,12 @@ export interface StripeElements {
  * All available options are here https://stripe.com/docs/stripe-js/appearance-api#supported-css-properties
  */
 export interface StripeAppearanceOptions {
-    variables?: Record<string, StripeUPEAppearanceValues>;
+    variables?: Record<string, StripeAppearanceValues>;
 
-    rules?: Record<string, Record<string, StripeUPEAppearanceValues>>;
+    rules?: Record<string, Record<string, StripeAppearanceValues>>;
 }
 
-export type StripeUPEAppearanceValues = string | string[] | number | undefined;
+export type StripeAppearanceValues = string | string[] | number | undefined;
 
 export interface StripeElementsOptions {
     /**
@@ -428,7 +428,7 @@ export interface StripeElementsOptions {
      * Fonts can be specified as [CssFontSource](https://stripe.com/docs/js/appendix/css_font_source_object)
      * or [CustomFontSource](https://stripe.com/docs/js/appendix/custom_font_source_object) objects.
      */
-    fonts?: CustomFont[];
+    fonts?: StripeCustomFont[];
 
     /**
      * A [locale](https://stripe.com/docs/js/appendix/supported_locales) to display placeholders and


### PR DESCRIPTION
## What?
Move all styling options for Stripe OCS to checkoput-js side.
Checkout-js PR: [https://github.com/bigcommerce/checkout-js/pull/2351](https://github.com/bigcommerce/checkout-js/pull/2351)

## Why?
To make Stripe widget more flexible for merchants with custom checkout. 

## Testing / Proof

https://github.com/user-attachments/assets/74fc3d46-48c9-4e0f-8dad-8bb69d8d1c11

<img width="1281" alt="Screenshot 2025-06-05 at 17 47 02" src="https://github.com/user-attachments/assets/90d184e4-e0af-44cb-944f-28915475047c" />


@bigcommerce/team-checkout @bigcommerce/team-payments
