### PR TITLE
feat(payment): PAYPAL-5712 Handle BraintreeSDK version mismatch caused by custom scripts added by merchants

### DIFF
--- a/packages/braintree-utils/src/braintree-script-loader.spec.ts
+++ b/packages/braintree-utils/src/braintree-script-loader.spec.ts
@@ -56,6 +56,7 @@ describe('BraintreeScriptLoader', () => {
         BRAINTREE_SDK_SCRIPTS_INTEGRITY[BRAINTREE_SDK_DEFAULT_VERSION];
     const braintreeSdkStableScriptsIntegrity =
         BRAINTREE_SDK_SCRIPTS_INTEGRITY[BRAINTREE_SDK_STABLE_VERSION];
+    const thirdPartyBraintreeVersion = '3.123.4';
 
     beforeEach(() => {
         mockWindow = { braintree: {} } as BraintreeHostWindow;
@@ -124,6 +125,25 @@ describe('BraintreeScriptLoader', () => {
                         integrity: braintreeSdkDefaultScriptsIntegrity[BraintreeModuleName.Client],
                     },
                 },
+            );
+            expect(client).toBe(clientMock);
+        });
+
+        it('loads the client with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+            const client = await braintreeScriptLoader.loadClient();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/client.min.js`,
+                undefined,
             );
             expect(client).toBe(clientMock);
         });
@@ -229,6 +249,25 @@ describe('BraintreeScriptLoader', () => {
                             braintreeSdkDefaultScriptsIntegrity[BraintreeModuleName.Fastlane],
                     },
                 },
+            );
+            expect(fastlane).toBe(fastlaneCreatorMock);
+        });
+
+        it('loads the fastlane with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+            const fastlane = await braintreeScriptLoader.loadFastlane();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/fastlane.min.js`,
+                undefined,
             );
             expect(fastlane).toBe(fastlaneCreatorMock);
         });
@@ -339,6 +378,25 @@ describe('BraintreeScriptLoader', () => {
             expect(paypalCheckout).toBe(paypalCheckoutMock);
         });
 
+        it('loads PayPal checkout with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+            const paypalCheckout = await braintreeScriptLoader.loadPaypalCheckout();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/paypal-checkout.min.js`,
+                undefined,
+            );
+            expect(paypalCheckout).toBe(paypalCheckoutMock);
+        });
+
         it('loads PayPal checkout throw error if braintree does not exist in window', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(
                 scriptLoader,
@@ -445,6 +503,25 @@ describe('BraintreeScriptLoader', () => {
             );
         });
 
+        it('loads local payment methods with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+
+            await braintreeScriptLoader.loadLocalPayment();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/local-payment.min.js`,
+                undefined,
+            );
+        });
+
         it('does not load module if it is already in the window', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(
                 scriptLoader,
@@ -521,6 +598,25 @@ describe('BraintreeScriptLoader', () => {
             );
         });
 
+        it('loads google payment methods with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+
+            await braintreeScriptLoader.loadGooglePayment();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/google-payment.min.js`,
+                undefined,
+            );
+        });
+
         it('does not load module if it is already in the window', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(
                 scriptLoader,
@@ -592,6 +688,25 @@ describe('BraintreeScriptLoader', () => {
                         integrity: braintreeSdkDefaultScriptsIntegrity[BraintreeModuleName.Paypal],
                     },
                 },
+            );
+        });
+
+        it('loads braintree paypal payment methods with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+
+            await braintreeScriptLoader.loadPaypal();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/paypal.min.js`,
+                undefined,
             );
         });
 
@@ -671,6 +786,25 @@ describe('BraintreeScriptLoader', () => {
             );
         });
 
+        it('loads threeDSecure methods with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+
+            await braintreeScriptLoader.load3DS();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/three-d-secure.min.js`,
+                undefined,
+            );
+        });
+
         it('does not load module if it is already in the window', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(
                 scriptLoader,
@@ -744,6 +878,25 @@ describe('BraintreeScriptLoader', () => {
                             braintreeSdkDefaultScriptsIntegrity[BraintreeModuleName.VisaCheckout],
                     },
                 },
+            );
+        });
+
+        it('loads visaCheckout methods with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+
+            await braintreeScriptLoader.loadVisaCheckout();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/visa-checkout.min.js`,
+                undefined,
             );
         });
 
@@ -823,6 +976,25 @@ describe('BraintreeScriptLoader', () => {
             );
         });
 
+        it('loads hostedFields methods with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+
+            await braintreeScriptLoader.loadHostedFields();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/hosted-fields.min.js`,
+                undefined,
+            );
+        });
+
         it('does not load module if it is already in the window', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(
                 scriptLoader,
@@ -894,6 +1066,25 @@ describe('BraintreeScriptLoader', () => {
                         integrity: braintreeSdkDefaultScriptsIntegrity[BraintreeModuleName.Venmo],
                     },
                 },
+            );
+        });
+
+        it('loads venmoCheckout methods with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+
+            await braintreeScriptLoader.loadVenmoCheckout();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/venmo.min.js`,
+                undefined,
             );
         });
 
@@ -969,6 +1160,25 @@ describe('BraintreeScriptLoader', () => {
                             braintreeSdkDefaultScriptsIntegrity[BraintreeModuleName.DataCollector],
                     },
                 },
+            );
+            expect(dataCollector).toBe(dataCollectorMock);
+        });
+
+        it('loads the data collector library with non-supported version of braintree sdk', async () => {
+            jest.spyOn(braintreeSDKVersionManager, 'getSDKVersion').mockReturnValueOnce(
+                thirdPartyBraintreeVersion,
+            );
+
+            const braintreeScriptLoader = new BraintreeScriptLoader(
+                scriptLoader,
+                mockWindow,
+                braintreeSDKVersionManager,
+            );
+            const dataCollector = await braintreeScriptLoader.loadDataCollector();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${thirdPartyBraintreeVersion}/js/data-collector.min.js`,
+                undefined,
             );
             expect(dataCollector).toBe(dataCollectorMock);
         });

