### PR TITLE
feat(payment): PAYPAL-5743 Create paypal-button-creation-service.ts in the paypal-utils package

### DIFF
--- a/packages/paypal-utils/src/paypal-button-creation-service.spec.ts
+++ b/packages/paypal-utils/src/paypal-button-creation-service.spec.ts
@@ -1,0 +1,560 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+
+import {
+    InvalidArgumentError,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getConsignment,
+    getShippingOption,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import {
+    getBillingAddressFromOrderDetails,
+    getPayPalOrderDetails,
+    getPayPalSDKMock,
+    getShippingAddressFromOrderDetails,
+} from './mocks';
+import PaypalButtonCreationService from './paypal-button-creation-service';
+import PayPalIntegrationService from './paypal-integration-service';
+import PayPalRequestSender from './paypal-request-sender';
+import PayPalSdkLoader from './paypal-sdk-script-loader';
+import { PayPalButtonsOptions, PayPalSDK, StyleButtonColor } from './paypal-types';
+
+describe('PayPalButtonCreationService', () => {
+    let formPoster: FormPoster;
+    let requestSender: RequestSender;
+    let eventEmitter: EventEmitter;
+    let paypalRequestSender: PayPalRequestSender;
+    let paypalSdkLoader: PayPalSdkLoader;
+    let paypalButtonCreationService: PaypalButtonCreationService;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let paypalIntegrationService: PayPalIntegrationService;
+    let paypalSdk: PayPalSDK;
+
+    const paypalOrderId = 'ORDER_ID';
+    const defaultMethodId = 'paypalcommercecredit';
+
+    const paypalShippingAddressPayloadMock = {
+        city: 'New York',
+        countryCode: 'US',
+        postalCode: '07564',
+        state: 'New York',
+    };
+
+    const paypalSelectedShippingOptionPayloadMock = {
+        amount: {
+            currency_code: 'USD',
+            value: '100',
+        },
+        id: '1',
+        label: 'Free shipping',
+        selected: true,
+        type: 'type_shipping',
+    };
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        formPoster = createFormPoster();
+        eventEmitter = new EventEmitter();
+        requestSender = createRequestSender();
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        paypalRequestSender = new PayPalRequestSender(requestSender);
+        paypalSdkLoader = new PayPalSdkLoader(getScriptLoader());
+
+        paypalSdk = getPayPalSDKMock();
+
+        paypalIntegrationService = new PayPalIntegrationService(
+            formPoster,
+            paymentIntegrationService,
+            paypalRequestSender,
+            paypalSdkLoader,
+        );
+
+        jest.spyOn(paypalIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalIntegrationService, 'createOrder');
+        jest.spyOn(paypalIntegrationService, 'tokenizePayment').mockImplementation(jest.fn());
+        jest.spyOn(paymentIntegrationService, 'updateBillingAddress').mockImplementation(jest.fn());
+        jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockImplementation(
+            jest.fn(),
+        );
+        jest.spyOn(paymentIntegrationService, 'selectShippingOption').mockImplementation(jest.fn());
+
+        jest.spyOn(paypalIntegrationService, 'getBillingAddressFromOrderDetails').mockReturnValue(
+            getBillingAddressFromOrderDetails(),
+        );
+        jest.spyOn(paypalIntegrationService, 'getShippingAddressFromOrderDetails').mockReturnValue(
+            getShippingAddressFromOrderDetails(),
+        );
+        jest.spyOn(paypalIntegrationService, 'updateOrder').mockImplementation(jest.fn());
+        jest.spyOn(paypalIntegrationService, 'submitPayment').mockImplementation(jest.fn());
+        jest.spyOn(paypalIntegrationService, 'getShippingOptionOrThrow').mockReturnValue(
+            getShippingOption(),
+        );
+
+        paypalButtonCreationService = new PaypalButtonCreationService(
+            paymentIntegrationService,
+            paypalIntegrationService,
+        );
+
+        jest.spyOn(paypalSdk, 'Buttons').mockImplementation((options: PayPalButtonsOptions) => {
+            eventEmitter.on('createOrder', () => {
+                if (options.createOrder) {
+                    options.createOrder();
+                }
+            });
+
+            eventEmitter.on(
+                'onClick',
+                // eslint-disable-next-line @typescript-eslint/no-misused-promises
+                async (jestSuccessExpectationsCallback, jestFailureExpectationsCallback) => {
+                    try {
+                        if (options.onClick) {
+                            await options.onClick(
+                                { fundingSource: 'PAYLATER' },
+                                {
+                                    reject: jest.fn(),
+                                    resolve: jest.fn(),
+                                },
+                            );
+
+                            if (
+                                jestSuccessExpectationsCallback &&
+                                typeof jestSuccessExpectationsCallback === 'function'
+                            ) {
+                                jestSuccessExpectationsCallback();
+                            }
+                        }
+                    } catch (error) {
+                        if (
+                            jestFailureExpectationsCallback &&
+                            typeof jestFailureExpectationsCallback === 'function'
+                        ) {
+                            jestFailureExpectationsCallback(error);
+                        }
+                    }
+                },
+            );
+
+            eventEmitter.on('onApprove', () => {
+                if (options.onApprove) {
+                    options.onApprove(
+                        { orderID: paypalOrderId },
+                        {
+                            order: {
+                                get: jest.fn(),
+                            },
+                        },
+                    );
+                }
+            });
+
+            eventEmitter.on('onCancel', () => {
+                if (options.onCancel) {
+                    options.onCancel();
+                }
+            });
+
+            eventEmitter.on('onShippingAddressChange', () => {
+                if (options.onShippingAddressChange) {
+                    options.onShippingAddressChange({
+                        orderId: paypalOrderId,
+                        shippingAddress: paypalShippingAddressPayloadMock,
+                    });
+                }
+            });
+
+            eventEmitter.on('onShippingOptionsChange', () => {
+                if (options.onShippingOptionsChange) {
+                    options.onShippingOptionsChange({
+                        orderId: paypalOrderId,
+                        selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
+                    });
+                }
+            });
+
+            return {
+                isEligible: jest.fn(() => true),
+                render: jest.fn(),
+                close: jest.fn(),
+            };
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('create paypal button with required options', () => {
+        paypalButtonCreationService.createPayPalButton('paypalcommerce', 'paypalcommercecredit', {
+            fundingSource: paypalSdk.FUNDING.PAYLATER,
+        });
+
+        expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+            fundingSource: paypalSdk.FUNDING.PAYLATER,
+            createOrder: expect.any(Function),
+            onApprove: expect.any(Function),
+            style: {
+                height: 40,
+            },
+        });
+    });
+
+    it('create PayPal button with the option to set the style', () => {
+        const styleOption = {
+            height: 45,
+            color: StyleButtonColor.gold,
+        };
+
+        paypalButtonCreationService.createPayPalButton('paypalcommerce', 'paypalcommercecredit', {
+            fundingSource: paypalSdk.FUNDING.PAYLATER,
+            style: styleOption,
+        });
+
+        expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+            fundingSource: paypalSdk.FUNDING.PAYLATER,
+            style: styleOption,
+            createOrder: expect.any(Function),
+            onApprove: expect.any(Function),
+        });
+    });
+
+    it('create PayPal button with onClick callback support', async () => {
+        const onClick = jest.fn();
+
+        paypalButtonCreationService.createPayPalButton('paypalcommerce', 'paypalcommercecredit', {
+            fundingSource: paypalSdk.FUNDING.PAYLATER,
+            onClick,
+        });
+
+        eventEmitter.emit('onClick');
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(onClick).toHaveBeenCalled();
+
+        expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+            fundingSource: paypalSdk.FUNDING.PAYLATER,
+            onClick,
+            createOrder: expect.any(Function),
+            onApprove: expect.any(Function),
+            style: {
+                height: 40,
+            },
+        });
+    });
+
+    it('create PayPal button with onCancel callback support', async () => {
+        const onCancel = jest.fn();
+
+        paypalButtonCreationService.createPayPalButton('paypalcommerce', 'paypalcommercecredit', {
+            fundingSource: paypalSdk.FUNDING.PAYLATER,
+            onCancel,
+        });
+
+        eventEmitter.emit('onCancel');
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(onCancel).toHaveBeenCalled();
+
+        expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+            fundingSource: paypalSdk.FUNDING.PAYLATER,
+            onCancel,
+            createOrder: expect.any(Function),
+            onApprove: expect.any(Function),
+            style: {
+                height: 40,
+            },
+        });
+    });
+
+    it('creates paypal order', async () => {
+        paypalButtonCreationService.createPayPalButton('paypalcommerce', 'paypalcommercecredit', {
+            fundingSource: paypalSdk.FUNDING.PAYLATER,
+        });
+
+        eventEmitter.emit('createOrder');
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(paypalIntegrationService.createOrder).toHaveBeenCalledWith('paypalcommerce');
+    });
+
+    it('throw an error if fundingSource is not valid', () => {
+        const onCancel = jest.fn();
+
+        try {
+            paypalButtonCreationService.createPayPalButton(
+                'paypalcommerce',
+                'paypalcommercecredit',
+                {
+                    fundingSource: 'not-valid-funding-source',
+                    onCancel,
+                },
+            );
+        } catch (e) {
+            expect(e).toBeInstanceOf(InvalidArgumentError);
+        }
+    });
+
+    describe('create PayPal button with onApprove callback support', () => {
+        describe('default flow', () => {
+            it('tokenizes payment on paypal approve', async () => {
+                paypalButtonCreationService.createPayPalButton(
+                    'paypalcommerce',
+                    'paypalcommercecredit',
+                    {
+                        fundingSource: paypalSdk.FUNDING.PAYLATER,
+                    },
+                );
+
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paypalIntegrationService.tokenizePayment).toHaveBeenCalledWith(
+                    defaultMethodId,
+                    paypalOrderId,
+                );
+            });
+        });
+
+        describe('when isHostedCheckoutEnabled is true', () => {
+            const paypalOrderDetails = getPayPalOrderDetails();
+            const getMock = jest.fn(() => Promise.resolve(paypalOrderDetails));
+            const onPaymentComplete = jest.fn();
+
+            beforeEach(() => {
+                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                    (options: PayPalButtonsOptions) => {
+                        eventEmitter.on('onApprove', () => {
+                            if (options.onApprove) {
+                                options.onApprove(
+                                    { orderID: paypalOrderId },
+                                    {
+                                        order: {
+                                            get: getMock,
+                                        },
+                                    },
+                                );
+                            }
+                        });
+
+                        return {
+                            render: jest.fn(),
+                            isEligible: jest.fn(() => true),
+                            close: jest.fn(),
+                        };
+                    },
+                );
+
+                paypalButtonCreationService.createPayPalButton(
+                    'paypalcommerce',
+                    'paypalcommercecredit',
+                    {
+                        fundingSource: paypalSdk.FUNDING.PAYLATER,
+                        onPaymentComplete,
+                    },
+                    true,
+                );
+            });
+
+            it('call onPaymentComplete when order is completed', async () => {
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paypalIntegrationService.submitPayment).toHaveBeenCalled();
+                expect(onPaymentComplete).toHaveBeenCalled();
+            });
+
+            it('takes order details data from paypal', async () => {
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(getMock).toHaveBeenCalled();
+            });
+
+            it('updates billing address with valid customers data', async () => {
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(
+                    paypalIntegrationService.getBillingAddressFromOrderDetails,
+                ).toHaveBeenCalledWith(getPayPalOrderDetails());
+                expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith(
+                    getBillingAddressFromOrderDetails(),
+                );
+            });
+
+            it('updates shipping address with valid customers data if physical items are available in the cart', async () => {
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(
+                    paypalIntegrationService.getShippingAddressFromOrderDetails,
+                ).toHaveBeenCalledWith(getPayPalOrderDetails());
+                expect(paymentIntegrationService.updateShippingAddress).toHaveBeenCalledWith(
+                    getShippingAddressFromOrderDetails(),
+                );
+            });
+
+            it('submits BC order with provided methodId', async () => {
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                    {},
+                    {
+                        params: {
+                            methodId: 'paypalcommercecredit',
+                        },
+                    },
+                );
+            });
+
+            it('submits BC payment to update BC order data', async () => {
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paypalIntegrationService.submitPayment).toHaveBeenCalledWith(
+                    defaultMethodId,
+                    paypalOrderId,
+                );
+            });
+        });
+    });
+
+    describe('create PayPal button with onShippingAddressChange callback support', () => {
+        it('updates billing and shipping address with data returned from PayPal', async () => {
+            const address = {
+                firstName: '',
+                lastName: '',
+                email: '',
+                phone: '',
+                company: '',
+                address1: '',
+                address2: '',
+                city: paypalShippingAddressPayloadMock.city,
+                countryCode: paypalShippingAddressPayloadMock.countryCode,
+                postalCode: paypalShippingAddressPayloadMock.postalCode,
+                stateOrProvince: '',
+                stateOrProvinceCode: paypalShippingAddressPayloadMock.state,
+                customFields: [],
+            };
+
+            jest.spyOn(paypalIntegrationService, 'getAddress').mockReturnValue(address);
+
+            paypalButtonCreationService.createPayPalButton(
+                'paypalcommerce',
+                'paypalcommercecredit',
+                {
+                    fundingSource: paypalSdk.FUNDING.PAYLATER,
+                },
+                true,
+            );
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith(address);
+            expect(paymentIntegrationService.updateShippingAddress).toHaveBeenCalledWith(address);
+        });
+
+        it('selects shipping option after address update', async () => {
+            paypalButtonCreationService.createPayPalButton(
+                'paypalcommerce',
+                'paypalcommercecredit',
+                {
+                    fundingSource: paypalSdk.FUNDING.PAYLATER,
+                },
+                true,
+            );
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalIntegrationService.getShippingOptionOrThrow).toHaveBeenCalled();
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                getShippingOption().id,
+            );
+        });
+
+        it('updates PayPal order after shipping option selection', async () => {
+            const consignment = getConsignment();
+
+            // INFO: lets imagine that it is a state that we get after consignmentActionCreator.selectShippingOption call
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getConsignmentsOrThrow',
+            ).mockReturnValue([consignment]);
+
+            paypalButtonCreationService.createPayPalButton(
+                'paypalcommerce',
+                'paypalcommercecredit',
+                {
+                    fundingSource: paypalSdk.FUNDING.PAYLATER,
+                },
+                true,
+            );
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalIntegrationService.updateOrder).toHaveBeenCalledWith('paypalcommerce');
+        });
+    });
+
+    describe('#onShippingOptionsChange button callback', () => {
+        it('selects shipping option', async () => {
+            paypalButtonCreationService.createPayPalButton(
+                'paypalcommerce',
+                'paypalcommercecredit',
+                {
+                    fundingSource: paypalSdk.FUNDING.PAYLATER,
+                },
+                true,
+            );
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalIntegrationService.getShippingOptionOrThrow).toHaveBeenCalled();
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                getShippingOption().id,
+            );
+        });
+
+        it('updates PayPal order', async () => {
+            paypalButtonCreationService.createPayPalButton(
+                'paypalcommerce',
+                'paypalcommercecredit',
+                {
+                    fundingSource: paypalSdk.FUNDING.PAYLATER,
+                },
+                true,
+            );
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalIntegrationService.updateOrder).toHaveBeenCalledWith('paypalcommerce');
+        });
+    });
+});

