### PR TITLE
chore(other): CHECKOUT-9469 Remove rolled out experiments

### DIFF
--- a/packages/core/src/billing/billing-address-action-creator.spec.ts
+++ b/packages/core/src/billing/billing-address-action-creator.spec.ts
@@ -405,12 +405,6 @@ describe('BillingAddressActionCreator', () => {
             it('emits actions if able to update billing address when experiment is enabled', async () => {
                 const configState = getConfigState();
 
-                if (configState.data && configState.data.storeConfig.checkoutSettings.features) {
-                    configState.data.storeConfig.checkoutSettings.features = {
-                        'CHECKOUT-8392.fix_billing_creation_in_checkout': true,
-                    };
-                }
-
                 const stateWithExperiment = {
                     ...state,
                     config: configState,

--- a/packages/core/src/billing/billing-address-action-creator.ts
+++ b/packages/core/src/billing/billing-address-action-creator.ts
@@ -34,10 +34,6 @@ export default class BillingAddressActionCreator {
         return (store) => {
             const state = store.getState();
             const checkout = state.checkout.getCheckout();
-            const isBillingFixExperimentEnabled =
-                state.config.getConfig()?.storeConfig.checkoutSettings.features[
-                    'CHECKOUT-8392.fix_billing_creation_in_checkout'
-                ] ?? true;
 
             if (!checkout) {
                 throw new MissingDataError(MissingDataErrorType.MissingCheckout);
@@ -73,7 +69,6 @@ export default class BillingAddressActionCreator {
                         const { body } = await this._createOrUpdateBillingAddress(
                             checkout.id,
                             billingAddressRequestBody,
-                            isBillingFixExperimentEnabled,
                             hasBillingAddress,
                             options,
                         );
@@ -101,10 +96,6 @@ export default class BillingAddressActionCreator {
             Observable.create((observer: Observer<UpdateBillingAddressAction>) => {
                 const state = store.getState();
                 const checkout = state.checkout.getCheckout();
-                const isBillingFixExperimentEnabled =
-                    state.config.getConfig()?.storeConfig.checkoutSettings.features[
-                        'CHECKOUT-8392.fix_billing_creation_in_checkout'
-                    ] ?? true;
 
                 if (!checkout) {
                     throw new MissingDataError(MissingDataErrorType.MissingCheckout);
@@ -136,7 +127,6 @@ export default class BillingAddressActionCreator {
                 this._createOrUpdateBillingAddress(
                     checkout.id,
                     billingAddressRequestBody,
-                    isBillingFixExperimentEnabled,
                     hasBillingAddress,
                     options,
                 )
@@ -184,19 +174,10 @@ export default class BillingAddressActionCreator {
     private _createOrUpdateBillingAddress(
         checkoutId: string,
         address: Partial<BillingAddressUpdateRequestBody>,
-        isBillingFixExperimentEnabled: boolean,
         hasBillingAddress: boolean,
         options?: RequestOptions,
     ): Promise<Response<Checkout>> {
-        if (isBillingFixExperimentEnabled) {
-            if (!hasBillingAddress) {
-                return this._requestSender.createAddress(checkoutId, address, options);
-            }
-
-            return this._requestSender.updateAddress(checkoutId, address, options);
-        }
-
-        if (!address.id) {
+        if (!hasBillingAddress) {
             return this._requestSender.createAddress(checkoutId, address, options);
         }
 

--- a/packages/core/src/checkout/checkout-action-creator.ts
+++ b/packages/core/src/checkout/checkout-action-creator.ts
@@ -24,7 +24,7 @@ export default class CheckoutActionCreator {
         id: string,
         options?: RequestOptions,
     ): ThunkAction<LoadCheckoutAction, InternalCheckoutSelectors> {
-        return (store) => {
+        return () => {
             return concat(
                 of(createAction(CheckoutActionType.LoadCheckoutRequested)),
                 merge(

--- a/packages/core/src/checkout/checkout-action-creator.ts
+++ b/packages/core/src/checkout/checkout-action-creator.ts
@@ -44,11 +44,7 @@ export default class CheckoutActionCreator {
                         .then(({ body }) => {
                             return createAction(
                                 CheckoutActionType.LoadCheckoutSucceeded,
-                                this._shouldTransformCustomerAddress(
-                                    store.getState().config.getStoreConfigOrThrow(),
-                                )
-                                    ? this._transformCustomerAddresses(body)
-                                    : body,
+                                this._transformCustomerAddresses(body),
                             );
                         });
                 }),
@@ -91,9 +87,7 @@ export default class CheckoutActionCreator {
 
                     return createAction(
                         CheckoutActionType.LoadCheckoutSucceeded,
-                        this._shouldTransformCustomerAddress(state.config.getStoreConfigOrThrow())
-                            ? this._transformCustomerAddresses(body)
-                            : body,
+                        this._transformCustomerAddresses(body),
                     );
                 }),
             ).pipe(
@@ -147,14 +141,6 @@ export default class CheckoutActionCreator {
 
             return this.loadCheckout(checkout.id, options)(store);
         };
-    }
-
-    private _shouldTransformCustomerAddress(storeConfig: StoreConfig): boolean {
-        return (
-            storeConfig.checkoutSettings.features[
-                'CHECKOUT-8183.set_shouldSaveAddress_false_for_existing_address'
-            ] ?? true
-        );
     }
 
     private _transformCustomerAddresses(body: Checkout): Checkout {

--- a/packages/core/src/checkout/checkout-action-creator.ts
+++ b/packages/core/src/checkout/checkout-action-creator.ts
@@ -5,7 +5,7 @@ import { catchError } from 'rxjs/operators';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
-import { ConfigActionCreator, StoreConfig } from '../config';
+import { ConfigActionCreator } from '../config';
 import { FormFieldsActionCreator } from '../form';
 
 import Checkout, { CheckoutRequestBody } from './checkout';

--- a/packages/core/src/shipping/consignment-action-creator.spec.ts
+++ b/packages/core/src/shipping/consignment-action-creator.spec.ts
@@ -875,12 +875,6 @@ describe('consignmentActionCreator', () => {
                 data: [consignment],
             };
 
-            if (configState.data && configState.data.storeConfig.checkoutSettings.features) {
-                configState.data.storeConfig.checkoutSettings.features = {
-                    'CHECKOUT-8999.remove_duplicate_shipping_option_call': true,
-                };
-            }
-
             const stateWithExperiment = {
                 ...state,
                 config: configState,

--- a/packages/core/src/shipping/consignment-action-creator.ts
+++ b/packages/core/src/shipping/consignment-action-creator.ts
@@ -2,8 +2,6 @@ import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-
 import { find } from 'lodash';
 import { Observable, Observer } from 'rxjs';
 
-import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
-
 import { AddressRequestBody } from '../address';
 import { Cart } from '../cart';
 import {
@@ -360,25 +358,17 @@ export default class ConsignmentActionCreator {
         return (store) =>
             Observable.create((observer: Observer<UpdateShippingOptionAction>) => {
                 const checkout = store.getState().checkout.getCheckout();
-                const { checkoutSettings } = store.getState().config.getStoreConfigOrThrow();
 
-                if (
-                    isExperimentEnabled(
-                        checkoutSettings.features,
-                        'CHECKOUT-8999.remove_duplicate_shipping_option_call',
-                    )
-                ) {
-                    const consignmentInMemory = store
-                        .getState()
-                        .consignments.getConsignmentById(consignment.id);
+                const consignmentInMemory = store
+                    .getState()
+                    .consignments.getConsignmentById(consignment.id);
 
-                    const alreadySelectedOptionId = consignmentInMemory?.selectedShippingOption?.id;
+                const alreadySelectedOptionId = consignmentInMemory?.selectedShippingOption?.id;
 
-                    if (alreadySelectedOptionId === consignment.shippingOptionId) {
-                        observer.complete();
+                if (alreadySelectedOptionId === consignment.shippingOptionId) {
+                    observer.complete();
 
-                        return;
-                    }
+                    return;
                 }
 
                 if (!checkout || !checkout.id) {

--- a/packages/core/src/spam-protection/spam-protection-action-creator.spec.ts
+++ b/packages/core/src/spam-protection/spam-protection-action-creator.spec.ts
@@ -131,12 +131,6 @@ describe('SpamProtectionActionCreator', () => {
         it('emits actions if able to execute spam protection again', async () => {
             const configState = getConfigState();
 
-            if (configState.data && configState.data.storeConfig.checkoutSettings.features) {
-                configState.data.storeConfig.checkoutSettings.features = {
-                    'CHECKOUT-8264.recaptcha_error_fix': true,
-                };
-            }
-
             const stateWithExperiment = {
                 ...state,
                 config: configState,

--- a/packages/core/src/spam-protection/spam-protection-action-creator.ts
+++ b/packages/core/src/spam-protection/spam-protection-action-creator.ts
@@ -23,12 +23,6 @@ export default class SpamProtectionActionCreator {
         options?: SpamProtectionOptions,
     ): ThunkAction<SpamProtectionAction, InternalCheckoutSelectors> {
         return (store) => {
-            const state = store.getState();
-            const isRecaptchaResetExperimentEnabled =
-                state.config.getConfig()?.storeConfig.checkoutSettings.features[
-                    'CHECKOUT-8264.recaptcha_error_fix'
-                ] ?? false;
-
             return concat(
                 of(createAction(SpamProtectionActionType.InitializeRequested, undefined)),
                 defer(async () => {
@@ -36,12 +30,10 @@ export default class SpamProtectionActionCreator {
                         ? options.containerId
                         : 'spamProtectionContainer';
 
-                    if (isRecaptchaResetExperimentEnabled) {
-                        const element = document.getElementById(spamProtectionElementId);
+                    const element = document.getElementById(spamProtectionElementId);
 
-                        if (element) {
-                            this._googleRecaptcha.reset(spamProtectionElementId);
-                        }
+                    if (element) {
+                        this._googleRecaptcha.reset(spamProtectionElementId);
                     }
 
                     if (!options && !document.getElementById(spamProtectionElementId)) {


### PR DESCRIPTION
## What/Why?
Remove following rolled out experiments
- CHECKOUT-8183_set_shouldSaveAddress_false_for_existing_address
- CHECKOUT-8392_fix_billing_creation_in_checkout
- CHECKOUT-8264_recaptcha_error_fix
- CHECKOUT-8999.remove_duplicate_shipping_option_call

## Rollout/Rollback
- revert this PR

## Testing
- CI