--- a/packages/braintree-utils/src/braintree-script-loader.ts
+++ b/packages/braintree-utils/src/braintree-script-loader.ts
@@ -4,6 +4,7 @@ import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/p
 
 import { BRAINTREE_SDK_SCRIPTS_INTEGRITY } from './braintree-sdk-scripts-integrity';
 import BraintreeSDKVersionManager from './braintree-sdk-version-manager';
+import isManageableBraintreeSDKVersion from './isManageableBraintreeSDKVersion';
 import {
     BraintreeClientCreator,
     BraintreeDataCollectorCreator,
@@ -160,10 +161,9 @@ export default class BraintreeScriptLoader {
 
         const scriptPath = `//js.braintreegateway.com/web/${braintreeSdkVersion}/js/${fileName}`;
 
-        const integrity = this.getIntegrityValuesByModuleName(
-            braintreeModuleName,
-            braintreeSdkVersion,
-        );
+        const integrity = isManageableBraintreeSDKVersion(braintreeSdkVersion)
+            ? this.getIntegrityValuesByModuleName(braintreeModuleName, braintreeSdkVersion)
+            : undefined;
 
         await this.scriptLoader.loadScript(
             scriptPath,

--- a/packages/braintree-utils/src/braintree-sdk-version-manager.spec.ts
+++ b/packages/braintree-utils/src/braintree-sdk-version-manager.spec.ts
@@ -7,6 +7,7 @@ import {
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
+import { BraintreeHostWindow } from './braintree';
 import {
     BRAINTREE_SDK_DEFAULT_VERSION,
     BRAINTREE_SDK_STABLE_VERSION,
@@ -17,6 +18,7 @@ describe('BraintreeSDKVersionManager', () => {
     let braintreeSDKVersionManager: BraintreeSDKVersionManager;
     let paymentIntegrationService: PaymentIntegrationService;
     let storeConfigMock: StoreConfig | undefined;
+    const braintreeWindow: BraintreeHostWindow = window;
 
     beforeEach(() => {
         storeConfigMock = getConfig().storeConfig;
@@ -31,6 +33,10 @@ describe('BraintreeSDKVersionManager', () => {
         );
 
         braintreeSDKVersionManager = new BraintreeSDKVersionManager(paymentIntegrationService);
+    });
+
+    afterEach(() => {
+        braintreeWindow.braintree = undefined;
     });
 
     it('instantiates braintree sdk version manager', () => {
@@ -60,5 +66,17 @@ describe('BraintreeSDKVersionManager', () => {
         );
 
         expect(braintreeSDKVersionManager.getSDKVersion()).toBe(BRAINTREE_SDK_DEFAULT_VERSION);
+    });
+
+    it('should get unmanageable version if exist in window.braintree', () => {
+        Object.defineProperty(braintreeWindow, 'braintree', {
+            value: {
+                client: {
+                    VERSION: '1.123.4',
+                },
+            },
+        });
+
+        expect(braintreeSDKVersionManager.getSDKVersion()).toBe('1.123.4');
     });
 });

--- a/packages/braintree-utils/src/braintree-sdk-version-manager.ts
+++ b/packages/braintree-utils/src/braintree-sdk-version-manager.ts
@@ -1,12 +1,17 @@
+import { find } from 'lodash';
+
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
 
+import { BraintreeHostWindow } from './braintree';
 import {
     BRAINTREE_SDK_DEFAULT_VERSION,
     BRAINTREE_SDK_STABLE_VERSION,
 } from './braintree-sdk-verison';
 
 export default class BraintreeSDKVersionManager {
+    private braintreeWindow: BraintreeHostWindow = window;
+
     constructor(private paymentIntegrationService: PaymentIntegrationService) {}
 
     getSDKVersion() {
@@ -14,10 +19,29 @@ export default class BraintreeSDKVersionManager {
         const storeConfig = state.getStoreConfig();
         const features = storeConfig?.checkoutSettings.features || {};
 
+        const preloadedVersion = this.getPreloadedSDKVersion();
+
+        if (preloadedVersion) {
+            return preloadedVersion;
+        }
+
         if (isExperimentEnabled(features, 'PAYPAL-5636.update_braintree_sdk_version')) {
             return BRAINTREE_SDK_DEFAULT_VERSION;
         }
 
         return BRAINTREE_SDK_STABLE_VERSION;
+    }
+
+    private getPreloadedSDKVersion(): void | string {
+        const braintree = this.braintreeWindow.braintree;
+
+        if (braintree) {
+            const preloadedVersion = find<{ VERSION?: string }>(
+                Object.values(braintree),
+                (module) => !!module.VERSION,
+            );
+
+            return preloadedVersion?.VERSION;
+        }
     }
 }

--- a/packages/braintree-utils/src/isManageableBraintreeSDKVersion.spec.ts
+++ b/packages/braintree-utils/src/isManageableBraintreeSDKVersion.spec.ts
@@ -1,0 +1,19 @@
+import {
+    BRAINTREE_SDK_DEFAULT_VERSION,
+    BRAINTREE_SDK_STABLE_VERSION,
+} from './braintree-sdk-verison';
+import isManageableBraintreeSDKVersion from './isManageableBraintreeSDKVersion';
+
+describe('isManageableBraintreeSDKVersion', () => {
+    it('returns true if default braintree version', () => {
+        expect(isManageableBraintreeSDKVersion(BRAINTREE_SDK_DEFAULT_VERSION)).toBe(true);
+    });
+
+    it('returns true if stable braintree version', () => {
+        expect(isManageableBraintreeSDKVersion(BRAINTREE_SDK_STABLE_VERSION)).toBe(true);
+    });
+
+    it('returns false if non-supported braintree version', () => {
+        expect(isManageableBraintreeSDKVersion('3.123.4')).toBe(false);
+    });
+});

--- a/packages/braintree-utils/src/isManageableBraintreeSDKVersion.ts
+++ b/packages/braintree-utils/src/isManageableBraintreeSDKVersion.ts
@@ -1,0 +1,9 @@
+import { BRAINTREE_SDK_SCRIPTS_INTEGRITY } from './braintree-sdk-scripts-integrity';
+
+function isManageableBraintreeSDKVersion(
+    version: string,
+): version is keyof typeof BRAINTREE_SDK_SCRIPTS_INTEGRITY {
+    return version in BRAINTREE_SDK_SCRIPTS_INTEGRITY;
+}
+
+export default isManageableBraintreeSDKVersion;


### PR DESCRIPTION
## What?

Added support for Braintree versions loaded from third-party resources.

## Why?

To prevent braintree version mismatches when it was loaded third-party resources.

## Testing / Proof

Downloaded Braintree version `3.112.0` from Script Manager for testing purposes.

Before

https://github.com/user-attachments/assets/9824ac94-d3a3-4d4a-a449-2b3f3305bc44

After

https://github.com/user-attachments/assets/fe6d7932-eedd-45b0-ba02-f98139eb058f

https://github.com/user-attachments/assets/4ffb3965-4ec4-4584-ac38-a8f9f37ad083

PDP and Cart Page were tested as well

@bigcommerce/team-checkout @bigcommerce/team-payments
