### PR TITLE
fix(payment): Stripe CS add second payment request for Stripe declined

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -1430,9 +1430,7 @@ describe('StripeOCSPaymentStrategy', () => {
 
         describe('savedPaymentMethods from confirmation session', () => {
             it('uses savedPaymentMethods from confirmation session instead of calling getSession again', async () => {
-                const existingMethods = [
-                    { id: 'pm_existing', type: 'card', billingDetails: {} },
-                ];
+                const existingMethods = [{ id: 'pm_existing', type: 'card', billingDetails: {} }];
                 const newMethods = [
                     ...existingMethods,
                     {
@@ -1477,9 +1475,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 mockFirstPaymentRequest(errorResponse);
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
-                await stripeCSPaymentStrategy.execute(
-                    getStripeOCSOrderRequestBodyMock(methodId),
-                );
+                await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
 
                 expect(getSessionMock).toHaveBeenCalledTimes(3);
                 expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(2, {

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -1330,6 +1330,169 @@ describe('StripeOCSPaymentStrategy', () => {
             ).toHaveBeenCalled();
         });
 
+        describe('sendSecondPaymentRequestOnStripeError', () => {
+            const mockPaymentMethodWithFlag = (sendSecondPaymentRequestOnStripeError: boolean) => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...getStripeOCSMock(),
+                    initializationData: {
+                        ...getStripeOCSMock().initializationData,
+                        sendSecondPaymentRequestOnStripeError,
+                    },
+                });
+            };
+
+            const mockStripeCheckoutWithConfirm = (confirmFn: jest.Mock) => {
+                jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                    Promise.resolve({
+                        ...getStripeCheckoutInstanceMock(),
+                        loadActions: () =>
+                            Promise.resolve({
+                                type: StripeLoadActionsResultType.SUCCESS,
+                                actions: {
+                                    ...getStripeCheckoutSessionActionsMock(),
+                                    confirm: confirmFn,
+                                },
+                            }),
+                    }),
+                );
+            };
+
+            it('sends second submitPayment request when flag is true and stripe returns error', async () => {
+                const stripeErrorMock = { message: 'Your card was declined' };
+
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({ error: stripeErrorMock });
+                mockStripeCheckoutWithConfirm(confirmPaymentMock);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).rejects.toThrow(PaymentMethodFailedError);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            });
+
+            it('throws PaymentMethodFailedError with stripe decline message even when second submitPayment fails', async () => {
+                const stripeErrorMock = { message: 'Your card was declined' };
+
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                mockFirstPaymentRequest(new Error('second payment failed'));
+                confirmPaymentMock = jest.fn().mockResolvedValue({ error: stripeErrorMock });
+                mockStripeCheckoutWithConfirm(confirmPaymentMock);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).rejects.toThrow('Your card was declined');
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            });
+
+            it('does not send second submitPayment when flag is false and stripe returns error', async () => {
+                const stripeErrorMock = { message: 'Your card was declined' };
+
+                mockPaymentMethodWithFlag(false);
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({ error: stripeErrorMock });
+                mockStripeCheckoutWithConfirm(confirmPaymentMock);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).rejects.toThrow(PaymentMethodFailedError);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
+            });
+
+            it('sends second submitPayment and throws when confirmation returns no session and flag is true', async () => {
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({});
+                mockStripeCheckoutWithConfirm(confirmPaymentMock);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).rejects.toThrow(PaymentMethodFailedError);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            });
+        });
+
+        describe('savedPaymentMethods from confirmation session', () => {
+            it('uses savedPaymentMethods from confirmation session instead of calling getSession again', async () => {
+                const existingMethods = [
+                    { id: 'pm_existing', type: 'card', billingDetails: {} },
+                ];
+                const newMethods = [
+                    ...existingMethods,
+                    {
+                        id: 'pm_new',
+                        type: 'card',
+                        billingDetails: {},
+                        card: { brand: 'visa', last4: '1234', expMonth: 12, expYear: 2030 },
+                    },
+                ];
+
+                const getSessionMock = jest
+                    .fn()
+                    .mockResolvedValueOnce(null) // initial email check
+                    .mockResolvedValueOnce(null) // during execute _updateCheckoutSessionData
+                    .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }); // before confirm
+
+                const confirmPaymentMockLocal = jest.fn().mockResolvedValue({
+                    session: {
+                        id: 'checkoutSessionId',
+                        savedPaymentMethods: newMethods,
+                        status: {
+                            paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
+                        },
+                    },
+                });
+
+                jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                    Promise.resolve({
+                        ...getStripeCheckoutInstanceMock(),
+                        loadActions: () =>
+                            Promise.resolve({
+                                type: StripeLoadActionsResultType.SUCCESS,
+                                actions: {
+                                    ...getStripeCheckoutSessionActionsMock(),
+                                    confirm: confirmPaymentMockLocal,
+                                    getSession: getSessionMock,
+                                },
+                            }),
+                    }),
+                );
+
+                mockFirstPaymentRequest(errorResponse);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+                await stripeCSPaymentStrategy.execute(
+                    getStripeOCSOrderRequestBodyMock(methodId),
+                );
+
+                expect(getSessionMock).toHaveBeenCalledTimes(3);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(2, {
+                    methodId,
+                    paymentData: {
+                        formattedPayload: expect.objectContaining({
+                            vault_payment_instrument: true,
+                        }),
+                    },
+                });
+            });
+        });
+
         describe('vaultings', () => {
             let confirmPaymentMockLocal: jest.Mock;
             let getSessionMock: jest.Mock;

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -336,8 +336,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         if (stripeError || !stripeCheckoutSession) {
             if (sendSecondPaymentRequestOnStripeError) {
                 // INFO: even in case when stripe payment confirmation was declined
-                // we need to send submitPayment request to update status of checkout session on BE side
-                // and after this we need to throw error to display decline message to the user.
+                // we need to send submitPayment request to update status of checkout session on BE side.
                 try {
                     await this.paymentIntegrationService.submitPayment(paymentPayload);
                 } catch {

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -20,6 +20,7 @@ import {
     StripeAdditionalActionRequired,
     StripeCheckoutInstance,
     StripeCheckoutSession,
+    StripeCheckoutSessionActionResult,
     StripeCheckoutSessionActions,
     StripeCheckoutSessionPaymentStatus,
     StripeClient,
@@ -111,7 +112,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         try {
             await this.paymentIntegrationService.submitPayment(paymentPayload);
         } catch (error) {
-            await this._processAdditionalAction(error, methodId);
+            await this._processAdditionalAction(error, gatewayId, methodId);
         }
     }
 
@@ -298,6 +299,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
     private async _processAdditionalAction(
         error: unknown,
+        gatewayId: string,
         methodId: string,
     ): Promise<PaymentIntegrationSelectors | undefined> {
         if (
@@ -310,24 +312,43 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         const { data: additionalActionData } = error.body?.additional_action_required || {};
         const { token } = additionalActionData || {};
         const existingStripeSavedPaymentMethods = await this._getStripeSavedPaymentMethodsOrThrow();
-        const { id: checkoutSessionId, status: checkoutSessionStatus } =
-            await this._confirmStripePaymentOrThrow(additionalActionData);
-        const newStripeSavedPaymentMethods = await this._getStripeSavedPaymentMethodsOrThrow();
+        const { session: stripeCheckoutSession, error: stripeError } = await this._confirmStripePayment(additionalActionData);
+        const newStripeSavedPaymentMethods = await this._getStripeSavedPaymentMethodsOrThrow(stripeCheckoutSession);
+        const { id: checkoutSessionId, status: checkoutSessionStatus } = stripeCheckoutSession || {};
         const newVaultedStripeInstrument = this._getNewVaultedStripeInstrument(
             existingStripeSavedPaymentMethods,
             newStripeSavedPaymentMethods,
         );
-
         const paymentPayload = this._getPaymentPayload(
             methodId,
             checkoutSessionId || token,
             newVaultedStripeInstrument,
         );
+        const { initializationData } = this.paymentIntegrationService
+            .getState()
+            .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
+        const { sendSecondPaymentRequestOnStripeError } = initializationData || {};
+
+        if (stripeError || !stripeCheckoutSession) {
+            if (sendSecondPaymentRequestOnStripeError) {
+                // INFO: even in case when stripe payment confirmation was declined
+                // we need to send submitPayment request to update status of checkout session on BE side
+                // and after this we need to throw error to display decline message to the user.
+                try {
+                    await this.paymentIntegrationService.submitPayment(paymentPayload);
+                } catch {
+                    // INFO: additional action should be ignored for this update status request.
+                    // will throw Stripe error message to the shopper.
+                }
+            }
+
+            throw new PaymentMethodFailedError(stripeError?.message);
+        }
 
         try {
             return await this.paymentIntegrationService.submitPayment(paymentPayload);
         } catch (error) {
-            if (checkoutSessionStatus.paymentStatus === StripeCheckoutSessionPaymentStatus.Paid) {
+            if (checkoutSessionStatus?.paymentStatus === StripeCheckoutSessionPaymentStatus.Paid) {
                 this.stripeIntegrationService.throwPaymentConfirmationProceedMessage();
             }
 
@@ -335,9 +356,9 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         }
     }
 
-    private async _confirmStripePaymentOrThrow(
+    private async _confirmStripePayment(
         additionalActionData: StripeAdditionalActionRequired['data'],
-    ): Promise<StripeCheckoutSession | never> {
+    ): Promise<StripeCheckoutSessionActionResult | never> {
         const { redirect_url } = additionalActionData || {};
 
         if (!this.stripeCheckout) {
@@ -346,16 +367,10 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
         const stripeActions = await this._getStripeActionsOrThrow();
 
-        const { session: stripeCheckoutSession, error: stripeError } = await stripeActions.confirm({
+        return await stripeActions.confirm({
             redirect: StripeStringConstants.IF_REQUIRED,
             returnUrl: redirect_url,
         });
-
-        if (stripeError || !stripeCheckoutSession) {
-            throw new PaymentMethodFailedError(stripeError?.message);
-        }
-
-        return stripeCheckoutSession;
     }
 
     private async _updateStripeShopperData(): Promise<void> {
@@ -409,7 +424,13 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         });
     }
 
-    private async _getStripeSavedPaymentMethodsOrThrow(): Promise<StripeSavedPaymentMethod[]> {
+    private async _getStripeSavedPaymentMethodsOrThrow(
+        stripeCheckoutSession?: StripeCheckoutSession,
+    ): Promise<StripeSavedPaymentMethod[]> {
+        if (stripeCheckoutSession?.savedPaymentMethods) {
+            return stripeCheckoutSession.savedPaymentMethods;
+        }
+
         const stripeActions = await this._getStripeActionsOrThrow();
         const { savedPaymentMethods } = (await stripeActions.getSession()) || {};
 

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -312,9 +312,13 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         const { data: additionalActionData } = error.body?.additional_action_required || {};
         const { token } = additionalActionData || {};
         const existingStripeSavedPaymentMethods = await this._getStripeSavedPaymentMethodsOrThrow();
-        const { session: stripeCheckoutSession, error: stripeError } = await this._confirmStripePayment(additionalActionData);
-        const newStripeSavedPaymentMethods = await this._getStripeSavedPaymentMethodsOrThrow(stripeCheckoutSession);
-        const { id: checkoutSessionId, status: checkoutSessionStatus } = stripeCheckoutSession || {};
+        const { session: stripeCheckoutSession, error: stripeError } =
+            await this._confirmStripePayment(additionalActionData);
+        const newStripeSavedPaymentMethods = await this._getStripeSavedPaymentMethodsOrThrow(
+            stripeCheckoutSession,
+        );
+        const { id: checkoutSessionId, status: checkoutSessionStatus } =
+            stripeCheckoutSession || {};
         const newVaultedStripeInstrument = this._getNewVaultedStripeInstrument(
             existingStripeSavedPaymentMethods,
             newStripeSavedPaymentMethods,
@@ -367,7 +371,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
         const stripeActions = await this._getStripeActionsOrThrow();
 
-        return await stripeActions.confirm({
+        return stripeActions.confirm({
             redirect: StripeStringConstants.IF_REQUIRED,
             returnUrl: redirect_url,
         });

--- a/packages/stripe-utils/src/index.ts
+++ b/packages/stripe-utils/src/index.ts
@@ -34,7 +34,9 @@ export {
     StripeInitCheckoutOptions,
     StripeLoadActionsResultType,
     StripeCheckoutSession,
+    StripeCheckoutSessionActionResult,
     StripeCheckoutSessionActions,
+    StripeCheckoutSessionConfirmationError,
     StripeCheckoutSessionPaymentStatus,
     StripeSavedPaymentMethod,
 } from './stripe';

--- a/packages/stripe-utils/src/stripe.ts
+++ b/packages/stripe-utils/src/stripe.ts
@@ -148,6 +148,14 @@ export interface StripeError {
     payment_intent: PaymentIntent;
 }
 
+export interface StripeCheckoutSessionConfirmationError {
+    code?: string;
+    message: string;
+    paymentFailed?: {
+        declineCode?: string;
+    };
+}
+
 export interface StripeElement {
     /**
      * The `element.mount` method attaches your element to the DOM.
@@ -524,7 +532,7 @@ export interface StripeLoadActionsResult {
 
 export interface StripeCheckoutSessionActionResult {
     type: StripeLoadActionsResultType;
-    error?: StripeError;
+    error?: StripeCheckoutSessionConfirmationError;
     session?: StripeCheckoutSession;
 }
 
@@ -766,6 +774,7 @@ export interface StripeInitializationData {
     captureMethod?: 'automatic' | 'manual';
     useNewStripeJsVersion?: boolean;
     checkoutSessionEnabled?: boolean;
+    sendSecondPaymentRequestOnStripeError?: boolean;
 }
 
 export interface StripeElementUpdateOptions {


### PR DESCRIPTION
## What/Why?
Add second payments request after decline payment by the Stripe.
Need this to update payment status on the BC side
Feature is under experiment `STRIPE-1391.update_payment_status_after_stripe_decline`

## Rollout/Rollback
Rollback this pr.

## Testing
Before:
<img width="1800" height="1042" alt="Screenshot 2026-04-09 at 13 46 24" src="https://github.com/user-attachments/assets/e0f5750f-3a0d-430c-aa40-113d3429950a" />
<img width="1448" height="519" alt="Screenshot 2026-04-09 at 13 46 37" src="https://github.com/user-attachments/assets/d14188fa-d9eb-4005-8c0c-491f5bb999b6" />

After:
<img width="1800" height="1043" alt="Screenshot 2026-04-09 at 13 41 48" src="https://github.com/user-attachments/assets/9968d529-dfcd-417b-8abf-60c64ad79c30" />
<img width="1456" height="489" alt="Screenshot 2026-04-09 at 13 42 09" src="https://github.com/user-attachments/assets/dd35b8b2-871f-4dda-9cff-5b56faa70bc6" />

Test coverage:
<img width="724" height="75" alt="Screenshot 2026-04-09 at 14 39 02" src="https://github.com/user-attachments/assets/833829d5-18fc-4cf7-9ff7-ddc976f350c9" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Stripe Checkout Session additional-action handling to optionally fire an extra `submitPayment` even when Stripe confirmation fails, which affects payment state transitions and error messaging. Risk is contained by a new initialization flag, but incorrect flag rollout could change how declines are recorded server-side.
> 
> **Overview**
> **Stripe Checkout Session additional-action handling now supports an optional “status update” payment call on Stripe declines.** When Stripe `confirm` returns an error or no session, `StripeCSPaymentStrategy` can (via new `initializationData.sendSecondPaymentRequestOnStripeError`) issue a second `submitPayment` to let the backend update the checkout-session status, then surface the Stripe decline message to the shopper.
> 
> The confirmation flow was refactored to return the full `confirm` result (session + error) and to reuse `savedPaymentMethods` from the confirmation session when present, avoiding an extra `getSession` fetch. Types in `stripe-utils` were updated accordingly (new `StripeCheckoutSessionConfirmationError`, updated `StripeCheckoutSessionActionResult`, and the new initialization flag), and unit tests were added to cover the new flag behavior and saved-method reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7b1925005969480c854a18aa5e4084f9baead34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->