### PR TITLE
fix(checkout): CHECKOUT-9506 Catch empty cart error message in mutation and return it to clients

### DIFF
--- a/packages/core/src/billing/billing-address-request-sender.spec.ts
+++ b/packages/core/src/billing/billing-address-request-sender.spec.ts
@@ -5,10 +5,11 @@ import {
     Response,
 } from '@bigcommerce/request-sender';
 
+import { EmptyCartError } from '../cart/errors';
 import { Checkout } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
-import { getResponse } from '../common/http-request/responses.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import BillingAddressRequestSender from './billing-address-request-sender';
 import { getBillingAddress } from './billing-addresses.mock';
@@ -75,6 +76,24 @@ describe('BillingAddressRequestSender', () => {
                 },
             );
         });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'put').mockReturnValue(Promise.reject(error));
+
+            await expect(
+                addressRequestSender.updateAddress('foo', getBillingAddress()),
+            ).rejects.toThrow(EmptyCartError);
+        });
     });
 
     describe('#createAddress()', () => {
@@ -117,6 +136,24 @@ describe('BillingAddressRequestSender', () => {
                     },
                 },
             );
+        });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
+
+            await expect(
+                addressRequestSender.createAddress('foo', getBillingAddress()),
+            ).rejects.toThrow(EmptyCartError);
         });
     });
 });

--- a/packages/core/src/cart/errors/empty-cart-error.spec.ts
+++ b/packages/core/src/cart/errors/empty-cart-error.spec.ts
@@ -1,0 +1,27 @@
+import EmptyCartError from './empty-cart-error';
+
+describe('EmptyCartError', () => {
+    it('returns error name and type', () => {
+        const error = new EmptyCartError();
+
+        expect(error.name).toBe('EmptyCartError');
+        expect(error.type).toBe('empty_cart');
+    });
+
+    it('returns default message when no custom message is provided', () => {
+        const error = new EmptyCartError();
+
+        expect(error.message).toBe(
+            'Your checkout could not be processed because your cart is empty. Please add items to your cart and try again.',
+        );
+    });
+
+    it('returns custom message when provided', () => {
+        const customMessage = 'Custom empty cart message';
+        const error = new EmptyCartError(customMessage);
+
+        expect(error.message).toBe(customMessage);
+        expect(error.name).toBe('EmptyCartError');
+        expect(error.type).toBe('empty_cart');
+    });
+});

--- a/packages/core/src/cart/errors/empty-cart-error.ts
+++ b/packages/core/src/cart/errors/empty-cart-error.ts
@@ -1,0 +1,16 @@
+import { StandardError } from '../../common/error/errors';
+
+/**
+ * This error is thrown when cart is removed or empty.
+ */
+export default class EmptyCartError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message ||
+                'Your checkout could not be processed because your cart is empty. Please add items to your cart and try again.',
+        );
+
+        this.name = 'EmptyCartError';
+        this.type = 'empty_cart';
+    }
+}

--- a/packages/core/src/cart/errors/index.ts
+++ b/packages/core/src/cart/errors/index.ts
@@ -1,3 +1,4 @@
 export { default as BuyNowCartCreationError } from './buy-now-cart-creation-error';
 export { default as CartChangedError } from './cart-changed-error';
 export { default as CartConsistencyError } from './cart-consistency-error';
+export { default as EmptyCartError } from './empty-cart-error';

--- a/packages/core/src/coupon/coupon-request-sender.spec.ts
+++ b/packages/core/src/coupon/coupon-request-sender.spec.ts
@@ -1,8 +1,9 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
+import { EmptyCartError } from '../cart/errors';
 import { getCheckoutWithCoupons } from '../checkout/checkouts.mock';
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
-import { getResponse } from '../common/http-request/responses.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import CouponRequestSender from './coupon-request-sender';
 
@@ -79,6 +80,24 @@ describe('Coupon Request Sender', () => {
                 },
             );
         });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
+
+            await expect(couponRequestSender.applyCoupon(checkoutId, couponCode)).rejects.toThrow(
+                EmptyCartError,
+            );
+        });
     });
 
     describe('#removeCoupon()', () => {
@@ -125,6 +144,24 @@ describe('Coupon Request Sender', () => {
                         include: defaultIncludes,
                     },
                 },
+            );
+        });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'delete').mockReturnValue(Promise.reject(error));
+
+            await expect(couponRequestSender.removeCoupon(checkoutId, couponCode)).rejects.toThrow(
+                EmptyCartError,
             );
         });
     });

