### PR TITLE
feat(payment): PSD2 error handling

### DIFF
--- a/packages/paypal-commerce-utils/src/utils/index.ts
+++ b/packages/paypal-commerce-utils/src/utils/index.ts
@@ -2,3 +2,4 @@ export { default as isPayPalCommerceAcceleratedCheckoutCustomer } from './is-pay
 export { default as isPayPalFastlaneCustomer } from './is-paypal-fastlane-customer';
 export { default as getFastlaneStyles } from './get-fastlane-styles';
 export { default as getPaypalMessagesStylesFromBNPLConfig } from './get-paypal-messages-styles-from-bnpl-config';
+export { default as isRedirectActionError } from './is-redirect-action-error';

--- a/packages/paypal-commerce-utils/src/utils/is-redirect-action-error.spec.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-redirect-action-error.spec.ts
@@ -1,0 +1,46 @@
+import isRedirectActionError from './is-redirect-action-error';
+
+describe('isRedirectActionError', () => {
+    it('returns true if error is redirect action type', () => {
+        const redirectActionError = {
+            status: 'error',
+            three_ds_result: {
+                acs_url: null,
+                payer_auth_request: null,
+                merchant_data: null,
+                callback_url: null,
+            },
+            body: {
+                additional_action_required: {
+                    type: 'offsite_redirect',
+                    data: {
+                        redirect_url: 'https://example.redirect.com',
+                    },
+                },
+            },
+            errors: [
+                {
+                    code: 'invalid_request_error',
+                    message:
+                        "We're experiencing difficulty processing your transaction. Please contact us or try again later.",
+                },
+            ],
+        };
+
+        expect(isRedirectActionError(redirectActionError)).toBe(true);
+    });
+
+    it('returns false if error is not redirect action type', () => {
+        const notRedirectActionError = {
+            status: 'error',
+            three_ds_result: {
+                acs_url: null,
+                payer_auth_request: null,
+                merchant_data: null,
+                callback_url: null,
+            },
+        };
+
+        expect(isRedirectActionError(notRedirectActionError)).toBe(false);
+    });
+});

--- a/packages/paypal-commerce-utils/src/utils/is-redirect-action-error.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-redirect-action-error.ts
@@ -1,0 +1,20 @@
+import { isRequestError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { ProviderError } from './is-paypal-commerce-provider-error';
+
+export interface RedirectActionError extends ProviderError {
+    body: {
+        additional_action_required: {
+            type: 'offsite_redirect';
+            data: {
+                redirect_url: string;
+            };
+        };
+    };
+}
+
+export default function isRedirectActionError(error: unknown): error is RedirectActionError {
+    return (
+        isRequestError(error) && error.body.additional_action_required?.type === 'offsite_redirect'
+    );
+}


### PR DESCRIPTION
## What?

Add error handling for redirect action

## Why?

To be able redirect user if there is `PSD2` related error

## Testing / Proof

Was testing with this PR https://github.com/bigcommerce/bigpay/pull/9096 on int store

![Screenshot 2025-06-16 at 15 40 47](https://github.com/user-attachments/assets/749bcb11-213a-4f5a-bba6-6b61ebb60369)

@bigcommerce/team-checkout @bigcommerce/team-payments
