### PR TITLE
fix(payment): Stripe OCS fix token property in payload

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -1264,6 +1264,9 @@ describe('StripeOCSPaymentStrategy', () => {
                 card: {
                     setup_future_usage: StripeInstrumentSetupFutureUsage.ON_SESSION,
                 },
+                us_bank_account: {
+                    verification_method: 'automatic',
+                },
             });
 
             await stripeOCSPaymentStrategy.initialize(stripeOptions);

--- a/packages/stripe-integration/src/stripe-utils/stripe.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe.ts
@@ -65,6 +65,7 @@ export interface PaymentIntent {
 
 export interface StripePIPaymentMethodSavingOptions {
     setup_future_usage?: StripeInstrumentSetupFutureUsage;
+    verification_method?: string;
 }
 
 export interface StripePIPaymentMethodOptions {


### PR DESCRIPTION
## What?
Fix issue with Credit Card vaulting token

## Why?
Incorrect token payload was send to payments confirmation request.

## Testing / Proof
Before:
<img width="1304" height="620" alt="Screenshot 2025-09-04 at 18 20 16" src="https://github.com/user-attachments/assets/6f2c9f2f-e6a2-4019-8e4f-3e9750f11864" />


After:
<img width="1308" height="599" alt="Screenshot 2025-09-04 at 18 17 22" src="https://github.com/user-attachments/assets/49c0d2f8-d530-483d-b4cd-93857fbd15d0" />


@bigcommerce/team-checkout @bigcommerce/team-payments
