### PR TITLE
feat(payment): PI-4976 [Access Worldpay] Open Banking

### DIFF
--- a/packages/core/src/hosted-form/hosted-form-order-data-transformer.ts
+++ b/packages/core/src/hosted-form/hosted-form-order-data-transformer.ts
@@ -31,10 +31,15 @@ export default class HostedFormOrderDataTransformer {
             'ccNumber',
             'ccCvv',
         ) as HostedCreditCardInstrument;
-        const paymentMethod = state.paymentMethods.getPaymentMethod(
+        let paymentMethod = state.paymentMethods.getPaymentMethod(
             payload.methodId,
             payload.gatewayId,
         );
+
+        if (paymentMethod?.gateway === 'worldpayaccess' && paymentMethod?.id === 'credit_card') {
+            paymentMethod = { ...paymentMethod, id: 'worldpayaccess', method: 'credit-card' };
+        }
+
         const paymentMethodMeta = state.paymentMethods.getPaymentMethodsMeta();
         const authToken =
             instrumentMeta && payment && isVaultedInstrument(payment)

--- a/packages/core/src/payment/instrument/supported-payment-instruments.ts
+++ b/packages/core/src/payment/instrument/supported-payment-instruments.ts
@@ -145,6 +145,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'worldpayaccess',
         method: 'credit_card',
     },
+    'worldpayaccess.open_banking': {
+        provider: 'worldpayaccess',
+        method: 'open_banking',
+    },
     squarev2: {
         provider: 'squarev2',
         method: 'credit_card',

--- a/packages/core/src/payment/instrument/supported-payment-instruments.ts
+++ b/packages/core/src/payment/instrument/supported-payment-instruments.ts
@@ -145,9 +145,9 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'worldpayaccess',
         method: 'credit_card',
     },
