### PR TITLE
chore(payment): CHECKOUT-9940 Update strategy resolution and check for exact keys

### DIFF
--- a/packages/core/src/common/registry/resolve-id-registry.spec.ts
+++ b/packages/core/src/common/registry/resolve-id-registry.spec.ts
@@ -180,4 +180,16 @@ describe('ResolveIdRegistry', () => {
             subject.getFactory({ gateway: 'bluesnapdirect' } as TestResolveId, true),
         ).toBeUndefined();
     });
+
+    it('returns exact match even when a more specific token with a shared key is registered first', () => {
+        subject = new ResolveIdRegistry(true);
+
+        const fooFactory = () => new FooStrategy();
+        const barFactory = () => new BarStrategy();
+
+        subject.register({ gateway: 'apms', id: 'foo' } as TestResolveId, fooFactory);
+        subject.register({ id: 'foo' } as TestResolveId, barFactory);
+
+        expect(subject.getFactory({ id: 'foo' } as TestResolveId, true)).toBe(barFactory);
+    });
 });

--- a/packages/core/src/common/registry/resolve-id-registry.ts
+++ b/packages/core/src/common/registry/resolve-id-registry.ts
@@ -97,15 +97,21 @@ export default class ResolveIdRegistry<TType, TToken extends { [key: string]: un
             }
         }
 
-        const matched = matchedResults[0];
+        const queryKeyCount = Object.keys(query).length;
 
-        if (
-            exactMatch &&
-            (matched?.matches !== Object.keys(query).length ||
-                matched?.matches !== matched?.totalKeys)
-        ) {
-            throw new Error('Unable to resolve to a registered token with the provided token.');
+        if (exactMatch) {
+            const exactResult = matchedResults.find(
+                (result) => result.matches === queryKeyCount && result.matches === result.totalKeys,
+            );
+
+            if (!exactResult) {
+                throw new Error('Unable to resolve to a registered token with the provided token.');
+            }
+
+            return exactResult.token;
         }
+
+        const matched = matchedResults[0];
 
         if (matched && matched.token) {
             return matched.token;


### PR DESCRIPTION
## What/Why?
Update strategy resolution and check for exact keys rather than matched[0]

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token resolution behavior when `exactMatch` is requested, which can alter which payment strategy factory is selected for some queries. Risk is moderate because it affects registry matching logic used at runtime, but is narrowly scoped and covered by a new regression test.
> 
> **Overview**
> Adjusts `ResolveIdRegistry`’s `exactMatch` resolution to **search all matched candidates for a true key-for-key match** (query key count equals both `matches` and the registered token’s key count), instead of validating only the top-weighted match.
> 
> Adds a regression test ensuring an exact token (e.g. `{ id: 'foo' }`) is returned even if a *more specific* token sharing a key (e.g. `{ gateway: 'apms', id: 'foo' }`) was registered first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa1ae420f1746b352a9b60bd91a304667bc9050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->