### PR TITLE
feat(payment): Hide banner implementation under the experiment in PPCP button strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -11,6 +11,7 @@ import {
     getBuyNowCart,
     getBuyNowCartRequestBody,
     getCart,
+    getConfig,
     getConsignment,
     getShippingOption,
     PaymentIntegrationServiceMock,
@@ -870,6 +871,31 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalCommerceSdkRenderMock).toHaveBeenCalledWith(
+                `#${defaultMessageContainerId}`,
+            );
+        });
+
+        it('do not render PayPal message if experiment is enabled', async () => {
+            const storeConfig = getConfig().storeConfig;
+            const storeConfigWithFeaturesOn = {
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5557.Hide_ppc_banner_implementation': true,
+                    },
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue(storeConfigWithFeaturesOn);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalledWith(
                 `#${defaultMessageContainerId}`,
             );
         });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -100,6 +100,14 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
 
         this.renderButton(containerId, methodId, paypalcommercecredit);
 
+        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
+        const isBannerImplementationDisabled =
+            features['PAYPAL-5557.Hide_ppc_banner_implementation'] ?? false;
+
+        if (isBannerImplementationDisabled) {
+            return;
+        }
+
         const messagingContainer =
             messagingContainerId && document.getElementById(messagingContainerId);
 


### PR DESCRIPTION
## What?

Hide banner implementation under the experiment in PPCP button strategy

## Why?

To manage the logic of banner implementation using an experiment

## Testing / Proof

Manual
Unit

@bigcommerce/team-checkout @bigcommerce/team-payments