--- a/packages/paypal-utils/src/paypal-button-creation-service.ts
+++ b/packages/paypal-utils/src/paypal-button-creation-service.ts
@@ -1,0 +1,165 @@
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import PayPalIntegrationService from './paypal-integration-service';
+import {
+    ApproveCallbackActions,
+    ApproveCallbackPayload,
+    PayPalButtonOptions,
+    PayPalButtons,
+    ShippingAddressChangeCallbackPayload,
+    ShippingOptionChangeCallbackPayload,
+} from './paypal-types';
+
+class PaypalButtonCreationService {
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private paypalIntegrationService: PayPalIntegrationService,
+    ) {}
+
+    createPayPalButton(
+        providerId: string,
+        methodId: string,
+        buttonOptions: PayPalButtonOptions,
+        isHostedCheckoutEnabled = false,
+    ): PayPalButtons {
+        const { style, fundingSource, onClick, onCancel, onPaymentComplete } = buttonOptions;
+
+        const paypalSdk = this.paypalIntegrationService.getPayPalSdkOrThrow();
+        const isAvailableFundingSource = Object.values(paypalSdk.FUNDING).includes(fundingSource);
+
+        if (!isAvailableFundingSource) {
+            throw new InvalidArgumentError(
+                `Unable to initialize PayPal button because "fundingSource" argument is not valid funding source.`,
+            );
+        }
+
+        const hostedCheckoutCallbacks = {
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                this.onShippingAddressChange(data, providerId),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                this.onShippingOptionsChange(data, providerId),
+            onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
+                this.onHostedCheckoutApprove(
+                    data,
+                    actions,
+                    methodId,
+                    providerId,
+                    onPaymentComplete,
+                ),
+        };
+
+        return paypalSdk.Buttons({
+            fundingSource,
+            style: this.paypalIntegrationService.getValidButtonStyle(style),
+            createOrder: () => this.paypalIntegrationService.createOrder(providerId),
+            onApprove: ({ orderID }: ApproveCallbackPayload) =>
+                this.paypalIntegrationService.tokenizePayment(methodId, orderID),
+            ...(onClick ? { onClick } : {}),
+            ...(onCancel ? { onCancel } : {}),
+            ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),
+        });
+    }
+
+    private async onHostedCheckoutApprove(
+        data: ApproveCallbackPayload,
+        actions: ApproveCallbackActions,
+        methodId: string,
+        providerId: string,
+        onComplete?: () => void,
+    ): Promise<boolean> {
+        if (!data.orderID) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        const state = this.paymentIntegrationService.getState();
+        const cart = state.getCartOrThrow();
+        const orderDetails = await actions.order.get();
+
+        try {
+            const billingAddress =
+                this.paypalIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
+
+            await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+
+            if (cart.lineItems.physicalItems.length > 0) {
+                const shippingAddress =
+                    this.paypalIntegrationService.getShippingAddressFromOrderDetails(orderDetails);
+
+                await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
+                await this.paypalIntegrationService.updateOrder(providerId);
+            }
+
+            await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
+            await this.paypalIntegrationService.submitPayment(methodId, data.orderID);
+
+            if (onComplete && typeof onComplete === 'function') {
+                onComplete();
+            }
+
+            return true; // FIXME: Do we really need to return true here?
+        } catch (error) {
+            if (typeof error === 'string') {
+                throw new Error(error);
+            }
+
+            throw error;
+        }
+    }
+
+    private async onShippingAddressChange(
+        data: ShippingAddressChangeCallbackPayload,
+        providerId: string,
+    ): Promise<void> {
+        const address = this.paypalIntegrationService.getAddress({
+            city: data.shippingAddress.city,
+            countryCode: data.shippingAddress.countryCode,
+            postalCode: data.shippingAddress.postalCode,
+            stateOrProvinceCode: data.shippingAddress.state,
+        });
+
+        try {
+            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
+            // on this stage we don't have access to valid customer's address accept shipping data
+            await this.paymentIntegrationService.updateBillingAddress(address);
+            await this.paymentIntegrationService.updateShippingAddress(address);
+
+            const shippingOption = this.paypalIntegrationService.getShippingOptionOrThrow();
+
+            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+            await this.paypalIntegrationService.updateOrder(providerId);
+        } catch (error) {
+            if (typeof error === 'string') {
+                throw new Error(error);
+            }
+
+            throw error;
+        }
+    }
+
+    private async onShippingOptionsChange(
+        data: ShippingOptionChangeCallbackPayload,
+        providerId: string,
+    ): Promise<void> {
+        const shippingOption = this.paypalIntegrationService.getShippingOptionOrThrow(
+            data.selectedShippingOption.id,
+        );
+
+        try {
+            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+            await this.paypalIntegrationService.updateOrder(providerId);
+        } catch (error) {
+            if (typeof error === 'string') {
+                throw new Error(error);
+            }
+
+            throw error;
+        }
+    }
+}
+
+export default PaypalButtonCreationService;

