### PR TITLE
feat(payment): Address is not populated to Klarna modal

### DIFF
--- a/packages/klarna-integration/src/klarnav2/klarna-payments.ts
+++ b/packages/klarna-integration/src/klarnav2/klarna-payments.ts
@@ -58,4 +58,8 @@ export interface KlarnaAddress {
     postal_code: string;
     region: string;
     email?: string;
+    organization_name?: string;
+}
+export interface KlarnaInitializationData {
+    enableBillie?: string;
 }

--- a/packages/klarna-integration/src/klarnav2/klarnav2.mock.ts
+++ b/packages/klarna-integration/src/klarnav2/klarnav2.mock.ts
@@ -159,3 +159,32 @@ export function getKlarna(): PaymentMethod {
         clientToken: 'foo',
     };
 }
+
+export function getKlarnaV2UpdateSessionParamsWithOrganizationName(): KlarnaUpdateSessionParams {
+    return {
+        billing_address: {
+            street_address: '12345 Testing Way',
+            city: 'Some City',
+            country: 'DE',
+            given_name: 'Test',
+            family_name: 'Tester',
+            postal_code: '95555',
+            region: 'Berlin',
+            email: 'test@bigcommerce.com',
+            phone: '555-555-5555',
+            organization_name: 'Bigcommerce',
+        },
+        shipping_address: {
+            street_address: '12345 Testing Way',
+            city: 'Some City',
+            country: 'US',
+            given_name: 'Test',
+            family_name: 'Tester',
+            postal_code: '95555',
+            region: 'California',
+            email: 'test@bigcommerce.com',
+            phone: '555-555-5555',
+            organization_name: 'Bigcommerce',
+        },
+    };
+}


### PR DESCRIPTION
## What?
Added `organization_name` to Klarna address payload.

## Why?
During implementation of new Klarna b2b payment method Billie, we realized that company name was not populated to Klarna. In this PR it was added.

Changes hidden behind experiment - [PI-3915.b2b_payment_session_for_klarna](https://app.launchdarkly.com/projects/default/flags/PI-3915.b2b_payment_session_for_klarna/targeting?env=integration&env=development&selected-env=integration)

## Testing / Proof
Tested manually

https://github.com/user-attachments/assets/a8618e05-8eb0-4775-9477-e23fe7592eae




@bigcommerce/team-checkout @bigcommerce/team-payments
