### PR TITLE
feat(payment): Stripe OCS Link captureMethod added

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
@@ -46,7 +46,7 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
     private _amountTransformer?: AmountTransformer;
     private _onComplete?: (orderId?: number) => Promise<never>;
     private _loadingIndicatorContainer?: string;
-
+    private _captureMethod?: 'automatic' | 'manual';
     private _currencyCode?: string;
 
     constructor(
@@ -88,7 +88,9 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
         }
 
         const { initializationData } = paymentMethod;
+        const { captureMethod } = initializationData;
 
+        this._captureMethod = captureMethod;
         this._stripeClient = await this.scriptLoader.getStripeClient(initializationData);
 
         await this._mountExpressCheckoutElement(
@@ -153,6 +155,7 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
             mode: 'payment',
             amount: this._toCents(cartAmount),
             currency: this._getCurrency(),
+            ...(this._captureMethod ? { captureMethod: this._captureMethod } : {}),
         };
 
         this._stripeElements = stripeExpressCheckoutClient.elements(elementsOptions);

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs.mock.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs.mock.ts
@@ -21,6 +21,7 @@ export const defaultAccordionStyles: Record<string, string | number> = { fieldTe
 export function getStripeOCSMock(method = methodId): PaymentMethod {
     return {
         id: method,
+        skipRedirectConfirmationAlert: true,
         gateway: gatewayId,
         logoUrl: '',
         method,

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs.ts
@@ -58,5 +58,6 @@ export interface StripeLinkV2Options {
     clientSecret?: string;
     mode?: string;
     currency?: string;
+    captureMethod?: 'automatic' | 'manual';
     amount?: number;
 }

--- a/packages/stripe-integration/src/stripe-utils/stripe.ts
+++ b/packages/stripe-integration/src/stripe-utils/stripe.ts
@@ -622,6 +622,7 @@ export interface StripeInitializationData {
     customerSessionToken?: string;
     enableLink?: boolean;
     allowRedisplayForStoredInstruments?: boolean;
+    captureMethod?: 'automatic' | 'manual';
 }
 
 export interface StripeElementUpdateOptions {


### PR DESCRIPTION
## What/Why?
Passing captureMethod to the Stripe OCS Link configuration. To make possible perform auth only orders.

## Rollout/Rollback
Revert this PR.

## Testing
Manual testing.

https://github.com/user-attachments/assets/fe9cf731-f4c4-49df-963c-b79f88538c99

