### PR TITLE
feat(payment): Enable Stripe OCS Link from control panel

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -65,7 +65,6 @@ describe('StripeOCSPaymentStrategy', () => {
         jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
             jest.fn(() => Promise.resolve(stripeUPEJsMock)),
         );
-        jest.spyOn(stripeScriptLoader, 'getElements').mockImplementation(jest.fn());
         jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValue(
             paymentIntegrationService.getState(),
         );
@@ -228,6 +227,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 wallets: {
                     applePay: StripeStringConstants.NEVER,
                     googlePay: StripeStringConstants.NEVER,
+                    link: StripeStringConstants.NEVER,
                 },
                 layout: {
                     type: 'accordion',
@@ -297,6 +297,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 wallets: {
                     applePay: StripeStringConstants.NEVER,
                     googlePay: StripeStringConstants.NEVER,
+                    link: StripeStringConstants.NEVER,
                 },
                 layout: {
                     type: 'accordion',
@@ -381,6 +382,134 @@ describe('StripeOCSPaymentStrategy', () => {
             await stripeOCSPaymentStrategy.initialize(stripeOptions);
 
             expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
+        });
+
+        it('should enable Link by initialization data option', async () => {
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(StripeEventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+            }));
+            const stripePaymentMethod = getStripeOCSMock();
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    create: createMock,
+                }),
+            );
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...stripePaymentMethod,
+                initializationData: {
+                    ...stripePaymentMethod.initializationData,
+                    enableLink: true,
+                },
+            });
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+            expect(createMock).toHaveBeenCalledWith(StripeElementType.PAYMENT, {
+                fields: {
+                    billingDetails: {
+                        email: StripeStringConstants.NEVER,
+                        address: {
+                            country: StripeStringConstants.NEVER,
+                            city: StripeStringConstants.NEVER,
+                            postalCode: StripeStringConstants.AUTO,
+                        },
+                    },
+                },
+                wallets: {
+                    applePay: StripeStringConstants.NEVER,
+                    googlePay: StripeStringConstants.NEVER,
+                    link: StripeStringConstants.AUTO,
+                },
+                layout: {
+                    type: 'accordion',
+                    defaultCollapsed: false,
+                    radios: true,
+                    spacedAccordionItems: false,
+                    visibleAccordionItemsCount: 0,
+                },
+                savePaymentMethod: {
+                    maxVisiblePaymentMethods: 20,
+                },
+                defaultValues: {
+                    billingDetails: {
+                        email: '',
+                    },
+                },
+            });
+        });
+
+        it('should Disable Link by initialization data option', async () => {
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(StripeEventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+            }));
+            const stripePaymentMethod = getStripeOCSMock();
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    create: createMock,
+                }),
+            );
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...stripePaymentMethod,
+                initializationData: {
+                    ...stripePaymentMethod.initializationData,
+                    enableLink: false,
+                },
+            });
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+            expect(createMock).toHaveBeenCalledWith(StripeElementType.PAYMENT, {
+                fields: {
+                    billingDetails: {
+                        email: StripeStringConstants.NEVER,
+                        address: {
+                            country: StripeStringConstants.NEVER,
+                            city: StripeStringConstants.NEVER,
+                            postalCode: StripeStringConstants.AUTO,
+                        },
+                    },
+                },
+                wallets: {
+                    applePay: StripeStringConstants.NEVER,
+                    googlePay: StripeStringConstants.NEVER,
+                    link: StripeStringConstants.NEVER,
+                },
+                layout: {
+                    type: 'accordion',
+                    defaultCollapsed: false,
+                    radios: true,
+                    spacedAccordionItems: false,
+                    visibleAccordionItemsCount: 0,
+                },
+                savePaymentMethod: {
+                    maxVisiblePaymentMethods: 20,
+                },
+                defaultValues: {
+                    billingDetails: {
+                        email: '',
+                    },
+                },
+            });
         });
     });
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -156,7 +156,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         }
 
         const { clientToken, initializationData } = paymentMethod;
-        const { shopperLanguage, customerSessionToken } = initializationData;
+        const { shopperLanguage, customerSessionToken, enableLink } = initializationData;
 
         if (!clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
@@ -204,6 +204,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
                 wallets: {
                     applePay: StripeStringConstants.NEVER,
                     googlePay: StripeStringConstants.NEVER,
+                    link: enableLink ? StripeStringConstants.AUTO : StripeStringConstants.NEVER,
                 },
                 layout,
                 savePaymentMethod: {

--- a/packages/stripe-integration/src/stripe-utils/stripe.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe.ts
@@ -609,6 +609,7 @@ export interface StripeInitializationData {
     stripeConnectedAccount: string;
     shopperLanguage: string;
     customerSessionToken?: string;
+    enableLink?: boolean;
 }
 
 export interface StripeElementUpdateOptions {


### PR DESCRIPTION
## What?
Add toggle for Stripe OCS Link logic on the payments step

## Why?
To control Link flow availability on payments step from Control Panel 

## Testing / Proof
Before:

https://github.com/user-attachments/assets/ee10ac9f-cb19-41fe-8647-7d1adfecd45e

After:

https://github.com/user-attachments/assets/aec4f9b4-bf6e-44d1-842c-bc2cbf51603c

<img width="697" height="76" alt="Screenshot 2025-07-21 at 13 45 12" src="https://github.com/user-attachments/assets/501d0633-cdb1-4046-ad07-73c779cd4c06" />


@bigcommerce/team-checkout @bigcommerce/team-payments
