### PR TITLE
refactor(checkout): PI-4255 deprecate CCAvenueMars

### DIFF
--- a/packages/offsite-integration/src/offsite-payment-strategy.spec.ts
+++ b/packages/offsite-integration/src/offsite-payment-strategy.spec.ts
@@ -67,18 +67,6 @@ describe('OffsitePaymentStrategy', () => {
             expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(payload, options);
         });
 
-        it('submits order with payment data if payment method is "ccavenuemars"', async () => {
-            options = { methodId: 'ccavenuemars' };
-            payload = {
-                ...payload,
-                payment: { methodId: options.methodId, gatewayId: options.gatewayId },
-            };
-
-            await strategy.execute(payload, options);
-
-            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(payload, options);
-        });
-
         it('initializes offsite payment flow', async () => {
             await strategy.execute(payload, options);
 

--- a/packages/offsite-integration/src/offsite-payment-strategy.ts
+++ b/packages/offsite-integration/src/offsite-payment-strategy.ts
@@ -80,10 +80,6 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
             return false;
         }
 
-        return (
-            payment.gatewayId === 'adyen' ||
-            payment.gatewayId === 'barclaycard' ||
-            payment.methodId === 'ccavenuemars'
-        );
+        return payment.gatewayId === 'adyen' || payment.gatewayId === 'barclaycard';
     }
 }


### PR DESCRIPTION
## What?
Remove CCAvenueMars-related code from repository

## Why?
CCAvenueMars is being deprecated

## Testing / Proof
Manual + unit tests

@bigcommerce/team-checkout @bigcommerce/team-payments
