### PR TITLE
chore(payment): CHECKOUT-9448 Pass checkout id as part of hosted form request

### DIFF
--- a/packages/core/src/hosted-form/hosted-field.spec.ts
+++ b/packages/core/src/hosted-form/hosted-field.spec.ts
@@ -40,6 +40,7 @@ describe('HostedField', () => {
             eventPoster as IframeEventPoster<HostedFieldEvent>,
             eventListener as IframeEventListener<HostedInputEventMap>,
             detachmentObserver as DetachmentObserver,
+            'some-checkout-id',
         );
     });
 
@@ -53,12 +54,12 @@ describe('HostedField', () => {
         expect(document.querySelector('#field-container-id iframe')).toBeDefined();
     });
 
-    it('sets iframe URL with version param', () => {
+    it('sets iframe URL with version param and checkout param', () => {
         field.attach();
 
         // tslint:disable-next-line:no-non-null-assertion
         expect(document.querySelector<HTMLIFrameElement>('#field-container-id iframe')!.src).toBe(
-            `${location.origin}/checkout/payment/hosted-field?version=1.0.0`,
+            `${location.origin}/checkout/payment/hosted-field?version=1.0.0&checkoutId=some-checkout-id`,
         );
     });
 

--- a/packages/core/src/hosted-form/hosted-field.ts
+++ b/packages/core/src/hosted-form/hosted-field.ts
@@ -45,11 +45,12 @@ export default class HostedField {
         private _eventPoster: IframeEventPoster<HostedFieldEvent>,
         private _eventListener: IframeEventListener<HostedInputEventMap>,
         private _detachmentObserver: DetachmentObserver,
+        private _checkoutId?: string,
         private _cardInstrument?: CardInstrument,
     ) {
         this._iframe = document.createElement('iframe');
 
-        this._iframe.src = `/checkout/payment/hosted-field?version=${LIBRARY_VERSION}`;
+        this._iframe.src = `/checkout/payment/hosted-field?version=${LIBRARY_VERSION}&checkoutId=${this._checkoutId}`;
         this._iframe.style.border = 'none';
         this._iframe.style.height = '100%';
         this._iframe.style.overflow = 'hidden';

--- a/packages/core/src/hosted-form/hosted-form-factory.spec.ts
+++ b/packages/core/src/hosted-form/hosted-form-factory.spec.ts
@@ -14,14 +14,18 @@ describe('HostedFormFactory', () => {
     });
 
     it('creates hosted form', () => {
-        const result = factory.create('https://store.foobar.com', {
-            fields: {
-                [HostedFieldType.CardCode]: { containerId: 'card-code' },
-                [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
-                [HostedFieldType.CardName]: { containerId: 'card-name' },
-                [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+        const result = factory.create(
+            'https://store.foobar.com',
+            {
+                fields: {
+                    [HostedFieldType.CardCode]: { containerId: 'card-code' },
+                    [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                    [HostedFieldType.CardName]: { containerId: 'card-name' },
+                    [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                },
             },
-        });
+            'some-checkout-id',
+        );
 
         expect(result).toBeInstanceOf(HostedForm);
     });

--- a/packages/core/src/hosted-form/hosted-form-factory.ts
+++ b/packages/core/src/hosted-form/hosted-form-factory.ts
@@ -20,7 +20,7 @@ import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer
 export default class HostedFormFactory {
     constructor(private _store: ReadableCheckoutStore) {}
 
-    create(host: string, options: LegacyHostedFormOptions): HostedForm {
+    create(host: string, options: LegacyHostedFormOptions, checkoutId?: string): HostedForm {
         const fieldTypes = Object.keys(options.fields) as HostedFieldType[];
         const fields = fieldTypes.reduce<HostedField[]>((result, type) => {
             const fields = options.fields as HostedStoredCardFieldOptionsMap &
@@ -42,6 +42,7 @@ export default class HostedFormFactory {
                     new IframeEventPoster(host),
                     new IframeEventListener(host),
                     new DetachmentObserver(new MutationObserverFactory()),
+                    checkoutId,
                     'instrumentId' in fieldOptions
                         ? this._getCardInstrument(fieldOptions.instrumentId)
                         : undefined,

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -98,7 +98,9 @@ describe('DefaultPaymentIntegrationService', () => {
         requestSender = createRequestSender();
         cartRequestSender = new CartRequestSender(requestSender);
         hostedFormFactory = new HostedFormFactory(store as CheckoutStore);
-        paymentIntegrationSelectors = {} as PaymentIntegrationSelectors;
+        paymentIntegrationSelectors = {
+            getCheckoutOrThrow: () => getCheckout(),
+        } as PaymentIntegrationSelectors;
 
         internalCheckoutSelectors = {
             order: {

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -66,7 +66,9 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
     }
 
     createHostedForm(host: string, options: HostedFormOptions): HostedForm {
-        return this._hostedFormFactory.create(host, options);
+        const checkoutId = this._storeProjection.getState().getCheckoutOrThrow().id;
+
+        return this._hostedFormFactory.create(host, options, checkoutId);
     }
 
     subscribe(


### PR DESCRIPTION
## What?
Pass checkout id as part of hosted form request

## Why?
In order to initialize hosted form pass checkout id so they can be initialized correctly for buy now carts as well.

## Testing / Proof
- CI

@bigcommerce/team-checkout @bigcommerce/team-payments