--- a/packages/core/src/coupon/coupon-request-sender.ts
+++ b/packages/core/src/coupon/coupon-request-sender.ts
@@ -1,5 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
+import { EmptyCartError } from '../cart/errors';
 import { Checkout, CHECKOUT_DEFAULT_INCLUDES, CheckoutIncludes } from '../checkout';
 import {
     ContentType,
@@ -22,17 +23,25 @@ export default class CouponRequestSender {
             ...SDK_VERSION_HEADERS,
         };
 
-        return this._requestSender.post(url, {
-            headers,
-            timeout,
-            params: {
-                include: joinIncludes([
-                    ...CHECKOUT_DEFAULT_INCLUDES,
-                    CheckoutIncludes.AvailableShippingOptions,
-                ]),
-            },
-            body: { couponCode },
-        });
+        return this._requestSender
+            .post<Checkout>(url, {
+                headers,
+                timeout,
+                params: {
+                    include: joinIncludes([
+                        ...CHECKOUT_DEFAULT_INCLUDES,
+                        CheckoutIncludes.AvailableShippingOptions,
+                    ]),
+                },
+                body: { couponCode },
+            })
+            .catch((err) => {
+                if (err.body.type === 'empty_cart') {
+                    throw new EmptyCartError();
+                }
+
+                throw err;
+            });
     }
 
     removeCoupon(
@@ -46,15 +55,23 @@ export default class CouponRequestSender {
             ...SDK_VERSION_HEADERS,
         };
 
-        return this._requestSender.delete(url, {
-            headers,
-            timeout,
-            params: {
-                include: joinIncludes([
-                    ...CHECKOUT_DEFAULT_INCLUDES,
-                    CheckoutIncludes.AvailableShippingOptions,
-                ]),
-            },
-        });
+        return this._requestSender
+            .delete<Checkout>(url, {
+                headers,
+                timeout,
+                params: {
+                    include: joinIncludes([
+                        ...CHECKOUT_DEFAULT_INCLUDES,
+                        CheckoutIncludes.AvailableShippingOptions,
+                    ]),
+                },
+            })
+            .catch((err) => {
+                if (err.body.type === 'empty_cart') {
+                    throw new EmptyCartError();
+                }
+
+                throw err;
+            });
     }
 }

--- a/packages/core/src/coupon/gift-certificate-request-sender.spec.ts
+++ b/packages/core/src/coupon/gift-certificate-request-sender.spec.ts
@@ -1,8 +1,9 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
+import { EmptyCartError } from '../cart/errors';
 import { getCheckoutWithGiftCertificates } from '../checkout/checkouts.mock';
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
-import { getResponse } from '../common/http-request/responses.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import GiftCertificateRequestSender from './gift-certificate-request-sender';
 
@@ -90,6 +91,24 @@ describe('Gift Certificate Request Sender', () => {
                 },
             );
         });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
+
+            await expect(
+                giftCertificateRequestSender.applyGiftCertificate(checkoutId, giftCertificateCode),
+            ).rejects.toThrow(EmptyCartError);
+        });
     });
 
     describe('#removeGiftCertificate()', () => {
@@ -144,6 +163,24 @@ describe('Gift Certificate Request Sender', () => {
                     },
                 },
             );
+        });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'delete').mockReturnValue(Promise.reject(error));
+
+            await expect(
+                giftCertificateRequestSender.removeGiftCertificate(checkoutId, giftCertificateCode),
+            ).rejects.toThrow(EmptyCartError);
         });
     });
 });

