### PR TITLE
refactor(payment): Moved Braintree Venmo payment strategy to packages

### DIFF
--- a/packages/braintree-integration/src/braintree-venmo/braintree-venmo-payment-strategy-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-venmo/braintree-venmo-payment-strategy-initialize-options.ts
@@ -1,0 +1,15 @@
+export default interface BraintreeVenmoPaymentStrategyInitializeOptions {
+    /**
+     * An option that can provide different payment authorization methods, for more information use the following link: https://developer.paypal.com/braintree/docs/guides/venmo/client-side/javascript/v3/#desktop-qr-code
+     * If no value is specified, it will be true
+     */
+    allowDesktop?: boolean;
+}
+
+export interface WithBraintreeVenmoInitializeOptions {
+    /**
+     * The options that are required to facilitate Braintree Venmo. They can be
+     * omitted unless you need to support Braintree Venmo.
+     */
+    braintreevenmo?: BraintreeVenmoPaymentStrategyInitializeOptions;
+}

--- a/packages/braintree-integration/src/braintree-venmo/braintree-venmo-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-venmo/braintree-venmo-payment-strategy.spec.ts
@@ -1,0 +1,342 @@
+import {
+    MissingDataError,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentMethodCancelledError,
+    PaymentMethodFailedError,
+    PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BraintreeVenmoPaymentStrategy from './braintree-venmo-payment-strategy';
+import {
+    BraintreeIntegrationService,
+    BraintreeScriptLoader,
+    BraintreeSDKVersionManager,
+    BraintreeTokenizePayload,
+    BraintreeVenmoCheckout,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
+import {
+    getConfig,
+    getOrderRequestBody,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { getBraintreeVenmo } from '../mocks/braintree.mock';
+import clearAllMocks = jest.clearAllMocks;
+
+describe('BraintreeVenmoPaymentStrategy', () => {
+    let braintreeVenmoPaymentStrategy: PaymentStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let braintreeIntegrationService: BraintreeIntegrationService;
+    let braintreeSDKVersionManager: BraintreeSDKVersionManager;
+    let paymentMethodMock: PaymentMethod;
+    let tokenizeMock: BraintreeVenmoCheckout['tokenize'];
+    let options: PaymentInitializeOptions;
+    const storeConfig = getConfig().storeConfig;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        braintreeSDKVersionManager = new BraintreeSDKVersionManager(paymentIntegrationService);
+        braintreeScriptLoader = new BraintreeScriptLoader(
+            getScriptLoader(),
+            window,
+            braintreeSDKVersionManager,
+        );
+        braintreeIntegrationService = new BraintreeIntegrationService(
+            braintreeScriptLoader,
+            window,
+        );
+        const braintreeTokenizePayload: BraintreeTokenizePayload = {
+            nonce: 'sampleNonce',
+            type: 'PaypalAccount',
+            details: {
+                username: 'sampleUsername',
+                email: 'sample@example.com',
+            },
+        };
+
+        tokenizeMock = jest.fn((callback) => callback(undefined, braintreeTokenizePayload));
+        paymentMethodMock = { ...getBraintreeVenmo() };
+        options = { methodId: paymentMethodMock.id };
+
+        braintreeVenmoPaymentStrategy = new BraintreeVenmoPaymentStrategy(
+            paymentIntegrationService,
+            braintreeIntegrationService,
+        );
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            getBraintreeVenmo(),
+        );
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfigOrThrow').mockReturnValue(
+            storeConfig,
+        );
+        jest.spyOn(braintreeScriptLoader, 'loadClient').mockResolvedValue({
+            create: jest.fn().mockResolvedValue({
+                request: jest.fn(),
+            }),
+        });
+        jest.spyOn(braintreeIntegrationService, 'getVenmoCheckout').mockResolvedValue({
+            tokenize: jest.fn().mockResolvedValue(tokenizeMock),
+            isBrowserSupported: jest.fn(),
+            teardown: jest.fn(),
+        });
+        jest.spyOn(braintreeIntegrationService, 'initialize');
+    });
+
+    it('creates an instance of the braintree venmo payment strategy', () => {
+        expect(braintreeVenmoPaymentStrategy).toBeInstanceOf(BraintreeVenmoPaymentStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('initializes the braintree venmo payment processor with the client token', async () => {
+            const options = { methodId: paymentMethodMock.id };
+
+            await braintreeVenmoPaymentStrategy.initialize(options);
+
+            expect(braintreeIntegrationService.initialize).toHaveBeenCalledWith(
+                paymentMethodMock.clientToken,
+            );
+            expect(braintreeIntegrationService.getVenmoCheckout).toHaveBeenCalled();
+        });
+
+        it('throws error if clientToken does not exist', async () => {
+            paymentMethodMock.clientToken = undefined;
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodMock);
+
+            try {
+                await braintreeVenmoPaymentStrategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throw error if getVenmoCheckout fails', async () => {
+            jest.spyOn(braintreeIntegrationService, 'getVenmoCheckout').mockReturnValue(
+                Promise.reject({
+                    name: 'notBraintreeError',
+                    message: 'my_message',
+                }),
+            );
+
+            try {
+                await braintreeVenmoPaymentStrategy.initialize(options);
+            } catch (error) {
+                expect((error as Error).message).toBe('my_message');
+            }
+        });
+
+        it('should initialize Venmo with an appropriate config', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        'PAYPAL-5406.braintree_venmo_web_fallback_support': true,
+                    },
+                },
+            });
+
+            await braintreeVenmoPaymentStrategy.initialize(options);
+
+            expect(braintreeIntegrationService.getVenmoCheckout).toHaveBeenCalledWith({
+                mobileWebFallBack: true,
+            });
+        });
+
+        it('should initialize Venmo with providing venmo options', async () => {
+            await braintreeVenmoPaymentStrategy.initialize({
+                ...options,
+                braintreevenmo: {
+                    allowDesktop: true,
+                },
+            });
+
+            expect(braintreeIntegrationService.getVenmoCheckout).toHaveBeenCalledWith({
+                allowDesktop: true,
+                mobileWebFallBack: true,
+            });
+        });
+    });
+
+    describe('#execute()', () => {
+        let orderRequestBody: OrderRequestBody;
+
+        beforeEach(() => {
+            jest.spyOn(paymentIntegrationService, 'submitOrder');
+            jest.spyOn(braintreeIntegrationService, 'getSessionId').mockResolvedValue(
+                'my_session_id',
+            );
+            orderRequestBody = getOrderRequestBody();
+            braintreeIntegrationService.getVenmoCheckout = jest.fn(
+                (): Promise<BraintreeVenmoCheckout> =>
+                    Promise.resolve({
+                        tokenize: tokenizeMock,
+                        isBrowserSupported: () => true,
+                        teardown: jest.fn(),
+                    }),
+            );
+        });
+
+        afterEach(() => {
+            clearAllMocks();
+        });
+
+        it('calls submit order with the order request information', async () => {
+            await braintreeVenmoPaymentStrategy.initialize(options);
+            await braintreeVenmoPaymentStrategy.execute(orderRequestBody, options);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith({
+                useStoreCredit: false,
+            });
+        });
+
+        it('refresh the state if paymentMethod has nonce value', async () => {
+            paymentMethodMock.nonce = 'some-nonce';
+
+            await braintreeVenmoPaymentStrategy.initialize(options);
+            await braintreeVenmoPaymentStrategy.execute(orderRequestBody, options);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledTimes(1);
+            expect(braintreeIntegrationService.initialize).toHaveBeenCalledTimes(1);
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledTimes(1);
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
+        });
+
+        it('pass the options to submitOrder', async () => {
+            await braintreeVenmoPaymentStrategy.initialize(options);
+            await braintreeVenmoPaymentStrategy.execute(orderRequestBody, options);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith({
+                useStoreCredit: false,
+            });
+        });
+
+        it('does not call braintreeVenmoCheckout.tokenize if a nonce is present', async () => {
+            paymentMethodMock.nonce = 'some-nonce';
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodMock);
+
+            const expected = expect.objectContaining({
+                paymentData: {
+                    formattedPayload: {
+                        vault_payment_instrument: null,
+                        set_as_default_stored_instrument: null,
+                        device_info: null,
+                        paypal_account: {
+                            token: 'some-nonce',
+                            email: null,
+                        },
+                    },
+                },
+            });
+
+            await braintreeVenmoPaymentStrategy.initialize({ methodId: paymentMethodMock.id });
+            await braintreeVenmoPaymentStrategy.execute(orderRequestBody, options);
+
+            expect(tokenizeMock).not.toHaveBeenCalled();
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expected);
+        });
+
+        it('throw error after user closed modal window', async () => {
+            const tokenizeMockError = jest.fn((callback) =>
+                callback(
+                    {
+                        name: 'BraintreeError',
+                        message: 'my_message',
+                        code: 'PAYPAL_POPUP_CLOSED',
+                    },
+                    undefined,
+                ),
+            );
+
+            braintreeIntegrationService.getVenmoCheckout = jest.fn(
+                (): Promise<BraintreeVenmoCheckout> =>
+                    Promise.resolve({
+                        tokenize: tokenizeMockError,
+                        isBrowserSupported: () => true,
+                        teardown: jest.fn(),
+                    }),
+            );
+
+            await braintreeVenmoPaymentStrategy.initialize(options);
+
+            await expect(
+                braintreeVenmoPaymentStrategy.execute(orderRequestBody, options),
+            ).rejects.toEqual(expect.any(PaymentMethodCancelledError));
+            expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+        });
+
+        it('throw error after tokenize error', async () => {
+            const tokenizeMockError = jest.fn((callback) =>
+                callback(
+                    {
+                        name: 'BraintreeError',
+                        message: 'my_message',
+                    },
+                    undefined,
+                ),
+            );
+
+            braintreeIntegrationService.getVenmoCheckout = jest.fn(
+                (): Promise<BraintreeVenmoCheckout> =>
+                    Promise.resolve({
+                        tokenize: tokenizeMockError,
+                        isBrowserSupported: () => true,
+                        teardown: jest.fn(),
+                    }),
+            );
+
+            await braintreeVenmoPaymentStrategy.initialize(options);
+
+            await expect(
+                braintreeVenmoPaymentStrategy.execute(orderRequestBody, options),
+            ).rejects.toEqual(expect.any(PaymentMethodFailedError));
+            expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+        });
+
+        it('throw error when no payment options exist', async () => {
+            await braintreeVenmoPaymentStrategy.initialize(options);
+
+            try {
+                await braintreeVenmoPaymentStrategy.execute({}, options);
+            } catch (error) {
+                expect(error).toEqual(expect.any(PaymentArgumentInvalidError));
+            }
+
+            expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('calls deinitialize in the braintree payment processor', async () => {
+            braintreeIntegrationService.teardown = jest.fn(() => Promise.resolve());
+
+            await braintreeVenmoPaymentStrategy.deinitialize();
+
+            expect(braintreeIntegrationService.teardown).toHaveBeenCalled();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await braintreeVenmoPaymentStrategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
+        });
+    });
+});

