### PR TITLE
feat(payment): PI-5057 Google Pay execute payment in modal window

### DIFF
--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -159,11 +159,15 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         return async (event: MouseEvent) => {
             event.preventDefault();
 
-            // TODO: Dispatch Widget Actions
             try {
                 this._googlePayPaymentProcessor.setShouldRequestShipping(false);
                 await this._googlePayPaymentProcessor.initializeWidget();
-                await this._interactWithPaymentSheet();
+
+                if (this._isDirectPayOnClickEnabled()) {
+                    await this._interactWithPaymentSheetAndPay();
+                } else {
+                    await this._interactWithPaymentSheet();
+                }
             } catch (error) {
                 let err: unknown = error;
 
@@ -215,6 +219,52 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         await this._paymentIntegrationService.loadCheckout();
         await this._paymentIntegrationService.loadPaymentMethod(this._getMethodId());
+        this._toggleLoadingIndicator(false);
+        this._toggleBlockDeinitialization(false);
+    }
+
+    protected async _interactWithPaymentSheetAndPay(): Promise<void> {
+        const response = await this._googlePayPaymentProcessor.showPaymentSheet();
+
+        this._toggleBlockDeinitialization(true);
+        this._toggleLoadingIndicator(true);
+
+        const methodId = this._getMethodId();
+
+        const state = this._paymentIntegrationService.getState();
+        const { features } = state.getStoreConfigOrThrow().checkoutSettings;
+        const isGooglePayDontOverrideAddresssExperimentOn = isExperimentEnabled(
+            features,
+            'PI-5031.google_pay_dont_override_address',
+        );
+
+        const billingAddress =
+            this._googlePayPaymentProcessor.mapToBillingAddressRequestBody(response);
+
+        if (billingAddress && !isGooglePayDontOverrideAddresssExperimentOn) {
+            await this._paymentIntegrationService.updateBillingAddress(billingAddress);
+        }
+
+        await this._googlePayPaymentProcessor.setExternalCheckoutXhr(methodId, response);
+
+        await this._paymentIntegrationService.loadCheckout();
+        await this._paymentIntegrationService.loadPaymentMethod(methodId);
+
+        const freshPaymentMethod = this._paymentIntegrationService
+            .getState()
+            .getPaymentMethodOrThrow<GooglePayInitializationData>(methodId);
+
+        await this._googlePayPaymentProcessor.initialize(
+            () => freshPaymentMethod,
+        );
+
+        await this.execute({ useStoreCredit: false, payment: { methodId } });
+
+        this._completeCheckoutFlow();
+    }
+
+    protected _completeCheckoutFlow(): void {
+        window.location.replace('/checkout/order-confirmation');
         this._toggleLoadingIndicator(false);
         this._toggleBlockDeinitialization(false);
     }
@@ -329,6 +379,17 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 },
             },
         };
+    }
+
+    private _isDirectPayOnClickEnabled(): boolean {
+        const { features } = this._paymentIntegrationService
+            .getState()
+            .getStoreConfigOrThrow().checkoutSettings;
+
+        return isExperimentEnabled(
+            features,
+            'PI-000.google_pay_direct_pay_on_click',
+        );
     }
 
     private _toggleBlockDeinitialization(isBlocked: boolean) {


### PR DESCRIPTION
## What/Why?

This behaiviour was tested on the following Google pay implementations:
Cybersource
AdyenV3 
CheckoutCom 
StripeOCS 
Orbital 
Authorize net 
Braintree 
PPCP 

## Rollout/Rollback

<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing

https://github.com/user-attachments/assets/dd2dc42f-7637-4434-81bc-ed877725328f

