### PR TITLE
chore(checkout): CHECKOUT-9950 Add experiment aware request sender

### DIFF
--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -1,9 +1,10 @@
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { createDataStoreProjection } from '../common/data-store';
 import { ErrorActionCreator, ErrorLogger } from '../common/error';
+import { ExperimentAwareRequestSender } from '../common/http-request';
 import { getDefaultLogger } from '../common/log';
 import { getEnvironment } from '../common/utility';
 import { ConfigActionCreator, ConfigRequestSender, ConfigState, ConfigWindow } from '../config';
@@ -113,12 +114,17 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     const { locale = '', shouldWarnMutation = true } = options || {};
     const requestSender = createRequestSender({ host: options && options.host });
     const store = createCheckoutStore({ config }, { shouldWarnMutation });
+    const experimentRequestSender = new ExperimentAwareRequestSender(requestSender, {
+        getBasePath: () => store.getState().config.getStoreConfig()?.links.baseUrl ?? undefined,
+        getFeatures: () =>
+            store.getState().config.getStoreConfig()?.checkoutSettings?.features ?? {},
+    }) as unknown as RequestSender;
     const paymentClient = createPaymentClient(store);
-    const orderRequestSender = new OrderRequestSender(requestSender);
-    const checkoutRequestSender = new CheckoutRequestSender(requestSender);
+    const orderRequestSender = new OrderRequestSender(experimentRequestSender);
+    const checkoutRequestSender = new CheckoutRequestSender(experimentRequestSender);
     const configActionCreator = new ConfigActionCreator(new ConfigRequestSender(requestSender));
     const spamProtection = createSpamProtection(createScriptLoader());
-    const spamProtectionRequestSender = new SpamProtectionRequestSender(requestSender);
+    const spamProtectionRequestSender = new SpamProtectionRequestSender(experimentRequestSender);
     const spamProtectionActionCreator = new SpamProtectionActionCreator(
         spamProtection,
         spamProtectionRequestSender,
@@ -128,10 +134,10 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new CheckoutValidator(checkoutRequestSender),
     );
     const subscriptionsActionCreator = new SubscriptionsActionCreator(
-        new SubscriptionsRequestSender(requestSender),
+        new SubscriptionsRequestSender(experimentRequestSender),
     );
     const formFieldsActionCreator = new FormFieldsActionCreator(
-        new FormFieldsRequestSender(requestSender),
+        new FormFieldsRequestSender(experimentRequestSender),
     );
     const checkoutActionCreator = new CheckoutActionCreator(
         checkoutRequestSender,
@@ -157,7 +163,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         rollOutLazyPaymentStrategies ? {} : customerStrategyFactories,
     );
     const extensionActionCreator = new ExtensionActionCreator(
-        new ExtensionRequestSender(requestSender),
+        new ExtensionRequestSender(experimentRequestSender),
     );
     const workerExtensionMessenger = new WorkerExtensionMessenger();
     const extensionMessenger = new ExtensionMessenger(store, workerExtensionMessenger);
@@ -169,48 +175,52 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         extensionMessenger,
         createExtensionEventBroadcaster(storeProjection, extensionMessenger),
         new BillingAddressActionCreator(
-            new BillingAddressRequestSender(requestSender),
+            new BillingAddressRequestSender(experimentRequestSender),
             subscriptionsActionCreator,
         ),
         checkoutActionCreator,
         configActionCreator,
         new CustomerActionCreator(
-            new CustomerRequestSender(requestSender),
+            new CustomerRequestSender(experimentRequestSender),
             checkoutActionCreator,
             spamProtectionActionCreator,
         ),
         new ConsignmentActionCreator(
-            new ConsignmentRequestSender(requestSender),
+            new ConsignmentRequestSender(experimentRequestSender),
             checkoutRequestSender,
         ),