--- a/packages/core/src/coupon/gift-certificate-request-sender.ts
+++ b/packages/core/src/coupon/gift-certificate-request-sender.ts
@@ -1,5 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
+import { EmptyCartError } from '../cart/errors';
 import { Checkout, CHECKOUT_DEFAULT_INCLUDES } from '../checkout';
 import {
     ContentType,
@@ -22,14 +23,22 @@ export default class GiftCertificateRequestSender {
             ...SDK_VERSION_HEADERS,
         };
 
-        return this._requestSender.post(url, {
-            headers,
-            timeout,
-            params: {
-                include: joinIncludes(CHECKOUT_DEFAULT_INCLUDES),
-            },
-            body: { giftCertificateCode },
-        });
+        return this._requestSender
+            .post<Checkout>(url, {
+                headers,
+                timeout,
+                params: {
+                    include: joinIncludes(CHECKOUT_DEFAULT_INCLUDES),
+                },
+                body: { giftCertificateCode },
+            })
+            .catch((err) => {
+                if (err.body.type === 'empty_cart') {
+                    throw new EmptyCartError();
+                }
+
+                throw err;
+            });
     }
 
     removeGiftCertificate(
@@ -43,12 +52,20 @@ export default class GiftCertificateRequestSender {
             ...SDK_VERSION_HEADERS,
         };
 
-        return this._requestSender.delete(url, {
-            headers,
-            timeout,
-            params: {
-                include: joinIncludes(CHECKOUT_DEFAULT_INCLUDES),
-            },
-        });
+        return this._requestSender
+            .delete<Checkout>(url, {
+                headers,
+                timeout,
+                params: {
+                    include: joinIncludes(CHECKOUT_DEFAULT_INCLUDES),
+                },
+            })
+            .catch((err) => {
+                if (err.body.type === 'empty_cart') {
+                    throw new EmptyCartError();
+                }
+
+                throw err;
+            });
     }
 }

--- a/packages/core/src/order/order-request-sender.spec.ts
+++ b/packages/core/src/order/order-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, createTimeout, Response } from '@bigcommerce/request-sender';
 
-import { CartConsistencyError } from '../cart/errors';
+import { CartConsistencyError, EmptyCartError } from '../cart/errors';
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
@@ -200,6 +200,27 @@ describe('OrderRequestSender', () => {
             await expect(orderRequestSender.submitOrder(payload)).rejects.toThrow(
                 InvalidShippingAddressError,
             );
+        });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
+
+            const payload = {
+                cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                useStoreCredit: false,
+            };
+
+            await expect(orderRequestSender.submitOrder(payload)).rejects.toThrow(EmptyCartError);
         });
 
         it('submits order and returns response with timeout', async () => {

--- a/packages/core/src/order/order-request-sender.ts
+++ b/packages/core/src/order/order-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 import { isNil, omitBy } from 'lodash';
 
-import { CartConsistencyError } from '../cart/errors';
+import { CartConsistencyError, EmptyCartError } from '../cart/errors';
 import {
     ContentType,
     joinIncludes,
@@ -82,6 +82,10 @@ export default class OrderRequestSender {
 
                 if (error.body.type === 'invalid_shipping_address') {
                     throw new InvalidShippingAddressError(error.body.detail);
+                }
+
+                if (error.body.type === 'empty_cart') {
+                    throw new EmptyCartError();
                 }
 
                 throw error;

--- a/packages/core/src/shipping/consignment-request-sender.spec.ts
+++ b/packages/core/src/shipping/consignment-request-sender.spec.ts
@@ -1,7 +1,9 @@
 import { createRequestSender, createTimeout } from '@bigcommerce/request-sender';
 
+import { EmptyCartError } from '../cart/errors';
 import { getCheckout } from '../checkout/checkouts.mock';
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
+import { getErrorResponse } from '../common/http-request/responses.mock';
 
 import ConsignmentRequestSender from './consignment-request-sender';
 import { getConsignmentRequestBody } from './consignments.mock';
@@ -117,6 +119,31 @@ describe('ConsignmentRequestSender', () => {
                 },
             );
         });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
+
+            await expect(
+                consignmentRequestSender.createConsignments(checkoutId, consignments, {
+                    ...options,
+                    params: {
+                        include: {
+                            'consignments.availableShippingOptions': false,
+                        },
+                    },
+                }),
+            ).rejects.toThrow(EmptyCartError);
+        });
     });
 
     describe('#updateConsignment()', () => {
@@ -184,6 +211,31 @@ describe('ConsignmentRequestSender', () => {
                 },
             );
         });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'put').mockReturnValue(Promise.reject(error));
+
+            await expect(
+                consignmentRequestSender.updateConsignment(checkoutId, consignment, {
+                    ...options,
+                    params: {
+                        include: {
+                            'consignments.availableShippingOptions': false,
+                        },
+                    },
+                }),
+            ).rejects.toThrow(EmptyCartError);
+        });
     });
 
     describe('#deleteConsignment()', () => {
@@ -220,6 +272,31 @@ describe('ConsignmentRequestSender', () => {
                     },
                 },
             );
+        });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'delete').mockReturnValue(Promise.reject(error));
+
+            await expect(
+                consignmentRequestSender.deleteConsignment(checkoutId, consignment.id, {
+                    ...options,
+                    params: {
+                        include: {
+                            'consignments.availableShippingOptions': false,
+                        },
+                    },
+                }),
+            ).rejects.toThrow(EmptyCartError);
         });
     });
 });

