### PR TITLE
Checkout-sdk exports issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
       "types": "./dist/types/integrations/*.d.ts",
       "import": "./dist/esm/integrations/*.js",
       "require": "./dist/cjs/integrations/*.js"
-    }
+    },
+    "./workspace-tools/package.json": "./packages/workspace-tools/package.json"
   },
   "files": [
     "dist/",
-    "docs/"
+    "docs/",
+    "packages/workspace-tools/"
   ],
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
## What/Why?

This PR resolves an `exports` map issue in `package.json` that prevented Nx from resolving the `workspace-tools` generator. Previously, Node blocked access to `@bigcommerce/checkout-sdk/workspace-tools/package.json` because it was not explicitly exported.

The change adds an explicit export for `./workspace-tools/package.json` and includes `packages/workspace-tools/` in the `files` array to ensure the generator is properly packaged and resolvable.

## Rollout/Rollback

This change will be rolled out as part of a standard npm package release.
To roll back, revert this commit and publish a new package version. There are no database migrations or complex dependencies.

## Testing

The change was validated by:
- Running `require.resolve('@bigcommerce/checkout-sdk/workspace-tools/package.json')`
- Performing an Nx generate dry-run for the `auto-export` generator.

To test, run `npm run bundle:watch` locally after pulling this branch. The previous error regarding `workspace-tools` resolution should no longer occur.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b156cc7-5367-4db8-827b-c6380b4e19db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b156cc7-5367-4db8-827b-c6380b4e19db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

