### PR TITLE
fix(payment): all Moneris payments fail on iOS devices

### DIFF
--- a/packages/moneris-integration/src/moneris-payment-strategy.test.ts
+++ b/packages/moneris-integration/src/moneris-payment-strategy.test.ts
@@ -242,7 +242,12 @@ describe('MonerisPaymentStrategy', () => {
                 bin: '1234',
             };
 
-            window.postMessage(JSON.stringify(mockMonerisIframeMessage), '*');
+            window.dispatchEvent(
+                new MessageEvent('message', {
+                    origin: 'https://www3.moneris.com',
+                    data: JSON.stringify(mockMonerisIframeMessage),
+                }),
+            );
             await expect(promise).rejects.toThrow(new Error('expected error message'));
             expect(paymentIntegrationService.submitPayment).not.toHaveBeenCalled();
         });
@@ -271,7 +276,13 @@ describe('MonerisPaymentStrategy', () => {
                 bin: '1234',
             };
 
-            window.postMessage(JSON.stringify(mockMonerisIframeMessage), '*');
+            window.dispatchEvent(
+                new MessageEvent('message', {
+                    origin: 'https://www3.moneris.com',
+                    data: JSON.stringify(mockMonerisIframeMessage),
+                }),
+            );
+
             await promise;
             expect(paymentIntegrationService.applyStoreCredit).toHaveBeenCalledWith(true);
             expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expectedPayment);
@@ -345,6 +356,9 @@ describe('MonerisPaymentStrategy', () => {
             await strategy.initialize(initializeOptions);
 
             const pendingExecution = strategy.execute(vaultingPayload, options);
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
             const mockMonerisIframeMessage = {
                 responseCode: ['001'],
                 errorMessage: null,
@@ -352,7 +366,13 @@ describe('MonerisPaymentStrategy', () => {
                 bin: '1234',
             };
 
-            window.postMessage(JSON.stringify(mockMonerisIframeMessage), '*');
+            window.dispatchEvent(
+                new MessageEvent('message', {
+                    origin: 'https://www3.moneris.com',
+                    data: JSON.stringify(mockMonerisIframeMessage),
+                }),
+            );
+
             await pendingExecution;
             expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expectedPayment);
         });
@@ -508,7 +528,12 @@ describe('MonerisPaymentStrategy', () => {
                 bin: '1234',
             };
 
-            window.postMessage(JSON.stringify(mockMonerisIframeMessage), '*');
+            window.dispatchEvent(
+                new MessageEvent('message', {
+                    origin: 'https://www3.moneris.com',
+                    data: JSON.stringify(mockMonerisIframeMessage),
+                }),
+            );
             await expect(promise).rejects.toThrow(new Error('expected error message'));
             await strategy.deinitialize();
             expect(window.removeEventListener).toHaveBeenCalledWith(
@@ -518,6 +543,20 @@ describe('MonerisPaymentStrategy', () => {
         });
         it('deinitializes strategy and removes the iframe if it exists', async () => {
             await strategy.initialize(initializeOptions);
+
+            const mockMonerisIframeMessage = {
+                responseCode: ['001'],
+                errorMessage: null,
+                dataKey: 'ABC123',
+                bin: '1234',
+            };
+
+            window.dispatchEvent(
+                new MessageEvent('message', {
+                    origin: 'https://esqa.moneris.com',
+                    data: JSON.stringify(mockMonerisIframeMessage),
+                }),
+            );
             await strategy.deinitialize();
             expect(container.childElementCount).toBe(0);
         });

--- a/packages/moneris-integration/src/moneris-payment-strategy.ts
+++ b/packages/moneris-integration/src/moneris-payment-strategy.ts
@@ -137,6 +137,7 @@ export default class MonerisPaymentStrategy {
 
         const testMode = paymentMethod.config.testMode;
         const paymentData = payment.paymentData || {};
+
         const instrumentSettings = isHostedInstrumentLike(paymentData)
             ? paymentData
             : { shouldSaveInstrument: false, shouldSetAsDefaultInstrument: false };
@@ -157,7 +158,10 @@ export default class MonerisPaymentStrategy {
             frameref.postMessage('tokenize', this.monerisURL(!!testMode));
 
             this.windowEventListener = (response: MessageEvent) => {
-                if (typeof response.data !== 'string') {
+                if (
+                    typeof response.data !== 'string' ||
+                    response.origin !== `https://${testMode ? 'esqa' : 'www3'}.moneris.com`
+                ) {
                     return;
                 }
 
@@ -282,6 +286,7 @@ export default class MonerisPaymentStrategy {
         iframe.id = IFRAME_NAME;
         iframe.style.border = 'none';
         iframe.src = `${this.monerisURL(testMode)}?${queryString}`;
+        iframe.allow = 'payment';
 
         container.appendChild(iframe);
 


### PR DESCRIPTION
## What?
added additional header so that we can access the full message response from Moneris on IOS mobile devices 

## Why?
to fix the payments failures

## Testing / Proof
Before:
![image](https://github.com/user-attachments/assets/542b9bbc-6cec-4d2f-afdc-9a271575f820)


After:

https://github.com/user-attachments/assets/1fd8e4ba-b0ab-4a02-8c7b-4518b49df1a6

https://github.com/user-attachments/assets/23599f64-3322-4d43-ad41-69aecb8ed094

