### PR TITLE
feat(payment): Create order after liability shift passed when 3ds is on

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -7,6 +7,7 @@ import {
     PaymentArgumentInvalidError,
     PaymentIntegrationService,
     PaymentMethod,
+    PaymentMethodInvalidError,
     UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
@@ -530,7 +531,21 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                 ).mockReturnValue(paymentMethodMock());
             });
 
-            it('creates order with fastlaneToken', async () => {
+            it('creates order with fastlaneToken when 3ds is on', async () => {
+                const paypalFastlaneSdkMock = {
+                    ...paypalFastlaneSdk,
+                    ThreeDomainSecureClient: {
+                        ...threeDomainSecureComponentMock,
+                        show: jest.fn().mockReturnValue({
+                            liabilityShift: 'YES',
+                            authenticationState: 'succeeded',
+                            nonce: 'paypal_fastlane_instrument_id_nonce_3ds',
+                        }),
+                    },
+                };
+                jest.spyOn(paypalCommerceSdk, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                    Promise.resolve(paypalFastlaneSdkMock),
+                );
                 await strategy.initialize(initializationOptions);
 
                 await strategy.execute(executeOptions);
@@ -539,6 +554,31 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                     cartId: cart.id,
                     fastlaneToken: 'paypal_fastlane_instrument_id_nonce',
                 });
+            });
+
+            it('does not create order if liability shift is not equal "YES"', async () => {
+                const paypalFastlaneSdkMock = {
+                    ...paypalFastlaneSdk,
+                    ThreeDomainSecureClient: {
+                        ...threeDomainSecureComponentMock,
+                        show: jest.fn().mockReturnValue({
+                            liabilityShift: 'UNKNOWN',
+                            authenticationState: 'succeeded',
+                            nonce: 'paypal_fastlane_instrument_id_nonce_3ds',
+                        }),
+                    },
+                };
+                jest.spyOn(paypalCommerceSdk, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                    Promise.resolve(paypalFastlaneSdkMock),
+                );
+                await strategy.initialize(initializationOptions);
+
+                try {
+                    await strategy.execute(executeOptions);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(PaymentMethodInvalidError);
+                    expect(paypalCommerceRequestSender.createOrder).not.toHaveBeenCalled();
+                }
             });
 
             it('calls threeDomainSecureComponent isEligible', async () => {


### PR DESCRIPTION
## What?
Create order after liability shift passed when 3ds is on

## Why?
When PPCP FL 3ds check is on and  liability shift will be "YES" it means that 3ds check passed successfully and only after that create order otherwise we will execute unnecessary operation which will create order that will not be used  

## Testing / Proof

https://github.com/user-attachments/assets/827336b8-6940-4be6-a18c-cadd33177c93


https://github.com/user-attachments/assets/c515c712-01cc-4535-a997-a274fa78dacb


https://github.com/user-attachments/assets/9fb48f4b-6d48-41d4-9c5c-99263c7a7a5a


https://github.com/user-attachments/assets/a5651ca2-0dfa-4ce2-8028-191bb97d59b8



@bigcommerce/team-checkout @bigcommerce/team-payments