-        new CountryActionCreator(new CountryRequestSender(requestSender, { locale })),
-        new CouponActionCreator(new CouponRequestSender(requestSender)),
+        new CountryActionCreator(new CountryRequestSender(experimentRequestSender, { locale })),
+        new CouponActionCreator(new CouponRequestSender(experimentRequestSender)),
         new CustomerStrategyActionCreator(
-            createCustomerStrategyRegistry(store, requestSender),
+            createCustomerStrategyRegistry(store, experimentRequestSender),
             customerRegistryV2,
             paymentIntegrationService,
         ),
         new ErrorActionCreator(),
-        new GiftCertificateActionCreator(new GiftCertificateRequestSender(requestSender)),
-        new InstrumentActionCreator(new InstrumentRequestSender(paymentClient, requestSender)),
+        new GiftCertificateActionCreator(new GiftCertificateRequestSender(experimentRequestSender)),
+        new InstrumentActionCreator(
+            new InstrumentRequestSender(paymentClient, experimentRequestSender),
+        ),
         orderActionCreator,
-        new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
+        new PaymentMethodActionCreator(new PaymentMethodRequestSender(experimentRequestSender)),
         new PaymentStrategyActionCreator(
-            createPaymentStrategyRegistry(store, paymentClient, requestSender),
+            createPaymentStrategyRegistry(store, paymentClient, experimentRequestSender),
             registryV2,
             orderActionCreator,
             spamProtectionActionCreator,
             paymentIntegrationService,
         ),
-        new PickupOptionActionCreator(new PickupOptionRequestSender(requestSender)),
+        new PickupOptionActionCreator(new PickupOptionRequestSender(experimentRequestSender)),
         new ShippingCountryActionCreator(
-            new ShippingCountryRequestSender(requestSender, { locale }),
+            new ShippingCountryRequestSender(experimentRequestSender, { locale }),
             store,
         ),
-        new ShippingStrategyActionCreator(createShippingStrategyRegistry(store, requestSender)),
-        new SignInEmailActionCreator(new SignInEmailRequestSender(requestSender)),
+        new ShippingStrategyActionCreator(
+            createShippingStrategyRegistry(store, experimentRequestSender),
+        ),
+        new SignInEmailActionCreator(new SignInEmailRequestSender(experimentRequestSender)),
         spamProtectionActionCreator,
-        new StoreCreditActionCreator(new StoreCreditRequestSender(requestSender)),
+        new StoreCreditActionCreator(new StoreCreditRequestSender(experimentRequestSender)),
         subscriptionsActionCreator,
         formFieldsActionCreator,
         extensionActionCreator,

