### PR TITLE
feat(payment): Added corresponding error for 422 payment status

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-initialize-options.ts
@@ -62,6 +62,11 @@ export default interface PayPalCommerceFastlanePaymentInitializeOptions {
     onChange?: (showPayPalCardSelector: () => Promise<CardInstrument | undefined>) => void;
 
     /**
+     * Callback that handles errors
+     */
+    onError?: (error: unknown) => void;
+
+    /**
      * Is a stylisation options for customizing PayPal Fastlane components
      *
      * Note: the styles for all PayPalCommerceFastlane strategies should be the same,


### PR DESCRIPTION
## What?
Added corresponding error for 422 payment status

## Why?
To show more user friendly error text

## Testing / Proof
<img width="1512" height="796" alt="Screenshot 2025-07-21 at 17 55 46" src="https://github.com/user-attachments/assets/9d32da34-8f4b-48af-9e9c-fe6c8a9ff766" />


@bigcommerce/team-checkout @bigcommerce/team-payments