--- a/packages/paypal-utils/src/paypal-types.ts
+++ b/packages/paypal-utils/src/paypal-types.ts
@@ -524,6 +524,14 @@ export interface PayPalButtonStyleOptions {
     label?: StyleButtonLabel;
 }
 
+export interface PayPalButtonOptions {
+    fundingSource: string;
+    style?: PayPalButtonStyleOptions;
+    onClick?: () => void;
+    onCancel?: () => void;
+    onPaymentComplete?: () => void;
+}
+
 /**
  *
  * PayPal Messages


### PR DESCRIPTION
## What/Why?

Created `paypal-button-creation-service.ts` in the `paypal-utils` package that will contain `createPayPalButton` method with paypal button creation code.

This service was created to prevent code duplication associated with PayPal button creation methods and to optimize the following strategies:

packages/paypal-commerce-integration

```
paypal-commerce
    paypal-commerce-button-strategy.ts
    paypal-commerce-customer-strategy.ts

paypal-commerce-alternative-methods
    paypal-commerce-alternative-methods-button-strategy.ts

paypal-commerce-credit
    paypal-commerce-credit-button-strategy.ts
    paypal-commerce-credit-customer-strategy.ts

paypal-commerce-venmo
    paypal-commerce-venmo-button-strategy.ts
    paypal-commerce-venmo-customer-strategy.ts

```
packages/bigcommerce-payments-integration

```
bigcommerce-payments
    bigcommerce-payments-button-strategy.ts
    bigcommerce-payments-customer-strategy.ts

bigcommerce-payments-alternative-methods
    bigcommerce-payments-alternative-methods-button-strategy.ts

bigcommerce-payments-paylater
    bigcommerce-payments-paylater-button-strategy.ts
    bigcommerce-payments-paylater-customer-strategy.ts

bigcommerce-payments-venmo
    bigcommerce-payments-venmo-button-strategy.ts
    bigcommerce-payments-venmo-customer-strategy.ts

```
## Rollout/Rollback

Revert

## Testing

it is not integrated but anyway manual testing was done successfully
