### PR TITLE
fix(payment): PI-4266 Apple Pay fails on product pages with reCAPTCHA…

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
@@ -428,6 +428,37 @@ describe('ApplePayButtonStrategy', () => {
             }
         });
 
+        it('creates buyNowCart on PDP page on button click for physical product and execute verifyCheckoutSpamProtection if shouldExecuteSpamCheck is true', async () => {
+            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(
+                Promise.resolve(getBuyNowCart()),
+            );
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getCheckoutOrThrow').mockReturnValue({
+                ...getCheckout(),
+                shouldExecuteSpamCheck: true,
+            });
+
+            const CheckoutButtonInitializeOptions =
+                getApplePayButtonInitializationOptionsWithBuyNow();
+
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const button = container.firstChild as HTMLElement;
+
+                if (button) {
+                    button.click();
+
+                    await applePaySession.onpaymentmethodselected();
+
+                    expect(paymentIntegrationService.createBuyNowCart).toHaveBeenCalled();
+                    expect(
+                        paymentIntegrationService.verifyCheckoutSpamProtection,
+                    ).toHaveBeenCalled();
+                }
+            }
+        });
+
         it('doesnt call applePaySession.onpaymentmethodselected Buy Now flow with for digital item', async () => {
             applePaySession.onpaymentmethodselected = jest.fn();
 

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -357,6 +357,13 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
             );
 
             await this._paymentIntegrationService.loadCheckout(buyNowCart.id);
+
+            const state = this._paymentIntegrationService.getState();
+            const { shouldExecuteSpamCheck } = state.getCheckoutOrThrow();
+
+            if (shouldExecuteSpamCheck) {
+                await this._paymentIntegrationService.verifyCheckoutSpamProtection();
+            }
         } catch (error) {
             throw new BuyNowCartCreationError();
         }


### PR DESCRIPTION
… enabled

## What?
Added verifyCheckoutSpamProtection method call for scenarios when customer want's to pay with ApplePay smart payment button from pdp and quickview.

## Why?
As we have spam protection check for scenarios when customer want's to pay with ApplePay smart payment button from cart and minicart https://github.com/bigcommerce/checkout-sdk-js/blob/b7a2a6f8ac607f5c3d070961f294f3e434cc6e68/packages/apple-pay-integration/src/apple-pay-button-strategy.ts#L111 , we don't have it for pdp and quickview because then checkout doesn't exist yet. In this PR there is added verifyCheckoutSpamProtection method call for such a scenarios. VerifyCheckoutSpamProtection is called after checkout is created and loaded. In payment flow it happens after customer clicks ApplePay payment button and before authenticating by finger print.

## Testing / Proof
Unit tests passed.
Tested manually. Unfortunately we can't complete the order when recording the screen so I can't attache any video.
When reCaptcha enabled, completed orders using ApplePay smart payment button from:
- Pdp 
- quickview
- cart
- minicart

https://github.com/user-attachments/assets/37dd1848-74a1-47f8-ae57-356d8f362f6d

<img width="1732" height="1026" alt="Zrzut ekranu 2025-08-20 o 18 32 27" src="https://github.com/user-attachments/assets/deb7567e-2694-49f2-a0b1-36540cf731be" />


@bigcommerce/team-checkout @bigcommerce/team-payments