--- a/packages/core/src/shipping/consignment-request-sender.ts
+++ b/packages/core/src/shipping/consignment-request-sender.ts
@@ -1,5 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
+import { EmptyCartError } from '../cart/errors';
 import { Checkout, CheckoutParams } from '../checkout';
 import {
     ContentType,
@@ -33,14 +34,22 @@ export default class ConsignmentRequestSender {
             ...SDK_VERSION_HEADERS,
         };
 
-        return this._requestSender.post(url, {
-            body: consignments,
-            params: {
-                include: joinOrMergeIncludes(DEFAULT_INCLUDES, include),
-            },
-            headers,
-            timeout,
-        });
+        return this._requestSender
+            .post<Checkout>(url, {
+                body: consignments,
+                params: {
+                    include: joinOrMergeIncludes(DEFAULT_INCLUDES, include),
+                },
+                headers,
+                timeout,
+            })
+            .catch((err) => {
+                if (err.body.type === 'empty_cart') {
+                    throw new EmptyCartError();
+                }
+
+                throw err;
+            });
     }
 
     updateConsignment(
@@ -55,14 +64,22 @@ export default class ConsignmentRequestSender {
             ...SDK_VERSION_HEADERS,
         };
 
-        return this._requestSender.put(url, {
-            body,
-            params: {
-                include: joinOrMergeIncludes(DEFAULT_INCLUDES, include),
-            },
-            headers,
-            timeout,
-        });
+        return this._requestSender
+            .put<Checkout>(url, {
+                body,
+                params: {
+                    include: joinOrMergeIncludes(DEFAULT_INCLUDES, include),
+                },
+                headers,
+                timeout,
+            })
+            .catch((err) => {
+                if (err.body.type === 'empty_cart') {
+                    throw new EmptyCartError();
+                }
+
+                throw err;
+            });
     }
 
     deleteConsignment(
@@ -77,6 +94,14 @@ export default class ConsignmentRequestSender {
         };
         const include = joinIncludes(DEFAULT_INCLUDES);
 
-        return this._requestSender.delete(url, { params: { include }, headers, timeout });
+        return this._requestSender
+            .delete<Checkout>(url, { params: { include }, headers, timeout })
+            .catch((err) => {
+                if (err.body.type === 'empty_cart') {
+                    throw new EmptyCartError();
+                }
+
+                throw err;
+            });
     }
 }

--- a/packages/core/src/spam-protection/spam-protection-request-sender.spec.ts
+++ b/packages/core/src/spam-protection/spam-protection-request-sender.spec.ts
@@ -1,8 +1,9 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
+import { EmptyCartError } from '../cart/errors';
 import { getCheckout } from '../checkout/checkouts.mock';
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
-import { getResponse } from '../common/http-request/responses.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import SpamProtectionRequestSender from './spam-protection-request-sender';
 
@@ -66,6 +67,24 @@ describe('SpamProtection Request Sender', () => {
                         token,
                     },
                 },
+            );
+        });
+
+        it('throws `EmptyCartError` if error type is `empty_cart`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 422,
+                    title: 'The request could not process',
+                    type: 'empty_cart',
+                },
+                undefined,
+                409,
+            );
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
+
+            await expect(spamProtectionRequestSender.validate(checkoutId, token)).rejects.toThrow(
+                EmptyCartError,
             );
         });
     });

--- a/packages/core/src/spam-protection/spam-protection-request-sender.ts
+++ b/packages/core/src/spam-protection/spam-protection-request-sender.ts
@@ -1,5 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
+import { EmptyCartError } from '../cart/errors';
 import { Checkout } from '../checkout';
 import { ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
@@ -17,6 +18,14 @@ export default class SpamProtectionRequestSender {
             ...SDK_VERSION_HEADERS,
         };
 
-        return this._requestSender.post(url, { body: { token }, headers, timeout });
+        return this._requestSender
+            .post<Checkout>(url, { body: { token }, headers, timeout })
+            .catch((err) => {
+                if (err.body.type === 'empty_cart') {
+                    throw new EmptyCartError();
+                }
+
+                throw err;
+            });
     }
 }


### PR DESCRIPTION
## What/Why?
Catch empty cart error message in mutation and return it to clients

## Rollout/Rollback
- revert this PR

## Testing
- CI