### PR TITLE
feat(payment): added unsupported credit card brands to braintree credit cards payment strategy

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -221,6 +221,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
                             cardExpiry: { containerId: 'cardExpiry' },
                         },
                     },
+                    unsupportedCardBrands: ['american-express', 'diners-club'],
                 },
             };
 
@@ -232,6 +233,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
             );
             expect(braintreePaymentProcessorMock.initializeHostedForm).toHaveBeenCalledWith(
                 options.braintree.form,
+                options.braintree.unsupportedCardBrands,
             );
             expect(braintreePaymentProcessorMock.isInitializedHostedForm).toHaveBeenCalled();
             expect(braintreePaymentProcessorMock.getSessionId).toHaveBeenCalled();

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -56,7 +56,10 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
             this._braintreePaymentProcessor.initialize(clientToken, braintree);
 
             if (this._isHostedPaymentFormEnabled(methodId, gatewayId) && braintree?.form) {
-                await this._braintreePaymentProcessor.initializeHostedForm(braintree.form);
+                await this._braintreePaymentProcessor.initializeHostedForm(
+                    braintree.form,
+                    braintree.unsupportedCardBrands,
+                );
                 this._isHostedFormInitialized =
                     this._braintreePaymentProcessor.isInitializedHostedForm();
             }

--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
@@ -17,6 +17,8 @@ describe('BraintreeHostedForm', () => {
     let formOptions: BraintreeFormOptions;
     let subject: BraintreeHostedForm;
 
+    const unsupportedCardBrands = ['american-express', 'maestro'];
+
     function appendContainer(id: string): HTMLElement {
         const container = document.createElement('div');
 
@@ -83,7 +85,7 @@ describe('BraintreeHostedForm', () => {
 
     describe('#initialize', () => {
         it('creates and configures hosted fields', async () => {
-            await subject.initialize(formOptions);
+            await subject.initialize(formOptions, unsupportedCardBrands);
 
             expect(braintreeSdkCreator.createHostedFields).toHaveBeenCalledWith({
                 fields: {
@@ -98,6 +100,10 @@ describe('BraintreeHostedForm', () => {
                     number: {
                         container: '#cardNumber',
                         placeholder: 'Card number',
+                        supportedCardBrands: {
+                            'american-express': false,
+                            maestro: false,
+                        },
                     },
                     cardholderName: {
                         container: '#cardName',

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
@@ -122,6 +122,29 @@ export interface BraintreePaymentInitializeOptions {
      * A callback for displaying error popup. This callback requires error object as parameter.
      */
     onError?(error: unknown): void;
+
+    /**
+     * A list of card brands that are not supported by the merchant.
+     *
+     * List of supported brands by braintree can be found here: https://braintree.github.io/braintree-web/current/module-braintree-web_hosted-fields.html#~field
+     * search for `supportedCardBrands` property.
+     *
+     * List of credit cards brands:
+     * 'visa',
+     * 'mastercard',
+     * 'american-express',
+     * 'diners-club',
+     * 'discover',
+     * 'jcb',
+     * 'union-pay',
+     * 'maestro',
+     * 'elo',
+     * 'mir',
+     * 'hiper',
+     * 'hipercard'
+     *
+     * */
+    unsupportedCardBrands?: string[];
 }
 
 /**
@@ -241,4 +264,19 @@ export interface BraintreeFormFieldValidateErrorData {
     fieldType: string;
     message: string;
     type: string;
+}
+
+export enum BraintreeSupportedCardBrands {
+    Visa = 'visa',
+    Mastercard = 'mastercard',
+    AmericanExpress = 'american-express',
+    DinersClub = 'diners-club',
+    Discover = 'discover',
+    Jcb = 'jcb',
+    UnionPay = 'union-pay',
+    Maestro = 'maestro',
+    Elo = 'elo',
+    Mir = 'mir',
+    Hiper = 'hiper',
+    Hipercard = 'hipercard',
 }

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -250,6 +250,8 @@ describe('BraintreePaymentProcessor', () => {
         it('initializes the hosted form', () => {
             braintreeHostedForm.initialize = jest.fn();
 
+            const unsupportedCardBrands = ['american-express', 'discover'];
+
             const braintreePaymentProcessor = new BraintreePaymentProcessor(
                 braintreeSDKCreator,
                 braintreeHostedForm,
@@ -264,10 +266,14 @@ describe('BraintreePaymentProcessor', () => {
                 },
             };
 
-            braintreePaymentProcessor.initializeHostedForm(hostedFormInitializationOptions);
+            braintreePaymentProcessor.initializeHostedForm(
+                hostedFormInitializationOptions,
+                unsupportedCardBrands,
+            );
 
             expect(braintreeHostedForm.initialize).toHaveBeenCalledWith(
                 hostedFormInitializationOptions,
+                unsupportedCardBrands,
             );
         });
     });

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -116,8 +116,11 @@ export default class BraintreePaymentProcessor {
             }));
     }
 
-    async initializeHostedForm(options: BraintreeFormOptions): Promise<void> {
-        return this._braintreeHostedForm.initialize(options);
+    async initializeHostedForm(
+        options: BraintreeFormOptions,
+        unsupportedCardBrands?: string[],
+    ): Promise<void> {
+        return this._braintreeHostedForm.initialize(options, unsupportedCardBrands);
     }
 
     validateHostedForm() {

--- a/packages/core/src/payment/strategies/braintree/is-braintree-supported-card-brand.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/is-braintree-supported-card-brand.spec.ts
@@ -1,0 +1,17 @@
+import { BraintreeSupportedCardBrands } from './braintree-payment-options';
+import { isBraintreeSupportedCardBrand } from './is-braintree-supported-card-brand';
+
+describe('isBraintreeSupportedCardBrand', () => {
+    it('returns true for all supported card brands', () => {
+        Object.values(BraintreeSupportedCardBrands).forEach((brand) => {
+            expect(isBraintreeSupportedCardBrand(brand)).toBe(true);
+        });
+    });
+
+    it('returns false for unsupported card brands', () => {
+        expect(isBraintreeSupportedCardBrand('DISCOVER')).toBe(false);
+        expect(isBraintreeSupportedCardBrand('MAESTRO')).toBe(false);
+        expect(isBraintreeSupportedCardBrand('')).toBe(false);
+        expect(isBraintreeSupportedCardBrand('random')).toBe(false);
+    });
+});

--- a/packages/core/src/payment/strategies/braintree/is-braintree-supported-card-brand.ts
+++ b/packages/core/src/payment/strategies/braintree/is-braintree-supported-card-brand.ts
@@ -1,0 +1,9 @@
+import { BraintreeSupportedCardBrands } from './braintree-payment-options';
+
+export const isBraintreeSupportedCardBrand = (
+    cardBrand: string,
+): cardBrand is BraintreeSupportedCardBrands => {
+    const supportedCardBrands = Object.values(BraintreeSupportedCardBrands);
+
+    return supportedCardBrands.includes(cardBrand as BraintreeSupportedCardBrands);
+};


### PR DESCRIPTION
## What?
Added unsupported credit card brands initialization option for BraintreeCreditCardsPaymentStrategy

## Why?
To prevent customers to use unsupported card brands Braintree hosted form will throw validation error and prevent order placement

## Testing / Proof
Unit tests
Manual tests
CI

For example if visa was added as unsupported card brand, then validation error occurs when customer clicks on "Place order" button:

https://github.com/user-attachments/assets/bb3be346-8195-4a84-bff1-b72f7c24d95e



