### PR TITLE
fix(payment): Google Pay payment step custom fields added

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
@@ -936,7 +936,7 @@ describe('GooglePayGateway', () => {
                 countryCode: 'US',
                 postalCode: '78703',
                 phone: '+1 555-555-5555',
-                customFields: [],
+                customFields: [{ fieldId: 'test field', fieldValue: '123123' }],
             };
 
             jest.spyOn(
@@ -945,6 +945,7 @@ describe('GooglePayGateway', () => {
             ).mockReturnValueOnce({
                 ...getBillingAddress(),
                 email: 'test.tester@bigcommerce.com',
+                customFields: [{ fieldId: 'test field', fieldValue: '123123' }],
             });
 
             const mappedAddress = gateway.mapToBillingAddressRequestBody(getCardDataResponse());

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -78,10 +78,11 @@ export default class GooglePayGateway {
             company = '',
             phone = '',
             email,
+            customFields = [],
         } = this._paymentIntegrationService.getState().getBillingAddress() || {};
 
         return {
-            ...this._mapToAddressRequestBody(billingAddress, company, phone),
+            ...this._mapToAddressRequestBody(billingAddress, company, phone, customFields),
             email: email || response.email,
         };
     }
@@ -458,6 +459,7 @@ export default class GooglePayGateway {
         address: GooglePayFullBillingAddress,
         company: string,
         phone: string,
+        customFields?: AddressRequestBody['customFields'],
     ): AddressRequestBody {
         const {
             name,
@@ -484,7 +486,7 @@ export default class GooglePayGateway {
             countryCode,
             postalCode,
             phone: phoneNumber || phone,
-            customFields: [],
+            customFields: customFields || [],
         };
     }
 


### PR DESCRIPTION
## What?
When user interacts with a Google Pay payment sheet, we update billing address. In case if merchant has required custom fields we will recieve an error, because we don't pass customFields on billing aggress updating. This PR fix this issue.

## Testing / Proof
Before:

https://github.com/user-attachments/assets/af272935-b9fa-4c93-9776-2a15f0cffc09

After:

https://github.com/user-attachments/assets/280f5b8e-b113-438a-9d1d-afcec3340e07



@bigcommerce/team-checkout @bigcommerce/team-payments