--- a/packages/core/src/common/http-request/experiment-aware-request-sender.spec.ts
+++ b/packages/core/src/common/http-request/experiment-aware-request-sender.spec.ts
@@ -1,0 +1,126 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import ExperimentAwareRequestSender, { ExperimentConfig } from './experiment-aware-request-sender';
+import { getResponse } from './responses.mock';
+
+describe('ExperimentAwareRequestSender', () => {
+    const EXPERIMENT_FLAG = 'CHECKOUT-9950.update_sf_checkout_url_for_subfolder';
+    const url = '/api/storefront/checkouts/123/billing-address';
+    const absoluteUrl = 'https://other-domain.com/api/storefront/checkouts/123/billing-address';
+    const options = { body: { foo: 'bar' } };
+    const response = getResponse({});
+
+    let requestSender: RequestSender;
+    let config: ExperimentConfig;
+    let sender: ExperimentAwareRequestSender;
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        jest.spyOn(requestSender, 'sendRequest').mockResolvedValue(response);
+        jest.spyOn(requestSender, 'get').mockResolvedValue(response);
+        jest.spyOn(requestSender, 'post').mockResolvedValue(response);
+        jest.spyOn(requestSender, 'put').mockResolvedValue(response);
+        jest.spyOn(requestSender, 'patch').mockResolvedValue(response);
+        jest.spyOn(requestSender, 'delete').mockResolvedValue(response);
+
+        config = {
+            getBasePath: jest.fn().mockReturnValue('https://store.example.com/en'),
+            getFeatures: jest.fn().mockReturnValue({ [EXPERIMENT_FLAG]: true }),
+        };
+
+        sender = new ExperimentAwareRequestSender(requestSender, config);
+    });
+
+    describe('passthrough methods (no URL prefixing)', () => {
+        it('forwards sendRequest without prefixing', async () => {
+            await sender.sendRequest(url, options);
+
+            expect(requestSender.sendRequest).toHaveBeenCalledWith(url, options);
+        });
+
+        it('forwards get without prefixing', async () => {
+            await sender.get(url, options);
+
+            expect(requestSender.get).toHaveBeenCalledWith(url, options);
+        });
+    });
+
+    describe('mutating methods with experiment enabled and basePath set', () => {
+        it('prefixes url for post', async () => {
+            await sender.post(url, options);
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://store.example.com/en/api/storefront/checkouts/123/billing-address',
+                options,
+            );
+        });
+
+        it('prefixes url for put', async () => {
+            await sender.put(url, options);
+
+            expect(requestSender.put).toHaveBeenCalledWith(
+                'https://store.example.com/en/api/storefront/checkouts/123/billing-address',
+                options,
+            );
+        });
+
+        it('prefixes url for patch', async () => {
+            await sender.patch(url, options);
+
+            expect(requestSender.patch).toHaveBeenCalledWith(
+                'https://store.example.com/en/api/storefront/checkouts/123/billing-address',
+                options,
+            );
+        });
+
+        it('prefixes url for delete', async () => {
+            await sender.delete(url, options);
+
+            expect(requestSender.delete).toHaveBeenCalledWith(
+                'https://store.example.com/en/api/storefront/checkouts/123/billing-address',
+                options,
+            );
+        });
+    });
+
+    describe('_prefixed guard conditions', () => {
+        it('does not prefix when experiment flag is disabled', async () => {
+            (config.getFeatures as jest.Mock).mockReturnValue({ [EXPERIMENT_FLAG]: false });
+
+            await sender.post(url, options);
+
+            expect(requestSender.post).toHaveBeenCalledWith(url, options);
+        });
+
+        it('does not prefix when features are empty (config not loaded yet)', async () => {
+            (config.getFeatures as jest.Mock).mockReturnValue({});
+
+            await sender.post(url, options);
+
+            expect(requestSender.post).toHaveBeenCalledWith(url, options);
+        });
+
+        it('does not prefix when basePath is undefined', async () => {
+            (config.getBasePath as jest.Mock).mockReturnValue(undefined);
+
+            await sender.post(url, options);
+
+            expect(requestSender.post).toHaveBeenCalledWith(url, options);
+        });
+
+        it('does not prefix when basePath ends with /checkout', async () => {
+            (config.getBasePath as jest.Mock).mockReturnValue('https://store.example.com/checkout');
+
+            await sender.post(url, options);
+
+            expect(requestSender.post).toHaveBeenCalledWith(url, options);
+        });
+
+        it('does not prefix when url is absolute', async () => {
+            await sender.post(absoluteUrl, options);
+
+            expect(requestSender.post).toHaveBeenCalledWith(absoluteUrl, options);
+        });
+    });
+});

