### PR TITLE
CHECKOUT-9450: Increase resource class for linting task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
     
   lint:
     <<: *node_executor
-    resource_class: medium+
+    resource_class: large
     steps:
       - ci/pre-setup
       - node/npm-install


### PR DESCRIPTION
## What/Why?

Increase the resource size for the `lint` job in CircleCI so it doesn't run out of resources.

## Rollout/Rollback

Revert

## Testing

CircleCI