--- a/packages/braintree-integration/src/braintree-venmo/braintree-venmo-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-venmo/braintree-venmo-payment-strategy.ts
@@ -1,0 +1,174 @@
+import {
+    BraintreeError,
+    BraintreeIntegrationService,
+    BraintreeTokenizePayload,
+    BraintreeVenmoCheckout,
+    isBraintreeError,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
+import {
+    FormattedPayload,
+    MissingDataError,
+    MissingDataErrorType,
+    OrderFinalizationNotRequiredError,
+    OrderPaymentRequestBody,
+    OrderRequestBody,
+    Payment,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentMethodCancelledError,
+    PaymentMethodFailedError,
+    PaymentStrategy,
+    PaypalInstrument,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
+import BraintreeVenmoPaymentStrategyInitializeOptions, {
+    WithBraintreeVenmoInitializeOptions,
+} from './braintree-venmo-payment-strategy-initialize-options';
+
+export default class BraintreeVenmoPaymentStrategy implements PaymentStrategy {
+    private braintreeVenmoCheckout?: BraintreeVenmoCheckout;
+    private venmoOptions?: BraintreeVenmoPaymentStrategyInitializeOptions;
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private braintreeIntegrationService: BraintreeIntegrationService,
+    ) {}
+
+    async initialize(
+        options: PaymentInitializeOptions & WithBraintreeVenmoInitializeOptions,
+    ): Promise<void> {
+        const { methodId } = options;
+
+        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        const state = this.paymentIntegrationService.getState();
+
+        this.venmoOptions = options.braintreevenmo;
+
+        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+
+        await this.initializeBraintreeVenmo(paymentMethod);
+    }
+
+    async execute(orderRequest: OrderRequestBody): Promise<void> {
+        const { payment, ...order } = orderRequest;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        try {
+            const paymentData = await this.preparePaymentData(payment);
+            await this.paymentIntegrationService.submitOrder(order);
+            await this.paymentIntegrationService.submitPayment(paymentData);
+        } catch (error) {
+            this.handleError(error);
+        }
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    async deinitialize(): Promise<void> {
+        await this.braintreeIntegrationService.teardown();
+
+        return Promise.resolve();
+    }
+
+    private handleError(error: unknown): never {
+        if (!isBraintreeError(error)) {
+            throw error;
+        }
+
+        if (error.code === 'PAYPAL_POPUP_CLOSED') {
+            throw new PaymentMethodCancelledError(error.message);
+        }
+
+        throw new PaymentMethodFailedError(error.message);
+    }
+
+    private async initializeBraintreeVenmo(paymentMethod: PaymentMethod): Promise<void> {
+        const { clientToken } = paymentMethod;
+
+        if (!clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const state = this.paymentIntegrationService.getState();
+        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
+        const isBraintreeVenmoWebFallbackSupport = isExperimentEnabled(
+            features,
+            'PAYPAL-5406.braintree_venmo_web_fallback_support',
+        );
+
+        try {
+            this.braintreeIntegrationService.initialize(clientToken);
+            this.braintreeVenmoCheckout = await this.braintreeIntegrationService.getVenmoCheckout({
+                ...(this.venmoOptions?.allowDesktop !== undefined
+                    ? { allowDesktop: this.venmoOptions.allowDesktop }
+                    : {}),
+                ...(isBraintreeVenmoWebFallbackSupport
+                    ? {
+                          mobileWebFallBack: isBraintreeVenmoWebFallbackSupport,
+                      }
+                    : {}),
+            });
+        } catch (error) {
+            this.handleError(error);
+        }
+    }
+
+    private async preparePaymentData(payment: OrderPaymentRequestBody): Promise<Payment> {
+        const state = this.paymentIntegrationService.getState();
+        const { nonce } = state.getPaymentMethodOrThrow(payment.methodId);
+
+        if (nonce) {
+            return { ...payment, paymentData: this.formattedPayload(nonce) };
+        }
+        const tokenizeResult = await this.braintreeVenmoTokenize();
+        const sessionId = await this.braintreeIntegrationService.getSessionId();
+
+        return {
+            ...payment,
+            paymentData: this.formattedPayload(
+                tokenizeResult.nonce,
+                tokenizeResult.details.email,
+                sessionId,
+            ),
+        };
+    }
+
+    private formattedPayload(
+        token: string,
+        email?: string,
+        sessionId?: string,
+    ): FormattedPayload<PaypalInstrument> {
+        return {
+            formattedPayload: {
+                vault_payment_instrument: null,
+                set_as_default_stored_instrument: null,
+                device_info: sessionId || null,
+                paypal_account: {
+                    token,
+                    email: email || null,
+                },
+            },
+        };
+    }
+
+    private braintreeVenmoTokenize(): Promise<BraintreeTokenizePayload> {
+        return new Promise((resolve, reject) => {
+            this.braintreeVenmoCheckout?.tokenize(
+                (error: BraintreeError | undefined, payload: BraintreeTokenizePayload) => {
+                    if (error) {
+                        return reject(error);
+                    }
+
+                    resolve(payload);
+                },
+            );
+        });
+    }
+}

--- a/packages/braintree-integration/src/braintree-venmo/create-braintree-venmo-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-venmo/create-braintree-venmo-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createBraintreeVenmoPaymentStrategy from './create-braintree-venmo-payment-strategy';
+import BraintreeVenmoPaymentStrategy from './braintree-venmo-payment-strategy';
+
+describe('createBraintreeVenmoPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('initializes braintree venmo payment strategy', () => {
+        const strategy = createBraintreeVenmoPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(BraintreeVenmoPaymentStrategy);
+    });
+});

