### PR TITLE
refactor(payment): updated ppcp fastlane implementation to use cookies instead of local storage

### DIFF
--- a/packages/bigcommerce-payments-utils/src/bigcommerce-payments-fastlane-utils.ts
+++ b/packages/bigcommerce-payments-utils/src/bigcommerce-payments-fastlane-utils.ts
@@ -108,16 +108,13 @@ export default class BigCommercePaymentsFastlaneUtils {
      */
     updateStorageSessionId(shouldBeRemoved: boolean, sessionId?: string): void {
         if (shouldBeRemoved) {
-            // TODO: Should be rewritten to cookies implementation
             this.browserStorage.removeItem('sessionId');
         } else {
-            // TODO: Should be rewritten to cookies implementation
             this.browserStorage.setItem('sessionId', sessionId);
         }
     }
 
     getStorageSessionId(): string {
-        // TODO: Should be rewritten to cookies implementation
         return this.browserStorage.getItem('sessionId') || '';
     }
 

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
@@ -393,7 +393,6 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
                 instruments: [bcInstrumentMock],
             });
             expect(paypalCommerceFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(
-                false,
                 cart.id,
             );
             expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith(bcAddressMock);

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.ts
@@ -201,10 +201,11 @@ export default class PayPalCommerceFastlaneShippingStrategy implements ShippingS
         const isAuthenticationFlowCanceled =
             authenticationResult.authenticationState === PayPalFastlaneAuthenticationState.CANCELED;
 
-        this._paypalCommerceFastlaneUtils.updateStorageSessionId(
-            isAuthenticationFlowCanceled,
-            cart.id,
-        );
+        if (isAuthenticationFlowCanceled) {
+            this._paypalCommerceFastlaneUtils.removeStorageSessionId();
+        } else {
+            this._paypalCommerceFastlaneUtils.updateStorageSessionId(cart.id);
+        }
 
         if (billingAddress) {
             await this._store.dispatch(

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
@@ -484,8 +484,8 @@ describe('PayPalCommerceFastlaneCustomerStrategy', () => {
                     ? consignments[0]?.availableShippingOptions[0].id
                     : undefined,
             );
+
             expect(paypalCommerceFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(
-                false,
                 cart.id,
             );
         });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -145,10 +145,12 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
             authenticationResult.authenticationState === PayPalFastlaneAuthenticationState.CANCELED;
 
         await this.updateCustomerDataState(methodId, authenticationResult);
-        this.paypalCommerceFastlaneUtils.updateStorageSessionId(
-            isAuthenticationFlowCanceled,
-            cartId,
-        );
+
+        if (isAuthenticationFlowCanceled) {
+            this.paypalCommerceFastlaneUtils.removeStorageSessionId();
+        } else {
+            this.paypalCommerceFastlaneUtils.updateStorageSessionId(cartId);
+        }
     }
 
     private async updateCustomerDataState(

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -158,6 +158,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
         jest.spyOn(paypalCommerceFastlaneUtils, 'initializePayPalFastlane');
         jest.spyOn(paypalCommerceFastlaneUtils, 'getStorageSessionId').mockReturnValue(cart.id);
         jest.spyOn(paypalCommerceFastlaneUtils, 'updateStorageSessionId');
+        jest.spyOn(paypalCommerceFastlaneUtils, 'removeStorageSessionId');
         jest.spyOn(paypalCommerceFastlaneUtils, 'lookupCustomerOrThrow').mockResolvedValue({
             customerContextId,
         });
@@ -372,7 +373,6 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                 paypalCommerceFastlaneUtils.mapPayPalFastlaneProfileToBcCustomerData,
             ).toHaveBeenCalledWith(methodId, authenticationResultMock);
             expect(paypalCommerceFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(
-                false,
                 cart.id,
             );
         });
@@ -466,7 +466,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                     },
                 },
             });
-            expect(paypalCommerceFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(true);
+            expect(paypalCommerceFastlaneUtils.removeStorageSessionId).toHaveBeenCalled();
         });
 
         it('successfully places order with vaulted instruments flow', async () => {
@@ -490,7 +490,7 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                     },
                 },
             });
