### PR TITLE
refactor(payment): cleanup unused code in BraintreeMessages class

### DIFF
--- a/packages/braintree-utils/src/braintree-messages.spec.ts
+++ b/packages/braintree-utils/src/braintree-messages.spec.ts
@@ -84,8 +84,7 @@ describe('BraintreeMessages', () => {
                 ...paymentMethod,
                 initializationData: {
                     ...paymentMethod.initializationData,
-                    enableCheckoutPaywallBanner: false,
-                    paypalBNPLConfiguration: null,
+                    paypalBNPLConfiguration: undefined,
                 },
             },
         );
@@ -93,40 +92,6 @@ describe('BraintreeMessages', () => {
         braintreeMessages.render(methodId, defaultMessageContainerId, MessagingPlacements.PAYMENT);
 
         expect(paypalSdkMock.Messages).not.toHaveBeenCalled();
-    });
-
-    describe('non BNPL implementation (old approach)', () => {
-        it('renders Braintree Message with provided configuration', () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    enableCheckoutPaywallBanner: true,
-                    paypalBNPLConfiguration: null,
-                },
-            });
-
-            braintreeMessages.render(
-                methodId,
-                defaultMessageContainerId,
-                MessagingPlacements.PAYMENT,
-            );
-
-            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
-                amount,
-                buyerCountry: 'US',
-                placement: 'payment',
-                style: {
-                    layout: 'text',
-                    logo: {
-                        type: 'inline',
-                    },
-                },
-            });
-        });
     });
 
     describe('BNPL implementation', () => {

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -113,7 +113,7 @@ export interface BraintreeInitializationData {
     isBraintreeAnalyticsV2Enabled?: boolean;
     shouldRunAcceleratedCheckout?: boolean; // TODO: only for BT AXO A/B testing purposes, hence should be removed after testing
     paymentButtonStyles?: Record<string, PaypalStyleOptions>;
-    paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[];
+    paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[] | null;
 }
 
 export interface BraintreePaypalRequest {


### PR DESCRIPTION
## What?
cleanup unused code in BraintreeMessages class

## Why?
BNPL Configurator feature was rolled out a while ago, so the code that was created for it now is a default state for messages implementation

## Testing / Proof
Unit tests
Manual tests
CI

Screenshots of banners rendered on cart and checkout pages:
<img width="600" alt="Screenshot 2025-07-07 at 11 31 18" src="https://github.com/user-attachments/assets/a9a27a5f-1d4b-469e-854f-0d888bd90f2a" />
<img width="596" alt="Screenshot 2025-07-07 at 11 32 07" src="https://github.com/user-attachments/assets/dfae3fee-7c28-4aab-9ae6-64a201e6c12a" />
<img width="500" alt="Screenshot 2025-07-07 at 11 32 20" src="https://github.com/user-attachments/assets/c385f3ba-9b1d-47da-93d2-76845d787e08" />

