### PR TITLE
feat(payment): Google Pay direct payment in modal

### DIFF
--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -740,6 +740,158 @@ describe('GooglePayPaymentStrategy', () => {
                 });
             });
         });
+
+        describe('when PI-5111.google_pay_direct_pay_on_click is enabled', () => {
+            const directPayStoreConfig = {
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    features: {
+                        ...storeConfig.checkoutSettings.features,
+                        'PI-5111.google_pay_direct_pay_on_click': true,
+                    },
+                },
+            };
+
+            beforeEach(async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getStoreConfigOrThrow',
+                ).mockReturnValue(directPayStoreConfig);
+
+                jest.spyOn(processor, 'mapToBillingAddressRequestBody').mockReturnValue(undefined);
+
+                await strategy.initialize(options);
+            });
+
+            it('should show loading indicator on button click', async () => {
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(LoadingShow).toHaveBeenCalled();
+            });
+
+            it('should call setExternalCheckoutXhr with methodId and payment sheet response', async () => {
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(processor.setExternalCheckoutXhr).toHaveBeenCalledWith(
+                    options.methodId,
+                    getCardDataResponse(),
+                );
+            });
+
+            it('should load checkout after receiving payment sheet response', async () => {
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.loadCheckout).toHaveBeenCalled();
+            });
+
+            it('should load payment method with the correct methodId', async () => {
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
+                    options.methodId,
+                );
+            });
+
+            it('should re-initialize processor with fresh payment method', async () => {
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                // called once in strategy.initialize() and once in _interactWithPaymentSheetAndPay
+                expect(processor.initialize).toHaveBeenCalledTimes(2);
+            });
+
+            it('should execute payment with methodId', async () => {
+                const executeSpy = jest.spyOn(strategy, 'execute');
+
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(executeSpy).toHaveBeenCalledWith({
+                    useStoreCredit: false,
+                    payment: { methodId: options.methodId },
+                });
+            });
+
+            it('should hide loading indicator after completing checkout', async () => {
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(LoadingHide).toHaveBeenCalled();
+            });
+
+            it('should update billing address if the "do not override address" experiment is OFF', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getStoreConfigOrThrow',
+                ).mockReturnValue({
+                    ...storeConfig,
+                    checkoutSettings: {
+                        ...storeConfig.checkoutSettings,
+                        features: {
+                            ...storeConfig.checkoutSettings.features,
+                            'PI-5111.google_pay_direct_pay_on_click': true,
+                            'PI-5031.google_pay_dont_override_address': false,
+                        },
+                    },
+                });
+
+                const billingAddress = { city: 'New York', address1: '5th Ave' };
+
+                jest.spyOn(processor, 'mapToBillingAddressRequestBody').mockReturnValue(
+                    billingAddress as BillingAddressRequestBody,
+                );
+
+                const updateAddressSpy = jest
+                    .spyOn(paymentIntegrationService, 'updateBillingAddress')
+                    .mockResolvedValue(paymentIntegrationService.getState());
+
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(updateAddressSpy).toHaveBeenCalledWith(billingAddress);
+            });
+
+            it('should NOT update billing address if the "do not override address" experiment is ON', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getStoreConfigOrThrow',
+                ).mockReturnValue({
+                    ...storeConfig,
+                    checkoutSettings: {
+                        ...storeConfig.checkoutSettings,
+                        features: {
+                            ...storeConfig.checkoutSettings.features,
+                            'PI-5111.google_pay_direct_pay_on_click': true,
+                            'PI-5031.google_pay_dont_override_address': true,
+                        },
+                    },
+                });
+
+                const updateAddressSpy = jest.spyOn(
+                    paymentIntegrationService,
+                    'updateBillingAddress',
+                );
+
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(updateAddressSpy).not.toHaveBeenCalled();
+            });
+        });
     });
 
     describe('#finalize', () => {

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -161,7 +161,12 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             try {
                 this._googlePayPaymentProcessor.setShouldRequestShipping(false);
                 await this._googlePayPaymentProcessor.initializeWidget();
-                await this._interactWithPaymentSheet();
+
+                if (this._isDirectPayOnClickEnabled()) {
+                    await this._interactWithPaymentSheetAndPay();
+                } else {
+                    await this._interactWithPaymentSheet();
+                }
             } catch (error) {
                 let err: unknown = error;
 
@@ -188,6 +193,50 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
             onPaymentSelect?.();
         };
+    }
+
+    protected async _interactWithPaymentSheetAndPay(): Promise<void> {
+        const response = await this._googlePayPaymentProcessor.showPaymentSheet();
+
+        this._toggleBlockDeinitialization(true);
+        this._toggleLoadingIndicator(true);
+
+        const methodId = this._getMethodId();
+
+        const state = this._paymentIntegrationService.getState();
+        const { features } = state.getStoreConfigOrThrow().checkoutSettings;
+        const isGooglePayDontOverrideAddresssExperimentOn = isExperimentEnabled(
+            features,
+            'PI-5031.google_pay_dont_override_address',
+        );
+
+        const billingAddress =
+            this._googlePayPaymentProcessor.mapToBillingAddressRequestBody(response);
+
+        if (billingAddress && !isGooglePayDontOverrideAddresssExperimentOn) {
+            await this._paymentIntegrationService.updateBillingAddress(billingAddress);
+        }
+
+        await this._googlePayPaymentProcessor.setExternalCheckoutXhr(methodId, response);
+
+        await this._paymentIntegrationService.loadCheckout();
+        await this._paymentIntegrationService.loadPaymentMethod(methodId);
+
+        const freshPaymentMethod = this._paymentIntegrationService
+            .getState()
+            .getPaymentMethodOrThrow<GooglePayInitializationData>(methodId);
+
+        await this._googlePayPaymentProcessor.initialize(() => freshPaymentMethod);
+
+        await this.execute({ useStoreCredit: false, payment: { methodId } });
+
+        this._completeCheckoutFlow();
+    }
+
+    protected _completeCheckoutFlow(): void {
+        window.location.replace('/checkout/order-confirmation');
+        this._toggleLoadingIndicator(false);
+        this._toggleBlockDeinitialization(false);
     }
 
     protected async _interactWithPaymentSheet(): Promise<void> {
@@ -324,6 +373,14 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 },
             },
         };
