### PR TITLE
feat(payment): PI-3946 Remove experiment: INT-5826.amazon_relative_url[checkout-js]

### DIFF
--- a/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.spec.ts
@@ -454,30 +454,6 @@ describe('AmazonPayV2PaymentProcessor', () => {
             );
         });
 
-        it('should provide a relative URL to create a checkout session', async () => {
-            const expectedOptions = getAmazonPayV2ButtonParamsMock() as AmazonPayV2ButtonParams;
-
-            expectedOptions.createCheckoutSession.url = `/remote-checkout/amazonpay/payment-session`;
-
-            const storeConfigMock = getConfig().storeConfig;
-
-            storeConfigMock.checkoutSettings.features = {
-                'INT-5826.amazon_relative_url': true,
-            };
-
-            jest.spyOn(checkoutState.config, 'getStoreConfigOrThrow').mockReturnValueOnce(
-                storeConfigMock,
-            );
-
-            await processor.initialize(amazonPayV2Mock);
-            renderAmazonPayButton();
-
-            expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(
-                expectedContainerId,
-                expectedOptions,
-            );
-        });
-
         describe('should use the new button params from API Version 2:', () => {
             beforeEach(() => {
                 const storeConfigMock = getConfig().storeConfig;

--- a/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
@@ -288,9 +288,7 @@ export default class AmazonPayV2PaymentProcessor {
 
         const createCheckoutSession = {
             method: checkoutSessionMethod,
-            url: features['INT-5826.amazon_relative_url']
-                ? `/remote-checkout/${methodId}/payment-session`
-                : `${shopPath}/remote-checkout/${methodId}/payment-session`,
+            url: `${shopPath}/remote-checkout/${methodId}/payment-session`,
             extractAmazonCheckoutSessionId,
         };
 


### PR DESCRIPTION
## What?
Removal of experiment INT-5826.amazon_relative_url from checkout-sdk-js

This experiment was only enabled for one store 1002086826. As customer is not using AmazonPay since 2024-04-15 we decided to rollout it.

## Testing / Proof
Manually tested

https://github.com/user-attachments/assets/18b71ef6-1425-475f-815f-a53dfce06f82



@bigcommerce/team-checkout @bigcommerce/team-payments
