### PR TITLE
chore(shipping): CHECKOUT-9812 Make costAfterDiscount required

### DIFF
--- a/packages/core/src/shipping/shipping-option.ts
+++ b/packages/core/src/shipping/shipping-option.ts
@@ -5,7 +5,7 @@ export default interface ShippingOption {
     isRecommended: boolean;
     imageUrl: string;
     cost: number;
-    costAfterDiscount?: number;
+    costAfterDiscount: number;
     transitTime: string;
     type: string;
 }

--- a/packages/core/src/shipping/shipping-options.mock.ts
+++ b/packages/core/src/shipping/shipping-options.mock.ts
@@ -3,6 +3,7 @@ import { ShippingOption } from '../shipping';
 export function getShippingOption(): ShippingOption {
     return {
         additionalDescription: 'Flat rate additional description',
+        costAfterDiscount: 0,
         description: 'Flat Rate',
         id: '0:61d4bb52f746477e1d4fb411221318c3',
         imageUrl: '',


### PR DESCRIPTION
## What/Why?
Make costAfterDiscount required in shipping option interface

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type tightening that may surface compile-time errors for any callers constructing `ShippingOption` without `costAfterDiscount`. No runtime logic changes beyond updating mocks.
> 
> **Overview**
> **Makes `ShippingOption.costAfterDiscount` required** by changing it from optional to a mandatory `number`.
> 
> Updates the shipping option mock (`getShippingOption`) to always provide `costAfterDiscount` (set to `0`) so typed consumers/tests continue to compile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 492d75f930054795c842df466606c034f8f8bbbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->