### PR TITLE
feat(payment): PAYPAL-5660 add Braintree PayPal message render condition

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
@@ -251,7 +251,27 @@ describe('BraintreePaypalPaymentStrategy', () => {
             );
         });
 
-        it('renders Braintree PayPal message', async () => {
+        it('renders Braintree PayPal message for braintreepaypalcredit', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({ ...paymentMethodMock, id: 'braintreepaypalcredit' });
+
+            const options = {
+                methodId: 'braintreepaypalcredit',
+                braintree: { bannerContainerId: 'banner-container-id' },
+            };
+
+            await strategy.initialize(options);
+
+            expect(braintreeMessages.render).toHaveBeenCalledWith(
+                'braintreepaypalcredit',
+                'banner-container-id',
+                'payment',
+            );
+        });
+
+        it('renders Braintree PayPal message if isCreditEnabled is falsy', async () => {
             const options = {
                 methodId: paymentMethodMock.id,
                 braintree: { bannerContainerId: 'banner-container-id' },
@@ -264,6 +284,26 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 'banner-container-id',
                 'payment',
             );
+        });
+
+        it('does NOT render Braintree PayPal message if method is not braintreepaypalcredit and isCreditEnabled is true', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethodMock,
+                id: 'braintreepaypal',
+                initializationData: { isCreditEnabled: true },
+            });
+
+            const options = {
+                methodId: 'braintreepaypal',
+                braintree: { bannerContainerId: 'banner-container-id' },
+            };
+
+            await strategy.initialize(options);
+
+            expect(braintreeMessages.render).not.toHaveBeenCalled();
         });
 
         it('throws error if unable to initialize', async () => {

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -267,7 +267,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
     }
 
     private async loadPaypalCheckoutInstance() {
-        const { clientToken, initializationData } = this.paymentMethod || {};
+        const { clientToken, initializationData, id: paymentMethodId } = this.paymentMethod || {};
 
         if (!clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
@@ -285,12 +285,20 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                 isCreditEnabled: initializationData?.isCreditEnabled,
             };
 
+            const isBraintreePaypalCredit = paymentMethodId === 'braintreepaypalcredit';
+            const shouldShowPayPalCreditBanner =
+                isBraintreePaypalCredit || !initializationData?.isCreditEnabled;
+
             await this.braintreeIntegrationService.getPaypalCheckout(
                 paypalCheckoutConfig,
                 (braintreePaypalCheckout) => {
-                    if (this.paymentMethod?.id && this.braintree?.bannerContainerId) {
+                    if (
+                        shouldShowPayPalCreditBanner &&
+                        paymentMethodId &&
+                        this.braintree?.bannerContainerId
+                    ) {
                         this.renderPayPalMessages(
-                            this.paymentMethod.id,
+                            paymentMethodId,
                             this.braintree.bannerContainerId,
                         );
                     }


### PR DESCRIPTION
## What?
Add condition for Braintree PayPal message render
...

## Why?
We have situations when Pay Later method (and button) on checkout page is disabled but BNPL messaging is still enabled
...

## Testing / Proof
Manual
Unit
...

@bigcommerce/team-checkout @bigcommerce/team-payments
