### PR TITLE
feat(payment): Stripe OCS add Link logic to accordion

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -239,12 +239,17 @@ describe('StripeOCSPaymentStrategy', () => {
                 savePaymentMethod: {
                     maxVisiblePaymentMethods: 20,
                 },
+                defaultValues: {
+                    billingDetails: {
+                        email: 'test@bigcommerce.com',
+                    },
+                },
             });
             expect(onErrorMock).not.toHaveBeenCalled();
             expect(stripeIntegrationService.mountElement).toHaveBeenCalled();
         });
 
-        it('should initialize if postal code unavailable', async () => {
+        it('should initialize if address information unavailable', async () => {
             const onErrorMock = jest.fn();
             const renderMock = jest.fn();
             const createMock = jest.fn().mockImplementation(() => ({
@@ -302,6 +307,11 @@ describe('StripeOCSPaymentStrategy', () => {
                 },
                 savePaymentMethod: {
                     maxVisiblePaymentMethods: 20,
+                },
+                defaultValues: {
+                    billingDetails: {
+                        email: '',
+                    },
                 },
             });
             expect(onErrorMock).not.toHaveBeenCalled();
@@ -1200,17 +1210,24 @@ describe('StripeOCSPaymentStrategy', () => {
     });
 
     describe('#deinitialize()', () => {
-        it('deinitializes stripe payment strategy', async () => {
-            const unmountMock = jest.fn();
-            const getElementMock = jest.fn().mockImplementation(() => ({
+        let unmountMock: jest.Mock;
+        let destroyMock: jest.Mock;
+        let getElementMock: jest.Mock;
+
+        beforeEach(() => {
+            unmountMock = jest.fn();
+            destroyMock = jest.fn();
+            getElementMock = jest.fn().mockImplementation(() => ({
                 mount: jest.fn(),
                 unmount: unmountMock,
                 on: jest.fn((_, callback) => callback(StripeEventMock)),
                 update: jest.fn(),
-                destroy: jest.fn(),
+                destroy: destroyMock,
                 collapse: jest.fn(),
             }));
+        });
 
+        it('deinitializes stripe payment strategy', async () => {
             jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
                 Promise.resolve({
                     ...stripeUPEJsMock.elements({}),
@@ -1223,9 +1240,10 @@ describe('StripeOCSPaymentStrategy', () => {
 
             expect(stripeIntegrationService.deinitialize).toHaveBeenCalled();
             expect(unmountMock).toHaveBeenCalled();
+            expect(destroyMock).toHaveBeenCalled();
         });
 
-        it('when stripe element not initialized', async () => {
+        it('when stripe payment element not initialized', async () => {
             await stripeOCSPaymentStrategy.initialize(getStripeOCSInitializeOptionsMock());
 
             jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -123,7 +123,10 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
     }
 
     deinitialize(): Promise<void> {
-        this.stripeElements?.getElement(StripeElementType.PAYMENT)?.unmount();
+        const paymentElement = this.stripeElements?.getElement(StripeElementType.PAYMENT);
+
+        paymentElement?.unmount();
+        paymentElement?.destroy();
         this.stripeIntegrationService.deinitialize();
         this.stripeElements = undefined;
         this.stripeClient = undefined;
@@ -180,7 +183,8 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         });
 
         const { getBillingAddress, getShippingAddress } = this.paymentIntegrationService.getState();
-        const { postalCode } = getShippingAddress() || getBillingAddress() || {};
+        const billingAddress = getBillingAddress();
+        const { postalCode } = getShippingAddress() || billingAddress || {};
 
         const stripeElement: StripeElement =
             this.stripeElements.getElement(StripeElementType.PAYMENT) ||
@@ -204,6 +208,11 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
                 layout,
                 savePaymentMethod: {
                     maxVisiblePaymentMethods: 20,
+                },
+                defaultValues: {
+                    billingDetails: {
+                        email: billingAddress?.email || '',
+                    },
                 },
             });
 

--- a/packages/stripe-integration/src/stripe-utils/stripe.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe.ts
@@ -335,6 +335,7 @@ export interface TermOptions {
 
 export interface StripeLayoutOptions {
     type?: 'accordion' | 'tabs';
+    linkInAccordion?: boolean;
     defaultCollapsed?: boolean;
     radios?: boolean;
     spacedAccordionItems?: boolean;
@@ -384,6 +385,7 @@ interface validationRequiredElement {
 
 interface PaymentDefaultValues {
     savePaymentMethod?: boolean;
+    billingDetails?: BillingDetailsOptions;
 }
 
 interface ShippingDefaultValues {


### PR DESCRIPTION
## What?
Add Stripe OCS Link email logic to Stripe accordion on the payments step

## Why?
To manage Stripe Link accordion item and prepare logic for Radio button fix on the Stripe side

## Testing / Proof
Before:

https://github.com/user-attachments/assets/d0cf51ec-84ab-4f39-a39b-0168177efaab

After:

https://github.com/user-attachments/assets/3a028e4d-5430-4266-89ea-eb62484f0539

<img width="694" height="73" alt="Screenshot 2025-07-18 at 12 39 31" src="https://github.com/user-attachments/assets/d18f518e-de1f-4809-b048-198a8788a0c7" />

@bigcommerce/team-checkout @bigcommerce/team-payments