-            expect(paypalCommerceFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(true);
+            expect(paypalCommerceFastlaneUtils.removeStorageSessionId).toHaveBeenCalled();
         });
 
         it('do not create an order if there is an error while receiving a payment order', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -56,7 +56,6 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
     async initialize(
         options: PaymentInitializeOptions & WithPayPalCommerceFastlanePaymentInitializeOptions,
     ): Promise<void> {
-        // TODO: remove paypalcommerceacceleratedcheckout if it was removed on checkout js side
         const { methodId, paypalcommercefastlane } = options;
 
         if (!methodId) {
@@ -153,8 +152,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
                 paymentPayload,
             );
 
-            // TODO: we should probably update this method with removeStorageSessionId for better reading experience
-            this.paypalCommerceFastlaneUtils.updateStorageSessionId(true);
+            this.paypalCommerceFastlaneUtils.removeStorageSessionId();
         } catch (error) {
             if (error instanceof Error && error.name !== 'FastlaneError') {
                 throw error;
@@ -231,10 +229,11 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
                 authenticationResult.authenticationState ===
                 PayPalFastlaneAuthenticationState.CANCELED;
 
-            this.paypalCommerceFastlaneUtils.updateStorageSessionId(
-                isAuthenticationFlowCanceled,
-                cart.id,
-            );
+            if (isAuthenticationFlowCanceled) {
+                this.paypalCommerceFastlaneUtils.removeStorageSessionId();
+            } else {
+                this.paypalCommerceFastlaneUtils.updateStorageSessionId(cart.id);
+            }
         } catch (error) {
             // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
         }

--- a/packages/paypal-commerce-utils/src/create-paypal-commerce-fastlane-utils.ts
+++ b/packages/paypal-commerce-utils/src/create-paypal-commerce-fastlane-utils.ts
@@ -1,7 +1,5 @@
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
-
 import PayPalCommerceFastlaneUtils from './paypal-commerce-fastlane-utils';
 
 export default function createPayPalCommerceFastlaneUtils(): PayPalCommerceFastlaneUtils {
-    return new PayPalCommerceFastlaneUtils(new BrowserStorage('paypalFastlane'));
+    return new PayPalCommerceFastlaneUtils();
 }

--- a/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.spec.ts
@@ -2,7 +2,7 @@ import {
     PaymentMethodClientUnavailableError,
     UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+import { CookieStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import { getPayPalFastlaneAuthenticationResultMock, getPayPalFastlaneSdk } from './mocks';
 import PayPalCommerceFastlaneUtils from './paypal-commerce-fastlane-utils';
@@ -13,7 +13,6 @@ import {
 } from './paypal-commerce-types';
 
 describe('PayPalCommerceFastlaneUtils', () => {
-    let browserStorage: BrowserStorage;
     let paypalFastlaneSdk: PayPalFastlaneSdk;
     let subject: PayPalCommerceFastlaneUtils;
 
@@ -59,10 +58,9 @@ describe('PayPalCommerceFastlaneUtils', () => {
     };
 
     beforeEach(() => {
-        browserStorage = new BrowserStorage('paypalFastlane');
         paypalFastlaneSdk = getPayPalFastlaneSdk();
 
-        subject = new PayPalCommerceFastlaneUtils(browserStorage);
+        subject = new PayPalCommerceFastlaneUtils();
 
         jest.spyOn(Date, 'now').mockImplementation(() => 1);
     });
@@ -164,30 +162,37 @@ describe('PayPalCommerceFastlaneUtils', () => {
     describe('#updateStorageSessionId', () => {
         const sessionIdMock = 'cartId123';
 
-        it('sets session id to browser storage', () => {
-            jest.spyOn(browserStorage, 'setItem');
+        it('updates browser cookies with session id', () => {
+            jest.spyOn(CookieStorage, 'set');
 
-            subject.updateStorageSessionId(false, sessionIdMock);
+            subject.updateStorageSessionId(sessionIdMock);
 
-            expect(browserStorage.setItem).toHaveBeenCalledWith('sessionId', sessionIdMock);
+            expect(CookieStorage.set).toHaveBeenCalledWith('bc-fastlane-sessionId', sessionIdMock, {
+                expires: expect.any(Date),
+                secure: true,
+            });
         });
+    });
 
-        it('removes session id from browser storage', () => {
-            jest.spyOn(browserStorage, 'removeItem');
+    describe('#removeStorageSessionId', () => {
+        it('removes session id from browser cookies', () => {
+            jest.spyOn(CookieStorage, 'remove');
 
-            subject.updateStorageSessionId(true, sessionIdMock);
+            subject.removeStorageSessionId();
 
-            expect(browserStorage.removeItem).toHaveBeenCalledWith('sessionId');
+            expect(CookieStorage.remove).toHaveBeenCalledWith('bc-fastlane-sessionId', {
+                secure: true,
+            });
         });
     });
 
     describe('#getStorageSessionId', () => {
         it('returns session id to browser storage', () => {
-            jest.spyOn(browserStorage, 'getItem');
+            jest.spyOn(CookieStorage, 'get');
 
             subject.getStorageSessionId();
 
-            expect(browserStorage.getItem).toHaveBeenCalledWith('sessionId');
+            expect(CookieStorage.get).toHaveBeenCalledWith('bc-fastlane-sessionId');
         });
     });
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -452,7 +452,7 @@ export interface PayPalFastlaneAuthenticationResult {
 export enum PayPalFastlaneAuthenticationState {
     SUCCEEDED = 'succeeded',
     FAILED = 'failed',
-    CANCELED = 'cancelled',
+    CANCELED = 'canceled',
     UNRECOGNIZED = 'unrecognized',
 }
 


### PR DESCRIPTION
## What?
Updated ppcp fastlane implementation to use cookies instead of local storage

## Why?
Local storage solution is not quite good in terms of security, since it is not possible to set expiration date for temporary data

## Testing / Proof
Unit tests
Manual tests
CI

Now session id that we use to manage Fastlane authentication check stored in cookies:
<img width="2560" height="1291" alt="Screenshot 2025-07-17 at 10 21 57" src="https://github.com/user-attachments/assets/c0366714-1541-45dc-8117-ff72d49b6df1" />

And as you can see, it is not present in local storage anymore:
<img width="1915" height="1148" alt="Screenshot 2025-07-17 at 11 35 18" src="https://github.com/user-attachments/assets/f3df61fc-f166-41e5-82cc-f33e5ad198e2" />



