### PR TITLE
feat(payment): Stripe OCS, broadcast customer token for stored cards

### DIFF
--- a/packages/stripe-integration/src/stripe-utils/stripe-script-loader.spec.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe-script-loader.spec.ts
@@ -93,7 +93,6 @@ describe('StripePayScriptLoader', () => {
 
             expect(stripeFactoryMock).toHaveBeenCalledWith('STRIPE_PUBLIC_KEY', {
                 betas: defaultBetas,
-                locale: 'en',
                 stripeAccount: 'STRIPE_CONNECTED_ACCOUNT',
                 apiVersion: defaultApiVersion,
             });

--- a/packages/stripe-integration/src/stripe-utils/stripe-script-loader.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe-script-loader.ts
@@ -2,7 +2,6 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import formatLocale from './format-locale';
 import {
     StripeClient,
     StripeElements,
@@ -27,10 +26,8 @@ export default class StripeScriptLoader {
         }
 
         const stripe = await this.load();
-        const { stripePublishableKey, stripeConnectedAccount, shopperLanguage } =
-            initializationData;
+        const { stripePublishableKey, stripeConnectedAccount } = initializationData;
         const options = {
-            ...(shopperLanguage ? { locale: formatLocale(shopperLanguage) } : {}),
             ...(stripeConnectedAccount ? { stripeAccount: stripeConnectedAccount } : {}),
             ...(betas ? { betas } : {}),
             ...(apiVersion ? { apiVersion } : {}),


### PR DESCRIPTION
## What?
Remove unnecessary `locale`  parameter for Stripe.

## Why?
No need to broadcast this option and add additional logic for getting localization.
Stripe detect shopper locale by default [https://docs.stripe.com/js/initializing#init_stripe_js-options-locale](https://docs.stripe.com/js/initializing#init_stripe_js-options-locale)

## Testing / Proof
Manually checked and unit tests

@bigcommerce/team-checkout @bigcommerce/team-payments
