### PR TITLE
refactor(payment): updated BigCommercePaymentsFastlane strategies implementation to use cookies instead of local storage

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-customer-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-customer-strategy.spec.ts
@@ -488,7 +488,6 @@ describe('BigCommercePaymentsFastlaneCustomerStrategy', () => {
                     : undefined,
             );
             expect(bigCommercePaymentsFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(
-                false,
                 cart.id,
             );
         });

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-customer-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-customer-strategy.ts
@@ -145,10 +145,12 @@ export default class BigCommercePaymentsFastlaneCustomerStrategy implements Cust
             authenticationResult.authenticationState === PayPalFastlaneAuthenticationState.CANCELED;
 
         await this.updateCustomerDataState(methodId, authenticationResult);
-        this.bigCommercePaymentsFastlaneUtils.updateStorageSessionId(
-            isAuthenticationFlowCanceled,
-            cartId,
-        );
+
+        if (isAuthenticationFlowCanceled) {
+            this.bigCommercePaymentsFastlaneUtils.removeStorageSessionId();
+        } else {
+            this.bigCommercePaymentsFastlaneUtils.updateStorageSessionId(cartId);
+        }
     }
 
     private async updateCustomerDataState(

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.spec.ts
@@ -163,6 +163,7 @@ describe('BigCommercePaymentsFastlanePaymentStrategy', () => {
             cart.id,
         );
         jest.spyOn(bigCommercePaymentsFastlaneUtils, 'updateStorageSessionId');
+        jest.spyOn(bigCommercePaymentsFastlaneUtils, 'removeStorageSessionId');
         jest.spyOn(bigCommercePaymentsFastlaneUtils, 'lookupCustomerOrThrow').mockResolvedValue({
             customerContextId,
         });
@@ -377,7 +378,6 @@ describe('BigCommercePaymentsFastlanePaymentStrategy', () => {
                 bigCommercePaymentsFastlaneUtils.mapPayPalFastlaneProfileToBcCustomerData,
             ).toHaveBeenCalledWith(methodId, authenticationResultMock);
             expect(bigCommercePaymentsFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(
-                false,
                 cart.id,
             );
         });
@@ -475,9 +475,7 @@ describe('BigCommercePaymentsFastlanePaymentStrategy', () => {
                     },
                 },
             });
-            expect(bigCommercePaymentsFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(
-                true,
-            );
+            expect(bigCommercePaymentsFastlaneUtils.removeStorageSessionId).toHaveBeenCalled();
         });
 
         it('successfully places order with vaulted instruments flow', async () => {
@@ -501,9 +499,7 @@ describe('BigCommercePaymentsFastlanePaymentStrategy', () => {
                     },
                 },
             });
