### PR TITLE
refactor(payment): updated paypal commerce credit strategies with BNPL changes after experiment rollout

### DIFF
--- a/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-payment-method.mock.ts
+++ b/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-payment-method.mock.ts
@@ -73,6 +73,7 @@ export default function getPayPalCommercePaymentMethod(): PaymentMethod {
                 },
             ],
         },
+        skipRedirectConfirmationAlert: false,
         type: 'PAYMENT_TYPE_API',
     };
 }

--- a/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-ratepay-payment-method.mock.ts
+++ b/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-ratepay-payment-method.mock.ts
@@ -18,6 +18,7 @@ export default function getPayPalCommerceRatePayPaymentMethod(): PaymentMethod {
             attributionId: '1123JLKJASD12',
             intent: 'capture',
         },
+        skipRedirectConfirmationAlert: false,
         type: 'PAYMENT_TYPE_API',
     };
 }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -847,6 +847,23 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
             expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
         });
 
+        it('does not render PayPal message if paypalBNPLConfiguration is not provided', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: undefined,
+                },
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
         it('initializes PayPal Messages component', async () => {
             await strategy.initialize(initializationOptions);
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.spec.ts
@@ -546,6 +546,23 @@ describe('PayPalCommerceCreditPaymentStrategy', () => {
             document.getElementById(defaultMessageContainerId)?.remove();
         });
 
+        it('does not render PayPal message when paypalBNPLConfiguration is not provided', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: undefined,
+                },
+            });
+
+            await strategy.initialize(options);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
         it('does not render PayPal message if banner is disabled in paypalBNPLConfiguration', async () => {
             jest.spyOn(
                 paymentIntegrationService.getState(),


### PR DESCRIPTION
## What?
Updated paypal commerce credit strategies with BNPL changes after experiment rollout

## Why?
BNPL experiment was rolled out to 100% a while ago, so this changes should be applied by default 

## Testing / Proof
Unit tests
Manual tests
CI
