### PR TITLE
feat(payment): Added BCP FL 3DS

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-types.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-types.ts
@@ -604,6 +604,7 @@ export interface PayPalCreateOrderRequestBody extends HostedInstrument, VaultedI
     cartId: string;
     metadataId?: string;
     setupToken?: boolean;
+    fastlaneToken?: string;
 }
 
 export enum PayPalOrderStatus {

--- a/packages/bigcommerce-payments-utils/src/bigcommerce-payments-types.ts
+++ b/packages/bigcommerce-payments-utils/src/bigcommerce-payments-types.ts
@@ -95,8 +95,40 @@ export type PayPalSdkComponents = Array<
  * PayPal Sdk instances
  *
  */
+export enum LiabilityShiftEnum {
+    Possible = 'POSSIBLE',
+    No = 'NO',
+    Unknown = 'UNKNOWN',
+    Yes = 'YES',
+}
+
+export interface threeDSecureParameters {
+    amount: string;
+    currency: string;
+    nonce: string;
+    threeDSRequested: boolean;
+    transactionContext: {
+        experience_context: {
+            brand_name?: string;
+            locale: string;
+            return_url: string;
+            cancel_url: string;
+        };
+    };
+}
+
 export interface PayPalFastlaneSdk {
+    ThreeDomainSecureClient: {
+        isEligible(params: threeDSecureParameters): Promise<boolean>;
+        show(): Promise<ThreeDomainSecureClientShowResponse>;
+    };
     Fastlane(options?: PayPalFastlaneOptions): Promise<PayPalFastlane>;
+}
+
+interface ThreeDomainSecureClientShowResponse {
+    liabilityShift: LiabilityShiftEnum;
+    authenticationState: TDSecureAuthenticationState;
+    nonce: string; // Enriched nonce or the original nonce
 }
 
 export interface PayPalMessagesSdk {
@@ -112,6 +144,12 @@ export interface PayPalApmSdk {
 
 export interface PayPalGooglePaySdk {
     Googlepay(): GooglePay;
+}
+
+export enum TDSecureAuthenticationState {
+    Succeeded = 'succeeded',
+    Cancelled = 'cancelled',
+    Errored = 'errored',
 }
 
 /**

--- a/packages/bigcommerce-payments-utils/src/mocks/get-paypal-fastlane-sdk.mock.ts
+++ b/packages/bigcommerce-payments-utils/src/mocks/get-paypal-fastlane-sdk.mock.ts
@@ -4,6 +4,10 @@ import getPayPalFastlane from './get-paypal-fastlane.mock';
 
 export default function getPayPalFastlaneSdk(): PayPalFastlaneSdk {
     return {
+        ThreeDomainSecureClient: {
+            isEligible: jest.fn(),
+            show: jest.fn(),
+        },
         Fastlane: () => Promise.resolve(getPayPalFastlane()),
     };
 }


### PR DESCRIPTION
## What?
Added BCP FL 3DS implementation

## Why?
To be able to use 3DSecure functionality

## Testing / Proof
Unit tests

@bigcommerce/team-checkout @bigcommerce/team-payments