--- a/packages/braintree-integration/src/braintree-venmo/create-braintree-venmo-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-venmo/create-braintree-venmo-payment-strategy.ts
@@ -1,0 +1,36 @@
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import BraintreeVenmoPaymentStrategy from './braintree-venmo-payment-strategy';
+import {
+    BraintreeHostWindow,
+    BraintreeIntegrationService,
+    BraintreeScriptLoader,
+    BraintreeSDKVersionManager,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+const createBraintreeVenmoPaymentStrategy: CheckoutButtonStrategyFactory<
+    BraintreeVenmoPaymentStrategy
+> = (paymentIntegrationService) => {
+    const braintreeHostWindow: BraintreeHostWindow = window;
+    const scriptLoader = getScriptLoader();
+    const braintreeSDKVersionManager = new BraintreeSDKVersionManager(paymentIntegrationService);
+    const braintreeScriptLoader = new BraintreeScriptLoader(
+        scriptLoader,
+        braintreeHostWindow,
+        braintreeSDKVersionManager,
+    );
+    const braintreeIntegrationService = new BraintreeIntegrationService(
+        braintreeScriptLoader,
+        braintreeHostWindow,
+    );
+
+    return new BraintreeVenmoPaymentStrategy(
+        paymentIntegrationService,
+        braintreeIntegrationService,
+    );
+};
+
+export default toResolvableModule(createBraintreeVenmoPaymentStrategy, [{ id: 'braintreevenmo' }]);

--- a/packages/braintree-integration/src/index.ts
+++ b/packages/braintree-integration/src/index.ts
@@ -45,7 +45,7 @@ export { default as createBraintreeVisaCheckoutCustomerStrategy } from './braint
  * Braintree Venmo
  */
 export { default as createBraintreeVenmoButtonStrategy } from './braintree-venmo/create-braintree-venmo-button-strategy';
-
+export { default as createBraintreeVenmoPaymentStrategy } from './braintree-venmo/create-braintree-venmo-payment-strategy';
 /**
  * Braintree Credit Card Payment Strategies
  */

--- a/packages/braintree-integration/src/mocks/braintree.mock.ts
+++ b/packages/braintree-integration/src/mocks/braintree.mock.ts
@@ -32,6 +32,24 @@ export function getBraintreeAcceleratedCheckoutPaymentMethod(): PaymentMethod {
     };
 }
 
+export function getBraintreeVenmo(): PaymentMethod {
+    return {
+        id: 'braintreevenmo',
+        logoUrl: '',
+        method: 'paypal',
+        supportedCards: [],
+        config: {
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'foo',
+        initializationData: {
+            isBrainteeVenmoEnabled: false,
+        },
+        skipRedirectConfirmationAlert: false,
+    };
+}
+
 export function getThreeDSecureMock(): BraintreeThreeDSecure {
     return {
         verifyCard: (_options, callback: Braintree3DSVerifyCardCallback) => {

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -469,8 +469,8 @@ export interface BraintreeVenmoCheckout extends BraintreeModule {
 }
 
 export interface BraintreeVenmoCreatorConfig extends BraintreeModuleCreatorConfig {
-    allowDesktop: boolean;
-    paymentMethodUsage: string;
+    allowDesktop?: boolean;
+    paymentMethodUsage?: string;
 }
 
 /**


### PR DESCRIPTION
## What?
Moved Braintree Venmo payment strategy to packages

## Why?
To use it from packages

## Testing / Proof


https://github.com/user-attachments/assets/48ad52b3-ac92-490f-85ba-1c3b4f77cf9f


@bigcommerce/team-checkout @bigcommerce/team-payments
