### PR TITLE
feat(payment): updated braintree-venmo-payment-strategy with providing initialization options

### DIFF
--- a/packages/core/src/payment/payment-request-options.ts
+++ b/packages/core/src/payment/payment-request-options.ts
@@ -5,6 +5,7 @@ import { RequestOptions } from '../common/http-request';
 import { BlueSnapV2PaymentInitializeOptions } from './strategies/bluesnapv2';
 import {
     BraintreePaymentInitializeOptions,
+    BraintreeVenmoInitializeOptions,
     BraintreeVisaCheckoutPaymentInitializeOptions,
 } from './strategies/braintree';
 import { DigitalRiverPaymentInitializeOptions } from './strategies/digitalriver';
@@ -80,4 +81,10 @@ export interface BasePaymentInitializeOptions extends PaymentRequestOptions {
      * They can be omitted unless you need to support PayPal Express.
      */
     paypalexpress?: PaypalExpressPaymentInitializeOptions;
+
+    /**
+     * The options that are required to initialize the Braintree Venmo payment method.
+     * They can be omitted unless you need to support Braintree Venmo.
+     */
+    braintreevenmo?: BraintreeVenmoInitializeOptions;
 }

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
@@ -301,11 +301,12 @@ describe('Braintree SDK Creator', () => {
                 onErrorCallback,
                 {
                     mobileWebFallBack: false,
+                    allowDesktop: false,
                 },
             );
 
             expect(braintreeVenmoCheckoutCreatorMock.create).toHaveBeenCalledWith(
-                expect.objectContaining({ mobileWebFallBack: false }),
+                expect.objectContaining({ mobileWebFallBack: false, allowDesktop: false }),
                 expect.any(Function),
             );
             expect(braintreeVenmoCheckout).toBe(braintreeVenmoCheckoutMock);

--- a/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-initialize-options.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-initialize-options.ts
@@ -1,0 +1,7 @@
+export default interface BraintreeVenmoInitializeOptions {
+    /**
+     * An option that can provide different payment authorization methods, for more information use the following link: https://developer.paypal.com/braintree/docs/guides/venmo/client-side/javascript/v3/#desktop-qr-code
+     * If no value is specified, it will be true
+     */
+    allowDesktop?: boolean;
+}

--- a/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.spec.ts
@@ -166,6 +166,20 @@ describe('BraintreeVenmoPaymentStrategy', () => {
                 mobileWebFallBack: true,
             });
         });
+
+        it('should intialize Venmo with providing venmo options', async () => {
+            await braintreeVenmoPaymentStrategy.initialize({
+                ...options,
+                braintreevenmo: {
+                    allowDesktop: true,
+                },
+            });
+
+            expect(braintreePaymentProcessorMock.getVenmoCheckout).toHaveBeenCalledWith({
+                allowDesktop: true,
+                mobileWebFallBack: true,
+            });
+        });
     });
 
     describe('#execute()', () => {

--- a/packages/core/src/payment/strategies/braintree/index.ts
+++ b/packages/core/src/payment/strategies/braintree/index.ts
@@ -5,6 +5,7 @@ export { BraintreePaymentInitializeOptions } from './braintree-payment-options';
 export { default as BraintreeCreditCardPaymentStrategy } from './braintree-credit-card-payment-strategy';
 export { default as BraintreePaymentProcessor } from './braintree-payment-processor';
 export { default as BraintreeVenmoPaymentStrategy } from './braintree-venmo-payment-strategy';
+export { default as BraintreeVenmoInitializeOptions } from './braintree-venmo-payment-initialize-options';
 export { default as BraintreeVisaCheckoutPaymentProcessor } from './braintree-visacheckout-payment-processor';
 export { default as BraintreeSDKCreator } from './braintree-sdk-creator';
 export { default as createBraintreePaymentProcessor } from './create-braintree-payment-processor';


### PR DESCRIPTION
## What?

Updated `braintree-venmo-payment-strategy` with providing initialization options

## Why?

To be able handle venmo auth flow based on `allowDesktop` option

## Testing / Proof

Manual

@bigcommerce/team-checkout @bigcommerce/team-payments
