### PR TITLE
fix(payment): removed typo from bigcommerce_payments_creditcardsscheckout in BigCommercePaymentsCreditCardsPaymentStrategy

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-credit-cards/bigcommerce-payments-credit-cards-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-credit-cards/bigcommerce-payments-credit-cards-payment-strategy.ts
@@ -141,7 +141,7 @@ export default class BigCommercePaymentsCreditCardsPaymentStrategy implements Pa
             // The condition gets triggered when customer pays with vaulted instrument and shipping address is trusted
             const { orderId } =
                 await this.bigCommercePaymentsIntegrationService.createOrderCardFields(
-                    'bigcommerce_payments_creditcardsscheckout',
+                    'bigcommerce_payments_creditcardscheckout',
                     this.getInstrumentParams(),
                 );
 


### PR DESCRIPTION
## What?
Fixed a typo in `bigcommerce_payments_creditcardscheckout` method name in BigCommercePaymentsCreditCardsPaymentStrategy

## Why?
So the PayPal order creation will not be failed with 503 server error

## Testing / Proof
Manual tests
CI
