### PR TITLE
feat(payment): PAYPAL-2615 moved braintree visa checkout to separate package

### DIFF
--- a/packages/braintree-integration/src/braintree-visa-checkout/braintree-visa-checkout-button-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-visa-checkout/braintree-visa-checkout-button-strategy.spec.ts
@@ -11,9 +11,11 @@ import {
     getBraintree,
     getDataCollectorMock,
     getDeviceDataMock,
+    getPaymentSuccessPayload,
     getVisaCheckoutMock,
     getVisaCheckoutSDKMock,
     VisaCheckoutHostWindow,
+    VisaCheckoutPaymentSuccessPayload,
     VisaCheckoutSDK,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
@@ -39,6 +41,7 @@ describe('BraintreeVisaCheckoutButtonStrategy', () => {
     let braintreeVisaCheckoutButtonElement: HTMLDivElement;
     let dataCollector: BraintreeDataCollector;
     let braintreeSDKVersionManager: BraintreeSDKVersionManager;
+    let visaPayload: VisaCheckoutPaymentSuccessPayload;
 
     const defaultContainerId = 'braintree-visa-checkout-button-mock-id';
 
@@ -48,6 +51,8 @@ describe('BraintreeVisaCheckoutButtonStrategy', () => {
     };
 
     beforeEach(() => {
+        visaPayload = getPaymentSuccessPayload();
+
         mockWindow = {} as VisaCheckoutHostWindow & BraintreeHostWindow;
 
         dataCollector = getDataCollectorMock();
@@ -180,13 +185,8 @@ describe('BraintreeVisaCheckoutButtonStrategy', () => {
         });
 
         it('visa Checkout tokenization', async () => {
-            // TODO: remove rule and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            visaCheckoutSDKMock.on = jest.fn((type, callback) => {
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                return type === 'payment.success' ? callback('data') : undefined;
+            jest.spyOn(visaCheckoutSDKMock, 'on').mockImplementation((_, callback) => {
+                callback(visaPayload, new Error());
             });
 
             await strategy.initialize(initializationOptions);
@@ -209,13 +209,8 @@ describe('BraintreeVisaCheckoutButtonStrategy', () => {
                 postal_code: '2008',
             });
 
-            // TODO: remove rule and update test with related type (PAYPAL-4383)
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            visaCheckoutSDKMock.on = jest.fn((type, callback) => {
-                // TODO: remove ts-ignore and update test with related type (PAYPAL-4383)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                return type === 'payment.success' ? callback('data') : undefined;
+            jest.spyOn(visaCheckoutSDKMock, 'on').mockImplementation((_, callback) => {
+                callback(visaPayload, new Error());
             });
 
             await strategy.initialize(initializationOptions);

--- a/packages/braintree-integration/src/braintree-visa-checkout/braintree-visa-checkout-payment-options.ts
+++ b/packages/braintree-integration/src/braintree-visa-checkout/braintree-visa-checkout-payment-options.ts
@@ -1,0 +1,18 @@
+export default interface BraintreeVisaCheckoutPaymentInitializeOptions {
+    /**
+     * A callback that gets called when Visa Checkout fails to initialize or
+     * selects a payment option.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error: Error): void;
+
+    /**
+     * A callback that gets called when the customer selects a payment option.
+     */
+    onPaymentSelect?(): void;
+}
+
+export interface WithBraintreeVisaCheckoutPaymentInitializeOptions {
+    braintreevisacheckout?: BraintreeVisaCheckoutPaymentInitializeOptions;
+}

--- a/packages/braintree-integration/src/braintree-visa-checkout/braintree-visa-checkout-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-visa-checkout/braintree-visa-checkout-payment-strategy.spec.ts
@@ -1,0 +1,297 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    BraintreeDataCollector,
+    BraintreeHostWindow,
+    BraintreeScriptLoader,
+    BraintreeSdk,
+    BraintreeSDKVersionManager,
+    BraintreeVisaCheckout,
+    getBraintree,
+    getDataCollectorMock,
+    getPaymentSuccessPayload,
+    getVisaCheckoutMock,
+    getVisaCheckoutSDKMock,
+    VisaCheckoutHostWindow,
+    VisaCheckoutPaymentSuccessPayload,
+    VisaCheckoutSDK,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
+import {
+    MissingDataError,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getOrderRequestBody,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BraintreeVisaCheckoutPaymentStrategy from './braintree-visa-checkout-payment-strategy';
+
+describe('BraintreeVisaCheckoutPaymentStrategy', () => {
+    let strategy: BraintreeVisaCheckoutPaymentStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let braintreeSdk: BraintreeSdk;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let formPoster: FormPoster;
+    let paymentMethodMock: PaymentMethod;
+    let braintreeVisaCheckout: BraintreeVisaCheckout;
+    let mockWindow: VisaCheckoutHostWindow;
+    let visaCheckoutSDKMock: VisaCheckoutSDK;
+    let braintreeVisaCheckoutButtonElement: HTMLDivElement;
+    let dataCollector: BraintreeDataCollector;
+    let braintreeSDKVersionManager: BraintreeSDKVersionManager;
+    let visaPayload: VisaCheckoutPaymentSuccessPayload;
+
+    const defaultContainerId = 'braintree-visa-checkout-button-mock-id';
+
+    beforeEach(() => {
+        visaPayload = getPaymentSuccessPayload();
+
+        mockWindow = {} as VisaCheckoutHostWindow & BraintreeHostWindow;
+
+        dataCollector = getDataCollectorMock();
+
+        visaCheckoutSDKMock = getVisaCheckoutSDKMock();
+
+        paymentMethodMock = {
+            ...getBraintree(),
+            clientToken: 'myVisaCheckoutToken',
+        };
+
+        braintreeVisaCheckoutButtonElement = document.createElement('div');
+        braintreeVisaCheckoutButtonElement.id = defaultContainerId;
+        document.body.appendChild(braintreeVisaCheckoutButtonElement);
+
+        braintreeVisaCheckout = getVisaCheckoutMock();
+
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        formPoster = createFormPoster();
+
+        braintreeSDKVersionManager = new BraintreeSDKVersionManager(paymentIntegrationService);
+        braintreeScriptLoader = new BraintreeScriptLoader(
+            getScriptLoader(),
+            mockWindow,
+            braintreeSDKVersionManager,
+        );
+        braintreeSdk = new BraintreeSdk(braintreeScriptLoader);
+
+        strategy = new BraintreeVisaCheckoutPaymentStrategy(
+            paymentIntegrationService,
+            formPoster,
+            braintreeSdk,
+        );
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethodMock,
+        );
+
+        jest.spyOn(paymentIntegrationService, 'submitOrder');
+        jest.spyOn(paymentIntegrationService, 'submitPayment');
+
+        jest.spyOn(braintreeSdk, 'initialize');
+        jest.spyOn(braintreeSdk, 'deinitialize');
+        jest.spyOn(braintreeSdk, 'getBraintreeVisaCheckout').mockResolvedValue(
+            braintreeVisaCheckout,
+        );
+        jest.spyOn(braintreeSdk, 'getDataCollectorOrThrow').mockResolvedValue(dataCollector);
+
+        jest.spyOn(braintreeSdk, 'getVisaCheckoutSdk').mockImplementation(() => {
+            mockWindow.V = visaCheckoutSDKMock;
+
+            return Promise.resolve(mockWindow.V);
+        });
+
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('creates an instance of BraintreeVisaCheckoutPaymentStrategy', () => {
+        expect(strategy).toBeInstanceOf(BraintreeVisaCheckoutPaymentStrategy);
+    });
+
+    describe('#initialize()', () => {
+        let visaCheckoutOptions: PaymentInitializeOptions;
+
+        beforeEach(() => {
+            visaCheckoutOptions = { methodId: 'braintreevisacheckout', braintreevisacheckout: {} };
+        });
+
+        it('loads visacheckout in test mode if enabled', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize(visaCheckoutOptions);
+
+            expect(braintreeSdk.getVisaCheckoutSdk).toHaveBeenLastCalledWith(true);
+        });
+
+        it('loads visacheckout without test mode if disabled', async () => {
+            paymentMethodMock.config.testMode = false;
+
+            await strategy.initialize(visaCheckoutOptions);
+
+            expect(braintreeSdk.getVisaCheckoutSdk).toHaveBeenLastCalledWith(false);
+        });
+
+        it('registers the error and success callbacks', async () => {
+            jest.spyOn(visaCheckoutSDKMock, 'on').mockImplementation((_, callback) => {
+                callback(visaPayload, new Error());
+            });
+            await strategy.initialize(visaCheckoutOptions);
+
+            expect(visaCheckoutSDKMock.on).toHaveBeenCalledWith(
+                'payment.success',
+                expect.any(Function),
+            );
+            expect(visaCheckoutSDKMock.on).toHaveBeenCalledWith(
+                'payment.error',
+                expect.any(Function),
+            );
+        });
+
+        describe('when payment.success', () => {
+            beforeEach(() => {
+                jest.spyOn(visaCheckoutSDKMock, 'on').mockImplementation((_, callback) => {
+                    callback(visaPayload, new Error());
+                });
+            });
+
+            it('reloads checkout and payment method', async () => {
+                await strategy.initialize(visaCheckoutOptions);
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.loadCheckout).toHaveBeenCalledTimes(1);
+                expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledTimes(2);
+                expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
+                    'braintreevisacheckout',
+                );
+            });
+
+            it('fires onPaymentSelect when there is been a change in payment method', async () => {
+                const onPaymentSelect = jest.fn();
+
+                await strategy.initialize({
+                    ...visaCheckoutOptions,
+                    braintreevisacheckout: {
+                        onPaymentSelect,
+                    },
+                });
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(onPaymentSelect).toHaveBeenCalled();
+            });
+        });
+
+        it('triggers onError from the options when there is a payment error', async () => {
+            const onError = jest.fn();
+            const errorMock = new Error();
+
+            jest.spyOn(visaCheckoutSDKMock, 'on').mockImplementation((_, callback) => {
+                callback(visaPayload, errorMock);
+            });
+
+            await strategy.initialize({
+                ...visaCheckoutOptions,
+                braintreevisacheckout: {
+                    onError,
+                },
+            });
+
+            expect(onError).toHaveBeenCalledWith(errorMock);
+        });
+    });
+
+    describe('#execute()', () => {
+        let orderRequestBody: OrderRequestBody;
+        let visaCheckoutOptions: PaymentInitializeOptions;
+
+        beforeEach(() => {
+            orderRequestBody = getOrderRequestBody();
+            paymentMethodMock.initializationData = { nonce: 'payment-nonce-for-visacheckout' };
+
+            visaCheckoutOptions = { methodId: 'braintreevisacheckout', braintreevisacheckout: {} };
+        });
+
+        it('calls submit order with the order request information', async () => {
+            await strategy.initialize(visaCheckoutOptions);
+            await strategy.execute(orderRequestBody, visaCheckoutOptions);
+
+            const { payment, ...order } = orderRequestBody;
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                order,
+                expect.any(Object),
+            );
+        });
+
+        it('pass the options to submitOrder', async () => {
+            await strategy.initialize(visaCheckoutOptions);
+            await strategy.execute(orderRequestBody, visaCheckoutOptions);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                expect.any(Object),
+                visaCheckoutOptions,
+            );
+        });
+
+        it('submitPayment with the right information', async () => {
+            const expected = {
+                ...orderRequestBody.payment,
+                paymentData: {
+                    nonce: 'payment-nonce-for-visacheckout',
+                },
+            };
+
+            await strategy.initialize(visaCheckoutOptions);
+            await strategy.execute(orderRequestBody, visaCheckoutOptions);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expected);
+        });
+
+        it('throws if a nonce is not present', async () => {
+            paymentMethodMock.initializationData = {};
+
+            await strategy.initialize(visaCheckoutOptions);
+
+            try {
+                await strategy.execute(orderRequestBody, visaCheckoutOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        beforeEach(async () => {
+            await strategy.initialize({
+                methodId: 'braintreevisacheckout',
+                braintreevisacheckout: {},
+            });
+        });
+
+        it('deinitializes BraintreeVisaCheckoutPaymentProcessor', async () => {
+            await strategy.deinitialize();
+
+            expect(braintreeSdk.deinitialize).toHaveBeenCalled();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await strategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
+        });
+    });
+});

--- a/packages/braintree-integration/src/braintree-visa-checkout/braintree-visa-checkout-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-visa-checkout/braintree-visa-checkout-payment-strategy.ts
@@ -1,0 +1,231 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { noop } from 'lodash';
+
+import {
+    BraintreeDataCollector,
+    BraintreeInitializationData,
+    BraintreeSdk,
+    BraintreeVisaCheckout,
+    VisaCheckoutAddress,
+    VisaCheckoutPaymentSuccessPayload,
+    VisaCheckoutTokenizedPayload,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
+import {
+    Address,
+    InvalidArgumentError,
+    LegacyAddress,
+    MissingDataError,
+    MissingDataErrorType,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentMethodFailedError,
+    PaymentRequestOptions,
+    PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { WithBraintreeVisaCheckoutPaymentInitializeOptions } from './braintree-visa-checkout-payment-options';
+
+export default class BraintreeVisaCheckoutPaymentStrategy implements PaymentStrategy {
+    private paymentMethod?: PaymentMethod<BraintreeInitializationData>;
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private formPoster: FormPoster,
+        private braintreeSdk: BraintreeSdk,
+    ) {}
+
+    async initialize(
+        options: PaymentInitializeOptions & WithBraintreeVisaCheckoutPaymentInitializeOptions,
+    ): Promise<void> {
+        const { braintreevisacheckout: visaCheckoutOptions, methodId } = options;
+
+        if (!visaCheckoutOptions) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.braintreevisacheckout" argument is not provided.',
+            );
+        }
+
+        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+
+        const state = this.paymentIntegrationService.getState();
+
+        this.paymentMethod = state.getPaymentMethodOrThrow(methodId);
+
+        const checkout = state.getCheckoutOrThrow();
+        const storeConfig = state.getStoreConfigOrThrow();
+
+        const { clientToken, config } = this.paymentMethod || {};
+
+        if (!clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const { onError = noop, onPaymentSelect = noop } = visaCheckoutOptions;
+
+        this.braintreeSdk.initialize(clientToken);
+
+        const braintreeVisaCheckout = await this.braintreeSdk.getBraintreeVisaCheckout();
+
+        const visaCheckoutSdk = await this.braintreeSdk.getVisaCheckoutSdk(config?.testMode);
+
+        const initOptions = braintreeVisaCheckout.createInitOptions({
+            settings: {
+                locale: storeConfig.storeProfile.storeLanguage,
+                shipping: {
+                    collectShipping: false,
+                },
+            },
+            paymentRequest: {
+                currencyCode: storeConfig.currency.code,
+                subtotal: String(checkout.subtotal),
+            },
+        });
+
+        await visaCheckoutSdk.init(initOptions);
+
+        visaCheckoutSdk.on(
+            'payment.success',
+            (paymentSuccessPayload: VisaCheckoutPaymentSuccessPayload) =>
+                this.tokenizePayment(braintreeVisaCheckout, paymentSuccessPayload)
+                    .then(() =>
+                        Promise.all([
+                            this.paymentIntegrationService.loadCheckout(),
+                            this.paymentIntegrationService.loadPaymentMethod(methodId),
+                        ]),
+                    )
+                    .then(() => onPaymentSelect())
+                    .catch((error) => onError(error)),
+        );
+        visaCheckoutSdk.on('payment.error', (_, error) => onError(error));
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
+        const { payment, ...order } = payload;
+
+        if (!payment) {
+            throw new InvalidArgumentError(
+                'Unable to submit payment because "payload.payment" argument is not provided.',
+            );
+        }
+
+        if (!this.paymentMethod?.initializationData?.nonce) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const { nonce } = this.paymentMethod.initializationData;
+
+        try {
+            await this.paymentIntegrationService.submitOrder(order, options);
+            await this.paymentIntegrationService.submitPayment({
+                ...payment,
+                paymentData: { nonce },
+            });
+        } catch (error) {
+            this.handleError(error);
+        }
+    }
+
+    finalize(): Promise<any> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    async deinitialize(): Promise<void> {
+        await this.braintreeSdk.deinitialize();
+    }
+
+    private async tokenizePayment(
+        braintreeVisaCheckout: BraintreeVisaCheckout,
+        payment: VisaCheckoutPaymentSuccessPayload,
+    ) {
+        return Promise.all([
+            braintreeVisaCheckout.tokenize(payment),
+            this.braintreeSdk.getDataCollectorOrThrow(),
+        ]).then(([payload, deviceData]) => {
+            const state = this.paymentIntegrationService.getState();
+
+            const shipping = state.getShippingAddress();
+            const billing = state.getBillingAddress();
+
+            const {
+                shippingAddress = this.mapToVisaCheckoutAddress(shipping),
+                billingAddress = this.mapToVisaCheckoutAddress(billing),
+            } = payload;
+
+            return this.postForm(
+                {
+                    ...payload,
+                    shippingAddress,
+                    billingAddress,
+                },
+                deviceData,
+            );
+        });
+    }
+
+    private mapToVisaCheckoutAddress(address?: Address): VisaCheckoutAddress {
+        if (!address) {
+            return {};
+        }
+
+        return {
+            firstName: address.firstName,
+            lastName: address.lastName,
+            phoneNumber: address.phone,
+            streetAddress: address.address1,
+            extendedAddress: address.address2,
+            locality: address.city,
+            region: address.stateOrProvinceCode,
+            countryCode: address.countryCode,
+            postalCode: address.postalCode,
+        };
+    }
+
+    private postForm(
+        paymentData: VisaCheckoutTokenizedPayload,
+        dataCollector: BraintreeDataCollector,
+    ) {
+        const { userData, billingAddress, shippingAddress, details: cardInformation } = paymentData;
+        const { userEmail } = userData;
+        const { deviceData } = dataCollector;
+
+        return this.formPoster.postForm('/checkout.php', {
+            payment_type: paymentData.type,
+            nonce: paymentData.nonce,
+            provider: 'braintreevisacheckout',
+            action: 'set_external_checkout',
+            device_data: deviceData,
+            card_information: JSON.stringify({
+                type: cardInformation.cardType,
+                number: cardInformation.lastTwo,
+            }),
+            billing_address: JSON.stringify(this.getAddress(userEmail, billingAddress)),
+            shipping_address: JSON.stringify(this.getAddress(userEmail, shippingAddress)),
+        });
+    }
+
+    private getAddress(email: string, address: VisaCheckoutAddress = {}): Partial<LegacyAddress> {
+        return {
+            email,
+            first_name: address.firstName,
+            last_name: address.lastName,
+            phone_number: address.phoneNumber,
+            address_line_1: address.streetAddress,
+            address_line_2: address.extendedAddress,
+            city: address.locality,
+            state: address.region,
+            country_code: address.countryCode,
+            postal_code: address.postalCode,
+        };
+    }
+
+    private handleError(error: unknown): never {
+        if (error instanceof Error && error.name === 'BraintreeError') {
+            throw new PaymentMethodFailedError(error.message);
+        }
+
+        throw error;
+    }
+}

--- a/packages/braintree-integration/src/braintree-visa-checkout/create-braintree-visa-checkout-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-visa-checkout/create-braintree-visa-checkout-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BraintreeVisaCheckoutPaymentStrategy from './braintree-visa-checkout-payment-strategy';
+import createBraintreeVisaCheckoutPaymentStrategy from './create-braintree-visa-checkout-payment-strategy';
+
+describe('createBraintreeVisaCheckoutPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates braintree visa checkout payment strategy', () => {
+        const strategy = createBraintreeVisaCheckoutPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(BraintreeVisaCheckoutPaymentStrategy);
+    });
+});

--- a/packages/braintree-integration/src/braintree-visa-checkout/create-braintree-visa-checkout-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-visa-checkout/create-braintree-visa-checkout-payment-strategy.ts
@@ -1,0 +1,36 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    BraintreeHostWindow,
+    BraintreeScriptLoader,
+    BraintreeSdk,
+    BraintreeSDKVersionManager,
+    VisaCheckoutHostWindow,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BraintreeVisaCheckoutPaymentStrategy from './braintree-visa-checkout-payment-strategy';
+
+const createBraintreeVisaCheckoutPaymentStrategy: PaymentStrategyFactory<
+    BraintreeVisaCheckoutPaymentStrategy
+> = (paymentIntegrationService) => {
+    const hostWindow: VisaCheckoutHostWindow & BraintreeHostWindow = window;
+    const braintreeSDKVersionManager = new BraintreeSDKVersionManager(paymentIntegrationService);
+    const braintreeSdk = new BraintreeSdk(
+        new BraintreeScriptLoader(getScriptLoader(), hostWindow, braintreeSDKVersionManager),
+    );
+
+    return new BraintreeVisaCheckoutPaymentStrategy(
+        paymentIntegrationService,
+        createFormPoster(),
+        braintreeSdk,
+    );
+};
+
+export default toResolvableModule(createBraintreeVisaCheckoutPaymentStrategy, [
+    { id: 'braintreevisacheckout' },
+]);

--- a/packages/braintree-integration/src/index.ts
+++ b/packages/braintree-integration/src/index.ts
@@ -40,6 +40,7 @@ export { WithBraintreeFastlanePaymentInitializeOptions } from './braintree-fastl
  */
 export { default as createBraintreeVisaCheckoutButtonStrategy } from './braintree-visa-checkout/create-braintree-visa-checkout-button-strategy';
 export { default as createBraintreeVisaCheckoutCustomerStrategy } from './braintree-visa-checkout/create-braintree-visa-checkout-customer-strategy';
+export { default as createBraintreeVisaCheckoutPaymentStrategy } from './braintree-visa-checkout/create-braintree-visa-checkout-payment-strategy';
 
 /**
  * Braintree Venmo

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -114,6 +114,7 @@ export interface BraintreeInitializationData {
     shouldRunAcceleratedCheckout?: boolean; // TODO: only for BT AXO A/B testing purposes, hence should be removed after testing
     paymentButtonStyles?: Record<string, PaypalStyleOptions>;
     paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[] | null;
+    nonce?: string;
 }
 
 export interface BraintreePaypalRequest {


### PR DESCRIPTION
## What/Why?

Move `BraintreeVisaCheckout` payment strategy to `braintree-integration` package

## Rollout/Rollback

Revert

## Testing

Integration was successfully tested with removing previous implementation in core. I am gonna remove previous implementation in separate PR.

https://github.com/user-attachments/assets/fb0bc9fe-a2c0-4777-8623-d07b3d1c45e4


