### PR TITLE
feat(payment): Stripe Upe allow_redirect added

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -1230,6 +1230,7 @@ describe('StripeUPEPaymentStrategy', () => {
                 expect(stripeUPEIntegrationService.mapStripePaymentData).toHaveBeenCalledWith(
                     expect.any(Object),
                     'redirect.url',
+                    true,
                 );
                 expect(stripeUPEJsMock.confirmPayment).toHaveBeenCalledTimes(1);
                 expect(stripeUPEJsMock.retrievePaymentIntent).not.toHaveBeenCalled();
@@ -1317,6 +1318,7 @@ describe('StripeUPEPaymentStrategy', () => {
                 expect(stripeUPEIntegrationService.mapStripePaymentData).toHaveBeenCalledWith(
                     expect.any(Object),
                     'redirect.url',
+                    true,
                 );
                 expect(stripeUPEJsMock.retrievePaymentIntent).toHaveBeenCalledTimes(1);
                 expect(stripeUPEJsMock.retrievePaymentIntent).toHaveBeenCalledWith(

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.ts
@@ -56,6 +56,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
     private _stripeUPEClient?: StripeClient;
     private _stripeElements?: StripeElements;
     private _isStripeElementUpdateEnabled?: boolean;
+    private _allowRedisplayForStoredInstruments?: boolean;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
@@ -243,7 +244,9 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         }
 
         const { clientToken, initializationData } = paymentMethod;
-        const { shopperLanguage } = initializationData;
+        const { shopperLanguage, allowRedisplayForStoredInstruments = false } = initializationData;
+
+        this._allowRedisplayForStoredInstruments = allowRedisplayForStoredInstruments;
 
         if (!clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
@@ -364,6 +367,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         const stripePaymentData = this.stripeIntegrationService.mapStripePaymentData(
             this._stripeElements,
             redirect_url,
+            !!this._allowRedisplayForStoredInstruments,
         );
         let stripeError: StripeError | undefined;
 

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe.mock.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe.mock.ts
@@ -26,6 +26,7 @@ export function getStripeUPEMock(method = 'card'): PaymentMethod {
             stripeConnectedAccount: 'key',
             browserLanguageEnabled: false,
             shopperLanguage: 'en',
+            allowRedisplayForStoredInstruments: true,
         },
         type: 'PAYMENT_TYPE_API',
         clientToken: 'clientToken',

--- a/packages/stripe-integration/src/stripe-utils/stripe-integration-service.spec.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe-integration-service.spec.ts
@@ -1,5 +1,4 @@
 import {
-    BillingAddress,
     MissingDataError,
     NotInitializedError,
     PaymentInitializeOptions,
@@ -627,14 +626,44 @@ describe('StripeIntegrationService', () => {
             });
         });
 
-        it('returns mapped payment data without state code', () => {
-            jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue({
-                ...getBillingAddress(),
-                stateOrProvinceCode: undefined,
-            } as unknown as BillingAddress);
-
+        it('returns mapped payment data with allow_redisplay: always', () => {
             expect(
-                stripeIntegrationService.mapStripePaymentData(stripeElementsMock, 'redirect.url'),
+                stripeIntegrationService.mapStripePaymentData(
+                    stripeElementsMock,
+                    'redirect.url',
+                    true,
+                ),
+            ).toEqual({
+                elements: stripeElementsMock,
+                redirect: 'if_required',
+                confirmParams: {
+                    payment_method_data: {
+                        allow_redisplay: 'always',
+                        billing_details: {
+                            email: 'test@bigcommerce.com',
+                            address: {
+                                city: 'Some City',
+                                country: 'US',
+                                line1: '12345 Testing Way',
+                                line2: '',
+                                postal_code: '95555',
+                                state: 'CA',
+                            },
+                            name: 'Test Tester',
+                        },
+                    },
+                    return_url: 'redirect.url',
+                },
+            });
+        });
+
+        it('returns mapped payment data without allow_redisplay: always', () => {
+            expect(
+                stripeIntegrationService.mapStripePaymentData(
+                    stripeElementsMock,
+                    'redirect.url',
+                    false,
+                ),
             ).toEqual({
                 elements: stripeElementsMock,
                 redirect: 'if_required',
@@ -648,6 +677,7 @@ describe('StripeIntegrationService', () => {
                                 line1: '12345 Testing Way',
                                 line2: '',
                                 postal_code: '95555',
+                                state: 'CA',
                             },
                             name: 'Test Tester',
                         },

--- a/packages/stripe-integration/src/stripe-utils/stripe-integration-service.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe-integration-service.ts
@@ -170,6 +170,7 @@ export default class StripeIntegrationService {
     mapStripePaymentData(
         stripeElements?: StripeElements,
         returnUrl?: string,
+        shouldAllowRedisplay = false,
     ): StripeConfirmPaymentData {
         const billingAddress = this.paymentIntegrationService.getState().getBillingAddress();
         const { firstName, lastName, email } = billingAddress || {};
@@ -188,6 +189,7 @@ export default class StripeIntegrationService {
             redirect: StripeStringConstants.IF_REQUIRED,
             confirmParams: {
                 payment_method_data: {
+                    ...(shouldAllowRedisplay ? { allow_redisplay: 'always' } : {}),
                     billing_details: {
                         email,
                         address,

--- a/packages/stripe-integration/src/stripe-utils/stripe.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe.ts
@@ -286,6 +286,7 @@ export interface BillingDetailsProperties {
  */
 export interface PaymentMethodDataOptions {
     billing_details: BillingDetailsOptions;
+    allow_redisplay?: 'always' | 'limited' | 'unspecified';
 }
 
 /**
@@ -619,6 +620,7 @@ export interface StripeInitializationData {
     shopperLanguage: string;
     customerSessionToken?: string;
     enableLink?: boolean;
+    allowRedisplayForStoredInstruments?: boolean;
 }
 
 export interface StripeElementUpdateOptions {


### PR DESCRIPTION
## What?
Added `allow_redirect` field on stripe confirmation method.
Related PR:
https://github.com/bigcommerce/bigcommerce/pull/64783

## Why?
To make possible to transfer vaulted cards from UPE to OCS.

## Testing / Proof
Manual testing

@bigcommerce/team-checkout @bigcommerce/team-payments
