### PR TITLE
feat(payment): Stripe OCS add status for  instrument vaulting

### DIFF
--- a/packages/stripe-integration/src/stripe-utils/stripe.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe.ts
@@ -54,6 +54,14 @@ export interface PaymentIntent {
      * The payment error encountered in the previous PaymentIntent confirmation. It will be cleared if the PaymentIntent is later updated for any reason.
      */
     last_payment_error: LastPaymentError | null;
+
+    payment_method_options?: StripePIPaymentMethodOptions;
+}
+
+export interface StripePIPaymentMethodOptions {
+    card?: {
+        setup_future_usage?: StripeInstrumentSetupFutureUsage;
+    };
 }
 
 /**
@@ -636,4 +644,9 @@ export interface LineItem {
 
 export interface StripeSavePaymentMethod {
     maxVisiblePaymentMethods?: number;
+}
+
+export enum StripeInstrumentSetupFutureUsage {
+    ON_SESSION = 'on_session',
+    OFF_SESSION = 'off_session',
 }


### PR DESCRIPTION
## What?
Add flag for saving Stripe OCS card payment instrument

## Why?
To handle card saving on the Stripe side and trigger saving process on BC side

## Testing / Proof

https://github.com/user-attachments/assets/d7b16f77-583c-43af-8819-b6d0f56b363c

<img width="716" height="80" alt="Screenshot 2025-07-14 at 13 59 01" src="https://github.com/user-attachments/assets/395a09c8-6de9-4128-bdf5-d4ebad5c8ffc" />


@bigcommerce/team-checkout @bigcommerce/team-payments
