### PR TITLE
Feat/stripe linkv2 loading indicator

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/create-stripe-link-v2-customer-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/create-stripe-link-v2-customer-strategy.ts
@@ -4,6 +4,7 @@ import {
     CustomerStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { DEFAULT_CONTAINER_STYLES, LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import { StripeIntegrationService, StripeScriptLoader } from '../stripe-utils';
 
@@ -13,11 +14,15 @@ const createStripeLinkV2CustomerStrategy: CustomerStrategyFactory<StripeLinkV2Cu
     paymentIntegrationService,
 ) => {
     const stripeScriptLoader = new StripeScriptLoader(getScriptLoader());
+    const loadingIndicator = new LoadingIndicator({
+        containerStyles: DEFAULT_CONTAINER_STYLES,
+    });
 
     return new StripeLinkV2CustomerStrategy(
         paymentIntegrationService,
         stripeScriptLoader,
         new StripeIntegrationService(paymentIntegrationService, stripeScriptLoader),
+        loadingIndicator,
     );
 };
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-customer-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-customer-initialize-options.ts
@@ -14,6 +14,8 @@ export default interface StripeOCSCustomerInitializeOptions {
     gatewayId: string;
 
     onComplete?: (orderId?: number) => Promise<never>;
+
+    loadingContainerId?: string;
 }
 
 export interface WithStripeOCSCustomerInitializeOptions {


### PR DESCRIPTION
## What?
Added loading indicator to the Stripe Link V2 customer strategy.
Related PR:
https://github.com/bigcommerce/checkout-js/pull/2421

## Why?
Because we need to show loading indicator during payment process.

## Testing / Proof
Manual testing

https://github.com/user-attachments/assets/6aa217a1-35a8-4cdf-b186-070f534d09a5



@bigcommerce/team-checkout @bigcommerce/team-payments
