### PR TITLE
feat(payment): Stripe OCS ACH vaulting

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -23,7 +23,9 @@ import {
     StripeClient,
     StripeElementType,
     StripeEventMock,
+    StripeInstrumentSetupFutureUsage,
     StripeIntegrationService,
+    StripePIPaymentMethodOptions,
     StripeScriptLoader,
     StripeStringConstants,
 } from '../stripe-utils';
@@ -1022,6 +1024,7 @@ describe('StripeOCSPaymentStrategy', () => {
             confirmPaymentMock = jest.fn().mockResolvedValue({
                 paymentIntent: {
                     id: 'paymentIntentId',
+                    client_secret: 'paymentIntentClientSecret',
                 },
             });
 
@@ -1058,7 +1061,7 @@ describe('StripeOCSPaymentStrategy', () => {
                     formattedPayload: {
                         cart_id: '',
                         credit_card_token: {
-                            token: 'paymentIntentId',
+                            token: 'paymentIntentClientSecret',
                         },
                         confirm: false,
                         payment_method_id: undefined,
@@ -1125,6 +1128,7 @@ describe('StripeOCSPaymentStrategy', () => {
             confirmPaymentMock = jest.fn().mockResolvedValue({
                 paymentIntent: {
                     id: 'paymentIntentId',
+                    client_secret: 'paymentIntentClientSecret',
                 },
             });
 
@@ -1150,7 +1154,7 @@ describe('StripeOCSPaymentStrategy', () => {
         });
     });
 
-    describe('#vaulted card instrument', () => {
+    describe('#vaulted instruments', () => {
         let errorResponse: RequestError;
         let confirmPaymentMock: jest.Mock;
         let retrievePaymentIntentMock: jest.Mock;
@@ -1161,15 +1165,12 @@ describe('StripeOCSPaymentStrategy', () => {
             );
         };
 
-        const mockSetupFutureUsage = (value?: string) => {
+        const mockSetupFutureUsage = (payment_method_options?: StripePIPaymentMethodOptions) => {
             confirmPaymentMock = jest.fn().mockResolvedValue({
                 paymentIntent: {
                     id: 'paymentIntentId',
-                    payment_method_options: {
-                        card: {
-                            setup_future_usage: value,
-                        },
-                    },
+                    client_secret: 'paymentIntentClientSecret',
+                    payment_method_options,
                 },
             });
 
@@ -1218,8 +1219,8 @@ describe('StripeOCSPaymentStrategy', () => {
             mockFirstPaymentRequest(errorResponse);
         });
 
-        it('should not store vaulted card instrument if stripe checkbox was not selected', async () => {
-            mockSetupFutureUsage(undefined);
+        it('should not store vaulted instrument if stripe checkbox was not selected', async () => {
+            mockSetupFutureUsage();
 
             await stripeOCSPaymentStrategy.initialize(stripeOptions);
             await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
@@ -1245,7 +1246,7 @@ describe('StripeOCSPaymentStrategy', () => {
                     formattedPayload: {
                         cart_id: '',
                         credit_card_token: {
-                            token: 'paymentIntentId',
+                            token: 'paymentIntentClientSecret',
                         },
                         confirm: false,
                         payment_method_id: undefined,
@@ -1256,7 +1257,11 @@ describe('StripeOCSPaymentStrategy', () => {
         });
 
         it('should store vaulted card instrument [on_session]', async () => {
-            mockSetupFutureUsage('on_session');
+            mockSetupFutureUsage({
+                card: {
+                    setup_future_usage: StripeInstrumentSetupFutureUsage.ON_SESSION,
+                },
+            });
 
             await stripeOCSPaymentStrategy.initialize(stripeOptions);
             await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
@@ -1282,7 +1287,7 @@ describe('StripeOCSPaymentStrategy', () => {
                     formattedPayload: {
                         cart_id: '',
                         credit_card_token: {
-                            token: 'paymentIntentId',
+                            token: 'paymentIntentClientSecret',
                         },
                         confirm: false,
                         payment_method_id: undefined,
@@ -1293,7 +1298,11 @@ describe('StripeOCSPaymentStrategy', () => {
         });
 
         it('should store vaulted card instrument [off_session]', async () => {
-            mockSetupFutureUsage('off_session');
+            mockSetupFutureUsage({
+                card: {
+                    setup_future_usage: StripeInstrumentSetupFutureUsage.OFF_SESSION,
+                },
+            });
 
             await stripeOCSPaymentStrategy.initialize(stripeOptions);
             await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
@@ -1319,7 +1328,89 @@ describe('StripeOCSPaymentStrategy', () => {
                     formattedPayload: {
                         cart_id: '',
                         credit_card_token: {
-                            token: 'paymentIntentId',
+                            token: 'paymentIntentClientSecret',
+                        },
+                        confirm: false,
+                        payment_method_id: undefined,
+                        vault_payment_instrument: true,
+                    },
+                },
+            });
+        });
+
+        it('should store vaulted ACH instrument [on_session]', async () => {
+            mockSetupFutureUsage({
+                us_bank_account: {
+                    setup_future_usage: StripeInstrumentSetupFutureUsage.ON_SESSION,
+                },
+            });
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId,
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: '',
+                        credit_card_token: {
+                            token: 'clientToken',
+                        },
+                        confirm: false,
+                        payment_method_id: undefined,
+                        vault_payment_instrument: false,
+                    },
+                },
+            });
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId,
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: '',
+                        tokenized_ach: {
+                            token: 'paymentIntentClientSecret',
+                        },
+                        confirm: false,
+                        payment_method_id: undefined,
+                        vault_payment_instrument: true,
+                    },
+                },
+            });
+        });
+
+        it('should store vaulted ACH instrument [off_session]', async () => {
+            mockSetupFutureUsage({
+                us_bank_account: {
+                    setup_future_usage: StripeInstrumentSetupFutureUsage.OFF_SESSION,
+                },
+            });
+
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId,
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: '',
+                        credit_card_token: {
+                            token: 'clientToken',
+                        },
+                        confirm: false,
+                        payment_method_id: undefined,
+                        vault_payment_instrument: false,
+                    },
+                },
+            });
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId,
+                paymentData: {
+                    formattedPayload: {
+                        cart_id: '',
+                        tokenized_ach: {
+                            token: 'paymentIntentClientSecret',
                         },
                         confirm: false,
                         payment_method_id: undefined,

--- a/packages/stripe-integration/src/stripe-utils/stripe.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe.ts
@@ -46,6 +46,11 @@ export interface PaymentIntent {
     id: string;
 
     /**
+     * The client secret of the PaymentIntent. Used for client-side retrieval using a publishable key.
+     */
+    client_secret?: string;
+
+    /**
      * Status of this PaymentIntent. Read more about each PaymentIntent [status](https://stripe.com/docs/payments/intents#intent-statuses).
      */
     status: 'succeeded' | string;
@@ -58,10 +63,13 @@ export interface PaymentIntent {
     payment_method_options?: StripePIPaymentMethodOptions;
 }
 
+export interface StripePIPaymentMethodSavingOptions {
+    setup_future_usage?: StripeInstrumentSetupFutureUsage;
+}
+
 export interface StripePIPaymentMethodOptions {
-    card?: {
-        setup_future_usage?: StripeInstrumentSetupFutureUsage;
-    };
+    card?: StripePIPaymentMethodSavingOptions;
+    us_bank_account?: StripePIPaymentMethodSavingOptions;
 }
 
 /**


### PR DESCRIPTION
## What?
Add ACH vaulting token to second payment confirmation request

## Why?
Need this change for ACH vaultings

## Testing / Proof
Before:
<img width="876" height="296" alt="Screenshot 2025-08-07 at 13 22 54" src="https://github.com/user-attachments/assets/44329b26-48ea-436e-94de-37c64e3945ee" />

After:
<img width="882" height="319" alt="Screenshot 2025-08-07 at 13 23 10" src="https://github.com/user-attachments/assets/7a80038f-e9f6-4c7f-8d8d-72a381cbcd4a" />

<img width="693" height="78" alt="Screenshot 2025-08-07 at 13 13 14" src="https://github.com/user-attachments/assets/cf256e12-4383-4ae3-a999-1f00f0fe3263" />


@bigcommerce/team-checkout @bigcommerce/team-payments
