### PR TITLE
fix(payment): PI-5195 AmazonPay checkout fix

### DIFF
--- a/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.spec.ts
@@ -398,11 +398,10 @@ describe('AmazonPayV2PaymentStrategy', () => {
             void strategy.execute(orderRequestBody, initializeOptions);
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(amazonPayV2PaymentProcessor.prepareCheckout).toHaveBeenNthCalledWith(
-                1,
-                expectedConfig,
-            );
-            expect(amazonPayButton.click).toHaveBeenCalled();
+            expect(
+                amazonPayV2PaymentProcessor.initCheckoutWithSessionConfig,
+            ).toHaveBeenNthCalledWith(1, expectedConfig);
+            expect(amazonPayButton.click).not.toHaveBeenCalled();
         });
 
         describe('should fail if...', () => {
@@ -459,7 +458,9 @@ describe('AmazonPayV2PaymentStrategy', () => {
                 );
 
                 expect(window.location.assign).not.toHaveBeenCalled();
-                expect(amazonPayV2PaymentProcessor.prepareCheckout).not.toHaveBeenCalled();
+                expect(
+                    amazonPayV2PaymentProcessor.initCheckoutWithSessionConfig,
+                ).not.toHaveBeenCalled();
             });
         });
     });

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.ts
@@ -128,10 +128,12 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
                     return new Promise(() => window.location.assign(redirect_url));
                 }
 
-                this.amazonPayV2PaymentProcessor.prepareCheckout(
+                this.amazonPayV2PaymentProcessor.initCheckoutWithSessionConfig(
                     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                     JSON.parse(redirect_url) as Required<AmazonPayV2CheckoutSessionConfig>,
                 );
+
+                return new Promise<never>(noop);
             }
         }
 

--- a/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.spec.ts
@@ -259,6 +259,69 @@ describe('AmazonPayV2PaymentProcessor', () => {
         });
     });
 
+    describe('#initCheckoutWithSessionConfig', () => {
+        const containerId = 'amazonpay-container';
+        let amazonPayV2ButtonParams: Required<AmazonPayV2NewButtonParams>;
+        let createCheckoutSessionConfig: Required<AmazonPayV2CheckoutSessionConfig>;
+
+        beforeEach(() => {
+            amazonPayV2ButtonParams =
+                getAmazonPayV2Ph4ButtonParamsMock() as Required<AmazonPayV2NewButtonParams>;
+
+            const { publicKeyId, createCheckoutSessionConfig: signedPayload } =
+                amazonPayV2ButtonParams;
+
+            createCheckoutSessionConfig = {
+                publicKeyId,
+                ...signedPayload,
+            };
+        });
+
+        describe('should initiate checkout immediately:', () => {
+            beforeEach(async () => {
+                await processor.initialize(amazonPayV2Mock);
+                processor.createButton(containerId, amazonPayV2ButtonParams);
+            });
+
+            test('config does not include publicKeyId because it has an environment prefix', () => {
+                const expectedConfig = {
+                    createCheckoutSessionConfig:
+                        amazonPayV2ButtonParams.createCheckoutSessionConfig,
+                };
+
+                processor.initCheckoutWithSessionConfig(createCheckoutSessionConfig);
+
+                const amazonPayV2Button: AmazonPayV2Button = (
+                    amazonPayV2SDKMock.Pay.renderButton as jest.Mock
+                ).mock.results[0].value;
+
+                expect(amazonPayV2Button.initCheckout).toHaveBeenNthCalledWith(1, expectedConfig);
+            });
+
+            test('config includes publicKeyId because it does not have an environment prefix', () => {
+                const expectedConfig = {
+                    createCheckoutSessionConfig,
+                };
+
+                createCheckoutSessionConfig.publicKeyId = 'foo';
+                processor.initCheckoutWithSessionConfig(createCheckoutSessionConfig);
+
+                const amazonPayV2Button: AmazonPayV2Button = (
+                    amazonPayV2SDKMock.Pay.renderButton as jest.Mock
+                ).mock.results[0].value;
+
+                expect(amazonPayV2Button.initCheckout).toHaveBeenNthCalledWith(1, expectedConfig);
+            });
+        });
+
+        it('throws an error when amazonPayV2Button is not initialized', () => {
+            const initCheckoutWithSessionConfig = () =>
+                processor.initCheckoutWithSessionConfig(createCheckoutSessionConfig);
+
+            expect(initCheckoutWithSessionConfig).toThrow(NotInitializedError);
+        });
+    });
+
     describe('#prepareCheckoutWithCreationRequestConfig', () => {
         const containerId = 'amazonpay-container';
         let amazonPayV2ButtonParams: Required<AmazonPayV2NewButtonParams>;

--- a/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
@@ -81,6 +81,18 @@ export default class AmazonPayV2PaymentProcessor {
         });
     }
 
+    /**
+     * Opens Amazon Pay checkout using a checkout session payload from BigPay
+     * (`additional_action_required`/APB)
+     */
+    initCheckoutWithSessionConfig(
+        createCheckoutSessionConfig: Required<AmazonPayV2CheckoutSessionConfig>,
+    ): void {
+        const requestConfig = this.prepareRequestConfig(createCheckoutSessionConfig);
+
+        this.getAmazonPayV2Button().initCheckout(requestConfig);
+    }
+
     prepareCheckoutWithCreationRequestConfig(
         createCheckoutConfig: () => Promise<
             | {

--- a/packages/amazon-pay-utils/src/mocks/amazon-pay-v2.mock.ts
+++ b/packages/amazon-pay-utils/src/mocks/amazon-pay-v2.mock.ts
@@ -134,6 +134,7 @@ export function getAmazonPayV2PaymentProcessorMock() {
         bindButton: jest.fn(),
         createButton: jest.fn(),
         prepareCheckout: jest.fn(),
+        initCheckoutWithSessionConfig: jest.fn(),
         prepareCheckoutWithCreationRequestConfig: jest.fn(),
         signout: jest.fn(() => Promise.resolve()),
         renderAmazonPayButton: jest.fn(),

--- a/packages/amazon-pay-utils/tsconfig.lib.json
+++ b/packages/amazon-pay-utils/tsconfig.lib.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "outDir": "../../dist/out-tsc",
         "declaration": true,
-        "types": []
+        "types": ["jest"]
     },
     "include": ["**/*.ts"],
     "exclude": ["**/*.spec.ts"]


### PR DESCRIPTION
## What/Why?
Amazon Pay button freezes after clicking Continue with Amazon Pay

## Rollout/Rollback

Revert this PR

## Testing

https://github.com/user-attachments/assets/899cfaec-9599-49f3-95a5-38e3f42a1cdf

