### PR TITLE
refactor(payment): updated Braintree Fastlane to use cookies instead of local storage

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
@@ -16,7 +16,6 @@ import {
     getGuestCustomer,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import BraintreeFastlaneCustomerStrategy from './braintree-fastlane-customer-strategy';
 import BraintreeFastlaneUtils from './braintree-fastlane-utils';
@@ -25,7 +24,6 @@ describe('BraintreeFastlaneCustomerStrategy', () => {
     let braintreeFastlaneUtils: BraintreeFastlaneUtils;
     let braintreeIntegrationService: BraintreeIntegrationService;
     let braintreeScriptLoader: BraintreeScriptLoader;
-    let browserStorage: BrowserStorage;
     let paymentIntegrationService: PaymentIntegrationService;
     let strategy: BraintreeFastlaneCustomerStrategy;
     let braintreeSDKVersionManager: BraintreeSDKVersionManager;
@@ -60,12 +58,10 @@ describe('BraintreeFastlaneCustomerStrategy', () => {
             braintreeScriptLoader,
             window,
         );
-        browserStorage = new BrowserStorage('paypalConnect');
         paymentIntegrationService = new PaymentIntegrationServiceMock();
         braintreeFastlaneUtils = new BraintreeFastlaneUtils(
             paymentIntegrationService,
             braintreeIntegrationService,
-            browserStorage,
         );
 
         strategy = new BraintreeFastlaneCustomerStrategy(

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.spec.ts
@@ -34,7 +34,7 @@ import {
     getShippingAddress,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+import { CookieStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import { getThreeDSecureMock } from '../mocks/braintree.mock';
 
@@ -46,7 +46,6 @@ describe('BraintreeFastlanePaymentStrategy', () => {
     let braintreeFastlaneMock: BraintreeFastlane;
     let braintreeIntegrationService: BraintreeIntegrationService;
     let braintreeScriptLoader: BraintreeScriptLoader;
-    let browserStorage: BrowserStorage;
     let paymentIntegrationService: PaymentIntegrationService;
     let strategy: BraintreeFastlanePaymentStrategy;
     let braintreeSdk: BraintreeSdk;
@@ -184,11 +183,9 @@ describe('BraintreeFastlanePaymentStrategy', () => {
             window,
         );
         paymentIntegrationService = new PaymentIntegrationServiceMock();
-        browserStorage = new BrowserStorage('paypalFastlane');
         braintreeFastlaneUtils = new BraintreeFastlaneUtils(
             paymentIntegrationService,
             braintreeIntegrationService,
-            browserStorage,
         );
 
         braintreeSdk = new BraintreeSdk(braintreeScriptLoader);
@@ -196,13 +193,12 @@ describe('BraintreeFastlanePaymentStrategy', () => {
         strategy = new BraintreeFastlanePaymentStrategy(
             paymentIntegrationService,
             braintreeFastlaneUtils,
-            browserStorage,
             braintreeSdk,
         );
 
-        jest.spyOn(browserStorage, 'getItem');
-        jest.spyOn(browserStorage, 'setItem');
-        jest.spyOn(browserStorage, 'removeItem');
+        jest.spyOn(CookieStorage, 'get');
+        jest.spyOn(CookieStorage, 'set');
+        jest.spyOn(CookieStorage, 'remove');
 
         jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
             paymentMethod,
@@ -378,7 +374,7 @@ describe('BraintreeFastlanePaymentStrategy', () => {
         });
 
         it('gets PayPal Fastlane component', async () => {
-            jest.spyOn(browserStorage, 'getItem').mockReturnValue(cart.id);
+            jest.spyOn(CookieStorage, 'get');
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentProviderCustomerOrThrow',
@@ -425,7 +421,7 @@ describe('BraintreeFastlanePaymentStrategy', () => {
                 'getPaymentProviderCustomerOrThrow',
             ).mockReturnValue({});
 
-            jest.spyOn(browserStorage, 'getItem').mockReturnValue('');
+            jest.spyOn(CookieStorage, 'get').mockReturnValue('');
 
             await strategy.initialize(defaultInitializationOptions);
 
@@ -449,7 +445,7 @@ describe('BraintreeFastlanePaymentStrategy', () => {
         });
 
         it('triggers fastlane authentication flow', async () => {
-            jest.spyOn(browserStorage, 'getItem').mockReturnValue(cart.id);
+            jest.spyOn(CookieStorage, 'get').mockReturnValue(cart.id);
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentProviderCustomerOrThrow',

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.ts
@@ -25,11 +25,10 @@ import {
     PaymentRequestOptions,
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
 
 import { WithBraintreeFastlanePaymentInitializeOptions } from './braintree-fastlane-payment-initialize-options';
 import BraintreeFastlaneUtils from './braintree-fastlane-utils';
-import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
 
 export default class BraintreeFastlanePaymentStrategy implements PaymentStrategy {
     private braintreeCardComponent?: BraintreeFastlaneCardComponent;
@@ -39,7 +38,6 @@ export default class BraintreeFastlanePaymentStrategy implements PaymentStrategy
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
         private braintreeFastlaneUtils: BraintreeFastlaneUtils,
-        private browserStorage: BrowserStorage,
         private braintreeSdk: BraintreeSdk,
     ) {}
 
@@ -134,7 +132,7 @@ export default class BraintreeFastlanePaymentStrategy implements PaymentStrategy
 
         await this.paymentIntegrationService.submitPayment(paymentPayload);
 
-        this.browserStorage.removeItem('sessionId');
+        this.braintreeFastlaneUtils.removeSessionIdFromCookies();
     }
 
     finalize(): Promise<void> {
@@ -328,7 +326,7 @@ export default class BraintreeFastlanePaymentStrategy implements PaymentStrategy
             ? paymentProviderCustomer
             : {};
 
-        const paypalFastlaneSessionId = this.browserStorage.getItem('sessionId');
+        const paypalFastlaneSessionId = this.braintreeFastlaneUtils.getSessionIdFromCookies();
 
         if (
             !customer.isGuest ||

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
@@ -21,7 +21,7 @@ import {
     getCustomer,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+import { CookieStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import { getBraintreeAcceleratedCheckoutPaymentMethod } from '../mocks/braintree.mock';
 
@@ -31,7 +31,6 @@ describe('BraintreeFastlaneUtils', () => {
     let braintreeFastlaneMock: BraintreeFastlane;
     let braintreeIntegrationService: BraintreeIntegrationService;
     let braintreeScriptLoader: BraintreeScriptLoader;
-    let browserStorage: BrowserStorage;
     let paymentIntegrationService: PaymentIntegrationService;
     let subject: BraintreeFastlaneUtils;
     let braintreeSDKVersionManager: BraintreeSDKVersionManager;
@@ -59,17 +58,15 @@ describe('BraintreeFastlaneUtils', () => {
             braintreeScriptLoader,
             window,
         );
-        browserStorage = new BrowserStorage('paypalConnect');
         paymentIntegrationService = new PaymentIntegrationServiceMock();
 
         subject = new BraintreeFastlaneUtils(
             paymentIntegrationService,
             braintreeIntegrationService,
-            browserStorage,
         );
 
-        jest.spyOn(browserStorage, 'removeItem');
-        jest.spyOn(browserStorage, 'setItem');
+        jest.spyOn(CookieStorage, 'remove');
+        jest.spyOn(CookieStorage, 'set');
 
         jest.spyOn(paymentIntegrationService, 'loadPaymentMethod');
         jest.spyOn(paymentIntegrationService, 'updateBillingAddress');
@@ -338,7 +335,10 @@ describe('BraintreeFastlaneUtils', () => {
             await subject.initializeBraintreeFastlaneOrThrow(methodId, undefined);
             await subject.runPayPalAuthenticationFlowOrThrow();
 
-            expect(browserStorage.setItem).toHaveBeenCalledWith('sessionId', cart.id);
+            expect(CookieStorage.set).toHaveBeenCalledWith('bc-fastlane-sessionId', cart.id, {
+                expires: expect.any(Date),
+                secure: true,
+            });
             expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith({
                 authenticationState: BraintreeFastlaneAuthenticationState.UNRECOGNIZED,
                 addresses: [],
@@ -397,7 +397,10 @@ describe('BraintreeFastlaneUtils', () => {
             await subject.initializeBraintreeFastlaneOrThrow(methodId, undefined);
             await subject.runPayPalAuthenticationFlowOrThrow();
 
-            expect(browserStorage.setItem).toHaveBeenCalledWith('sessionId', cart.id);
+            expect(CookieStorage.set).toHaveBeenCalledWith('bc-fastlane-sessionId', cart.id, {
+                expires: expect.any(Date),
+                secure: true,
+            });
             expect(braintreeFastlaneMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
             expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith(
                 updatePaymentProviderCustomerPayload,
@@ -481,7 +484,10 @@ describe('BraintreeFastlaneUtils', () => {
             await subject.initializeBraintreeFastlaneOrThrow(methodId, undefined);
             await subject.runPayPalAuthenticationFlowOrThrow();
 
-            expect(browserStorage.setItem).toHaveBeenCalledWith('sessionId', cart.id);
+            expect(CookieStorage.set).toHaveBeenCalledWith('bc-fastlane-sessionId', cart.id, {
+                expires: expect.any(Date),
+                secure: true,
+            });
             expect(braintreeFastlaneMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
             expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith(
                 updatePaymentProviderCustomerPayload,
@@ -506,7 +512,7 @@ describe('BraintreeFastlaneUtils', () => {
             await subject.initializeBraintreeFastlaneOrThrow(methodId, undefined);
             await subject.runPayPalAuthenticationFlowOrThrow();
 
-            expect(browserStorage.removeItem).toHaveBeenCalledWith('sessionId');
+            expect(CookieStorage.remove).toHaveBeenCalledWith('bc-fastlane-sessionId');
             expect(braintreeFastlaneMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
             expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith(
                 updatePaymentProviderCustomerPayload,

--- a/packages/braintree-integration/src/braintree-fastlane/create-braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/create-braintree-fastlane-customer-strategy.ts
@@ -10,7 +10,6 @@ import {
     CustomerStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import BraintreeFastlaneCustomerStrategy from './braintree-fastlane-customer-strategy';
 import BraintreeFastlaneUtils from './braintree-fastlane-utils';
@@ -28,11 +27,9 @@ const createBraintreeFastlaneCustomerStrategy: CustomerStrategyFactory<
         ),
         braintreeHostWindow,
     );
-    const browserStorage = new BrowserStorage('paypalFastlane');
     const braintreeFastlaneUtils = new BraintreeFastlaneUtils(
         paymentIntegrationService,
         braintreeIntegrationService,
-        browserStorage,
     );
 
     return new BraintreeFastlaneCustomerStrategy(paymentIntegrationService, braintreeFastlaneUtils);

--- a/packages/braintree-integration/src/braintree-fastlane/create-braintree-fastlane-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/create-braintree-fastlane-payment-strategy.ts
@@ -11,7 +11,6 @@ import {
     PaymentStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import BraintreeFastlanePaymentStrategy from './braintree-fastlane-payment-strategy';
 import BraintreeFastlaneUtils from './braintree-fastlane-utils';
@@ -29,12 +28,10 @@ const createBraintreeFastlanePaymentStrategy: PaymentStrategyFactory<
         ),
         braintreeHostWindow,
     );
-    const browserStorage = new BrowserStorage('paypalFastlane');
 
     const braintreeFastlaneUtils = new BraintreeFastlaneUtils(
         paymentIntegrationService,
         braintreeIntegrationService,
-        browserStorage,
     );
 
     const braintreeScriptLoader = new BraintreeScriptLoader(
@@ -48,7 +45,6 @@ const createBraintreeFastlanePaymentStrategy: PaymentStrategyFactory<
     return new BraintreeFastlanePaymentStrategy(
         paymentIntegrationService,
         braintreeFastlaneUtils,
-        browserStorage,
         braintreeSdk,
     );
 };

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
@@ -31,7 +31,6 @@ import {
     TimeoutError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
-
 import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
 
 import BraintreeRequestSender from '../braintree-request-sender';

--- a/packages/braintree-integration/src/braintree-request-sender.spec.ts
+++ b/packages/braintree-integration/src/braintree-request-sender.spec.ts
@@ -1,10 +1,10 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
 import {
     ContentType,
     INTERNAL_USE_ONLY,
     SDK_VERSION_HEADERS,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
 import { getResponse } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import BraintreeRequestSender from './braintree-request-sender';

--- a/packages/braintree-integration/src/braintree-request-sender.ts
+++ b/packages/braintree-integration/src/braintree-request-sender.ts
@@ -1,7 +1,6 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 
 import { BraintreeOrderStatusData } from '@bigcommerce/checkout-sdk/braintree-utils';
-
 import {
     ContentType,
     INTERNAL_USE_ONLY,

--- a/packages/braintree-integration/src/mocks/braintree.mock.ts
+++ b/packages/braintree-integration/src/mocks/braintree.mock.ts
@@ -3,7 +3,6 @@ import {
     BraintreeThreeDSecure,
     PaypalButtonStyleColorOption,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
-
 import {
     DefaultCheckoutButtonHeight,
     PaymentMethod,
@@ -29,7 +28,6 @@ export function getBraintreeAcceleratedCheckoutPaymentMethod(): PaymentMethod {
 
 export function getThreeDSecureMock(): BraintreeThreeDSecure {
     return {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         verifyCard: (_options, callback: Braintree3DSVerifyCardCallback) => {
             if (callback) {
                 callback({ code: '' }, { nonce: 'fastlane_token_mock' });

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
@@ -14,7 +14,7 @@ import {
     getPaymentMethod,
     getShippingAddress,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+import { CookieStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutStore, createCheckoutStore } from '../../../checkout';
@@ -142,8 +142,8 @@ describe('BraintreeFastlaneShippingStrategy', () => {
         jest.spyOn(store.getState().billingAddress, 'getBillingAddress').mockReturnValue(
             getBillingAddress(),
         );
-        jest.spyOn(BrowserStorage.prototype, 'getItem').mockReturnValue(getCart().id);
-        jest.spyOn(BrowserStorage.prototype, 'removeItem').mockImplementation(jest.fn());
+        jest.spyOn(CookieStorage, 'get').mockReturnValue(getCart().id);
+        jest.spyOn(CookieStorage, 'remove').mockImplementation(jest.fn());
         // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -339,7 +339,7 @@ describe('BraintreeFastlaneShippingStrategy', () => {
                 store.getState().paymentProviderCustomer,
                 'getPaymentProviderCustomer',
             ).mockReturnValue(undefined);
-            jest.spyOn(BrowserStorage.prototype, 'getItem').mockReturnValue('123');
+            jest.spyOn(CookieStorage, 'get').mockReturnValue('123');
 
             const strategy = createStrategy();
 
@@ -452,7 +452,7 @@ describe('BraintreeFastlaneShippingStrategy', () => {
             await strategy.initialize(defaultOptions);
 
             expect(triggerAuthenticationFlowMock).toHaveBeenCalled();
-            expect(BrowserStorage.prototype.removeItem).toHaveBeenCalledWith('sessionId');
+            expect(CookieStorage.remove).toHaveBeenCalledWith('bc-fastlane-sessionId');
             expect(updatePaymentProviderCustomerMock).toHaveBeenCalledWith({
                 authenticationState: BraintreeFastlaneAuthenticationState.CANCELED,
                 addresses: [],

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
@@ -10,7 +10,7 @@ import {
     getFastlaneStyles,
     isBraintreeAcceleratedCheckoutCustomer,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+import { CookieStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import { AddressRequestBody } from '../../../address';
 import { BillingAddressActionCreator } from '../../../billing';
@@ -32,8 +32,6 @@ import { ShippingInitializeOptions, ShippingRequestOptions } from '../../shippin
 import ShippingStrategy from '../shipping-strategy';
 
 export default class BraintreeFastlaneShippingStrategy implements ShippingStrategy {
-    private _browserStorage: BrowserStorage;
-
     constructor(
         private _store: CheckoutStore,
         private _billingAddressActionCreator: BillingAddressActionCreator,
@@ -41,9 +39,7 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator,
         private _braintreeIntegrationService: BraintreeIntegrationService,
-    ) {
-        this._browserStorage = new BrowserStorage('paypalFastlane');
-    }
+    ) {}
 
     updateAddress(
         address: AddressRequestBody,
@@ -126,7 +122,7 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
     private _shouldRunAuthenticationFlow(): boolean {
         const state = this._store.getState();
         const cartId = state.cart.getCart()?.id;
-        const paypalFastlaneSessionId = this._browserStorage.getItem('sessionId');
+        const paypalFastlaneSessionId = CookieStorage.get('bc-fastlane-sessionId') || '';
         const paymentProviderCustomer = state.paymentProviderCustomer.getPaymentProviderCustomer();
         const braintreePaymentProviderCustomer = isBraintreeAcceleratedCheckoutCustomer(
             paymentProviderCustomer,
@@ -197,7 +193,7 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
                 }),
             );
 
-            this._browserStorage.removeItem('sessionId');
+            CookieStorage.remove('bc-fastlane-sessionId');
 
             return;
         }


### PR DESCRIPTION
## What?
Updated Braintree Fastlane to use cookies instead of local storage

## Why?
Cookies or local storage used for Fastlane integration to keep cart/session id there, so it can be used to check if customer was authorised into Fastlane in current session to trigger Fastlane authorisation once again (it does not require customer interaction) to get Fastlane data and fill in checkout form. However when customer cancels Fastlane authorisation, then session id will not be set to browser memory and Fastlane authentication will not be triggered in this session anymore, until customer force it by clicking continue button in customer step.

Keeping session id somewhere in browser memory is crucial for Fastlane authentication to work properly and do not bother customers with annoying OTPs. However the best place to keep this data is as a cookie, because it has expiration date and can be cleaned up automatically.

## Testing / Proof
Unit tests
Manual tests
CI

<img width="1512" height="822" alt="Screenshot 2025-07-30 at 18 37 41" src="https://github.com/user-attachments/assets/5bad5eb4-48fe-4db0-b753-9a3161caeabc" />

