### PR TITLE
feat(payment): PAYPAL-5875 covered shipping callbacks with experiment

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -62,6 +62,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
     const paypalCommerceSdkRenderMock = jest.fn();
 
     const buyNowCartRequestBody = getBuyNowCartRequestBody();
+    const storeConfig = getConfig().storeConfig;
 
     const buyNowPayPalCommerceCreditOptions: PayPalCommerceCreditButtonInitializeOptions = {
         buyNowInitializeOptions: {
@@ -187,6 +188,17 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         jest.spyOn(payPalMessagesSdk, 'Messages').mockImplementation(() => ({
             render: paypalCommerceSdkRenderMock,
         }));
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfigOrThrow').mockReturnValue({
+            ...storeConfig,
+            checkoutSettings: {
+                ...storeConfig.checkoutSettings,
+                features: {
+                    ...storeConfig.checkoutSettings.features,
+                    'PAYPAL-5716.app_switch_functionality': false,
+                },
+            },
+        });
 
         jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
             (options: PayPalCommerceButtonsOptions) => {
@@ -443,6 +455,19 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         });
 
         it('initializes PayPal button to render (with shipping options feature enabled)', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': false,
+                    },
+                },
+            });
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
                 initializationData: {
@@ -464,6 +489,43 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('initializes PayPal button to render without shipping options when appSwitch enabled', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': true,
+                    },
+                },
+            });
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYLATER,
+                style: paypalCommerceCreditOptions.style,
+                createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });
@@ -893,7 +955,6 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         });
 
         it('do not render PayPal message if experiment is enabled', async () => {
-            const storeConfig = getConfig().storeConfig;
             const storeConfigWithFeaturesOn = {
                 ...storeConfig,
                 checkoutSettings: {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -11,6 +11,7 @@ import {
     getBuyNowCart,
     getBuyNowCartRequestBody,
     getCart,
+    getConfig,
     getConsignment,
     getShippingOption,
     PaymentIntegrationServiceMock,
@@ -68,6 +69,8 @@ describe('PayPalCommerceButtonStrategy', () => {
         containerId: defaultButtonContainerId,
         paypalcommerce: buyNowPayPalCommerceOptions,
     };
+
+    const storeConfig = getConfig().storeConfig;
 
     const paypalCommerceOptions: PayPalCommerceButtonInitializeOptions = {
         style: {
@@ -392,6 +395,19 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
 
         it('initializes PayPal button to render (with shipping options feature enabled)', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': false,
+                    },
+                },
+            });
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
                 initializationData: {
@@ -413,6 +429,43 @@ describe('PayPalCommerceButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('initializes PayPal button to render without shipping options when appSwitch enabled', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': true,
+                    },
+                },
+            });
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYPAL,
+                style: paypalCommerceOptions.style,
+                createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });
@@ -692,6 +745,19 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
 
         it('updates billing and shipping address with data returned from PayPal', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': false,
+                    },
+                },
+            });
             const address = {
                 firstName: '',
                 lastName: '',
@@ -721,6 +787,19 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
 
         it('selects shipping option after address update', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': false,
+                    },
+                },
+            });
             await strategy.initialize(initializationOptions);
 
             eventEmitter.emit('onShippingAddressChange');
@@ -734,6 +813,19 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
 
         it('updates PayPal order after shipping option selection', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': false,
+                    },
+                },
+            });
             const consignment = getConsignment();
 
             // INFO: lets imagine that it is a state that we get after consignmentActionCreator.selectShippingOption call
@@ -769,6 +861,19 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
 
         it('selects shipping option', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': false,
+                    },
+                },
+            });
             await strategy.initialize(initializationOptions);
 
             eventEmitter.emit('onShippingOptionsChange');
@@ -782,6 +887,19 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
 
         it('updates PayPal order', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': false,
+                    },
+                },
+            });
             await strategy.initialize(initializationOptions);
 
             eventEmitter.emit('onShippingOptionsChange');

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -8,6 +8,7 @@ import {
     PaymentMethod,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
+    getConfig,
     getConsignment,
     getShippingOption,
     PaymentIntegrationServiceMock,
@@ -55,6 +56,8 @@ describe('PayPalCommerceCustomerStrategy', () => {
         paypalcommerce: paypalCommerceOptions,
     };
 
+    const storeConfig = getConfig().storeConfig;
+
     beforeEach(() => {
         eventEmitter = new EventEmitter();
         paymentMethod = getPayPalCommercePaymentMethod();
@@ -98,6 +101,17 @@ describe('PayPalCommerceCustomerStrategy', () => {
         jest.spyOn(paypalCommerceIntegrationService, 'getShippingOptionOrThrow').mockReturnValue(
             getShippingOption(),
         );
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfigOrThrow').mockReturnValue({
+            ...storeConfig,
+            checkoutSettings: {
+                ...storeConfig.checkoutSettings,
+                features: {
+                    ...storeConfig.checkoutSettings.features,
+                    'PAYPAL-5716.app_switch_functionality': false,
+                },
+            },
+        });
 
         jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
             (options: PayPalCommerceButtonsOptions) => {
@@ -280,6 +294,19 @@ describe('PayPalCommerceCustomerStrategy', () => {
         it('initializes paypal buttons with config related to hosted checkout feature', async () => {
             jest.spyOn(
                 paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': false,
+                    },
+                },
+            });
+            jest.spyOn(
+                paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',
             ).mockReturnValue({
                 ...paymentMethod,
@@ -301,6 +328,46 @@ describe('PayPalCommerceCustomerStrategy', () => {
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+                onClick: expect.any(Function),
+            });
+        });
+
+        it('initializes paypal buttons without shipping callbacks what appSwitch enabled', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PAYPAL-5716.app_switch_functionality': true,
+                    },
+                },
+            });
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYPAL,
+                style: {
+                    height: DefaultCheckoutButtonHeight,
+                    color: StyleButtonColor.silver,
+                    label: 'checkout',
+                },
+                createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
             });


### PR DESCRIPTION
## What/Why?
Covered shipping callbacks with experiment to turn them off when appSwitch enabled

## Rollout/Rollback
Revert

## Testing
Unit tests
