### PR TITLE
feat(payment): New logic for PayPal BNPL banner on checkout page

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-script-loader.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-script-loader.spec.ts
@@ -7,11 +7,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import BigCommercePaymentsScriptLoader from './bigcommerce-payments-script-loader';
-import {
-    BigCommercePaymentsHostWindow,
-    BigCommercePaymentsScriptParams,
-    PayPalSDK,
-} from './bigcommerce-payments-types';
+import { BigCommercePaymentsHostWindow, PayPalSDK } from './bigcommerce-payments-types';
 import { getBigCommercePaymentsPaymentMethod, getPayPalSDKMock } from './mocks';
 
 describe('BigCommercePaymentsScriptLoader', () => {
@@ -19,9 +15,6 @@ describe('BigCommercePaymentsScriptLoader', () => {
     let paypalLoader: BigCommercePaymentsScriptLoader;
     let paypalSdk: PayPalSDK;
     let paymentMethod: PaymentMethod;
-    let paypalLoadScript: (
-        options: BigCommercePaymentsScriptParams,
-    ) => Promise<{ paypal: PayPalSDK }>;
 
     beforeEach(() => {
         loader = createScriptLoader();
@@ -39,7 +32,6 @@ describe('BigCommercePaymentsScriptLoader', () => {
 
     afterEach(() => {
         (window as BigCommercePaymentsHostWindow).paypal = undefined;
-        (window as BigCommercePaymentsHostWindow).paypalLoadScript = undefined;
     });
 
     it('throws an error if initializationData is missing', async () => {
@@ -423,43 +415,6 @@ describe('BigCommercePaymentsScriptLoader', () => {
             await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
         } catch (error) {
             expect(error).toEqual(expectedError);
-        }
-    });
-
-    it('throw error if unable window.paypalLoadScript', async () => {
-        jest.spyOn(loader, 'loadScript').mockImplementation(() => {
-            (window as BigCommercePaymentsHostWindow).paypalLoadScript = undefined;
-
-            return Promise.resolve();
-        });
-
-        try {
-            await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
-        } catch (error) {
-            expect(error).toEqual(new PaymentMethodClientUnavailableError());
-        }
-    });
-
-    it('throws an error if paypal is not loaded due to some issues', async () => {
-        paypalLoadScript = jest.fn(
-            () =>
-                new Promise((_, reject) => {
-                    (window as BigCommercePaymentsHostWindow).paypal = undefined;
-
-                    return reject(undefined);
-                }),
-        );
-
-        jest.spyOn(loader, 'loadScript').mockImplementation(() => {
-            (window as BigCommercePaymentsHostWindow).paypalLoadScript = paypalLoadScript;
-
-            return Promise.resolve();
-        });
-
-        try {
-            await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
-        } catch (error) {
-            expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
         }
     });
 });

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-types.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-types.ts
@@ -237,7 +237,6 @@ export type ComponentsScriptType = Array<
 
 export interface BigCommercePaymentsHostWindow extends Window {
     paypal?: PayPalSDK;
-    paypalLoadScript?: (options: BigCommercePaymentsScriptParams) => Promise<{ paypal: PayPalSDK }>;
 }
 
 /**

--- a/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.spec.ts
@@ -8,18 +8,13 @@ import {
 
 import { getPayPalCommercePaymentMethod, getPayPalSDKMock } from './mocks';
 import PayPalCommerceScriptLoader from './paypal-commerce-script-loader';
-import {
-    PayPalCommerceHostWindow,
-    PayPalCommerceScriptParams,
-    PayPalSDK,
-} from './paypal-commerce-types';
+import { PayPalCommerceHostWindow, PayPalSDK } from './paypal-commerce-types';
 
 describe('PayPalCommerceScriptLoader', () => {
     let loader: ScriptLoader;
     let paypalLoader: PayPalCommerceScriptLoader;
     let paypalSdk: PayPalSDK;
     let paymentMethod: PaymentMethod;
-    let paypalLoadScript: (options: PayPalCommerceScriptParams) => Promise<{ paypal: PayPalSDK }>;
 
     beforeEach(() => {
         loader = createScriptLoader();
@@ -37,7 +32,6 @@ describe('PayPalCommerceScriptLoader', () => {
 
     afterEach(() => {
         (window as PayPalCommerceHostWindow).paypal = undefined;
-        (window as PayPalCommerceHostWindow).paypalLoadScript = undefined;
     });
 
     it('throws an error if initializationData is missing', async () => {
@@ -421,43 +415,6 @@ describe('PayPalCommerceScriptLoader', () => {
             await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
         } catch (error) {
             expect(error).toEqual(expectedError);
-        }
-    });
-
-    it('throw error if unable window.paypalLoadScript', async () => {
-        jest.spyOn(loader, 'loadScript').mockImplementation(() => {
-            (window as PayPalCommerceHostWindow).paypalLoadScript = undefined;
-
-            return Promise.resolve();
-        });
-
-        try {
-            await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
-        } catch (error) {
-            expect(error).toEqual(new PaymentMethodClientUnavailableError());
-        }
-    });
-
-    it('throws an error if paypal is not loaded due to some issues', async () => {
-        paypalLoadScript = jest.fn(
-            () =>
-                new Promise((_, reject) => {
-                    (window as PayPalCommerceHostWindow).paypal = undefined;
-
-                    return reject(undefined);
-                }),
-        );
-
-        jest.spyOn(loader, 'loadScript').mockImplementation(() => {
-            (window as PayPalCommerceHostWindow).paypalLoadScript = paypalLoadScript;
-
-            return Promise.resolve();
-        });
-
-        try {
-            await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
-        } catch (error) {
-            expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
         }
     });
 });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -231,7 +231,6 @@ export type ComponentsScriptType = Array<
 
 export interface PayPalCommerceHostWindow extends Window {
     paypal?: PayPalSDK;
-    paypalLoadScript?: (options: PayPalCommerceScriptParams) => Promise<{ paypal: PayPalSDK }>;
 }
 
 /**
@@ -259,6 +258,14 @@ export interface PayPalCommerceInitializationData {
     shouldRenderFields?: boolean;
     shouldRunAcceleratedCheckout?: boolean;
     paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>;
+    paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[];
+}
+
+export interface PayPalBNPLConfigurationItem {
+    id: string;
+    name: string;
+    status: boolean;
+    styles: Record<string, string>;
 }
 
 /**

--- a/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-payment-strategy.ts
@@ -1,7 +1,10 @@
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
 import {
     PaymentStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PayPalCommerceSdk } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import createPayPalCommerceIntegrationService from '../create-paypal-commerce-integration-service';
@@ -15,6 +18,7 @@ const createPayPalCommercePaymentStrategy: PaymentStrategyFactory<PayPalCommerce
     new PayPalCommercePaymentStrategy(
         paymentIntegrationService,
         createPayPalCommerceIntegrationService(paymentIntegrationService),
+        new PayPalCommerceSdk(getScriptLoader()),
         new LoadingIndicator({
             containerStyles: LOADING_INDICATOR_STYLES,
         }),

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-initialize-options.ts
@@ -48,7 +48,12 @@ export default interface PayPalCommercePaymentInitializeOptions {
     /**
      * The CSS selector of a container where the payment widget should be inserted into.
      */
-    container: string;
+    container?: string;
+
+    /**
+     * The location to insert the Pay Later Messages.
+     */
+    bannerContainerId?: string;
 
     /**
      * If there is no need to initialize the Smart Payment Button, simply pass false as the option value.
@@ -88,13 +93,13 @@ export default interface PayPalCommercePaymentInitializeOptions {
      *
      * @returns reject() or resolve()
      */
-    onValidate(resolve: () => void, reject: () => void): Promise<void>;
+    onValidate?(resolve: () => void, reject: () => void): Promise<void>;
 
     /**
      * A callback for submitting payment form that gets called
      * when buyer approved PayPal account.
      */
-    submitForm(): void;
+    submitForm?(): void;
 }
 
 export interface WithPayPalCommercePaymentInitializeOptions {


### PR DESCRIPTION
## What?

New logic for PayPal BNPL banner on checkout page.

## Why?

In order to display BNPL banner on checkout page when `isPayPalCreditAvailable` is true, logic has been added to `paypal-commerce-payment-strategy.ts`

**Additional updates**

removed `paypalLoadScript` since we do not need this method due changed script loading method

## Testing / Proof

Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
