### PR TITLE
fix(customer): Fetch updated checkout after carts are merged

### DIFF
--- a/packages/core/src/customer/customer-action-creator.spec.ts
+++ b/packages/core/src/customer/customer-action-creator.spec.ts
@@ -329,11 +329,8 @@ describe('CustomerActionCreator', () => {
                 ...getCustomerResponseBody(),
                 data: {
                     ...getCustomerResponseBody().data,
-                    customer: {
-                        ...getCustomerResponseBody().data.customer,
-                        persistentCartRetrievalInformation: {
-                            id: 'persistent-cart-id',
-                        },
+                    persistentCartRetrievalInformation: {
+                        id: 'persistent-cart-id',
                     },
                 },
             };

--- a/packages/core/src/customer/customer-action-creator.spec.ts
+++ b/packages/core/src/customer/customer-action-creator.spec.ts
@@ -338,11 +338,11 @@ describe('CustomerActionCreator', () => {
                 },
             };
 
-            await from(customerActionCreator.signInCustomer(credentials)(store)).toPromise();
-
             jest.spyOn(customerRequestSender, 'signInCustomer').mockReturnValue(
                 Promise.resolve(getResponse(responseWithCrossDevice)),
             );
+
+            await from(customerActionCreator.signInCustomer(credentials)(store)).toPromise();
 
             expect(checkoutActionCreator.loadCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/customer/internal-customer-responses.ts
+++ b/packages/core/src/customer/internal-customer-responses.ts
@@ -6,4 +6,7 @@ export type InternalCustomerResponseBody = InternalResponseBody<InternalCustomer
 
 export interface InternalCustomerResponseData {
     customer: InternalCustomer;
+    persistentCartRetrievalInformation?: {
+        id: string;
+    };
 }


### PR DESCRIPTION
## What?
Fetch updated checkout after carts are merged

## Why?
If persistent cart is enabled, carts are merged on sign-in. We should reload checkout and settings for the new id.

## Testing / Proof

https://github.com/user-attachments/assets/9aff308f-bac8-4345-b137-f03d5730c893

<img width="1495" height="759" alt="Screenshot 2025-07-11 at 10 37 55 am" src="https://github.com/user-attachments/assets/727714a5-e7f8-4c6f-9669-e4dd65ac48c0" />