--- a/packages/core/src/common/http-request/experiment-aware-request-sender.ts
+++ b/packages/core/src/common/http-request/experiment-aware-request-sender.ts
@@ -1,0 +1,54 @@
+import { RequestOptions, RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { StoreConfig } from '../../config';
+
+export interface ExperimentConfig {
+    getBasePath: () => string | undefined;
+    getFeatures: () => StoreConfig['checkoutSettings']['features'];
+}
+
+export default class ExperimentAwareRequestSender {
+    constructor(private _requestSender: RequestSender, private _config: ExperimentConfig) {}
+
+    sendRequest<T>(url: string, options?: RequestOptions): Promise<Response<T>> {
+        return this._requestSender.sendRequest(url, options);
+    }
+
+    get<T>(url: string, options?: RequestOptions): Promise<Response<T>> {
+        return this._requestSender.get(url, options);
+    }
+
+    post<T>(url: string, options?: RequestOptions): Promise<Response<T>> {
+        return this._requestSender.post(this._prefixed(url), options);
+    }
+
+    put<T>(url: string, options?: RequestOptions): Promise<Response<T>> {
+        return this._requestSender.put(this._prefixed(url), options);
+    }
+
+    patch<T>(url: string, options?: RequestOptions): Promise<Response<T>> {
+        return this._requestSender.patch(this._prefixed(url), options);
+    }
+
+    delete<T>(url: string, options?: RequestOptions): Promise<Response<T>> {
+        return this._requestSender.delete(this._prefixed(url), options);
+    }
+
+    private _prefixed(url: string): string {
+        const basePath = this._config.getBasePath();
+
+        const isExperimentEnabled =
+            this._config.getFeatures()['CHECKOUT-9950.update_sf_checkout_url_for_subfolder'];
+
+        if (
+            !isExperimentEnabled ||
+            !basePath ||
+            basePath.endsWith('/checkout') ||
+            /^https?:\/\//.test(url)
+        ) {
+            return url;
+        }
+
+        return `${basePath}${url}`;
+    }
+}

--- a/packages/core/src/common/http-request/index.ts
+++ b/packages/core/src/common/http-request/index.ts
@@ -1,6 +1,9 @@
 export * from './internal-api-headers';
 export * from './sdk-version-headers';
 
+export { default as ExperimentAwareRequestSender } from './experiment-aware-request-sender';
+export type { ExperimentConfig } from './experiment-aware-request-sender';
+
 export { default as InternalResponseBody } from './internal-response-body';
 export { default as ContentType } from './content-type';
 export { default as RequestOptions } from './request-options';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -74,6 +74,7 @@ export interface PaymentSettings {
 }
 
 export interface StoreLinks {
+    baseUrl?: string | null;
     cartLink: string;
     checkoutLink: string;
     createAccountLink: string;

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -74,6 +74,7 @@ export interface PaymentSettings {
 }
 
 export interface StoreLinks {
+    baseUrl?: string | null;
     cartLink: string;
     checkoutLink: string;
     createAccountLink: string;


### PR DESCRIPTION
## What/Why?
Add experiment aware request sender to append subfolder locale before making API requests.

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast

- When a store has subfolder for base path

https://github.com/user-attachments/assets/dde17fe4-3b3c-48d8-99c5-dca72e0d0bdf

- When a store does not have subfolder for base path

https://github.com/user-attachments/assets/fd3fa065-77ee-40a1-aafc-997699b749d5

- When a store does not have subfolder for base path but checkout is on subfolder

https://github.com/user-attachments/assets/4d63ca01-937b-4976-b6c2-58a7c118c627

- For a store with no subfolder and experiment on

https://github.com/user-attachments/assets/b0420662-490e-47d0-bf44-efcd9e6375d1

- For a store with no subfolder and experiment off

https://github.com/user-attachments/assets/11de7b89-a6f4-409d-b966-f63b1ce41b52





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core checkout networking by routing many mutating API calls through a new URL-prefixing wrapper gated by a feature flag; mistakes could cause checkout write requests to hit the wrong endpoint in some configurations.
> 
> **Overview**
> **Adds `ExperimentAwareRequestSender`** to conditionally prefix *mutating* request URLs (`post`/`put`/`patch`/`delete`) with the store `links.baseUrl` when the `CHECKOUT-9950.update_sf_checkout_url_for_subfolder` feature flag is enabled, while leaving `get`/`sendRequest` unchanged and skipping prefixing for absolute URLs or when `baseUrl` ends with `/checkout`.
> 
> **Routes most checkout request senders through the new wrapper** in `createCheckoutService` (order, checkout, consignments, customer, coupons, instruments, shipping, etc.) so write operations can target subfolder storefront URLs; adds unit coverage for the prefixing and guard conditions. Also extends `StoreLinks` in both `core` and `payment-integration-api` configs to include optional `baseUrl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df4477db41ee603f793c0ed0fb0766ea179fa2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->