### PR TITLE
feat(payment): Added BCP FL corresponding error for 422 payment status

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-initialize-options.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-initialize-options.ts
@@ -66,7 +66,6 @@ export default interface BigCommercePaymentsFastlanePaymentInitializeOptions {
      */
     onError?: (error: unknown) => void;
 
-
     /**
      * Is a stylisation options for customizing BigCommercePayments Fastlane components
      *

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-initialize-options.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-initialize-options.ts
@@ -62,6 +62,12 @@ export default interface BigCommercePaymentsFastlanePaymentInitializeOptions {
     onChange?: (showPayPalCardSelector: () => Promise<CardInstrument | undefined>) => void;
 
     /**
+     * Callback that handles errors
+     */
+    onError?: (error: unknown) => void;
+
+
+    /**
      * Is a stylisation options for customizing BigCommercePayments Fastlane components
      *
      * Note: the styles for all BigCommercePaymentsFastlane strategies should be the same,

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.ts
@@ -78,6 +78,8 @@ export default class BigCommercePaymentsFastlanePaymentStrategy implements Payme
             );
         }
 
+        this.bigcommerce_payments_fastlane = bigcommerce_payments_fastlane;
+
         if (
             !bigcommerce_payments_fastlane.onInit ||
             typeof bigcommerce_payments_fastlane.onInit !== 'function'

--- a/packages/bigcommerce-payments-utils/src/index.ts
+++ b/packages/bigcommerce-payments-utils/src/index.ts
@@ -21,3 +21,5 @@ export { default as PayPalSdkHelper } from './paypal-sdk-helper';
  */
 export { default as createBigCommercePaymentsFastlaneUtils } from './create-bigcommerce-payments-fastlane-utils';
 export { default as BigCommercePaymentsFastlaneUtils } from './bigcommerce-payments-fastlane-utils';
+
+export { default as isBigcommerceFastlaneRequestError } from './utils/is-bigcommerce-fastlane-request-error';

--- a/packages/bigcommerce-payments-utils/src/utils/is-bigcommerce-fastlane-request-error.spec.ts
+++ b/packages/bigcommerce-payments-utils/src/utils/is-bigcommerce-fastlane-request-error.spec.ts
@@ -1,0 +1,17 @@
+import isBigcommerceFastlaneRequestError, {
+    BigcommerceFastlaneRequestError,
+} from './is-bigcommerce-fastlane-request-error';
+
+describe('isBigcommerceFastlaneRequestError', () => {
+    it('should return true if paypal fastlane request is invalid', () => {
+        const invalidRequestError: BigcommerceFastlaneRequestError = {
+            name: 'Error',
+            message: 'Invalid request',
+            response: {
+                name: 'INVALID_REQUEST',
+            },
+        };
+
+        expect(isBigcommerceFastlaneRequestError(invalidRequestError)).toBe(true);
+    });
+});

--- a/packages/bigcommerce-payments-utils/src/utils/is-bigcommerce-fastlane-request-error.ts
+++ b/packages/bigcommerce-payments-utils/src/utils/is-bigcommerce-fastlane-request-error.ts
@@ -1,19 +1,19 @@
 export interface BigcommerceFastlaneRequestError {
-  name: string;
-  message: string;
-  response: {
     name: string;
-  };
+    message: string;
+    response: {
+        name: string;
+    };
 }
 
 export default function isBigcommerceFastlaneRequestError(
-  error: unknown,
+    error: unknown,
 ): error is BigcommerceFastlaneRequestError {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'message' in error &&
-    'response' in error &&
-    'name' in (error as BigcommerceFastlaneRequestError).response
-  );
+    return (
+        typeof error === 'object' &&
+        error !== null &&
+        'message' in error &&
+        'response' in error &&
+        'name' in (error as BigcommerceFastlaneRequestError).response
+    );
 }

--- a/packages/bigcommerce-payments-utils/src/utils/is-bigcommerce-fastlane-request-error.ts
+++ b/packages/bigcommerce-payments-utils/src/utils/is-bigcommerce-fastlane-request-error.ts
@@ -1,0 +1,19 @@
+export interface BigcommerceFastlaneRequestError {
+  name: string;
+  message: string;
+  response: {
+    name: string;
+  };
+}
+
+export default function isBigcommerceFastlaneRequestError(
+  error: unknown,
+): error is BigcommerceFastlaneRequestError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    'response' in error &&
+    'name' in (error as BigcommerceFastlaneRequestError).response
+  );
+}


### PR DESCRIPTION
## What?
Added BCP FL corresponding error for 422 payment status

## Why?
To show more user friendly error text

## Testing / Proof
Unit  tests
<img width="1512" height="796" alt="Screenshot 2025-07-21 at 17 55 46" src="https://github.com/user-attachments/assets/3d2b0815-3ed3-4cb8-9dce-d8ad90b0179f" />

@bigcommerce/team-checkout @bigcommerce/team-payments
