### PR TITLE
feat(payment): Stripe OCS add state code to stripe confirmation details

### DIFF
--- a/packages/stripe-integration/src/stripe-utils/stripe-integration-service.spec.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe-integration-service.spec.ts
@@ -1,4 +1,5 @@
 import {
+    BillingAddress,
     MissingDataError,
     NotInitializedError,
     PaymentInitializeOptions,
@@ -601,6 +602,37 @@ describe('StripeIntegrationService', () => {
         });
 
         it('returns mapped payment data', () => {
+            expect(
+                stripeIntegrationService.mapStripePaymentData(stripeElementsMock, 'redirect.url'),
+            ).toEqual({
+                elements: stripeElementsMock,
+                redirect: 'if_required',
+                confirmParams: {
+                    payment_method_data: {
+                        billing_details: {
+                            email: 'test@bigcommerce.com',
+                            address: {
+                                city: 'Some City',
+                                country: 'US',
+                                line1: '12345 Testing Way',
+                                line2: '',
+                                postal_code: '95555',
+                                state: 'CA',
+                            },
+                            name: 'Test Tester',
+                        },
+                    },
+                    return_url: 'redirect.url',
+                },
+            });
+        });
+
+        it('returns mapped payment data without state code', () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue({
+                ...getBillingAddress(),
+                stateOrProvinceCode: undefined,
+            } as unknown as BillingAddress);
+
             expect(
                 stripeIntegrationService.mapStripePaymentData(stripeElementsMock, 'redirect.url'),
             ).toEqual({

--- a/packages/stripe-integration/src/stripe-utils/stripe-integration-service.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe-integration-service.ts
@@ -237,7 +237,14 @@ export default class StripeIntegrationService {
 
     private _mapStripeAddress(address?: Address): AddressOptions {
         if (address) {
-            const { city, address1, address2, countryCode: country, postalCode } = address;
+            const {
+                city,
+                address1,
+                address2,
+                countryCode: country,
+                postalCode,
+                stateOrProvinceCode,
+            } = address;
 
             return {
                 city,
@@ -245,6 +252,7 @@ export default class StripeIntegrationService {
                 postal_code: postalCode,
                 line1: address1,
                 line2: address2,
+                ...(stateOrProvinceCode ? { state: stateOrProvinceCode } : {}),
             };
         }
 


### PR DESCRIPTION
## What?
Add state code field to Stripe confirmation billing details

## Why?
Some Stripe APMs require state code

## Testing / Proof
Before

https://github.com/user-attachments/assets/b985e0f9-b35f-480f-8077-93ecbfbf57e2

After

https://github.com/user-attachments/assets/320537bc-d046-40da-b07a-feca390ed7f0

<img width="675" height="74" alt="Screenshot 2025-07-16 at 12 32 48" src="https://github.com/user-attachments/assets/75882666-4796-4156-b11c-387add795056" />


@bigcommerce/team-checkout @bigcommerce/team-payments
