### PR TITLE
feat(payment): Add Stripe Adaptive Pricing support to Checkout Session strategy

### DIFF
--- a/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,7 +1,10 @@
 import { CustomerAddress } from '../customer';
 import { CardInstrument } from '../payment';
 
-export type PaymentProviderCustomer = PayPalConnectCustomer | StripeAcceleratedCheckoutCustomer;
+export type PaymentProviderCustomer =
+    | PayPalConnectCustomer
+    | StripeAcceleratedCheckoutCustomer
+    | StripeCheckoutSessionCustomer;
 
 export interface PayPalConnectCustomer {
     authenticationState?: string;
@@ -11,4 +14,9 @@ export interface PayPalConnectCustomer {
 
 export interface StripeAcceleratedCheckoutCustomer {
     stripeLinkAuthenticationState?: boolean;
+}
+
+export interface StripeCheckoutSessionCustomer {
+    isCustomerCurrencySelected?: boolean;
+    customerCurrency?: string;
 }

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -240,6 +240,7 @@ describe('StripeOCSPaymentStrategy', () => {
             await stripeCSPaymentStrategy.initialize({
                 ...stripeOptions,
                 stripeocs: {
+                    ...stripeOptions.stripeocs,
                     containerId: 'containerId',
                     render: renderMock,
                     onError: onErrorMock,
@@ -456,7 +457,7 @@ describe('StripeOCSPaymentStrategy', () => {
             };
 
             it('should update email if checkout session is not set', async () => {
-                mockStripeCheckout();
+                mockStripeCheckout({} as StripeCheckoutSession);
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
 
@@ -470,20 +471,6 @@ describe('StripeOCSPaymentStrategy', () => {
                     paymentIntegrationService.getState(),
                     'getBillingAddress',
                 ).mockReturnValue(undefined);
-                mockStripeCheckout({ email: '' } as StripeCheckoutSession);
-
-                await stripeCSPaymentStrategy.initialize(stripeOptions);
-
-                expect(stripeIntegrationService.mountElement).toHaveBeenCalled();
-                expect(getSessionMock).toHaveBeenCalled();
-                expect(updateEmailMock).toHaveBeenCalledWith('');
-            });
-
-            it('should update email if checkout session email is not set and billing address email is not set', async () => {
-                jest.spyOn(
-                    paymentIntegrationService.getState(),
-                    'getBillingAddress',
-                ).mockReturnValue({ email: '' } as BillingAddress);
                 mockStripeCheckout({ email: '' } as StripeCheckoutSession);
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
@@ -517,7 +504,6 @@ describe('StripeOCSPaymentStrategy', () => {
                                 actions: {
                                     ...getStripeCheckoutSessionActionsMock(),
                                     updateShippingAddress: updateShippingAddressMock,
-                                    getSession: jest.fn(() => Promise.resolve(null)),
                                 },
                             }),
                     }),
@@ -576,7 +562,6 @@ describe('StripeOCSPaymentStrategy', () => {
                                 actions: {
                                     ...getStripeCheckoutSessionActionsMock(),
                                     updateBillingAddress: updateBillingAddressMock,
-                                    getSession: jest.fn(() => Promise.resolve(null)),
                                 },
                             }),
                     }),
@@ -617,6 +602,209 @@ describe('StripeOCSPaymentStrategy', () => {
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
 
                 expect(updateBillingAddressMock).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('adaptive pricing', () => {
+            const mockPaymentMethodWithAdaptivePricing = (adaptivePricingEnabled: boolean) => {
+                const stripePaymentMethod = getStripeOCSMock();
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...stripePaymentMethod,
+                    initializationData: {
+                        ...stripePaymentMethod.initializationData,
+                        adaptivePricingEnabled,
+                    },
+                });
+            };
+
+            const mockStripeCheckoutWithCurrencySelector = (onMock: jest.Mock = jest.fn()) => {
+                const currencySelectorMountMock = jest.fn();
+                const currencySelectorElement = {
+                    mount: currencySelectorMountMock,
+                    unmount: jest.fn(),
+                    on: onMock,
+                    update: jest.fn(),
+                    destroy: jest.fn(),
+                    collapse: jest.fn(),
+                };
+
+                jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                    Promise.resolve({
+                        ...getStripeCheckoutInstanceMock(),
+                        createCurrencySelectorElement: jest.fn(() => currencySelectorElement),
+                    }),
+                );
+
+                return { currencySelectorMountMock, currencySelectorElement };
+            };
+
+            it('should pass adaptivePricing allowed true when adaptivePricingEnabled is true', async () => {
+                mockPaymentMethodWithAdaptivePricing(true);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(stripeScriptLoader.getStripeCheckout).toHaveBeenCalledWith(
+                    expect.anything(),
+                    expect.objectContaining({
+                        adaptivePricing: { allowed: true },
+                    }),
+                );
+            });
+
+            it('should pass adaptivePricing allowed false when adaptivePricingEnabled is not set', async () => {
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(stripeScriptLoader.getStripeCheckout).toHaveBeenCalledWith(
+                    expect.anything(),
+                    expect.objectContaining({
+                        adaptivePricing: { allowed: false },
+                    }),
+                );
+            });
+
+            it('should call onError when adaptivePricingEnabled is true but currencySelectorContainerId is not provided', async () => {
+                const onErrorMock = jest.fn();
+
+                mockPaymentMethodWithAdaptivePricing(true);
+
+                await stripeCSPaymentStrategy.initialize({
+                    ...stripeOptions,
+                    stripeocs: {
+                        containerId: 'containerId',
+                        render: jest.fn(),
+                        onError: onErrorMock,
+                    },
+                });
+
+                expect(onErrorMock).toHaveBeenCalledWith(expect.any(NotInitializedError));
+            });
+
+            it('should mount currency selector element when adaptivePricingEnabled is true', async () => {
+                mockPaymentMethodWithAdaptivePricing(true);
+                const { currencySelectorMountMock } = mockStripeCheckoutWithCurrencySelector();
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(currencySelectorMountMock).toHaveBeenCalledWith(
+                    `#currencySelectorContainerId`,
+                );
+            });
+
+            it('should not mount currency selector element when adaptivePricingEnabled is false', async () => {
+                mockPaymentMethodWithAdaptivePricing(false);
+                const { currencySelectorMountMock } = mockStripeCheckoutWithCurrencySelector();
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(currencySelectorMountMock).not.toHaveBeenCalled();
+            });
+
+            it('should not mount currency selector element when adaptivePricingEnabled is not set', async () => {
+                const { currencySelectorMountMock } = mockStripeCheckoutWithCurrencySelector();
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(currencySelectorMountMock).not.toHaveBeenCalled();
+            });
+
+            it('should call updatePaymentProviderCustomer when currency changes to a different currency', async () => {
+                const currencyEvent = {
+                    complete: false,
+                    elementType: 'currencySelector',
+                    empty: false,
+                    value: { currency: 'EUR' },
+                };
+
+                mockPaymentMethodWithAdaptivePricing(true);
+                mockStripeCheckoutWithCurrencySelector(
+                    jest.fn((_, callback) => callback(currencyEvent)),
+                );
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(
+                    paymentIntegrationService.updatePaymentProviderCustomer,
+                ).toHaveBeenCalledWith({
+                    isCustomerCurrencySelected: true,
+                    customerCurrency: 'eur',
+                });
+            });
+
+            it('should set isCustomerCurrencySelected to false when currency matches cart currency', async () => {
+                const currencyEvent = {
+                    complete: false,
+                    elementType: 'currencySelector',
+                    empty: false,
+                    value: { currency: 'USD' },
+                };
+
+                mockPaymentMethodWithAdaptivePricing(true);
+                mockStripeCheckoutWithCurrencySelector(
+                    jest.fn((_, callback) => callback(currencyEvent)),
+                );
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(
+                    paymentIntegrationService.updatePaymentProviderCustomer,
+                ).toHaveBeenCalledWith({
+                    isCustomerCurrencySelected: false,
+                    customerCurrency: 'usd',
+                });
+            });
+
+            it('should not call updatePaymentProviderCustomer when event value has no currency', async () => {
+                mockPaymentMethodWithAdaptivePricing(true);
+                mockStripeCheckoutWithCurrencySelector(
+                    jest.fn((_, callback) => callback(StripeEventMock)),
+                );
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(
+                    paymentIntegrationService.updatePaymentProviderCustomer,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('should not call updatePaymentProviderCustomer when event has no value', async () => {
+                const noValueEvent = {
+                    complete: false,
+                    elementType: 'currencySelector',
+                    empty: true,
+                };
+
+                mockPaymentMethodWithAdaptivePricing(true);
+                mockStripeCheckoutWithCurrencySelector(
+                    jest.fn((_, callback) => callback(noValueEvent)),
+                );
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(
+                    paymentIntegrationService.updatePaymentProviderCustomer,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('should not mount currency selector when element creation returns null', async () => {
+                jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                    Promise.resolve({
+                        ...getStripeCheckoutInstanceMock(),
+                        getCurrencySelectorElement: jest.fn().mockReturnValue(null),
+                        createCurrencySelectorElement: jest.fn().mockReturnValue(null),
+                    }),
+                );
+
+                mockPaymentMethodWithAdaptivePricing(true);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(
+                    paymentIntegrationService.updatePaymentProviderCustomer,
+                ).not.toHaveBeenCalled();
             });
         });
     });
@@ -660,6 +848,34 @@ describe('StripeOCSPaymentStrategy', () => {
 
             expect(unmountMock).toHaveBeenCalled();
             expect(destroyMock).toHaveBeenCalled();
+        });
+
+        it('deinitializes currency selector element', async () => {
+            const currencySelectorUnmountMock = jest.fn();
+            const currencySelectorDestroyMock = jest.fn();
+
+            jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                Promise.resolve({
+                    ...getStripeCheckoutInstanceMock(),
+                    getPaymentElement: getElementMock,
+                    getCurrencySelectorElement: jest.fn().mockReturnValue({
+                        mount: jest.fn(),
+                        unmount: currencySelectorUnmountMock,
+                        on: jest.fn(),
+                        update: jest.fn(),
+                        destroy: currencySelectorDestroyMock,
+                        collapse: jest.fn(),
+                    }),
+                }),
+            );
+
+            await stripeCSPaymentStrategy.initialize(getStripeOCSInitializeOptionsMock());
+            await stripeCSPaymentStrategy.deinitialize();
+
+            expect(unmountMock).toHaveBeenCalled();
+            expect(destroyMock).toHaveBeenCalled();
+            expect(currencySelectorUnmountMock).toHaveBeenCalled();
+            expect(currencySelectorDestroyMock).toHaveBeenCalled();
         });
     });
 
@@ -759,6 +975,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 stripeocs: {
                     render: jest.fn(),
                     containerId: 'containerId',
+                    currencySelectorContainerId: 'currencySelectorContainerId',
                 },
             });
             await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
@@ -800,10 +1017,16 @@ describe('StripeOCSPaymentStrategy', () => {
                 }),
             );
 
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(getStripeOCSMock(methodId));
+
             await stripeCSPaymentStrategy.initialize({
                 ...stripeOptions,
                 methodId,
                 stripeocs: {
+                    ...stripeOptions.stripeocs,
                     render: jest.fn(),
                     containerId: 'containerId',
                     paymentMethodSelect: paymentMethodSelectMock,
@@ -1443,8 +1666,8 @@ describe('StripeOCSPaymentStrategy', () => {
 
                 const getSessionMock = jest
                     .fn()
-                    .mockResolvedValueOnce(null) // initial email check
-                    .mockResolvedValueOnce(null) // during execute _updateCheckoutSessionData
+                    .mockResolvedValueOnce({}) // initial email check
+                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
                     .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }); // before confirm
 
                 const confirmPaymentMockLocal = jest.fn().mockResolvedValue({
@@ -1534,8 +1757,8 @@ describe('StripeOCSPaymentStrategy', () => {
 
                 getSessionMock = jest
                     .fn()
-                    .mockResolvedValueOnce(null) // initial email check
-                    .mockResolvedValueOnce(null) // initial email check (during execute _updateCheckoutSessionData)
+                    .mockResolvedValueOnce({}) // initial email check
+                    .mockResolvedValueOnce({}) // initial email check (during execute _updateCheckoutSessionData)
                     .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }) // before confirm
                     .mockResolvedValueOnce({ savedPaymentMethods: newMethods }); // after confirm
 
@@ -1576,8 +1799,8 @@ describe('StripeOCSPaymentStrategy', () => {
 
                 getSessionMock = jest
                     .fn()
-                    .mockResolvedValueOnce(null) // initial email check
-                    .mockResolvedValueOnce(null) // during execute _updateCheckoutSessionData
+                    .mockResolvedValueOnce({}) // initial email check
+                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
                     .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }) // before confirm
                     .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }); // after confirm (same methods)
 
@@ -1609,8 +1832,8 @@ describe('StripeOCSPaymentStrategy', () => {
             it('should not save instrument when savedPaymentMethods is undefined in session', async () => {
                 getSessionMock = jest
                     .fn()
-                    .mockResolvedValueOnce(null) // initial email check
-                    .mockResolvedValueOnce(null) // during execute _updateCheckoutSessionData
+                    .mockResolvedValueOnce({}) // initial email check
+                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
                     .mockResolvedValueOnce({}) // before confirm (no savedPaymentMethods field)
                     .mockResolvedValueOnce({}); // after confirm (no savedPaymentMethods field)
 
@@ -1659,8 +1882,8 @@ describe('StripeOCSPaymentStrategy', () => {
 
                 getSessionMock = jest
                     .fn()
-                    .mockResolvedValueOnce(null) // initial email check
-                    .mockResolvedValueOnce(null) // during execute _updateCheckoutSessionData
+                    .mockResolvedValueOnce({}) // initial email check
+                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
                     .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }) // before confirm
                     .mockResolvedValueOnce({ savedPaymentMethods: newMethods }); // after confirm
 
@@ -1711,8 +1934,8 @@ describe('StripeOCSPaymentStrategy', () => {
 
                 getSessionMock = jest
                     .fn()
-                    .mockResolvedValueOnce(null) // initial email check
-                    .mockResolvedValueOnce(null) // during execute _updateCheckoutSessionData
+                    .mockResolvedValueOnce({}) // initial email check
+                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
                     .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }) // before confirm
                     .mockResolvedValueOnce({ savedPaymentMethods: newMethods }); // after confirm
 
@@ -1745,10 +1968,10 @@ describe('StripeOCSPaymentStrategy', () => {
             it('should not save instrument when Stripe checkout session returns null', async () => {
                 getSessionMock = jest
                     .fn()
-                    .mockResolvedValueOnce(null) // initial email check
-                    .mockResolvedValueOnce(null) // during execute _updateCheckoutSessionData
-                    .mockResolvedValueOnce(null) // before confirm
-                    .mockResolvedValueOnce(null); // after confirm
+                    .mockResolvedValueOnce({}) // initial email check
+                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
+                    .mockResolvedValueOnce({}) // before confirm
+                    .mockResolvedValueOnce({}); // after confirm
 
                 confirmPaymentMockLocal = jest.fn().mockResolvedValue({
                     session: {

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -11,6 +11,7 @@ import {
     PaymentInitializeOptions,
     PaymentIntegrationSelectors,
     PaymentIntegrationService,
+    PaymentMethod,
     PaymentMethodFailedError,
     PaymentRequestOptions,
     PaymentStrategy,
@@ -61,19 +62,25 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        const { clientToken } = this.paymentIntegrationService
+        let paymentMethod = this.paymentIntegrationService
             .getState()
             .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
 
-        if (!clientToken) {
+        if (!paymentMethod?.clientToken) {
             await this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
                 params: { method: methodId },
             });
+
+            paymentMethod = this.paymentIntegrationService
+                .getState()
+                .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
         }
 
         try {
-            await this._initializeStripeElement(stripeocs, gatewayId, methodId);
+            await this._initStripeCheckoutSession(stripeocs, paymentMethod);
             await this._updateStripeShopperData();
+            this._initializePaymentElement(stripeocs, paymentMethod);
+            this._initializeAdaptivePricingElement(stripeocs, paymentMethod);
         } catch (error) {
             if (error instanceof Error) {
                 stripeocs.onError?.(error);
@@ -122,9 +129,12 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
     deinitialize(): Promise<void> {
         const paymentElement = this.stripeCheckout?.getPaymentElement();
+        const currencySelectorElement = this.stripeCheckout?.getCurrencySelectorElement();
 
         paymentElement?.unmount();
         paymentElement?.destroy();
+        currencySelectorElement?.unmount();
+        currencySelectorElement?.destroy();
         this.stripeCheckout = undefined;
         this.stripeClient = undefined;
         this.selectedMethodId = undefined;
@@ -132,14 +142,11 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         return Promise.resolve();
     }
 
-    private async _initializeStripeElement(
+    private async _initStripeCheckoutSession(
         stripe: StripeOCSPaymentInitializeOptions,
-        gatewayId: string,
-        methodId: string,
-    ) {
-        const { clientToken, initializationData } = this.paymentIntegrationService
-            .getState()
-            .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
+        paymentMethod: PaymentMethod<StripeInitializationData>,
+    ): Promise<void> {
+        const { clientToken, initializationData } = paymentMethod;
 
         if (!clientToken || !initializationData) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
@@ -147,17 +154,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
         this.stripeClient = await this._loadStripeJs(initializationData);
 
-        const { enableLink } = initializationData;
-        const {
-            appearance,
-            containerId,
-            fonts,
-            layout,
-            render,
-            paymentMethodSelect,
-            handleClosePaymentMethod,
-            togglePreloader,
-        } = stripe;
+        const { appearance, fonts } = stripe;
 
         this.stripeCheckout = await this.scriptLoader.getStripeCheckout(this.stripeClient, {
             clientSecret: clientToken,
@@ -166,9 +163,26 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
                 fonts,
             },
             adaptivePricing: {
-                allowed: false,
+                allowed: !!initializationData?.adaptivePricingEnabled,
             },
         });
+    }
+
+    private _initializePaymentElement(
+        stripe: StripeOCSPaymentInitializeOptions,
+        paymentMethod: PaymentMethod<StripeInitializationData>,
+    ) {
+        const { initializationData, id: methodId, gateway } = paymentMethod;
+
+        const { enableLink } = initializationData || {};
+        const {
+            containerId,
+            layout,
+            render,
+            paymentMethodSelect,
+            handleClosePaymentMethod,
+            togglePreloader,
+        } = stripe;
 
         const stripeElement = this._getStripeElement({
             fields: {
@@ -186,7 +200,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
             layout,
         });
 
-        if (!stripeElement) {
+        if (!stripeElement || !gateway) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
@@ -201,7 +215,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         });
 
         stripeElement.on(StripeElementEvent.CHANGE, (event: StripeEventType) => {
-            this._onStripeElementChange(event, gatewayId, methodId, paymentMethodSelect);
+            this._onStripeElementChange(event, gateway, methodId, paymentMethodSelect);
         });
 
         handleClosePaymentMethod?.(this._collapseStripeElement.bind(this));
@@ -387,7 +401,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
     private async _updateStripeEmail(stripeActions: StripeCheckoutSessionActions): Promise<void> {
         const stripeCheckoutSession = await stripeActions.getSession();
 
-        if (stripeCheckoutSession?.email) {
+        if (stripeCheckoutSession.email) {
             return;
         }
 
@@ -435,7 +449,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         }
 
         const stripeActions = await this._getStripeActionsOrThrow();
-        const { savedPaymentMethods } = (await stripeActions.getSession()) || {};
+        const { savedPaymentMethods } = await stripeActions.getSession();
 
         return savedPaymentMethods || [];
     }
@@ -461,5 +475,55 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         }
 
         return { credit_card_token: { token } };
+    }
+
+    private _initializeAdaptivePricingElement(
+        stripe: StripeOCSPaymentInitializeOptions,
+        paymentMethod: PaymentMethod<StripeInitializationData>,
+    ): void {
+        const { initializationData } = paymentMethod;
+        const { currencySelectorContainerId } = stripe;
+
+        if (!initializationData?.adaptivePricingEnabled) {
+            return;
+        }
+
+        if (!currencySelectorContainerId) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const currencySelectorElement = this._getCurrencySelectorElement();
+
+        if (!currencySelectorElement) {
+            return;
+        }
+
+        currencySelectorElement.mount(`#${currencySelectorContainerId}`);
+
+        this._initAdaptivePricingEvents(currencySelectorElement);
+    }
+
+    private _getCurrencySelectorElement(): StripeElement | undefined {
+        return (
+            this.stripeCheckout?.getCurrencySelectorElement() ||
+            this.stripeCheckout?.createCurrencySelectorElement()
+        );
+    }
+
+    private _initAdaptivePricingEvents(currencySelectorElement: StripeElement): void {
+        currencySelectorElement.on(StripeElementEvent.CHANGE, async (event: StripeEventType) => {
+            if (!event.value || !('currency' in event.value)) {
+                return;
+            }
+
+            const { currency } = this.paymentIntegrationService.getState().getCartOrThrow();
+            const currencyCode = currency.code.toLowerCase();
+            const stripeCurrencyCode = event.value.currency.toLowerCase();
+
+            await this.paymentIntegrationService.updatePaymentProviderCustomer({
+                isCustomerCurrencySelected: currencyCode !== stripeCurrencyCode,
+                customerCurrency: stripeCurrencyCode,
+            });
+        });
     }
 }

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
@@ -35,6 +35,11 @@ export default interface StripeOCSPaymentInitializeOptions extends StripePayment
     containerId: string;
 
     /**
+     * The location to insert the currency selector form field.
+     */
+    currencySelectorContainerId?: string;
+
+    /**
      * Checkout styles from store theme
      */
     style?: Record<string, StripeAppearanceValues>;

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs.mock.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs.mock.ts
@@ -51,6 +51,7 @@ export function getStripeOCSInitializeOptionsMock(
         gatewayId,
         [gatewayId]: {
             containerId: `${gatewayId}-${methodId}-component-field`,
+            currencySelectorContainerId: 'currencySelectorContainerId',
             layout: defaultAccordionLayout,
             appearance,
             render: jest.fn(),

--- a/packages/stripe-utils/src/stripe-script-loader.ts
+++ b/packages/stripe-utils/src/stripe-script-loader.ts
@@ -130,7 +130,7 @@ export default class StripeScriptLoader {
             const stripeCheckoutSession = await actions.getSession();
             const stripeSessionIdFromOptions = options.clientSecret.split('_secret_')[0];
 
-            if (stripeCheckoutSession?.id === stripeSessionIdFromOptions) {
+            if (stripeCheckoutSession.id === stripeSessionIdFromOptions) {
                 return stripeCheckout;
             }
         } catch (error) {

--- a/packages/stripe-utils/src/stripe.mock.ts
+++ b/packages/stripe-utils/src/stripe.mock.ts
@@ -6,6 +6,7 @@ import {
 
 import {
     StripeCheckoutInstance,
+    StripeCheckoutSession,
     StripeCheckoutSessionActions,
     StripeClient,
     StripeElement,
@@ -172,7 +173,7 @@ export function getRetrievePaymentIntentResponseWithError() {
 export function getStripeCheckoutSessionActionsMock(): StripeCheckoutSessionActions {
     return {
         updateEmail: jest.fn(),
-        getSession: jest.fn(),
+        getSession: jest.fn(() => Promise.resolve({} as StripeCheckoutSession)),
         confirm: jest.fn(),
         updateShippingAddress: jest.fn(),
         updateBillingAddress: jest.fn(),
@@ -188,5 +189,7 @@ export function getStripeCheckoutInstanceMock(): StripeCheckoutInstance {
             }),
         createPaymentElement: jest.fn(() => getStripeElementMock()),
         getPaymentElement: jest.fn().mockReturnValue(null),
+        getCurrencySelectorElement: jest.fn().mockReturnValue(null),
+        createCurrencySelectorElement: jest.fn(() => getStripeElementMock()),
     };
 }

--- a/packages/stripe-utils/src/stripe.ts
+++ b/packages/stripe-utils/src/stripe.ts
@@ -234,6 +234,12 @@ export interface StripePaymentEvent extends StripeEvent {
     collapsed?: boolean;
 }
 
+export interface StripeCurrencyEvent extends StripeEvent {
+    value: {
+        currency: string;
+    };
+}
+
 export interface Address {
     city: string;
     country: string;
@@ -244,6 +250,7 @@ export interface Address {
 }
 
 export type StripeEventType =
+    | StripeCurrencyEvent
     | StripeShippingEvent
     | StripeCustomerEvent
     | StripePaymentEvent
@@ -495,6 +502,22 @@ export interface StripeCheckoutSessionStatus {
     paymentStatus: StripeCheckoutSessionPaymentStatus;
 }
 
+export interface StripeCheckoutSessionAmount {
+    minorUnitsAmount: number;
+    amount: string;
+}
+
+export interface StripeCheckoutSessionTotal {
+    appliedBalance: StripeCheckoutSessionAmount;
+    balanceAppliedToNextInvoice: boolean;
+    discount: StripeCheckoutSessionAmount;
+    shippingRate: StripeCheckoutSessionAmount;
+    subtotal: StripeCheckoutSessionAmount;
+    taxExclusive: StripeCheckoutSessionAmount;
+    taxInclusive: StripeCheckoutSessionAmount;
+    total: StripeCheckoutSessionAmount;
+}
+
 export interface StripeCheckoutSession {
     id: string;
     savedPaymentMethods?: StripeSavedPaymentMethod[];
@@ -510,13 +533,15 @@ export interface StripeCheckoutSession {
     status: StripeCheckoutSessionStatus;
     tax: unknown;
     taxAmounts: unknown;
-    total: unknown;
+    total: StripeCheckoutSessionTotal;
 }
 
 export interface StripeCheckoutInstance {
     loadActions(): Promise<StripeLoadActionsResult>;
     createPaymentElement(options?: StripeElementsCreateOptions): StripeElement;
     getPaymentElement(): StripeElement | null;
+    getCurrencySelectorElement(): StripeElement | null;
+    createCurrencySelectorElement(): StripeElement;
 }
 
 export enum StripeLoadActionsResultType {
@@ -544,7 +569,7 @@ export interface StripeCheckoutSessionActions {
     updateBillingAddress(
         billingAddress: StripeAddressValues,
     ): Promise<StripeCheckoutSessionActionResult>;
-    getSession(): Promise<StripeCheckoutSession | null>;
+    getSession(): Promise<StripeCheckoutSession>;
     confirm(
         options: StripeCheckoutSessionConfirmPaymentData,
     ): Promise<StripeCheckoutSessionActionResult>;
@@ -775,6 +800,8 @@ export interface StripeInitializationData {
     useNewStripeJsVersion?: boolean;
     checkoutSessionEnabled?: boolean;
     sendSecondPaymentRequestOnStripeError?: boolean;
+    adaptivePricingEnabled?: boolean;
+    hasSectionOnTopOfPaymentsList?: boolean;
 }
 
 export interface StripeElementUpdateOptions {


### PR DESCRIPTION
## What/Why?
Add Adaptive Pricing feature to the Stripe payments strategy.
Allow shoppers to view prices and pay in their local currency via Stripe Adaptive Pricing.
Feature will be toggle from CP  - `initializationData.adaptivePricingEnabled`. This option also depends to the experiment `PROJECT-7835.stripe_ocs_adaptive_pricing`

Related PRs:

[https://github.com/bigcommerce/checkout-js/pull/2944](https://github.com/bigcommerce/checkout-js/pull/2944)

[https://github.com/bigcommerce/checkout-js/pull/2948](https://github.com/bigcommerce/checkout-js/pull/2948)

[https://github.com/bigcommerce/checkout-js/pull/2949](https://github.com/bigcommerce/checkout-js/pull/2949)

## Rollout/Rollback
Rollback this PR.

## Testing

https://github.com/user-attachments/assets/80a24fa9-331a-4bdf-a0ac-5e75b49fd726



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds adaptive pricing/currency selection into the Stripe Checkout Session payment flow and changes session typing/assumptions (e.g., `getSession()` no longer nullable), which could affect initialization and shopper data updates if Stripe returns unexpected session data.
> 
> **Overview**
> Enables Stripe *Adaptive Pricing* for the Checkout Session strategy by passing `adaptivePricing.allowed` from `initializationData.adaptivePricingEnabled`, optionally mounting a new currency selector element (via `currencySelectorContainerId`), and deinitializing it alongside the payment element.
> 
> When the shopper changes currency, the strategy now updates `PaymentProviderCustomer` with `isCustomerCurrencySelected` and `customerCurrency`. Supporting types/mocks/tests are updated (new `StripeCurrencyEvent`, currency selector APIs on `StripeCheckoutInstance`, richer `StripeCheckoutSession.total`, and `StripeCheckoutSessionActions.getSession()` treated as non-null).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30744ede635fcb47a326a1f4282d47871b97ccd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->