### PR TITLE
chore(checkout): CHECKOUT-9902 Update logging to get details when strategy resolution fails

### DIFF
--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -11,6 +11,7 @@ import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
+import { getDefaultLogger } from '../common/log';
 import {
     LoadOrderPaymentsAction,
     OrderActionCreator,
@@ -286,11 +287,18 @@ export default class PaymentStrategyActionCreator {
         try {
             strategy = this._strategyRegistry.getByMethod(method);
         } catch {
-            strategy = this._strategyRegistryV2.get({
-                id: method.id,
-                gateway: method.gateway,
-                type: method.type,
-            });
+            try {
+                strategy = this._strategyRegistryV2.get({
+                    id: method.id,
+                    gateway: method.gateway,
+                    type: method.type,
+                });
+            } catch (error) {
+                getDefaultLogger().error(
+                    `[PaymentStrategyActionCreator] Unable to resolve V2 strategy for id: ${method.id}, gateway: ${method.gateway}, type: ${method.type}`,
+                );
+                throw error;
+            }
         }
 
         return strategy;


### PR DESCRIPTION
## What/Why?
From previous effort to log details, we found that there are calls that fail when the query has `{default: true}`. Which is triggering a fallback path. 

Hence update logging to identify what might actually be the query that throws this error.

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds additional error logging around payment strategy resolution without changing control flow beyond rethrowing the same error.
> 
> **Overview**
> Adds defensive logging in `PaymentStrategyActionCreator._getStrategy` when the fallback lookup in `PaymentStrategyRegistryV2.get` throws, emitting the `method.id`, `gateway`, and `type` before rethrowing the error.
> 
> Also imports `getDefaultLogger` to support the new log line; no other payment execution/initialization/finalization behavior is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb2393977f9bb07f5581800a9b661c39ea537658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->