### PR TITLE
feat(payment): fastlane success flow fix

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -597,7 +597,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                         ...threeDomainSecureComponentMock,
                         show: jest.fn().mockReturnValue({
                             liabilityShift: 'possible',
-                            authenticationState: 'success',
+                            authenticationState: 'succeeded',
                             nonce: 'paypal_fastlane_instrument_id_nonce_3ds',
                         }),
                     },

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -414,11 +414,8 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
         );
 
         if (isThreeDomainSecureEligible) {
-            const {
-                liabilityShift, // "no", "unknown", "possible"
-                authenticationState, // "success", "cancelled", "errored"
-                nonce, // Enriched nonce or the original nonce
-            } = await threeDomainSecureComponent.show();
+            const { liabilityShift, authenticationState, nonce } =
+                await threeDomainSecureComponent.show();
 
             if (
                 liabilityShift === LiabilityShiftEnum.No ||
@@ -427,7 +424,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
                 throw new PaymentMethodInvalidError();
             }
 
-            if (authenticationState === TDSecureAuthenticationState.Success) {
+            if (authenticationState === TDSecureAuthenticationState.Succeeded) {
                 return nonce;
             }
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -113,11 +113,11 @@ export interface PayPalFastlaneSdk {
 interface ThreeDomainSecureClientShowResponse {
     liabilityShift: LiabilityShiftEnum;
     authenticationState: TDSecureAuthenticationState;
-    nonce: string;
+    nonce: string; // Enriched nonce or the original nonce
 }
 
 export enum TDSecureAuthenticationState {
-    Success = 'success',
+    Succeeded = 'succeeded',
     Cancelled = 'cancelled',
     Errored = 'errored',
 }


### PR DESCRIPTION
## What?

Updated `authenticationState` statuses

## Why?

To fix issue with fastlane success flow

## Testing / Proof

`authenticationState` does not have `success` state, only `succeeded`

<img width="1144" alt="Screenshot 2025-06-23 at 11 14 09" src="https://github.com/user-attachments/assets/f44308bc-39be-4deb-b5c2-3c81a2314076" />


@bigcommerce/team-checkout @bigcommerce/team-payments