-    'worldpayaccess.open_banking': {
+    'worldpayaccess.credit_card': {
         provider: 'worldpayaccess',
-        method: 'open_banking',
+        method: 'credit_card',
     },
     squarev2: {
         provider: 'squarev2',

--- a/packages/core/src/payment/payment-request-transformer.ts
+++ b/packages/core/src/payment/payment-request-transformer.ts
@@ -155,11 +155,11 @@ export default class PaymentRequestTransformer {
             return { ...paymentMethod, id: paymentMethod.initializationData.gateway };
         }
 
-        // Sub-methods carry the provider name in `gateway` and the method name in `id`.
-        // BigPay's mapToId uses `id` as the gateway field unless `method === 'multi-option'`,
-        // so we swap `id` with `gateway` here to ensure the correct provider is sent.
-        if (paymentMethod.gateway) {
-            return { ...paymentMethod, id: paymentMethod.gateway };
+        // Worldpay Access: sub-methods carry the provider name in `gateway` and the method
+        // name in `id`. BigPay's mapToId uses `id` as the gateway field unless
+        // `method === 'multi-option'`, so we align with hosted-form-order-data-transformer
+        if (paymentMethod.gateway === 'worldpayaccess' && paymentMethod.id === 'credit_card') {
+            return { ...paymentMethod, id: 'worldpayaccess', method: 'credit-card' };
         }
 
         if (paymentMethod.id === CheckoutButtonMethodType.BRAINTREE_VENMO) {

--- a/packages/core/src/payment/payment-request-transformer.ts
+++ b/packages/core/src/payment/payment-request-transformer.ts
@@ -155,6 +155,13 @@ export default class PaymentRequestTransformer {
             return { ...paymentMethod, id: paymentMethod.initializationData.gateway };
         }
 
+        // Sub-methods carry the provider name in `gateway` and the method name in `id`.
+        // BigPay's mapToId uses `id` as the gateway field unless `method === 'multi-option'`,
+        // so we swap `id` with `gateway` here to ensure the correct provider is sent.
+        if (paymentMethod.gateway) {
+            return { ...paymentMethod, id: paymentMethod.gateway };
+        }
+
         if (paymentMethod.id === CheckoutButtonMethodType.BRAINTREE_VENMO) {
             return { ...paymentMethod, id: CheckoutButtonMethodType.BRAINTREE_PAYPAL };
         }

--- a/packages/worldpayaccess-integration/src/create-worldpayaccess-open-banking-payment-strategy.spec.ts
+++ b/packages/worldpayaccess-integration/src/create-worldpayaccess-open-banking-payment-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createWorldpayAccessOpenBankingPaymentStrategy from './create-worldpayaccess-open-banking-payment-strategy';
+import WorldpayAccessOpenBankingPaymentStrategy from './worldpayaccess-open-banking-payment-strategy';
+
+describe('createWorldpayAccessOpenBankingPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates Worldpay Access Open Banking payment strategy', () => {
+        const strategy =
+            createWorldpayAccessOpenBankingPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(WorldpayAccessOpenBankingPaymentStrategy);
+    });
+});

--- a/packages/worldpayaccess-integration/src/create-worldpayaccess-open-banking-payment-strategy.spec.ts
+++ b/packages/worldpayaccess-integration/src/create-worldpayaccess-open-banking-payment-strategy.spec.ts
@@ -12,8 +12,7 @@ describe('createWorldpayAccessOpenBankingPaymentStrategy', () => {
     });
 
     it('instantiates Worldpay Access Open Banking payment strategy', () => {
-        const strategy =
-            createWorldpayAccessOpenBankingPaymentStrategy(paymentIntegrationService);
+        const strategy = createWorldpayAccessOpenBankingPaymentStrategy(paymentIntegrationService);
 
         expect(strategy).toBeInstanceOf(WorldpayAccessOpenBankingPaymentStrategy);
     });

--- a/packages/worldpayaccess-integration/src/create-worldpayaccess-open-banking-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/create-worldpayaccess-open-banking-payment-strategy.ts
@@ -5,9 +5,10 @@ import {
 
 import WorldpayAccessOpenBankingPaymentStrategy from './worldpayaccess-open-banking-payment-strategy';
 
-const createWorldpayAccessOpenBankingPaymentStrategy: PaymentStrategyFactory<WorldpayAccessOpenBankingPaymentStrategy> =
-    (paymentIntegrationService) =>
-        new WorldpayAccessOpenBankingPaymentStrategy(paymentIntegrationService);
+const createWorldpayAccessOpenBankingPaymentStrategy: PaymentStrategyFactory<
+    WorldpayAccessOpenBankingPaymentStrategy
+> = (paymentIntegrationService) =>
+    new WorldpayAccessOpenBankingPaymentStrategy(paymentIntegrationService);
 
 export default toResolvableModule(createWorldpayAccessOpenBankingPaymentStrategy, [
     { id: 'open_banking', gateway: 'worldpayaccess' },

--- a/packages/worldpayaccess-integration/src/create-worldpayaccess-open-banking-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/create-worldpayaccess-open-banking-payment-strategy.ts
@@ -1,0 +1,14 @@
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import WorldpayAccessOpenBankingPaymentStrategy from './worldpayaccess-open-banking-payment-strategy';
+
+const createWorldpayAccessOpenBankingPaymentStrategy: PaymentStrategyFactory<WorldpayAccessOpenBankingPaymentStrategy> =
+    (paymentIntegrationService) =>
+        new WorldpayAccessOpenBankingPaymentStrategy(paymentIntegrationService);
+
+export default toResolvableModule(createWorldpayAccessOpenBankingPaymentStrategy, [
+    { id: 'open_banking', gateway: 'worldpayaccess' },
+]);

--- a/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.ts
@@ -13,4 +13,5 @@ const createWorldpayAccessPaymentStrategy: PaymentStrategyFactory<WorldpayAccess
 
 export default toResolvableModule(createWorldpayAccessPaymentStrategy, [
     { gateway: 'worldpayaccess', id: 'credit_card' },
+    { id: 'worldpayaccess' },
 ]);

--- a/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.ts
@@ -11,4 +11,4 @@ const createWorldpayAccessPaymentStrategy: PaymentStrategyFactory<WorldpayAccess
     return new WorldpayAccessPaymetStrategy(paymentIntegrationService);
 };
 
-export default toResolvableModule(createWorldpayAccessPaymentStrategy, [{ id: 'worldpayaccess' }]);
+export default toResolvableModule(createWorldpayAccessPaymentStrategy, [{ gateway: 'worldpayaccess', id: 'credit_card' }]);

--- a/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/create-worldpayaccess-payment-strategy.ts
@@ -11,4 +11,6 @@ const createWorldpayAccessPaymentStrategy: PaymentStrategyFactory<WorldpayAccess
     return new WorldpayAccessPaymetStrategy(paymentIntegrationService);
 };
 
-export default toResolvableModule(createWorldpayAccessPaymentStrategy, [{ gateway: 'worldpayaccess', id: 'credit_card' }]);
+export default toResolvableModule(createWorldpayAccessPaymentStrategy, [
+    { gateway: 'worldpayaccess', id: 'credit_card' },
+]);

--- a/packages/worldpayaccess-integration/src/index.ts
+++ b/packages/worldpayaccess-integration/src/index.ts
@@ -1,2 +1,6 @@
 export { default as createWorldpayAccessPaymentStrategy } from './create-worldpayaccess-payment-strategy';
-export { WithWorldpayAccessPaymentInitializeOptions } from './worldpayaccess-payment-options';
+export { default as createWorldpayAccessOpenBankingPaymentStrategy } from './create-worldpayaccess-open-banking-payment-strategy';
+export {
+    WithWorldpayAccessPaymentInitializeOptions,
+    WorldpayAccessOpenBankingInstrument,
+} from './worldpayaccess-payment-options';

--- a/packages/worldpayaccess-integration/src/index.ts
+++ b/packages/worldpayaccess-integration/src/index.ts
@@ -1,6 +1,3 @@
 export { default as createWorldpayAccessPaymentStrategy } from './create-worldpayaccess-payment-strategy';
 export { default as createWorldpayAccessOpenBankingPaymentStrategy } from './create-worldpayaccess-open-banking-payment-strategy';
-export {
-    WithWorldpayAccessPaymentInitializeOptions,
-    WorldpayAccessOpenBankingInstrument,
-} from './worldpayaccess-payment-options';
+export { WithWorldpayAccessPaymentInitializeOptions } from './worldpayaccess-payment-options';

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
@@ -1,15 +1,10 @@
 import {
     OrderFinalizationNotRequiredError,
+    OrderRequestBody,
     PaymentArgumentInvalidError,
     PaymentIntegrationService,
-    RequestError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import {
-    getErrorPaymentResponseBody,
-    getResponse,
-    PaymentIntegrationServiceMock,
-} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
-import { OrderRequestBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import WorldpayAccessOpenBankingPaymentStrategy from './worldpayaccess-open-banking-payment-strategy';
 
@@ -25,7 +20,6 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
     describe('#execute()', () => {
         afterEach(() => {
             (paymentIntegrationService.submitOrder as jest.Mock).mockClear();
-            (paymentIntegrationService.submitPayment as jest.Mock).mockClear();
         });
 
         it('throws error when payment is missing', async () => {
@@ -34,97 +28,11 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
             await expect(strategy.execute({})).rejects.toThrow(PaymentArgumentInvalidError);
         });
 
-        it('submits order and payment with open_banking payload', async () => {
-            await strategy.initialize();
-
-            const payload = {
-                payment: {
-                    methodId: 'open_banking',
-                    gatewayId: 'worldpayaccess',
-                    paymentData: {
-                        open_banking: {
-                            bank_code: '1345',
-                        },
-                    },
-                },
-            };
-
-            const expectedPayment = {
-                methodId: 'open_banking',
-                gatewayId: 'worldpayaccess',
-                paymentData: {
-                    formattedPayload: {
-                        open_banking: {
-                            bank_code: '1345',
-                        },
-                    },
-                },
-            };
-
-            await strategy.execute(payload as OrderRequestBody);
-
-            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
-            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
-                expectedPayment,
-            );
-        });
-
-        it('uses worldpayaccess as gatewayId when gatewayId is omitted', async () => {
-            await strategy.initialize();
-
-            const payload = {
-                payment: {
-                    methodId: 'open_banking',
-                    paymentData: {
-                        open_banking: {
-                            bank_code: '9999',
-                        },
-                    },
-                },
-            };
-
-            await strategy.execute(payload as OrderRequestBody);
-
-            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    gatewayId: 'worldpayaccess',
-                    paymentData: { formattedPayload: { open_banking: { bank_code: '9999' } } },
-                }),
-            );
-        });
-
-        it('rejects when error is not additional_action_required', async () => {
-            await strategy.initialize();
-
-            const payload = {
-                payment: {
-                    methodId: 'open_banking',
-                    gatewayId: 'worldpayaccess',
-                    paymentData: {
-                        open_banking: { bank_code: '1345' },
-                    },
-                },
-            };
-
-            const error = new RequestError(getResponse(getErrorPaymentResponseBody()));
-
-            jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
-                Promise.reject(error),
-            );
-
-            await expect(strategy.execute(payload as OrderRequestBody)).rejects.toThrow(
-                error,
-            );
-        });
-
         it('redirects when additional_action_required with redirect_url is returned', async () => {
             const payload = {
                 payment: {
                     methodId: 'open_banking',
                     gatewayId: 'worldpayaccess',
-                    paymentData: {
-                        open_banking: { bank_code: '1345' },
-                    },
                 },
             };
 
@@ -137,21 +45,6 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
             await strategy.initialize();
 
             const redirectUrl = 'https://bank.example.com/authorize';
-            const error = new RequestError(
-                getResponse({
-                    ...getErrorPaymentResponseBody(),
-                    status: 'additional_action_required',
-                    additional_action_required: {
-                        data: {
-                            redirect_url: redirectUrl,
-                        },
-                    },
-                }),
-            );
-
-            jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
-                Promise.reject(error),
-            );
 
             void strategy.execute(payload as OrderRequestBody);
             await new Promise((resolve) => process.nextTick(resolve));
@@ -170,9 +63,7 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
 
     describe('#finalize()', () => {
         it('throws error to inform that order finalization is not required', async () => {
-            await expect(strategy.finalize()).rejects.toThrow(
-                OrderFinalizationNotRequiredError,
-            );
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
         });
     });
 

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
@@ -1,0 +1,186 @@
+import {
+    OrderFinalizationNotRequiredError,
+    PaymentArgumentInvalidError,
+    PaymentIntegrationService,
+    RequestError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getErrorPaymentResponseBody,
+    getResponse,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import { OrderRequestBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import WorldpayAccessOpenBankingPaymentStrategy from './worldpayaccess-open-banking-payment-strategy';
+
+describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
+    let strategy: WorldpayAccessOpenBankingPaymentStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+        strategy = new WorldpayAccessOpenBankingPaymentStrategy(paymentIntegrationService);
+    });
+
+    describe('#execute()', () => {
+        afterEach(() => {
+            (paymentIntegrationService.submitOrder as jest.Mock).mockClear();
+            (paymentIntegrationService.submitPayment as jest.Mock).mockClear();
+        });
+
+        it('throws error when payment is missing', async () => {
+            await strategy.initialize();
+
+            await expect(strategy.execute({})).rejects.toThrow(PaymentArgumentInvalidError);
+        });
+
+        it('submits order and payment with open_banking payload', async () => {
+            await strategy.initialize();
+
+            const payload = {
+                payment: {
+                    methodId: 'open_banking',
+                    gatewayId: 'worldpayaccess',
+                    paymentData: {
+                        open_banking: {
+                            bank_code: '1345',
+                        },
+                    },
+                },
+            };
+
+            const expectedPayment = {
+                methodId: 'open_banking',
+                gatewayId: 'worldpayaccess',
+                paymentData: {
+                    formattedPayload: {
+                        open_banking: {
+                            bank_code: '1345',
+                        },
+                    },
+                },
+            };
+
+            await strategy.execute(payload as OrderRequestBody);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                expectedPayment,
+            );
+        });
+
+        it('uses worldpayaccess as gatewayId when gatewayId is omitted', async () => {
+            await strategy.initialize();
+
+            const payload = {
+                payment: {
+                    methodId: 'open_banking',
+                    paymentData: {
+                        open_banking: {
+                            bank_code: '9999',
+                        },
+                    },
+                },
+            };
+
+            await strategy.execute(payload as OrderRequestBody);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    gatewayId: 'worldpayaccess',
+                    paymentData: { formattedPayload: { open_banking: { bank_code: '9999' } } },
+                }),
+            );
+        });
+
+        it('rejects when error is not additional_action_required', async () => {
+            await strategy.initialize();
+
+            const payload = {
+                payment: {
+                    methodId: 'open_banking',
+                    gatewayId: 'worldpayaccess',
+                    paymentData: {
+                        open_banking: { bank_code: '1345' },
+                    },
+                },
+            };
+
+            const error = new RequestError(getResponse(getErrorPaymentResponseBody()));
+
+            jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
+                Promise.reject(error),
+            );
+
+            await expect(strategy.execute(payload as OrderRequestBody)).rejects.toThrow(
+                error,
+            );
+        });
+
+        it('redirects when additional_action_required with redirect_url is returned', async () => {
+            const payload = {
+                payment: {
+                    methodId: 'open_banking',
+                    gatewayId: 'worldpayaccess',
+                    paymentData: {
+                        open_banking: { bank_code: '1345' },
+                    },
+                },
+            };
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    replace: jest.fn(),
+                },
+            });
+
+            await strategy.initialize();
+
+            const redirectUrl = 'https://bank.example.com/authorize';
+            const error = new RequestError(
+                getResponse({
+                    ...getErrorPaymentResponseBody(),
+                    status: 'additional_action_required',
+                    additional_action_required: {
+                        data: {
+                            redirect_url: redirectUrl,
+                        },
+                    },
+                }),
+            );
+
+            jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
+                Promise.reject(error),
+            );
+
+            void strategy.execute(payload as OrderRequestBody);
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(window.location.replace).toHaveBeenCalledWith(redirectUrl);
+        });
+    });
+
+    describe('#initialize()', () => {
+        it('initializes the strategy successfully', async () => {
+            const result = await strategy.initialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(
+                OrderFinalizationNotRequiredError,
+            );
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy', async () => {
+            const result = await strategy.deinitialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+});

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
@@ -40,11 +40,26 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
                 value: {
                     replace: jest.fn(),
                 },
+                writable: true,
+                configurable: true,
             });
 
             await strategy.initialize();
 
