### PR TITLE
feat(payment): added bigcommerce payment related instruments to a list of supported instruments

### DIFF
--- a/packages/core/src/payment/instrument/supported-payment-instruments.ts
+++ b/packages/core/src/payment/instrument/supported-payment-instruments.ts
@@ -161,6 +161,14 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'paypalcommerce',
         method: 'paypal',
     },
+    bigcommerce_payments_creditcards: {
+        provider: 'bigcommerce_payments',
+        method: 'credit_card',
+    },
+    bigcommerce_payments: {
+        provider: 'bigcommerce_payments',
+        method: 'paypal',
+    },
     tdonlinemart: {
         provider: 'tdonlinemart',
         method: 'credit_card',


### PR DESCRIPTION
## What?
Added bigcommerce payment related instruments to a list of supported instruments

## Why?
So vaulted instruments will be rendered in payment section of checkout page 

## Testing / Proof
Manual tests
CI

<img width="611" height="207" alt="Screenshot 2025-07-11 at 11 53 34" src="https://github.com/user-attachments/assets/7181eadd-2f6a-44f0-9669-f6ec0cec040e" />

