### PR TITLE
feat(payment): PAYPAL-6378 catch all unrecognized states to avoid placing an order with a wrong nonce value provided by default in specific 3DSecure silent fallthrough scenario

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -671,6 +671,32 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                 );
             });
 
+            it('catch unrecognized states when show() resolves due to customers issue (e.g. Access Control Server failures)', async () => {
+                const paypalFastlaneSdkMock = {
+                    ...paypalFastlaneSdk,
+                    ThreeDomainSecureClient: {
+                        ...threeDomainSecureComponentMock,
+                        show: jest.fn().mockReturnValue({
+                            liabilityShift: LiabilityShiftEnum.Possible,
+                            authenticationState: 'UNRECOGNIZED_AUTH_STATE',
+                            nonce: 'paypal_fastlane_instrument_id_nonce_3ds',
+                        }),
+                    },
+                };
+
+                jest.spyOn(paypalSdkScriptLoader, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                    Promise.resolve(paypalFastlaneSdkMock),
+                );
+
+                await strategy.initialize(initializationOptions);
+
+                try {
+                    await strategy.execute(executeOptions);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(Error);
+                }
+            });
+
             it('throws an error if liabilityShift no or unknown', async () => {
                 const paypalFastlaneSdkMock = {
                     ...paypalFastlaneSdk,

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -463,6 +463,8 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
             ) {
                 return threeDSNonce;
             }
+
+            throw new PaymentMethodInvalidError();
         }
 
         return nonce;


### PR DESCRIPTION
## What/Why?

Catch all unrecognized states to avoid placing an order with a wrong nonce value provided by default in specific 3DSecure silent fallthrough scenario.

Based on user experience, there may be cases where the verification process ends with an unrecognized status, which results in an incorrect nonce parameter being passed when sending a payment request as part of the 3D Secure procedure. To avoid this, an error must be generated, and no actions related to payment requests should be performed in this case.

## Rollout/Rollback

Revert

## Testing

Manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes 3DS nonce selection in the PayPal Fastlane payment flow to throw on previously-unhandled authentication outcomes, which can block checkout if state mapping differs from expectations.
> 
> **Overview**
> Prevents checkout from proceeding with an incorrect PayPal Fastlane token when the 3DS `show()` call returns an unrecognized `authenticationState`.
> 
> In `paypal-commerce-fastlane-payment-strategy.ts`, `get3DSNonce()` now **throws `PaymentMethodInvalidError` for any non-success 3DS result not explicitly handled**, instead of silently falling through and returning the original nonce.
> 
> Adds a spec covering the new behavior to ensure `execute()` errors (and avoids order creation) when `show()` resolves with an unknown authentication state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f0c67b427af7f901bdeda9cbe348db26cfd13dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->