### PR TITLE
refactor(payment): removed no BNPL related code from BCP strategies

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-button-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-button-strategy.spec.ts
@@ -865,6 +865,23 @@ describe('BigCommercePaymentsPayLaterButtonStrategy', () => {
             expect(bigCommercePaymentsSdkRenderMock).not.toHaveBeenCalled();
         });
 
+        it('does not render PayPal message if paypalBNPLConfiguration is not provided', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: undefined,
+                },
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(bigCommercePaymentsSdkRenderMock).not.toHaveBeenCalled();
+        });
+
         it('initializes PayPal Messages component', async () => {
             await strategy.initialize(initializationOptions);
 

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-button-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-button-strategy.ts
@@ -112,23 +112,19 @@ export default class BigCommercePaymentsPayLaterButtonStrategy implements Checko
             const paymentMethod =
                 state.getPaymentMethodOrThrow<BigCommercePaymentsInitializationData>(methodId);
 
-            // TODO: update paypalBNPLConfiguration with empty array as default value when PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
-            const { paypalBNPLConfiguration } = paymentMethod.initializationData || {};
-            let bannerConfiguration: PayPalBNPLConfigurationItem | undefined;
+            const { paypalBNPLConfiguration = [] } = paymentMethod.initializationData || {};
+            const bannerConfiguration =
+                paypalBNPLConfiguration && paypalBNPLConfiguration.find(({ id }) => id === 'cart');
 
-            if (paypalBNPLConfiguration) {
-                bannerConfiguration = paypalBNPLConfiguration.find(({ id }) => id === 'cart');
-
-                if (!bannerConfiguration?.status) {
-                    return;
-                }
-
-                // TODO: remove this attributes reset when content service and PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
-                messagingContainer.removeAttribute('data-pp-style-logo-type');
-                messagingContainer.removeAttribute('data-pp-style-logo-position');
-                messagingContainer.removeAttribute('data-pp-style-text-color');
-                messagingContainer.removeAttribute('data-pp-style-text-size');
+            if (!bannerConfiguration?.status) {
+                return;
             }
+
+            // TODO: remove this when data attributes will be removed from related cart banner container in content service
+            messagingContainer.removeAttribute('data-pp-style-logo-type');
+            messagingContainer.removeAttribute('data-pp-style-logo-position');
+            messagingContainer.removeAttribute('data-pp-style-text-color');
+            messagingContainer.removeAttribute('data-pp-style-text-size');
 
             const payPalSdkHelper = await this.payPalSdkHelper.getPayPalMessages(
                 paymentMethod,
@@ -327,21 +323,14 @@ export default class BigCommercePaymentsPayLaterButtonStrategy implements Checko
     private renderMessages(
         paypalMessagesSdk: PayPalMessagesSdk,
         messagingContainerId: string,
-        bannerConfiguration?: PayPalBNPLConfigurationItem, // TODO: this should not be optional when PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
+        bannerConfiguration: PayPalBNPLConfigurationItem,
     ): void {
         const checkout = this.paymentIntegrationService.getState().getCheckoutOrThrow();
-        const grandTotal = checkout.outstandingBalance;
-        // TODO: default style can be removed when PROJECT-6784.paypal_commerce_bnpl_configurator experiment is rolled out to 100%
-        const style = bannerConfiguration
-            ? getPaypalMessagesStylesFromBNPLConfig(bannerConfiguration)
-            : {
-                  layout: 'text',
-              };
 
         const paypalMessagesOptions: MessagingOptions = {
-            amount: grandTotal,
+            amount: checkout.outstandingBalance,
             placement: 'cart',
-            style,
+            style: getPaypalMessagesStylesFromBNPLConfig(bannerConfiguration),
         };
 
         const paypalMessages = paypalMessagesSdk.Messages(paypalMessagesOptions);

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-payment-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-payment-strategy.spec.ts
@@ -571,6 +571,23 @@ describe('BigCommercePaymentsPayLaterPaymentStrategy', () => {
             expect(bigCommercePaymentsSdkRenderMock).not.toHaveBeenCalled();
         });
 
+        it('does not render PayPal message when paypalBNPLConfiguration is not provided', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    paypalBNPLConfiguration: undefined,
+                },
+            });
+
+            await strategy.initialize(options);
+
+            expect(bigCommercePaymentsSdkRenderMock).not.toHaveBeenCalled();
+        });
+
         it('initializes PayPal Messages component', async () => {
             await strategy.initialize(options);
 

--- a/packages/bigcommerce-payments-integration/src/mocks/get-bigcommerce-payments-payment-method.mock.ts
+++ b/packages/bigcommerce-payments-integration/src/mocks/get-bigcommerce-payments-payment-method.mock.ts
@@ -73,6 +73,7 @@ export default function getBigCommercePaymentsPaymentMethod(): PaymentMethod {
                 },
             ],
         },
+        skipRedirectConfirmationAlert: false,
         type: 'PAYMENT_TYPE_API',
     };
 }

