### PR TITLE
fix(payment): Update locale for Stripe OCS

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -16,7 +16,6 @@ import {
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
-    formatStripeLocale,
     isStripePaymentEvent,
     isStripePaymentMethodLike,
     StripeAdditionalActionRequired,
@@ -160,7 +159,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         }
 
         const { clientToken, initializationData } = paymentMethod;
-        const { shopperLanguage, customerSessionToken, enableLink } = initializationData;
+        const { customerSessionToken, enableLink } = initializationData;
 
         if (!clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
@@ -182,7 +181,6 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         this.stripeElements = await this.scriptLoader.getElements(this.stripeClient, {
             clientSecret: clientToken,
             customerSessionClientSecret: customerSessionToken,
-            locale: formatStripeLocale(shopperLanguage),
             appearance,
             fonts,
         });


### PR DESCRIPTION
## What/Why?
Remove explicit `locale` parameter from Stripe Elements (`getElements`) configuration in the OCS payment strategy
The Stripe client already [receives the locale](https://github.com/bigcommerce/checkout-sdk-js/blob/master/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts#L255) via `getCartLocale()` during initialization, and Elements inherits it from the client — passing it again was redundant.

## Rollout/Rollback
Rollback this PR

## Testing
Before:
<img width="2519" height="1197" alt="Screenshot 2026-04-14 at 13 35 24" src="https://github.com/user-attachments/assets/d8eaa148-a481-4139-8f85-43428bcc6d73" />
 
After:
<img width="2553" height="1193" alt="Screenshot 2026-04-14 at 13 46 11" src="https://github.com/user-attachments/assets/7864383e-c5b8-436c-81d4-11b1818295cc" />

<img width="708" height="73" alt="Screenshot 2026-04-14 at 14 25 00" src="https://github.com/user-attachments/assets/f695bc70-3495-4a2d-9778-5757fbbbb806" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only removes an explicit `locale` override when creating Stripe Elements for OCS, relying on the Stripe client/cart locale instead.
> 
> **Overview**
> Updates the Stripe OCS payment strategy to **stop passing an explicit `locale`** into `StripeScriptLoader.getElements`, relying on the locale already configured on the Stripe client.
> 
> This also removes the now-unused `formatStripeLocale` import and the `shopperLanguage` initialization-data usage tied to that Elements configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e944e9b01b2aba5d30a2d761fad87eb3b6c50ffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->