-            expect(bigCommercePaymentsFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(
-                true,
-            );
+            expect(bigCommercePaymentsFastlaneUtils.removeStorageSessionId).toHaveBeenCalled();
         });
 
         it('do not create an order if there is an error while receiving a payment order', async () => {

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.ts
@@ -163,8 +163,7 @@ export default class BigCommercePaymentsFastlanePaymentStrategy implements Payme
                 paymentPayload,
             );
 
-            // TODO: we should probably update this method with removeStorageSessionId for better reading experience
-            this.bigCommercePaymentsFastlaneUtils.updateStorageSessionId(true);
+            this.bigCommercePaymentsFastlaneUtils.removeStorageSessionId();
         } catch (error) {
             if (
                 isBigcommerceFastlaneRequestError(error) &&
@@ -254,10 +253,11 @@ export default class BigCommercePaymentsFastlanePaymentStrategy implements Payme
                 authenticationResult.authenticationState ===
                 PayPalFastlaneAuthenticationState.CANCELED;
 
-            this.bigCommercePaymentsFastlaneUtils.updateStorageSessionId(
-                isAuthenticationFlowCanceled,
-                cart.id,
-            );
+            if (isAuthenticationFlowCanceled) {
+                this.bigCommercePaymentsFastlaneUtils.removeStorageSessionId();
+            } else {
+                this.bigCommercePaymentsFastlaneUtils.updateStorageSessionId(cart.id);
+            }
         } catch (error) {
             // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
         }

--- a/packages/bigcommerce-payments-utils/src/bigcommerce-payments-fastlane-utils.spec.ts
+++ b/packages/bigcommerce-payments-utils/src/bigcommerce-payments-fastlane-utils.spec.ts
@@ -2,7 +2,7 @@ import {
     PaymentMethodClientUnavailableError,
     UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+import { CookieStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import BigCommercePaymentsFastlaneUtils from './bigcommerce-payments-fastlane-utils';
 import {
@@ -13,7 +13,6 @@ import {
 import { getPayPalFastlaneAuthenticationResultMock, getPayPalFastlaneSdk } from './mocks';
 
 describe('BigCommercePaymentsFastlaneUtils', () => {
-    let browserStorage: BrowserStorage;
     let paypalFastlaneSdk: PayPalFastlaneSdk;
     let subject: BigCommercePaymentsFastlaneUtils;
 
@@ -59,10 +58,9 @@ describe('BigCommercePaymentsFastlaneUtils', () => {
     };
 
     beforeEach(() => {
-        browserStorage = new BrowserStorage('paypalFastlane');
         paypalFastlaneSdk = getPayPalFastlaneSdk();
 
-        subject = new BigCommercePaymentsFastlaneUtils(browserStorage);
+        subject = new BigCommercePaymentsFastlaneUtils();
 
         jest.spyOn(Date, 'now').mockImplementation(() => 1);
     });
@@ -164,30 +162,35 @@ describe('BigCommercePaymentsFastlaneUtils', () => {
     describe('#updateStorageSessionId', () => {
         const sessionIdMock = 'cartId123';
 
-        it('sets session id to browser storage', () => {
-            jest.spyOn(browserStorage, 'setItem');
+        it('updates browser cookies with session id', () => {
+            jest.spyOn(CookieStorage, 'set');
 
-            subject.updateStorageSessionId(false, sessionIdMock);
+            subject.updateStorageSessionId(sessionIdMock);
 
-            expect(browserStorage.setItem).toHaveBeenCalledWith('sessionId', sessionIdMock);
+            expect(CookieStorage.set).toHaveBeenCalledWith('bc-fastlane-sessionId', sessionIdMock, {
+                expires: expect.any(Date),
+                secure: true,
+            });
         });
+    });
 
-        it('removes session id from browser storage', () => {
-            jest.spyOn(browserStorage, 'removeItem');
+    describe('#removeStorageSessionId', () => {
+        it('removes session id from browser cookies', () => {
+            jest.spyOn(CookieStorage, 'remove');
 
-            subject.updateStorageSessionId(true, sessionIdMock);
+            subject.removeStorageSessionId();
 
-            expect(browserStorage.removeItem).toHaveBeenCalledWith('sessionId');
+            expect(CookieStorage.remove).toHaveBeenCalledWith('bc-fastlane-sessionId');
         });
     });
 
     describe('#getStorageSessionId', () => {
         it('returns session id to browser storage', () => {
-            jest.spyOn(browserStorage, 'getItem');
+            jest.spyOn(CookieStorage, 'get');
 
             subject.getStorageSessionId();
 
-            expect(browserStorage.getItem).toHaveBeenCalledWith('sessionId');
+            expect(CookieStorage.get).toHaveBeenCalledWith('bc-fastlane-sessionId');
         });
     });
 

--- a/packages/bigcommerce-payments-utils/src/bigcommerce-payments-types.ts
+++ b/packages/bigcommerce-payments-utils/src/bigcommerce-payments-types.ts
@@ -448,7 +448,7 @@ export interface PayPalFastlaneAuthenticationResult {
 export enum PayPalFastlaneAuthenticationState {
     SUCCEEDED = 'succeeded',
     FAILED = 'failed',
-    CANCELED = 'cancelled',
+    CANCELED = 'canceled',
     UNRECOGNIZED = 'unrecognized',
 }
 

--- a/packages/bigcommerce-payments-utils/src/create-bigcommerce-payments-fastlane-utils.ts
+++ b/packages/bigcommerce-payments-utils/src/create-bigcommerce-payments-fastlane-utils.ts
@@ -1,7 +1,5 @@
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
-
 import BigCommercePaymentsFastlaneUtils from './bigcommerce-payments-fastlane-utils';
 
 export default function createBigCommercePaymentsFastlaneUtils(): BigCommercePaymentsFastlaneUtils {
-    return new BigCommercePaymentsFastlaneUtils(new BrowserStorage('paypalFastlane'));
+    return new BigCommercePaymentsFastlaneUtils();
 }

--- a/packages/core/src/shipping/strategies/bigcommerce-payments/bigcommerce-payments-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/bigcommerce-payments/bigcommerce-payments-fastlane-shipping-strategy.spec.ts
@@ -400,7 +400,6 @@ describe('BigCommercePaymentsFastlaneShippingStrategy', () => {
                 instruments: [bcInstrumentMock],
             });
             expect(bigCommercePaymentsFastlaneUtils.updateStorageSessionId).toHaveBeenCalledWith(
-                false,
                 cart.id,
             );
             expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith(bcAddressMock);

--- a/packages/core/src/shipping/strategies/bigcommerce-payments/bigcommerce-payments-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/bigcommerce-payments/bigcommerce-payments-fastlane-shipping-strategy.ts
@@ -200,10 +200,11 @@ export default class BigCommercePaymentsFastlaneShippingStrategy implements Ship
         const isAuthenticationFlowCanceled =
             authenticationResult.authenticationState === PayPalFastlaneAuthenticationState.CANCELED;
 
-        this._bigCommercePaymentsFastlaneUtils.updateStorageSessionId(
-            isAuthenticationFlowCanceled,
-            cart.id,
-        );
+        if (isAuthenticationFlowCanceled) {
+            this._bigCommercePaymentsFastlaneUtils.removeStorageSessionId();
+        } else {
+            this._bigCommercePaymentsFastlaneUtils.updateStorageSessionId(cart.id);
+        }
 
         if (billingAddress) {
             await this._store.dispatch(

--- a/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.spec.ts
@@ -180,9 +180,7 @@ describe('PayPalCommerceFastlaneUtils', () => {
 
             subject.removeStorageSessionId();
 
-            expect(CookieStorage.remove).toHaveBeenCalledWith('bc-fastlane-sessionId', {
-                secure: true,
-            });
+            expect(CookieStorage.remove).toHaveBeenCalledWith('bc-fastlane-sessionId');
         });
     });
 

--- a/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-fastlane-utils.ts
@@ -118,7 +118,7 @@ export default class PayPalCommerceFastlaneUtils {
     }
 
     removeStorageSessionId(): void {
-        CookieStorage.remove('bc-fastlane-sessionId', { secure: true });
+        CookieStorage.remove('bc-fastlane-sessionId');
     }
 
     getStorageSessionId(): string {


### PR DESCRIPTION
## What?
updated BigCommercePaymentsFastlane strategies implementation to use cookies instead of local storage

## Why?
Cookies usage for session id storage is better, because it is possible to set proper expiration date

## Testing / Proof
Unit tests
Manual tests
CI
