### PR TITLE
feat(payment): [FE]Deprecate PROJECT-3828.add_3ds_support_on_squarev2 experiment 

### DIFF
--- a/packages/squarev2-integration/src/mocks/squarev2-method.mock.ts
+++ b/packages/squarev2-integration/src/mocks/squarev2-method.mock.ts
@@ -1,6 +1,6 @@
 import { PaymentMethod } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-export function getSquareV2(): PaymentMethod {
+export function getSquareV2(isSquareV2ApiV2Enabled: boolean): PaymentMethod {
     return {
         id: 'squarev2',
         logoUrl: '',
@@ -18,6 +18,7 @@ export function getSquareV2(): PaymentMethod {
         initializationData: {
             applicationId: 'test',
             env: 'bar',
+            isSquareV2ApiV2Enabled,
             locationId: 'foo',
             paymentData: {
                 nonce: undefined,

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
@@ -50,7 +50,7 @@ describe('SquareV2PaymentStrategy', () => {
         loadPaymentMethodMock.mockReturnValue(paymentIntegrationService.getState());
 
         jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
-            getSquareV2(),
+            getSquareV2(false),
         );
 
         processor = new SquareV2PaymentProcessor(
@@ -165,6 +165,10 @@ describe('SquareV2PaymentStrategy', () => {
         });
 
         it('should verify the buyer to get the verification token', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(getSquareV2(true));
             toggle3dsExperiment(true);
 
             await strategy.execute(payload);
@@ -211,6 +215,10 @@ describe('SquareV2PaymentStrategy', () => {
                 },
             };
 
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(getSquareV2(true));
             toggle3dsExperiment(true);
 
             await strategy.execute(payload);
@@ -230,6 +238,10 @@ describe('SquareV2PaymentStrategy', () => {
                     },
                 };
 
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue(getSquareV2(true));
                 toggle3dsExperiment(true);
 
                 await strategy.initialize(options);
@@ -329,7 +341,7 @@ describe('SquareV2PaymentStrategy', () => {
 
                 toggle3dsExperiment(true);
 
-                const defaultPaymentMethod = getSquareV2();
+                const defaultPaymentMethod = getSquareV2(true);
 
                 jest.spyOn(
                     paymentIntegrationService.getState(),
@@ -349,7 +361,7 @@ describe('SquareV2PaymentStrategy', () => {
                 jest.spyOn(
                     paymentIntegrationService.getState(),
                     'getPaymentMethodOrThrow',
-                ).mockReturnValue(getSquareV2());
+                ).mockReturnValue(getSquareV2(true));
 
                 let executeError;
 

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.ts
@@ -75,7 +75,7 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
         const submitPaymentPayload =
             paymentData && isVaultedInstrument(paymentData)
                 ? await this._getVaultedInstrumentPayload(methodId, paymentData)
-                : await this._getCardPayload(shouldSaveInstrument);
+                : await this._getCardPayload(methodId, shouldSaveInstrument);
 
         await this._paymentIntegrationService.submitPayment({
             ...payment,
@@ -97,7 +97,7 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
         return this._squareV2PaymentProcessor.deinitialize();
     }
 
-    private _shouldVerify(): boolean {
+    private shouldVerify(): boolean {
         const { features } = this._paymentIntegrationService
             .getState()
             .getStoreConfigOrThrow().checkoutSettings;
@@ -105,10 +105,17 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
         return features['PROJECT-3828.add_3ds_support_on_squarev2'];
     }
 
-    private async _getCardPayload(shouldSaveInstrument?: boolean) {
+    private async _getCardPayload(methodId: string, shouldSaveInstrument?: boolean) {
+        const { getPaymentMethodOrThrow } = this._paymentIntegrationService.getState();
+        const { initializationData } = getPaymentMethodOrThrow<SquareInitializationData>(methodId);
+
         const cardTokenizationResult = await this._squareV2PaymentProcessor.tokenize();
 
-        if (!this._shouldVerify()) {
+        if (
+            initializationData && 'isSquareV2ApiV2Enabled' in initializationData
+                ? !initializationData.isSquareV2ApiV2Enabled
+                : !this.shouldVerify()
+        ) {
             return {
                 credit_card_token: {
                     token: cardTokenizationResult,
@@ -150,8 +157,15 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
         methodId: string,
         paymentData: VaultedInstrument,
     ): Promise<SquareFormattedVaultedInstrument> {
+        const { getPaymentMethodOrThrow } = this._paymentIntegrationService.getState();
+        const { initializationData } = getPaymentMethodOrThrow<SquareInitializationData>(methodId);
+
         const { instrumentId } = paymentData;
-        const verificationToken = this._shouldVerify()
+        const shouldVerify =
+            initializationData && 'isSquareV2ApiV2Enabled' in initializationData
+                ? initializationData.isSquareV2ApiV2Enabled
+                : this.shouldVerify();
+        const verificationToken = shouldVerify
             ? await this._squareV2PaymentProcessor.verifyBuyer(
                   await this._getSquareCardIdOrThrow(methodId, instrumentId),
                   SquareIntent.CHARGE,

--- a/packages/squarev2-integration/src/types.ts
+++ b/packages/squarev2-integration/src/types.ts
@@ -7,6 +7,7 @@ export interface SquarePaymentMethodInitializationData {
 
 export interface SquareInitializationData {
     cardId?: string;
+    isSquareV2ApiV2Enabled?: boolean;
 }
 
 export interface SquareCreditCardTokens {


### PR DESCRIPTION
BE part for more context- https://github.com/bigcommerce/bigcommerce/pull/63976 

## What/Why?
`As PROJECT-3828.add_3ds_support_on_squarev2` experiment will be deprecated. The functionality it covers is moved to control panel in BE part and is received by FE in `isSquareV2ApiV2Enabled` property in `initializationData`.
Temporary we left experiment PROJECT-3828.add_3ds_support_on_squarev2 in the code in the code. It will be removed when we will be sure that new solution is working.

Changes are hidden under experiment `PI-2867_squarev2_use_bigpay_feature_insteadof_science_3ds`

## Testing / Proof
Tested manually

https://github.com/user-attachments/assets/fce57c94-5e5e-4641-a751-54356ea867c0

@bigcommerce/team-checkout @bigcommerce/team-payments