--- a/packages/bigcommerce-payments-integration/src/mocks/get-bigcommerce-payments-ratepay-payment-method.mock.ts
+++ b/packages/bigcommerce-payments-integration/src/mocks/get-bigcommerce-payments-ratepay-payment-method.mock.ts
@@ -18,6 +18,7 @@ export default function getBigCommercePaymentsRatePayPaymentMethod(): PaymentMet
             attributionId: '1123JLKJASD12',
             intent: 'capture',
         },
+        skipRedirectConfirmationAlert: false,
         type: 'PAYMENT_TYPE_API',
     };
 }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
@@ -15,6 +15,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { PayPalApmSdk, PayPalCommerceSdk } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
 
 import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
 import {
@@ -29,7 +30,6 @@ import {
 import PayPalCommerceAlternativeMethodsPaymentOptions, {
     WithPayPalCommerceAlternativeMethodsPaymentInitializeOptions,
 } from './paypal-commerce-alternative-methods-payment-initialize-options';
-import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
 
 const POLLING_INTERVAL = 3000;
 const MAX_POLLING_TIME = 300000;
@@ -64,6 +64,7 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
             paypalcommercealternativemethods,
         } = options;
         const paypalOptions = paypalcommercealternativemethods || paypalcommerce;
+
         this.paypalcommercealternativemethods = paypalcommercealternativemethods;
 
         if (!methodId) {
@@ -91,6 +92,7 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
         );
         const { orderId, shouldRenderFields } = paymentMethod.initializationData || {};
         const features = state.getStoreConfigOrThrow().checkoutSettings.features;
+
         this.isPollingEnabled = isExperimentEnabled(
             features,
             'PAYPAL-5192.paypal_commerce_ideal_polling',

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -117,11 +117,18 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
                 state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
 
             const { paypalBNPLConfiguration = [] } = paymentMethod.initializationData || {};
-            const bannerConfiguration = paypalBNPLConfiguration.find(({ id }) => id === 'cart');
+            const bannerConfiguration =
+                paypalBNPLConfiguration && paypalBNPLConfiguration.find(({ id }) => id === 'cart');
 
             if (!bannerConfiguration?.status) {
                 return;
             }
+
+            // TODO: remove this code when data attributes will be removed from the banner container in content service
+            messagingContainer.removeAttribute('data-pp-style-logo-type');
+            messagingContainer.removeAttribute('data-pp-style-logo-position');
+            messagingContainer.removeAttribute('data-pp-style-text-color');
+            messagingContainer.removeAttribute('data-pp-style-text-size');
 
             const paypalSdk = await this.paypalCommerceSdk.getPayPalMessages(
                 paymentMethod,

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
@@ -73,7 +73,9 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
         const { bannerContainerId = '', container } = paypalOptions;
 
         if (document.getElementById(bannerContainerId)) {
-            const bannerConfiguration = paypalBNPLConfiguration.find(({ id }) => id === 'checkout');
+            const bannerConfiguration =
+                paypalBNPLConfiguration &&
+                paypalBNPLConfiguration.find(({ id }) => id === 'checkout');
 
             if (!bannerConfiguration?.status) {
                 return;


### PR DESCRIPTION
## What?
Removed no BNPL related code from BCP strategies

## Why?
BNPL Configurator related experiment was rolled out a while ago, so non BNPL related code will not be used on anymore

## Testing / Proof
Unit tests
CI