+    }
+
+    private _isDirectPayOnClickEnabled(): boolean {
+        const { features } = this._paymentIntegrationService
+            .getState()
+            .getStoreConfigOrThrow().checkoutSettings;
+
+        return isExperimentEnabled(features, 'PI-5111.google_pay_direct_pay_on_click');
     }
 
     private _toggleBlockDeinitialization(isBlocked: boolean) {


### PR DESCRIPTION
## What/Why?
Added direct pay in Google pay modal window



## Rollout/Rollback
Disable experiment 
PI-5111.google_pay_direct_pay_on_click

## Testing

https://github.com/user-attachments/assets/e61a613d-f1ff-4c64-a9c6-371e743b2535



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Google Pay checkout path that submits an order/payment and redirects immediately from the payment sheet when `PI-5111.google_pay_direct_pay_on_click` is enabled, which could affect checkout completion and address updates if edge cases aren’t handled. Gated by a feature flag, limiting blast radius.
> 
> **Overview**
> **Adds an experiment-gated “direct pay” flow for Google Pay button clicks.** When `PI-5111.google_pay_direct_pay_on_click` is enabled, the strategy now shows the payment sheet, optionally updates billing address (respecting `PI-5031.google_pay_dont_override_address`), refreshes checkout/payment method, re-initializes the processor, submits the order/payment via `execute`, then redirects to `/checkout/order-confirmation`.
> 
> **Tests updated** to cover the new direct-pay path, including loading indicator behavior, XHR setup, checkout/payment method reload, processor re-init, payment execution, and billing-address override rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70a2fb1983d22df1cc8cb5c1bee9465ebfe9d7c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->