### PR TITLE
feat(payment): Updated venmo button strategy with providing loadDefaultCheckout to load store config

### DIFF
--- a/packages/braintree-integration/src/braintree-venmo/braintree-venmo-button-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-venmo/braintree-venmo-button-strategy.spec.ts
@@ -215,6 +215,7 @@ describe('BraintreeVenmoButtonStrategy', () => {
 
             expect(braintreeSdk.initialize).toHaveBeenCalledWith(paymentMethodMock.clientToken);
             expect(braintreeSdk.getVenmoCheckoutOrThrow).toHaveBeenCalled();
+            expect(paymentIntegrationService.loadDefaultCheckout).toHaveBeenCalled();
         });
 
         it('successfully renders braintree venmo button', async () => {

--- a/packages/braintree-integration/src/braintree-venmo/braintree-venmo-button-strategy.ts
+++ b/packages/braintree-integration/src/braintree-venmo/braintree-venmo-button-strategy.ts
@@ -107,6 +107,8 @@ export default class BraintreeVenmoButtonStrategy implements CheckoutButtonStrat
             );
         }
 
+        await this.paymentIntegrationService.loadDefaultCheckout();
+
         this.onError = braintreevenmo?.onError || this.handleError;
         this.braintreeSdk.initialize(clientToken);
 


### PR DESCRIPTION
## What?

Updated venmo button strategy with providing `loadDefaultCheckout` to load store config

## Why?

To manage correct braintree version need to get to store config before braintree client load.

## Testing / Proof

Before

<img width="1511" height="861" alt="Screenshot 2025-08-05 at 10 24 07" src="https://github.com/user-attachments/assets/11b313e5-47f7-4e8c-889d-380357499428" />

After

<img width="758" height="414" alt="Screenshot 2025-08-05 at 10 24 27" src="https://github.com/user-attachments/assets/cfbb1d20-be4f-4a03-9049-246c561c8895" />

@bigcommerce/team-checkout @bigcommerce/team-payments
