### PR TITLE
feat(payment): Stripe OCS, broadcast customer token for stored cards

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
@@ -120,7 +120,9 @@ describe('StripeLinkV2CustomerStrategy', () => {
 
         it('loads Stripe client and mounts element successfully', () => {
             // TODO remove mock id below
-            expect(scriptLoader.getStripeClient).toHaveBeenCalledWith('key');
+            expect(scriptLoader.getStripeClient).toHaveBeenCalledWith(
+                getStripeOCSMock().initializationData,
+            );
             expect(elements.create).toHaveBeenCalledWith(
                 'expressCheckout',
                 expressCheckoutOptionsMock,

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
@@ -79,7 +79,7 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
 
         this._stripePublishableKey = stripePublishableKey;
 
-        this._stripeClient = await this.scriptLoader.getStripeClient(this._stripePublishableKey);
+        this._stripeClient = await this.scriptLoader.getStripeClient(initializationData);
 
         await this._mountExpressCheckoutElement(container, this._stripeClient, buttonHeight);
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
@@ -62,6 +62,5 @@ export default interface StripeOCSPaymentInitializeOptions {
 }
 
 export interface WithStripeOCSPaymentInitializeOptions {
-    stripeupe?: StripeOCSPaymentInitializeOptions;
     stripeocs?: StripeOCSPaymentInitializeOptions;
 }

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -236,6 +236,9 @@ describe('StripeOCSPaymentStrategy', () => {
                     spacedAccordionItems: false,
                     visibleAccordionItemsCount: 0,
                 },
+                savePaymentMethod: {
+                    maxVisiblePaymentMethods: 20,
+                },
             });
             expect(onErrorMock).not.toHaveBeenCalled();
             expect(stripeIntegrationService.mountElement).toHaveBeenCalled();
@@ -296,6 +299,9 @@ describe('StripeOCSPaymentStrategy', () => {
                     radios: true,
                     spacedAccordionItems: false,
                     visibleAccordionItemsCount: 0,
+                },
+                savePaymentMethod: {
+                    maxVisiblePaymentMethods: 20,
                 },
             });
             expect(onErrorMock).not.toHaveBeenCalled();

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-constants.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-constants.ts
@@ -1,0 +1,9 @@
+export const STRIPE_CLIENT_BETAS = [
+    'payment_element_beta_2',
+    'alipay_pm_beta_1',
+    'link_default_integration_beta_1',
+    'shipping_address_element_beta_1',
+    'address_element_beta_1',
+];
+
+export const STRIPE_CLIENT_API_VERSION = '2020-03-02;alipay_beta=v1;link_beta=v1';

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-customer-strategy.ts
@@ -23,6 +23,7 @@ import {
 } from '../stripe-utils';
 
 import isStripeAcceleratedCheckoutCustomer from './is-stripe-accelerated-checkout-customer';
+import { STRIPE_CLIENT_API_VERSION, STRIPE_CLIENT_BETAS } from './stripe-upe-constants';
 import { WithStripeUPECustomerInitializeOptions } from './stripeupe-customer-initialize-options';
 
 export default class StripeUPECustomerStrategy implements CustomerStrategy {
@@ -67,10 +68,6 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentToken);
         }
 
-        const {
-            initializationData: { stripePublishableKey, stripeConnectedAccount },
-        } = paymentMethod;
-
         const { email } = state.getCustomerOrThrow();
         const paymentProviderCustomer = state.getPaymentProviderCustomerOrThrow();
         const stripePaymentProviderCustomer = isStripeAcceleratedCheckoutCustomer(
@@ -108,8 +105,9 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
             }
 
             stripeUPEClient = await this.scriptLoader.getStripeClient(
-                stripePublishableKey,
-                stripeConnectedAccount,
+                paymentMethod.initializationData,
+                STRIPE_CLIENT_BETAS,
+                STRIPE_CLIENT_API_VERSION,
             );
 
             this._stripeElements = await this.scriptLoader.getElements(stripeUPEClient, {

--- a/packages/stripe-integration/src/stripe-utils/stripe-script-loader.spec.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe-script-loader.spec.ts
@@ -74,7 +74,6 @@ describe('StripePayScriptLoader', () => {
     });
 
     describe('#getElements', () => {
-        // const elementsOptions: StripeElementsOptions = { clientSecret: 'myToken' };
         const stripeFactoryMock = jest.fn(() => getStripeJsMock());
 
         beforeEach(() => {

--- a/packages/stripe-integration/src/stripe-utils/stripe.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe.ts
@@ -318,6 +318,7 @@ export interface FieldsOptions {
 export interface WalletOptions {
     applePay?: AutoOrNever;
     googlePay?: AutoOrNever;
+    link?: AutoOrNever;
 }
 
 export interface TermOptions {
@@ -340,7 +341,7 @@ export interface StripeElementsCreateOptions {
     fields?: FieldsOptions;
     wallets?: WalletOptions;
     allowedCountries?: string[];
-    defaultValues?: ShippingDefaultValues | CustomerDefaultValues;
+    defaultValues?: ShippingDefaultValues | CustomerDefaultValues | PaymentDefaultValues;
     validation?: validationElement;
     display?: { name: DisplayName };
     terms?: TermOptions;
@@ -362,6 +363,7 @@ export interface StripeElementsCreateOptions {
         paypal: StripeStringConstants.NEVER;
     };
     buttonHeight?: number;
+    savePaymentMethod?: StripeSavePaymentMethod;
 }
 
 interface validationElement {
@@ -370,6 +372,10 @@ interface validationElement {
 
 interface validationRequiredElement {
     required?: string;
+}
+
+interface PaymentDefaultValues {
+    savePaymentMethod?: boolean;
 }
 
 interface ShippingDefaultValues {
@@ -470,6 +476,12 @@ export interface StripeElementsOptions {
      * Refer to our docs to accept a payment and learn about how client_secret should be handled.
      */
     clientSecret?: string;
+
+    /**
+     * A token that represents the Stripe customer session.
+     * Stripe documentation: https://docs.stripe.com/api/checkout/sessions
+     */
+    customerSessionClientSecret?: string;
 
     /**
      * Match the design of your site with the appearance option.
@@ -586,6 +598,7 @@ export interface StripeInitializationData {
     stripePublishableKey: string;
     stripeConnectedAccount: string;
     shopperLanguage: string;
+    customerSessionToken?: string;
 }
 
 export interface StripeElementUpdateOptions {
@@ -619,4 +632,8 @@ export enum StripeElementEvent {
 export interface LineItem {
     name: string;
     amount: number;
+}
+
+export interface StripeSavePaymentMethod {
+    maxVisiblePaymentMethods?: number;
 }


### PR DESCRIPTION
## What?
• Add customer session token to stripe element.
• Stripe beta features per module.

## Why?
To add stored curds on the stripe side.

## Testing / Proof
TBD

@bigcommerce/team-checkout @bigcommerce/team-payments