-            const redirectUrl = 'https://bank.example.com/authorize';
+            const redirectUrl =
+                'https://secure-test.worldpay.com/example';
+
+            jest.spyOn(paymentIntegrationService, 'submitPayment').mockRejectedValueOnce({
+                body: {
+                    status: 'additional_action_required',
+                    additional_action_required: {
+                        type: 'offsite_redirect',
+                        data: {
+                            redirect_url: redirectUrl,
+                        },
+                    },
+                },
+            });
 
             void strategy.execute(payload as OrderRequestBody);
             await new Promise((resolve) => process.nextTick(resolve));

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
@@ -46,8 +46,7 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
 
             await strategy.initialize();
 
-            const redirectUrl =
-                'https://secure-test.worldpay.com/example';
+            const redirectUrl = 'https://secure-test.worldpay.com/example';
 
             jest.spyOn(paymentIntegrationService, 'submitPayment').mockRejectedValueOnce({
                 body: {

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
@@ -22,8 +22,7 @@ export default class WorldpayAccessOpenBankingPaymentStrategy implements Payment
             await this._paymentIntegrationService.submitPayment(payment);
         } catch (error) {
             if (this._isWorldpayAccessRedirectResponse(error)) {
-                const redirectUrl =
-                    error.body.additional_action_required.data.redirect_url;
+                const redirectUrl = error.body.additional_action_required.data.redirect_url;
 
                 return new Promise(() => window.location.replace(redirectUrl));
             }

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
@@ -1,0 +1,103 @@
+import {
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentIntegrationService,
+    PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import {
+    WorldpayAccessOpenBankingInstrument,
+    WorldpayAccessRedirectResponse,
+} from './worldpayaccess-payment-options';
+
+function isWorldpayAccessOpenBankingInstrument(
+    paymentData: unknown,
+): paymentData is WorldpayAccessOpenBankingInstrument {
+    if (typeof paymentData !== 'object' || paymentData === null) {
+        return false;
+    }
+
+    const data = paymentData as Record<string, unknown>;
+
+    return typeof data.bankCode === 'string';
+}
+
+export default class WorldpayAccessOpenBankingPaymentStrategy implements PaymentStrategy {
+    constructor(private _paymentIntegrationService: PaymentIntegrationService) {}
+
+    async execute(payload: OrderRequestBody): Promise<void> {
+        const paymentPayload = this._formatPaymentPayload(payload);
+
+        console.log({ paymentPayload });
+
+        await this._paymentIntegrationService.submitOrder();
+
+        try {
+            await this._paymentIntegrationService.submitPayment(paymentPayload);
+        } catch (error) {
+            if (this._isWorldpayAccessRedirectResponse(error)) {
+                const redirectUrl = error.body.additional_action_required.data.redirect_url;
+
+                return new Promise(() => window.location.replace(redirectUrl));
+            }
+
+            return Promise.reject(error);
+        }
+    }
+
+    initialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    private _formatPaymentPayload({ payment }: OrderRequestBody) {
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        if (!payment.paymentData || !isWorldpayAccessOpenBankingInstrument(payment.paymentData)) {
+            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        }
+
+        return {
+            methodId: payment.methodId,
+            gatewayId: payment.gatewayId || 'worldpayaccess',
+            paymentData: {
+                formattedPayload: {
+                    open_banking: {
+                        bank_code: payment.paymentData.bankCode,
+                    },
+                },
+            },
+        };
+    }
+
+    private _isWorldpayAccessRedirectResponse(
+        response: unknown,
+    ): response is WorldpayAccessRedirectResponse {
+        if (typeof response !== 'object' || response === null) {
+            return false;
+        }
+
+        const partialResponse = response as Partial<WorldpayAccessRedirectResponse>;
+
+        if (!partialResponse.body) {
+            return false;
+        }
+
+        const partialBody = partialResponse.body;
+
+        return (
+            partialBody.status === 'additional_action_required' &&
+            !!partialBody.additional_action_required?.data?.redirect_url
+        );
+    }
+}

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
@@ -6,38 +6,24 @@ import {
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import {
-    WorldpayAccessOpenBankingInstrument,
-    WorldpayAccessRedirectResponse,
-} from './worldpayaccess-payment-options';
-
-function isWorldpayAccessOpenBankingInstrument(
-    paymentData: unknown,
-): paymentData is WorldpayAccessOpenBankingInstrument {
-    if (typeof paymentData !== 'object' || paymentData === null) {
-        return false;
-    }
-
-    const data = paymentData as Record<string, unknown>;
-
-    return typeof data.bankCode === 'string';
-}
+import { WorldpayAccessRedirectResponse } from './worldpayaccess-payment-options';
 
 export default class WorldpayAccessOpenBankingPaymentStrategy implements PaymentStrategy {
     constructor(private _paymentIntegrationService: PaymentIntegrationService) {}
 
-    async execute(payload: OrderRequestBody): Promise<void> {
-        const paymentPayload = this._formatPaymentPayload(payload);
-
-        console.log({ paymentPayload });
+    async execute({ payment }: OrderRequestBody): Promise<void> {
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
 
         await this._paymentIntegrationService.submitOrder();
 
         try {
-            await this._paymentIntegrationService.submitPayment(paymentPayload);
+            await this._paymentIntegrationService.submitPayment(payment);
         } catch (error) {
             if (this._isWorldpayAccessRedirectResponse(error)) {
-                const redirectUrl = error.body.additional_action_required.data.redirect_url;
+                const redirectUrl =
+                    error.body.additional_action_required.data.redirect_url;
 
                 return new Promise(() => window.location.replace(redirectUrl));
             }
@@ -58,28 +44,6 @@ export default class WorldpayAccessOpenBankingPaymentStrategy implements Payment
         return Promise.resolve();
     }
 
-    private _formatPaymentPayload({ payment }: OrderRequestBody) {
-        if (!payment) {
-            throw new PaymentArgumentInvalidError(['payment']);
-        }
-
-        if (!payment.paymentData || !isWorldpayAccessOpenBankingInstrument(payment.paymentData)) {
-            throw new PaymentArgumentInvalidError(['payment.paymentData']);
-        }
-
-        return {
-            methodId: payment.methodId,
-            gatewayId: payment.gatewayId || 'worldpayaccess',
-            paymentData: {
-                formattedPayload: {
-                    open_banking: {
-                        bank_code: payment.paymentData.bankCode,
-                    },
-                },
-            },
-        };
-    }
-
     private _isWorldpayAccessRedirectResponse(
         response: unknown,
     ): response is WorldpayAccessRedirectResponse {
@@ -97,7 +61,7 @@ export default class WorldpayAccessOpenBankingPaymentStrategy implements Payment
 
         return (
             partialBody.status === 'additional_action_required' &&
-            !!partialBody.additional_action_required?.data?.redirect_url
+            !!partialBody.additional_action_required.data.redirect_url
         );
     }
 }

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
@@ -56,11 +56,16 @@ export default class WorldpayAccessOpenBankingPaymentStrategy implements Payment
             return false;
         }
 
-        const partialBody = partialResponse.body;
+        const partialBody = partialResponse.body as {
+            status?: string;
+            additional_action_required?: {
+                data?: { redirect_url?: string };
+            };
+        };
 
         return (
             partialBody.status === 'additional_action_required' &&
-            !!partialBody.additional_action_required.data.redirect_url
+            !!partialBody.additional_action_required?.data?.redirect_url
         );
     }
 }

--- a/packages/worldpayaccess-integration/src/worldpayaccess-payment-options.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-payment-options.ts
@@ -39,24 +39,16 @@ export interface WithWorldpayAccessPaymentInitializeOptions {
 }
 
 /**
- * Payment instrument for Worldpay Access Open Banking.
- * Sent in the payment request with gateway "worldpayaccess" and method "open_banking".
- */
-export interface WorldpayAccessOpenBankingInstrument {
-    bankCode: string;
-}
-
-/**
  * Error response body when the backend requires a redirect (e.g. Open Banking).
  */
 export interface WorldpayAccessRedirectResponse {
     body: {
         additional_action_required: {
+            type: string;
             data: {
                 redirect_url: string;
             };
         };
         status: string;
-        provider_data?: string;
     };
 }

--- a/packages/worldpayaccess-integration/src/worldpayaccess-payment-options.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-payment-options.ts
@@ -37,3 +37,26 @@ export interface WithWorldpayAccessPaymentInitializeOptions {
      */
     worldpay?: WorldpayAccessPaymentInitializeOptions;
 }
+
+/**
+ * Payment instrument for Worldpay Access Open Banking.
+ * Sent in the payment request with gateway "worldpayaccess" and method "open_banking".
+ */
+export interface WorldpayAccessOpenBankingInstrument {
+    bankCode: string;
+}
+
+/**
+ * Error response body when the backend requires a redirect (e.g. Open Banking).
+ */
+export interface WorldpayAccessRedirectResponse {
+    body: {
+        additional_action_required: {
+            data: {
+                redirect_url: string;
+            };
+        };
+        status: string;
+        provider_data?: string;
+    };
+}


### PR DESCRIPTION
## What/Why?

Add payment strategy for Access Worldpay Open Banking APM
As the backend part is still WIP, the redirect to Worldpay was mocked for demo purposes.

## Rollout/Rollback

Revert

## Testing

https://github.com/user-attachments/assets/65a1dd1d-c6fb-4e8d-8b95-c8c29ee0c528

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Worldpay Access Open Banking payment strategy with redirect handling and adjusts payment-method ID/gateway mapping in core transformers, which can affect how Worldpay Access payments are routed and tokenized.
> 
> **Overview**
> Adds a new Worldpay Access *Open Banking* payment strategy that submits the order, attempts payment submission, and performs a browser redirect when the backend responds with `additional_action_required` and a `redirect_url`.
> 
> Normalizes Worldpay Access credit-card method identification in core request/hosted-form transformers (and expands `supported-payment-instruments` with `worldpayaccess.credit_card`) so Worldpay Access sub-methods resolve consistently across payment flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6f705a6b6c70dfa2c7c23c32aad0b0cf3869ebf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->