### PR TITLE
fix(payment): updated provider id used for order creation in BCP Ratepay Payment strategy

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-ratepay/bigcommerce-payments-ratepay-payment-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-ratepay/bigcommerce-payments-ratepay-payment-strategy.spec.ts
@@ -344,6 +344,13 @@ describe('BigCommercePaymentsRatePayPaymentStrategy', () => {
             await strategy.initialize(initializationOptions);
             await strategy.execute(payload);
 
+            expect(bigCommercePaymentsIntegrationService.createOrder).toHaveBeenCalledWith(
+                'bigcommerce_payments_apmscheckout',
+                {
+                    metadataId: expect.any(String),
+                },
+            );
+
             expect(bigCommercePaymentsIntegrationService.getOrderStatus).toHaveBeenCalledWith(
                 'bigcommerce_payments_apms',
                 { params: { useMetadata: true } },

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-ratepay/bigcommerce-payments-ratepay-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-ratepay/bigcommerce-payments-ratepay-payment-strategy.ts
@@ -131,7 +131,7 @@ export default class BigCommercePaymentsRatePayPaymentStrategy implements Paymen
 
         try {
             const orderId = await this.bigCommercePaymentsIntegrationService.createOrder(
-                'bigcommerce_payments_apms_checkout',
+                'bigcommerce_payments_apmscheckout',
                 { metadataId: this.guid },
             );
 


### PR DESCRIPTION
## What?
Updated provider id used for order creation in BCP Ratepay Payment strategy

## Why?
So BE request will not fail due to wrong provider input

## Testing / Proof
Manual tests
Unit tests
CI

<img width="979" height="151" alt="Screenshot 2025-07-17 at 14 50 40" src="https://github.com/user-attachments/assets/0b2807a3-b252-4aff-a24c-7e1180ce3058" />

