### PR TITLE
feat(checkout) CHECKOUT-9885: Load B2B token and save in state

### DIFF
--- a/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
@@ -72,8 +72,8 @@ describe('B2BTokenActionCreator', () => {
                 customer.id,
                 storeHash,
                 checkout.channelId,
-                undefined,
                 b2bBaseUrl,
+                undefined,
             );
         });
 

--- a/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
@@ -17,15 +17,13 @@ describe('B2BTokenActionCreator', () => {
     let requestSender: B2BTokenRequestSender;
     let actionCreator: B2BTokenActionCreator;
 
-    const jwtResponse = getResponse({ token: 'bc-jwt-token' });
     const b2bResponse = getResponse({ code: 200, data: { token: 'b2b-auth-token' } });
 
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreState());
         requestSender = new B2BTokenRequestSender(createRequestSender());
 
-        jest.spyOn(requestSender, 'getBCJWT').mockResolvedValue(jwtResponse);
-        jest.spyOn(requestSender, 'fetchB2BToken').mockResolvedValue(b2bResponse);
+        jest.spyOn(requestSender, 'getB2BToken').mockResolvedValue(b2bResponse);
 
         jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
             getConfig().storeConfig,
@@ -51,24 +49,17 @@ describe('B2BTokenActionCreator', () => {
             ]);
         });
 
-        it('calls getBCJWT with b2bClientId from checkout settings', async () => {
-            const { b2bClientId } = getConfig().storeConfig.checkoutSettings;
-
-            await from(actionCreator.loadB2BToken()(store)).toPromise();
-
-            expect(requestSender.getBCJWT).toHaveBeenCalledWith(b2bClientId ?? '', undefined);
-        });
-
-        it('calls fetchB2BToken with state data, BC JWT, and b2bBaseUrl from checkout settings', async () => {
+        it('calls getB2BToken with state data and b2bServiceDetails from checkout settings', async () => {
             const customer = getCustomer();
             const checkout = getCheckout();
             const { storeHash } = getConfig().storeConfig.storeProfile;
-            const { b2bBaseUrl } = getConfig().storeConfig.checkoutSettings;
+            const { b2bBaseUrl, b2bClientId } =
+                getConfig().storeConfig.checkoutSettings.b2bServiceDetails!;
 
             await from(actionCreator.loadB2BToken()(store)).toPromise();
 
-            expect(requestSender.fetchB2BToken).toHaveBeenCalledWith(
-                'bc-jwt-token',
+            expect(requestSender.getB2BToken).toHaveBeenCalledWith(
+                b2bClientId,
                 customer.id,
                 storeHash,
                 checkout.channelId,
@@ -77,26 +68,8 @@ describe('B2BTokenActionCreator', () => {
             );
         });
 
-        it('emits error actions if getBCJWT fails', async () => {
-            jest.spyOn(requestSender, 'getBCJWT').mockRejectedValue(getErrorResponse());
-
-            const errorHandler = jest.fn((action) => of(action));
-            const actions = await from(actionCreator.loadB2BToken()(store))
-                .pipe(catchError(errorHandler), toArray())
-                .toPromise();
-
-            expect(errorHandler).toHaveBeenCalled();
-            expect(actions).toEqual([
-                { type: B2BTokenActionType.LoadB2BTokenRequested },
-                expect.objectContaining({
-                    type: B2BTokenActionType.LoadB2BTokenFailed,
-                    error: true,
-                }),
-            ]);
-        });
-
-        it('emits error actions if fetchB2BToken fails', async () => {
-            jest.spyOn(requestSender, 'fetchB2BToken').mockRejectedValue(getErrorResponse());
+        it('emits error actions if getB2BToken fails', async () => {
+            jest.spyOn(requestSender, 'getB2BToken').mockRejectedValue(getErrorResponse());
 
             const errorHandler = jest.fn((action) => of(action));
             const actions = await from(actionCreator.loadB2BToken()(store))

--- a/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
@@ -1,0 +1,107 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { CheckoutStore, createCheckoutStore } from '../checkout';
+import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { getConfig } from '../config/configs.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { getCheckout } from '../checkout/checkouts.mock';
+
+import B2BTokenActionCreator from './b2b-token-action-creator';
+import { B2BTokenActionType } from './b2b-token-actions';
+import B2BTokenRequestSender from './b2b-token-request-sender';
+
+describe('B2BTokenActionCreator', () => {
+    let store: CheckoutStore;
+    let requestSender: B2BTokenRequestSender;
+    let actionCreator: B2BTokenActionCreator;
+
+    const jwtResponse = getResponse({ token: 'bc-jwt-token' });
+    const b2bResponse = getResponse({ code: 200, data: { token: 'b2b-auth-token' } });
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = new B2BTokenRequestSender(createRequestSender());
+
+        jest.spyOn(requestSender, 'getBCJWT').mockResolvedValue(jwtResponse);
+        jest.spyOn(requestSender, 'exchangeForB2BToken').mockResolvedValue(b2bResponse);
+
+        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
+            getConfig().storeConfig,
+        );
+        jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue(getCustomer());
+        jest.spyOn(store.getState().checkout, 'getCheckoutOrThrow').mockReturnValue(getCheckout());
+
+        actionCreator = new B2BTokenActionCreator(requestSender);
+    });
+
+    describe('#loadB2BToken()', () => {
+        it('emits load actions on success', async () => {
+            const actions = await from(actionCreator.loadB2BToken('my-client-id')(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: B2BTokenActionType.LoadB2BTokenRequested },
+                {
+                    type: B2BTokenActionType.LoadB2BTokenSucceeded,
+                    payload: { token: 'b2b-auth-token' },
+                },
+            ]);
+        });
+
+        it('calls getBCJWT with the provided appClientId', async () => {
+            await from(actionCreator.loadB2BToken('my-client-id')(store)).toPromise();
+
+            expect(requestSender.getBCJWT).toHaveBeenCalledWith('my-client-id', undefined);
+        });
+
+        it('calls exchangeForB2BToken with state data and BC JWT', async () => {
+            const customer = getCustomer();
+            const checkout = getCheckout();
+            const { storeHash } = getConfig().storeConfig.storeProfile;
+
+            await from(actionCreator.loadB2BToken('my-client-id')(store)).toPromise();
+
+            expect(requestSender.exchangeForB2BToken).toHaveBeenCalledWith(
+                'bc-jwt-token',
+                customer.id,
+                storeHash,
+                checkout.channelId,
+                undefined,
+            );
+        });
+
+        it('emits error actions if getBCJWT fails', async () => {
+            jest.spyOn(requestSender, 'getBCJWT').mockRejectedValue(getErrorResponse());
+
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(actionCreator.loadB2BToken('my-client-id')(store))
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: B2BTokenActionType.LoadB2BTokenRequested },
+                expect.objectContaining({ type: B2BTokenActionType.LoadB2BTokenFailed, error: true }),
+            ]);
+        });
+
+        it('emits error actions if exchangeForB2BToken fails', async () => {
+            jest.spyOn(requestSender, 'exchangeForB2BToken').mockRejectedValue(getErrorResponse());
+
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(actionCreator.loadB2BToken('my-client-id')(store))
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: B2BTokenActionType.LoadB2BTokenRequested },
+                expect.objectContaining({ type: B2BTokenActionType.LoadB2BTokenFailed, error: true }),
+            ]);
+        });
+    });
+});

--- a/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
@@ -3,11 +3,10 @@ import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
 import { CheckoutStore, createCheckoutStore } from '../checkout';
-import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { getCheckout, getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 import { getConfig } from '../config/configs.mock';
 import { getCustomer } from '../customer/customers.mock';
-import { getCheckout } from '../checkout/checkouts.mock';
 
 import B2BTokenActionCreator from './b2b-token-action-creator';
 import { B2BTokenActionType } from './b2b-token-actions';
@@ -85,7 +84,10 @@ describe('B2BTokenActionCreator', () => {
             expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
                 { type: B2BTokenActionType.LoadB2BTokenRequested },
-                expect.objectContaining({ type: B2BTokenActionType.LoadB2BTokenFailed, error: true }),
+                expect.objectContaining({
+                    type: B2BTokenActionType.LoadB2BTokenFailed,
+                    error: true,
+                }),
             ]);
         });
 
@@ -100,7 +102,10 @@ describe('B2BTokenActionCreator', () => {
             expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
                 { type: B2BTokenActionType.LoadB2BTokenRequested },
-                expect.objectContaining({ type: B2BTokenActionType.LoadB2BTokenFailed, error: true }),
+                expect.objectContaining({
+                    type: B2BTokenActionType.LoadB2BTokenFailed,
+                    error: true,
+                }),
             ]);
         });
     });

--- a/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
@@ -25,7 +25,7 @@ describe('B2BTokenActionCreator', () => {
         requestSender = new B2BTokenRequestSender(createRequestSender());
 
         jest.spyOn(requestSender, 'getBCJWT').mockResolvedValue(jwtResponse);
-        jest.spyOn(requestSender, 'exchangeForB2BToken').mockResolvedValue(b2bResponse);
+        jest.spyOn(requestSender, 'fetchB2BToken').mockResolvedValue(b2bResponse);
 
         jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
             getConfig().storeConfig,
@@ -38,7 +38,7 @@ describe('B2BTokenActionCreator', () => {
 
     describe('#loadB2BToken()', () => {
         it('emits load actions on success', async () => {
-            const actions = await from(actionCreator.loadB2BToken('my-client-id')(store))
+            const actions = await from(actionCreator.loadB2BToken()(store))
                 .pipe(toArray())
                 .toPromise();
 
@@ -51,25 +51,29 @@ describe('B2BTokenActionCreator', () => {
             ]);
         });
 
-        it('calls getBCJWT with the provided appClientId', async () => {
-            await from(actionCreator.loadB2BToken('my-client-id')(store)).toPromise();
+        it('calls getBCJWT with b2bClientId from checkout settings', async () => {
+            const { b2bClientId } = getConfig().storeConfig.checkoutSettings;
 
-            expect(requestSender.getBCJWT).toHaveBeenCalledWith('my-client-id', undefined);
+            await from(actionCreator.loadB2BToken()(store)).toPromise();
+
+            expect(requestSender.getBCJWT).toHaveBeenCalledWith(b2bClientId ?? '', undefined);
         });
 
-        it('calls exchangeForB2BToken with state data and BC JWT', async () => {
+        it('calls fetchB2BToken with state data, BC JWT, and b2bBaseUrl from checkout settings', async () => {
             const customer = getCustomer();
             const checkout = getCheckout();
             const { storeHash } = getConfig().storeConfig.storeProfile;
+            const { b2bBaseUrl } = getConfig().storeConfig.checkoutSettings;
 
-            await from(actionCreator.loadB2BToken('my-client-id')(store)).toPromise();
+            await from(actionCreator.loadB2BToken()(store)).toPromise();
 
-            expect(requestSender.exchangeForB2BToken).toHaveBeenCalledWith(
+            expect(requestSender.fetchB2BToken).toHaveBeenCalledWith(
                 'bc-jwt-token',
                 customer.id,
                 storeHash,
                 checkout.channelId,
                 undefined,
+                b2bBaseUrl,
             );
         });
 
@@ -77,7 +81,7 @@ describe('B2BTokenActionCreator', () => {
             jest.spyOn(requestSender, 'getBCJWT').mockRejectedValue(getErrorResponse());
 
             const errorHandler = jest.fn((action) => of(action));
-            const actions = await from(actionCreator.loadB2BToken('my-client-id')(store))
+            const actions = await from(actionCreator.loadB2BToken()(store))
                 .pipe(catchError(errorHandler), toArray())
                 .toPromise();
 
@@ -91,11 +95,11 @@ describe('B2BTokenActionCreator', () => {
             ]);
         });
 
-        it('emits error actions if exchangeForB2BToken fails', async () => {
-            jest.spyOn(requestSender, 'exchangeForB2BToken').mockRejectedValue(getErrorResponse());
+        it('emits error actions if fetchB2BToken fails', async () => {
+            jest.spyOn(requestSender, 'fetchB2BToken').mockRejectedValue(getErrorResponse());
 
             const errorHandler = jest.fn((action) => of(action));
-            const actions = await from(actionCreator.loadB2BToken('my-client-id')(store))
+            const actions = await from(actionCreator.loadB2BToken()(store))
                 .pipe(catchError(errorHandler), toArray())
                 .toPromise();
 

--- a/packages/core/src/b2b-token/b2b-token-action-creator.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.ts
@@ -1,0 +1,51 @@
+import { createAction, ThunkAction } from '@bigcommerce/data-store';
+import { concat, defer, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { InternalCheckoutSelectors } from '../checkout';
+import { throwErrorAction } from '../common/error';
+import { RequestOptions } from '../common/http-request';
+
+import { B2BTokenActionType, LoadB2BTokenAction } from './b2b-token-actions';
+import B2BTokenRequestSender from './b2b-token-request-sender';
+
+export default class B2BTokenActionCreator {
+    constructor(private _requestSender: B2BTokenRequestSender) {}
+
+    loadB2BToken(
+        appClientId: string,
+        options?: RequestOptions,
+    ): ThunkAction<LoadB2BTokenAction, InternalCheckoutSelectors> {
+        return (store) => {
+            const state = store.getState();
+            const { storeHash } = state.config.getStoreConfigOrThrow().storeProfile;
+            const { id: customerId } = state.customer.getCustomerOrThrow();
+            const { channelId } = state.checkout.getCheckoutOrThrow();
+
+            return concat(
+                of(createAction(B2BTokenActionType.LoadB2BTokenRequested)),
+                defer(async () => {
+                    const { body: jwtBody } = await this._requestSender.getBCJWT(
+                        appClientId,
+                        options,
+                    );
+                    const { body } = await this._requestSender.exchangeForB2BToken(
+                        jwtBody.token,
+                        customerId,
+                        storeHash,
+                        channelId,
+                        options,
+                    );
+
+                    return createAction(B2BTokenActionType.LoadB2BTokenSucceeded, {
+                        token: body.data.token,
+                    });
+                }),
+            ).pipe(
+                catchError((error) =>
+                    throwErrorAction(B2BTokenActionType.LoadB2BTokenFailed, error),
+                ),
+            );
+        };
+    }
+}

--- a/packages/core/src/b2b-token/b2b-token-action-creator.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.ts
@@ -9,6 +9,10 @@ import { RequestOptions } from '../common/http-request';
 import { B2BTokenActionType, LoadB2BTokenAction } from './b2b-token-actions';
 import B2BTokenRequestSender from './b2b-token-request-sender';
 
+// TODO: Remove once all stores have b2bServiceDetails configured in checkout settings
+const DEFAULT_B2B_BASE_URL = 'https://api-b2b.bigcommerce.com';
+const DEFAULT_B2B_CLIENT_ID = 'dl7c39mdpul6hyc489yk0vzxl6jesyx';
+
 export default class B2BTokenActionCreator {
     constructor(private _requestSender: B2BTokenRequestSender) {}
 
@@ -18,23 +22,16 @@ export default class B2BTokenActionCreator {
         return (store) => {
             const state = store.getState();
             const { storeHash } = state.config.getStoreConfigOrThrow().storeProfile;
-            // TODO: Remove fallback to default b2bClientId once all stores have it configured in checkout settings
-            const {
-                b2bBaseUrl = 'https://api-b2b.bigcommerce.com',
-                b2bClientId = 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
-            } = state.config.getStoreConfigOrThrow().checkoutSettings;
+            const { b2bBaseUrl = DEFAULT_B2B_BASE_URL, b2bClientId = DEFAULT_B2B_CLIENT_ID } =
+                state.config.getStoreConfigOrThrow().checkoutSettings.b2bServiceDetails ?? {};
             const { id: customerId } = state.customer.getCustomerOrThrow();
             const { channelId } = state.checkout.getCheckoutOrThrow();
 
             return concat(
                 of(createAction(B2BTokenActionType.LoadB2BTokenRequested)),
                 defer(async () => {
-                    const { body: jwtBody } = await this._requestSender.getBCJWT(
+                    const { body } = await this._requestSender.getB2BToken(
                         b2bClientId,
-                        options,
-                    );
-                    const { body } = await this._requestSender.fetchB2BToken(
-                        jwtBody.token,
                         customerId,
                         storeHash,
                         channelId,

--- a/packages/core/src/b2b-token/b2b-token-action-creator.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.ts
@@ -18,6 +18,7 @@ export default class B2BTokenActionCreator {
         return (store) => {
             const state = store.getState();
             const { storeHash } = state.config.getStoreConfigOrThrow().storeProfile;
+            // TODO: Remove fallback to default b2bClientId once all stores have it configured in checkout settings
             const {
                 b2bBaseUrl = 'https://api-b2b.bigcommerce.com',
                 b2bClientId = 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
@@ -37,8 +38,8 @@ export default class B2BTokenActionCreator {
                         customerId,
                         storeHash,
                         channelId,
-                        options,
                         b2bBaseUrl,
+                        options,
                     );
 
                     return createAction(B2BTokenActionType.LoadB2BTokenSucceeded, {

--- a/packages/core/src/b2b-token/b2b-token-action-creator.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.ts
@@ -10,8 +10,8 @@ import { B2BTokenActionType, LoadB2BTokenAction } from './b2b-token-actions';
 import B2BTokenRequestSender from './b2b-token-request-sender';
 
 // TODO: Remove once all stores have b2bServiceDetails configured in checkout settings
-const DEFAULT_B2B_BASE_URL = 'https://api-b2b.bigcommerce.com';
-const DEFAULT_B2B_CLIENT_ID = 'dl7c39mdpul6hyc489yk0vzxl6jesyx';
+const DEFAULT_B2B_BASE_URL = '';
+const DEFAULT_B2B_CLIENT_ID = '';
 
 export default class B2BTokenActionCreator {
     constructor(private _requestSender: B2BTokenRequestSender) {}

--- a/packages/core/src/b2b-token/b2b-token-action-creator.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.ts
@@ -13,12 +13,15 @@ export default class B2BTokenActionCreator {
     constructor(private _requestSender: B2BTokenRequestSender) {}
 
     loadB2BToken(
-        appClientId: string,
         options?: RequestOptions,
     ): ThunkAction<LoadB2BTokenAction, InternalCheckoutSelectors> {
         return (store) => {
             const state = store.getState();
             const { storeHash } = state.config.getStoreConfigOrThrow().storeProfile;
+            const {
+                b2bBaseUrl = 'https://api-b2b.bigcommerce.com',
+                b2bClientId = 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
+            } = state.config.getStoreConfigOrThrow().checkoutSettings;
             const { id: customerId } = state.customer.getCustomerOrThrow();
             const { channelId } = state.checkout.getCheckoutOrThrow();
 
@@ -26,15 +29,16 @@ export default class B2BTokenActionCreator {
                 of(createAction(B2BTokenActionType.LoadB2BTokenRequested)),
                 defer(async () => {
                     const { body: jwtBody } = await this._requestSender.getBCJWT(
-                        appClientId,
+                        b2bClientId,
                         options,
                     );
-                    const { body } = await this._requestSender.exchangeForB2BToken(
+                    const { body } = await this._requestSender.fetchB2BToken(
                         jwtBody.token,
                         customerId,
                         storeHash,
                         channelId,
                         options,
+                        b2bBaseUrl,
                     );
 
                     return createAction(B2BTokenActionType.LoadB2BTokenSucceeded, {

--- a/packages/core/src/b2b-token/b2b-token-actions.ts
+++ b/packages/core/src/b2b-token/b2b-token-actions.ts
@@ -1,6 +1,6 @@
 import { Action } from '@bigcommerce/data-store';
 
-import B2BToken from './b2b-token';
+import { B2BToken } from './b2b-token-state';
 
 export enum B2BTokenActionType {
     LoadB2BTokenRequested = 'LOAD_B2B_TOKEN_REQUESTED',

--- a/packages/core/src/b2b-token/b2b-token-actions.ts
+++ b/packages/core/src/b2b-token/b2b-token-actions.ts
@@ -1,0 +1,26 @@
+import { Action } from '@bigcommerce/data-store';
+
+import B2BToken from './b2b-token';
+
+export enum B2BTokenActionType {
+    LoadB2BTokenRequested = 'LOAD_B2B_TOKEN_REQUESTED',
+    LoadB2BTokenSucceeded = 'LOAD_B2B_TOKEN_SUCCEEDED',
+    LoadB2BTokenFailed = 'LOAD_B2B_TOKEN_FAILED',
+}
+
+export type LoadB2BTokenAction =
+    | LoadB2BTokenRequestedAction
+    | LoadB2BTokenSucceededAction
+    | LoadB2BTokenFailedAction;
+
+export interface LoadB2BTokenRequestedAction extends Action {
+    type: B2BTokenActionType.LoadB2BTokenRequested;
+}
+
+export interface LoadB2BTokenSucceededAction extends Action<B2BToken> {
+    type: B2BTokenActionType.LoadB2BTokenSucceeded;
+}
+
+export interface LoadB2BTokenFailedAction extends Action<Error> {
+    type: B2BTokenActionType.LoadB2BTokenFailed;
+}

--- a/packages/core/src/b2b-token/b2b-token-reducer.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-reducer.spec.ts
@@ -1,0 +1,48 @@
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+
+import { B2BTokenActionType } from './b2b-token-actions';
+import b2bTokenReducer from './b2b-token-reducer';
+import B2BTokenState, { DEFAULT_STATE } from './b2b-token-state';
+
+describe('b2bTokenReducer()', () => {
+    let initialState: B2BTokenState;
+
+    beforeEach(() => {
+        initialState = DEFAULT_STATE;
+    });
+
+    it('returns loading state on requested', () => {
+        const action = createAction(B2BTokenActionType.LoadB2BTokenRequested);
+        const state = b2bTokenReducer(initialState, action);
+
+        expect(state.statuses.isLoading).toBe(true);
+        expect(state.errors.loadError).toBeUndefined();
+    });
+
+    it('stores token and clears loading state on success', () => {
+        const token = { token: 'my-b2b-token' };
+        const action = createAction(B2BTokenActionType.LoadB2BTokenSucceeded, token);
+        const state = b2bTokenReducer(initialState, action);
+
+        expect(state.data).toEqual(token);
+        expect(state.statuses.isLoading).toBe(false);
+        expect(state.errors.loadError).toBeUndefined();
+    });
+
+    it('stores error and clears loading state on failure', () => {
+        const error = new Error('Failed to load B2B token');
+        const action = createErrorAction(B2BTokenActionType.LoadB2BTokenFailed, error);
+        const state = b2bTokenReducer(initialState, action);
+
+        expect(state.errors.loadError).toBe(error);
+        expect(state.statuses.isLoading).toBe(false);
+        expect(state.data).toBeUndefined();
+    });
+
+    it('returns previous state for unknown actions', () => {
+        const action = { type: 'UNKNOWN_ACTION' } as any;
+        const state = b2bTokenReducer(initialState, action);
+
+        expect(state).toEqual(initialState);
+    });
+});

--- a/packages/core/src/b2b-token/b2b-token-reducer.ts
+++ b/packages/core/src/b2b-token/b2b-token-reducer.ts
@@ -1,0 +1,72 @@
+import { Action, combineReducers, composeReducers } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
+import { objectSet } from '../common/utility';
+
+import B2BToken from './b2b-token';
+import { B2BTokenActionType, LoadB2BTokenAction } from './b2b-token-actions';
+import B2BTokenState, {
+    B2BTokenErrorsState,
+    B2BTokenStatusesState,
+    DEFAULT_STATE,
+} from './b2b-token-state';
+
+export default function b2bTokenReducer(
+    state: B2BTokenState = DEFAULT_STATE,
+    action: Action,
+): B2BTokenState {
+    const reducer = combineReducers<B2BTokenState>({
+        data: dataReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
+        statuses: statusesReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: B2BToken | undefined,
+    action: LoadB2BTokenAction,
+): B2BToken | undefined {
+    switch (action.type) {
+        case B2BTokenActionType.LoadB2BTokenSucceeded:
+            return action.payload;
+
+        default:
+            return data;
+    }
+}
+
+function errorsReducer(
+    errors: B2BTokenErrorsState = DEFAULT_STATE.errors,
+    action: LoadB2BTokenAction,
+): B2BTokenErrorsState {
+    switch (action.type) {
+        case B2BTokenActionType.LoadB2BTokenRequested:
+        case B2BTokenActionType.LoadB2BTokenSucceeded:
+            return objectSet(errors, 'loadError', undefined);
+
+        case B2BTokenActionType.LoadB2BTokenFailed:
+            return objectSet(errors, 'loadError', action.payload);
+
+        default:
+            return errors;
+    }
+}
+
+function statusesReducer(
+    statuses: B2BTokenStatusesState = DEFAULT_STATE.statuses,
+    action: LoadB2BTokenAction,
+): B2BTokenStatusesState {
+    switch (action.type) {
+        case B2BTokenActionType.LoadB2BTokenRequested:
+            return objectSet(statuses, 'isLoading', true);
+
+        case B2BTokenActionType.LoadB2BTokenFailed:
+        case B2BTokenActionType.LoadB2BTokenSucceeded:
+            return objectSet(statuses, 'isLoading', false);
+
+        default:
+            return statuses;
+    }
+}

--- a/packages/core/src/b2b-token/b2b-token-reducer.ts
+++ b/packages/core/src/b2b-token/b2b-token-reducer.ts
@@ -3,9 +3,9 @@ import { Action, combineReducers, composeReducers } from '@bigcommerce/data-stor
 import { clearErrorReducer } from '../common/error';
 import { objectSet } from '../common/utility';
 
-import B2BToken from './b2b-token';
 import { B2BTokenActionType, LoadB2BTokenAction } from './b2b-token-actions';
 import B2BTokenState, {
+    B2BToken,
     B2BTokenErrorsState,
     B2BTokenStatusesState,
     DEFAULT_STATE,

--- a/packages/core/src/b2b-token/b2b-token-reducer.ts
+++ b/packages/core/src/b2b-token/b2b-token-reducer.ts
@@ -24,10 +24,7 @@ export default function b2bTokenReducer(
     return reducer(state, action);
 }
 
-function dataReducer(
-    data: B2BToken | undefined,
-    action: LoadB2BTokenAction,
-): B2BToken | undefined {
+function dataReducer(data: B2BToken | undefined, action: LoadB2BTokenAction): B2BToken | undefined {
     switch (action.type) {
         case B2BTokenActionType.LoadB2BTokenSucceeded:
             return action.payload;

--- a/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
@@ -47,9 +47,9 @@ describe('B2BTokenRequestSender', () => {
         });
     });
 
-    describe('#exchangeForB2BToken()', () => {
-        it('posts to B2B login endpoint with correct payload', async () => {
-            await b2bTokenRequestSender.exchangeForB2BToken('bc-jwt', 123, 'abc123', 1);
+    describe('#fetchB2BToken()', () => {
+        it('posts to default B2B login endpoint when no b2bBaseUrl provided', async () => {
+            await b2bTokenRequestSender.fetchB2BToken('bc-jwt', 123, 'abc123', 1);
 
             expect(requestSender.post).toHaveBeenCalledWith(
                 'https://api-b2b.bigcommerce.com/api/v2/login',
@@ -63,6 +63,24 @@ describe('B2BTokenRequestSender', () => {
                     },
                     timeout: undefined,
                 },
+            );
+        });
+
+        it('posts to custom b2bBaseUrl when provided', async () => {
+            await b2bTokenRequestSender.fetchB2BToken(
+                'bc-jwt',
+                123,
+                'abc123',
+                1,
+                undefined,
+                'https://api-b2b.staging.zone',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.staging.zone/api/v2/login',
+                expect.objectContaining({
+                    body: expect.objectContaining({ bcToken: 'bc-jwt' }),
+                }),
             );
         });
     });

--- a/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
@@ -8,86 +8,70 @@ describe('B2BTokenRequestSender', () => {
     let requestSender: RequestSender;
     let b2bTokenRequestSender: B2BTokenRequestSender;
 
+    const jwtToken = 'bc-jwt-token';
+    const b2bToken = 'b2b-token-value';
+
     beforeEach(() => {
         requestSender = createRequestSender();
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        jest.spyOn(requestSender, 'get').mockResolvedValue({ body: { token: 'bc-jwt-token' } });
+        jest.spyOn(requestSender, 'get').mockResolvedValue({ body: { token: jwtToken } });
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         jest.spyOn(requestSender, 'post').mockResolvedValue({
-            body: { code: 200, data: { token: 'b2b-token-value' } },
+            body: { code: 200, data: { token: b2bToken } },
         });
 
         b2bTokenRequestSender = new B2BTokenRequestSender(requestSender);
     });
 
-    describe('#getBCJWT()', () => {
-        it('sends GET to /customer/current.jwt with app_client_id param', async () => {
-            await b2bTokenRequestSender.getBCJWT('my-client-id');
+    describe('#getB2BToken()', () => {
+        it('fetches BC JWT then exchanges it for a B2B token', async () => {
+            await b2bTokenRequestSender.getB2BToken(
+                'my-client-id',
+                123,
+                'abc123',
+                1,
+                'https://api-b2b.bigcommerce.com',
+            );
 
             expect(requestSender.get).toHaveBeenCalledWith('/customer/current.jwt', {
                 params: { app_client_id: 'my-client-id' },
                 headers: SDK_VERSION_HEADERS,
                 timeout: undefined,
             });
-        });
-
-        it('passes timeout option through', async () => {
-            const timeout = {};
-
-            await b2bTokenRequestSender.getBCJWT('my-client-id', { timeout: timeout as any });
-
-            expect(requestSender.get).toHaveBeenCalledWith(
-                '/customer/current.jwt',
-                expect.objectContaining({ timeout }),
-            );
-        });
-    });
-
-    describe('#fetchB2BToken()', () => {
-        it('posts to the provided b2bBaseUrl', async () => {
-            await b2bTokenRequestSender.fetchB2BToken(
-                'bc-jwt',
-                123,
-                'abc123',
-                1,
-                'https://api-b2b.bigcommerce.com',
-                undefined,
-            );
 
             expect(requestSender.post).toHaveBeenCalledWith(
                 'https://api-b2b.bigcommerce.com/api/v2/login',
                 {
+                    credentials: false,
                     headers: { 'Content-Type': 'application/json' },
                     body: {
-                        bcToken: 'bc-jwt',
+                        bcToken: jwtToken,
                         customerId: 123,
                         storeHash: 'abc123',
                         channelId: 1,
                     },
-                    credentials: false,
                     timeout: undefined,
                 },
             );
         });
 
-        it('posts to custom b2bBaseUrl when provided', async () => {
-            await b2bTokenRequestSender.fetchB2BToken(
-                'bc-jwt',
+        it('uses the provided b2bBaseUrl for the token exchange', async () => {
+            await b2bTokenRequestSender.getB2BToken(
+                'my-client-id',
                 123,
                 'abc123',
                 1,
                 'https://api-b2b.staging.zone',
-                undefined,
             );
 
             expect(requestSender.post).toHaveBeenCalledWith(
                 'https://api-b2b.staging.zone/api/v2/login',
                 expect.objectContaining({
-                    body: expect.objectContaining({ bcToken: 'bc-jwt' }),
+                    body: expect.objectContaining({ bcToken: jwtToken }),
                 }),
             );
         });

--- a/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
@@ -48,8 +48,15 @@ describe('B2BTokenRequestSender', () => {
     });
 
     describe('#fetchB2BToken()', () => {
-        it('posts to default B2B login endpoint when no b2bBaseUrl provided', async () => {
-            await b2bTokenRequestSender.fetchB2BToken('bc-jwt', 123, 'abc123', 1);
+        it('posts to the provided b2bBaseUrl', async () => {
+            await b2bTokenRequestSender.fetchB2BToken(
+                'bc-jwt',
+                123,
+                'abc123',
+                1,
+                'https://api-b2b.bigcommerce.com',
+                undefined,
+            );
 
             expect(requestSender.post).toHaveBeenCalledWith(
                 'https://api-b2b.bigcommerce.com/api/v2/login',
@@ -57,10 +64,11 @@ describe('B2BTokenRequestSender', () => {
                     headers: { 'Content-Type': 'application/json' },
                     body: {
                         bcToken: 'bc-jwt',
-                        customerId: '123',
+                        customerId: 123,
                         storeHash: 'abc123',
-                        channelId: '1',
+                        channelId: 1,
                     },
+                    credentials: false,
                     timeout: undefined,
                 },
             );
@@ -72,8 +80,8 @@ describe('B2BTokenRequestSender', () => {
                 123,
                 'abc123',
                 1,
-                undefined,
                 'https://api-b2b.staging.zone',
+                undefined,
             );
 
             expect(requestSender.post).toHaveBeenCalledWith(

--- a/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
@@ -1,0 +1,69 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { SDK_VERSION_HEADERS } from '../common/http-request';
+
+import B2BTokenRequestSender from './b2b-token-request-sender';
+
+describe('B2BTokenRequestSender', () => {
+    let requestSender: RequestSender;
+    let b2bTokenRequestSender: B2BTokenRequestSender;
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        jest.spyOn(requestSender, 'get').mockResolvedValue({ body: { token: 'bc-jwt-token' } });
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        jest.spyOn(requestSender, 'post').mockResolvedValue({
+            body: { code: 200, data: { token: 'b2b-token-value' } },
+        });
+
+        b2bTokenRequestSender = new B2BTokenRequestSender(requestSender);
+    });
+
+    describe('#getBCJWT()', () => {
+        it('sends GET to /customer/current.jwt with app_client_id param', async () => {
+            await b2bTokenRequestSender.getBCJWT('my-client-id');
+
+            expect(requestSender.get).toHaveBeenCalledWith('/customer/current.jwt', {
+                params: { app_client_id: 'my-client-id' },
+                headers: SDK_VERSION_HEADERS,
+                timeout: undefined,
+            });
+        });
+
+        it('passes timeout option through', async () => {
+            const timeout = {};
+
+            await b2bTokenRequestSender.getBCJWT('my-client-id', { timeout: timeout as any });
+
+            expect(requestSender.get).toHaveBeenCalledWith(
+                '/customer/current.jwt',
+                expect.objectContaining({ timeout }),
+            );
+        });
+    });
+
+    describe('#exchangeForB2BToken()', () => {
+        it('posts to B2B login endpoint with correct payload', async () => {
+            await b2bTokenRequestSender.exchangeForB2BToken('bc-jwt', 123, 'abc123', 1);
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/login',
+                {
+                    headers: { 'Content-Type': 'application/json' },
+                    body: {
+                        bcToken: 'bc-jwt',
+                        customerId: '123',
+                        storeHash: 'abc123',
+                        channelId: '1',
+                    },
+                    timeout: undefined,
+                },
+            );
+        });
+    });
+});

--- a/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
@@ -1,6 +1,7 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import { SDK_VERSION_HEADERS } from '../common/http-request';
+import { getResponse } from '../common/http-request/responses.mock';
 
 import B2BTokenRequestSender from './b2b-token-request-sender';
 
@@ -14,15 +15,10 @@ describe('B2BTokenRequestSender', () => {
     beforeEach(() => {
         requestSender = createRequestSender();
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        jest.spyOn(requestSender, 'get').mockResolvedValue({ body: { token: jwtToken } });
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        jest.spyOn(requestSender, 'post').mockResolvedValue({
-            body: { code: 200, data: { token: b2bToken } },
-        });
+        jest.spyOn(requestSender, 'get').mockResolvedValue(getResponse({ token: jwtToken }));
+        jest.spyOn(requestSender, 'post').mockResolvedValue(
+            getResponse({ code: 200, data: { token: b2bToken } }),
+        );
 
         b2bTokenRequestSender = new B2BTokenRequestSender(requestSender);
     });

--- a/packages/core/src/b2b-token/b2b-token-request-sender.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.ts
@@ -2,8 +2,6 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
-const B2B_BASE_URL = 'https://api-b2b.bigcommerce.com';
-
 export interface BCJWTResponseBody {
     token: string;
 }
@@ -31,8 +29,8 @@ export default class B2BTokenRequestSender {
         customerId: number,
         storeHash: string,
         channelId: number,
+        b2bBaseUrl: string,
         options?: RequestOptions,
-        b2bBaseUrl: string = B2B_BASE_URL,
     ): Promise<Response<B2BTokenResponseBody>> {
         return this._requestSender.post(`${b2bBaseUrl}/api/v2/login`, {
             timeout: options?.timeout,

--- a/packages/core/src/b2b-token/b2b-token-request-sender.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.ts
@@ -2,10 +2,6 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
-export interface BCJWTResponseBody {
-    token: string;
-}
-
 export interface B2BTokenResponseBody {
     code: number;
     data: {
@@ -16,28 +12,29 @@ export interface B2BTokenResponseBody {
 export default class B2BTokenRequestSender {
     constructor(private _requestSender: RequestSender) {}
 
-    getBCJWT(appClientId: string, options?: RequestOptions): Promise<Response<BCJWTResponseBody>> {
-        return this._requestSender.get('/customer/current.jwt', {
-            timeout: options?.timeout,
-            params: { app_client_id: appClientId },
-            headers: SDK_VERSION_HEADERS,
-        });
-    }
-
-    fetchB2BToken(
-        bcToken: string,
+    async getB2BToken(
+        appClientId: string,
         customerId: number,
         storeHash: string,
         channelId: number,
         b2bBaseUrl: string,
         options?: RequestOptions,
     ): Promise<Response<B2BTokenResponseBody>> {
+        const { body: jwtBody } = await this._requestSender.get<{ token: string }>(
+            '/customer/current.jwt',
+            {
+                timeout: options?.timeout,
+                params: { app_client_id: appClientId },
+                headers: SDK_VERSION_HEADERS,
+            },
+        );
+
         return this._requestSender.post(`${b2bBaseUrl}/api/v2/login`, {
             timeout: options?.timeout,
             credentials: false,
             headers: { 'Content-Type': 'application/json' },
             body: {
-                bcToken,
+                bcToken: jwtBody.token,
                 customerId,
                 storeHash,
                 channelId,

--- a/packages/core/src/b2b-token/b2b-token-request-sender.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.ts
@@ -1,0 +1,47 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
+
+const B2B_BASE_URL = 'https://api-b2b.bigcommerce.com';
+
+export interface BCJWTResponseBody {
+    token: string;
+}
+
+export interface B2BTokenResponseBody {
+    code: number;
+    data: {
+        token: string;
+    };
+}
+
+export default class B2BTokenRequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    getBCJWT(appClientId: string, options?: RequestOptions): Promise<Response<BCJWTResponseBody>> {
+        return this._requestSender.get('/customer/current.jwt', {
+            timeout: options?.timeout,
+            params: { app_client_id: appClientId },
+            headers: SDK_VERSION_HEADERS,
+        });
+    }
+
+    exchangeForB2BToken(
+        bcToken: string,
+        customerId: number,
+        storeHash: string,
+        channelId: number,
+        options?: RequestOptions,
+    ): Promise<Response<B2BTokenResponseBody>> {
+        return this._requestSender.post(`${B2B_BASE_URL}/api/v2/login`, {
+            timeout: options?.timeout,
+            headers: { 'Content-Type': 'application/json' },
+            body: {
+                bcToken,
+                customerId: String(customerId),
+                storeHash,
+                channelId: String(channelId),
+            },
+        });
+    }
+}

--- a/packages/core/src/b2b-token/b2b-token-request-sender.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.ts
@@ -36,12 +36,13 @@ export default class B2BTokenRequestSender {
     ): Promise<Response<B2BTokenResponseBody>> {
         return this._requestSender.post(`${b2bBaseUrl}/api/v2/login`, {
             timeout: options?.timeout,
+            credentials: false,
             headers: { 'Content-Type': 'application/json' },
             body: {
                 bcToken,
-                customerId: String(customerId),
+                customerId,
                 storeHash,
-                channelId: String(channelId),
+                channelId,
             },
         });
     }

--- a/packages/core/src/b2b-token/b2b-token-request-sender.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.ts
@@ -26,14 +26,15 @@ export default class B2BTokenRequestSender {
         });
     }
 
-    exchangeForB2BToken(
+    fetchB2BToken(
         bcToken: string,
         customerId: number,
         storeHash: string,
         channelId: number,
         options?: RequestOptions,
+        b2bBaseUrl: string = B2B_BASE_URL,
     ): Promise<Response<B2BTokenResponseBody>> {
-        return this._requestSender.post(`${B2B_BASE_URL}/api/v2/login`, {
+        return this._requestSender.post(`${b2bBaseUrl}/api/v2/login`, {
             timeout: options?.timeout,
             headers: { 'Content-Type': 'application/json' },
             body: {

--- a/packages/core/src/b2b-token/b2b-token-selector.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-selector.spec.ts
@@ -1,0 +1,55 @@
+import { createB2BTokenSelectorFactory } from './b2b-token-selector';
+import B2BTokenState, { DEFAULT_STATE } from './b2b-token-state';
+
+describe('createB2BTokenSelectorFactory()', () => {
+    const createSelector = createB2BTokenSelectorFactory();
+
+    it('returns undefined token when no data is loaded', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getToken()).toBeUndefined();
+    });
+
+    it('returns the token string when data is loaded', () => {
+        const state: B2BTokenState = {
+            ...DEFAULT_STATE,
+            data: { token: 'my-b2b-token' },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getToken()).toBe('my-b2b-token');
+    });
+
+    it('returns false for isLoading when not loading', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.isLoading()).toBe(false);
+    });
+
+    it('returns true for isLoading when loading', () => {
+        const state: B2BTokenState = {
+            ...DEFAULT_STATE,
+            statuses: { isLoading: true },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.isLoading()).toBe(true);
+    });
+
+    it('returns undefined for getLoadError when no error', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getLoadError()).toBeUndefined();
+    });
+
+    it('returns error for getLoadError when there is an error', () => {
+        const error = new Error('B2B token load failed');
+        const state: B2BTokenState = {
+            ...DEFAULT_STATE,
+            errors: { loadError: error },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getLoadError()).toBe(error);
+    });
+});

--- a/packages/core/src/b2b-token/b2b-token-selector.ts
+++ b/packages/core/src/b2b-token/b2b-token-selector.ts
@@ -1,0 +1,38 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { createSelector } from '../common/selector';
+
+import B2BTokenState, { DEFAULT_STATE } from './b2b-token-state';
+
+export default interface B2BTokenSelector {
+    getToken(): string | undefined;
+    getLoadError(): Error | undefined;
+    isLoading(): boolean;
+}
+
+export type B2BTokenSelectorFactory = (state: B2BTokenState) => B2BTokenSelector;
+
+export function createB2BTokenSelectorFactory(): B2BTokenSelectorFactory {
+    const getToken = createSelector(
+        (state: B2BTokenState) => state.data?.token,
+        (token) => () => token,
+    );
+
+    const getLoadError = createSelector(
+        (state: B2BTokenState) => state.errors.loadError,
+        (error) => () => error,
+    );
+
+    const isLoading = createSelector(
+        (state: B2BTokenState) => !!state.statuses.isLoading,
+        (status) => () => status,
+    );
+
+    return memoizeOne((state: B2BTokenState = DEFAULT_STATE): B2BTokenSelector => {
+        return {
+            getToken: getToken(state),
+            getLoadError: getLoadError(state),
+            isLoading: isLoading(state),
+        };
+    });
+}

--- a/packages/core/src/b2b-token/b2b-token-state.ts
+++ b/packages/core/src/b2b-token/b2b-token-state.ts
@@ -1,0 +1,20 @@
+import B2BToken from './b2b-token';
+
+export default interface B2BTokenState {
+    data?: B2BToken;
+    errors: B2BTokenErrorsState;
+    statuses: B2BTokenStatusesState;
+}
+
+export interface B2BTokenErrorsState {
+    loadError?: Error;
+}
+
+export interface B2BTokenStatusesState {
+    isLoading?: boolean;
+}
+
+export const DEFAULT_STATE: B2BTokenState = {
+    errors: {},
+    statuses: {},
+};

--- a/packages/core/src/b2b-token/b2b-token-state.ts
+++ b/packages/core/src/b2b-token/b2b-token-state.ts
@@ -1,4 +1,6 @@
-import B2BToken from './b2b-token';
+export interface B2BToken {
+    token: string;
+}
 
 export default interface B2BTokenState {
     data?: B2BToken;

--- a/packages/core/src/b2b-token/b2b-token.ts
+++ b/packages/core/src/b2b-token/b2b-token.ts
@@ -1,0 +1,3 @@
+export default interface B2BToken {
+    token: string;
+}

--- a/packages/core/src/b2b-token/b2b-token.ts
+++ b/packages/core/src/b2b-token/b2b-token.ts
@@ -1,3 +1,0 @@
-export default interface B2BToken {
-    token: string;
-}

--- a/packages/core/src/b2b-token/index.ts
+++ b/packages/core/src/b2b-token/index.ts
@@ -1,0 +1,11 @@
+export { default as B2BTokenActionCreator } from './b2b-token-action-creator';
+export { B2BTokenActionType, LoadB2BTokenAction } from './b2b-token-actions';
+export { default as b2bTokenReducer } from './b2b-token-reducer';
+export {
+    default as B2BTokenSelector,
+    B2BTokenSelectorFactory,
+    createB2BTokenSelectorFactory,
+} from './b2b-token-selector';
+export { default as B2BTokenState } from './b2b-token-state';
+export { default as B2BTokenRequestSender } from './b2b-token-request-sender';
+export { default as B2BToken } from './b2b-token';

--- a/packages/core/src/b2b-token/index.ts
+++ b/packages/core/src/b2b-token/index.ts
@@ -6,6 +6,5 @@ export {
     B2BTokenSelectorFactory,
     createB2BTokenSelectorFactory,
 } from './b2b-token-selector';
-export { default as B2BTokenState } from './b2b-token-state';
+export { B2BToken, default as B2BTokenState } from './b2b-token-state';
 export { default as B2BTokenRequestSender } from './b2b-token-request-sender';
-export { default as B2BToken } from './b2b-token';

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -11,6 +11,7 @@ import {
     PaymentStrategy as PaymentStrategyV2,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
+import { B2BTokenActionCreator, B2BTokenRequestSender } from '../b2b-token';
 import {
     BillingAddressActionCreator,
     BillingAddressActionType,
@@ -418,6 +419,7 @@ describe('CheckoutService', () => {
             storeProjection,
             extensionMessenger,
             extensionEventBroadcaster,
+            new B2BTokenActionCreator(new B2BTokenRequestSender(requestSender)),
             billingAddressActionCreator,
             checkoutActionCreator,
             configActionCreator,

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { bindDecorator as bind } from '@bigcommerce/checkout-sdk/utility';
 
 import { AddressRequestBody } from '../address';
+import { B2BTokenActionCreator } from '../b2b-token';
 import { BillingAddressActionCreator, BillingAddressRequestBody } from '../billing';
 import { DataStoreProjection } from '../common/data-store';
 import { ErrorActionCreator, ErrorMessageTransformer } from '../common/error';
@@ -86,6 +87,7 @@ export default class CheckoutService {
         private _storeProjection: DataStoreProjection<CheckoutSelectors>,
         private _extensionMessenger: ExtensionMessenger,
         private _extensionEventBroadcaster: ExtensionEventBroadcaster,
+        private _b2bTokenActionCreator: B2BTokenActionCreator,
         private _billingAddressActionCreator: BillingAddressActionCreator,
         private _checkoutActionCreator: CheckoutActionCreator,
         private _configActionCreator: ConfigActionCreator,
@@ -676,6 +678,28 @@ export default class CheckoutService {
         const action = this._signInEmailActionCreator.sendSignInEmail(signInEmailRequest, options);
 
         return this._dispatch(action, { queueId: 'signInEmail' });
+    }
+
+    /**
+     * Retrieves a B2B authentication token for the current customer.
+     *
+     * The token can be used to authenticate requests to B2B REST and GraphQL
+     * endpoints. The customer must be signed in for this method to succeed.
+     *
+     * ```js
+     * const state = await service.getB2BToken('my-app-client-id');
+     *
+     * console.log(state.data.getB2BToken());
+     * ```
+     *
+     * @param appClientId - The B2B application client ID used to generate the BC JWT.
+     * @param options - Options for the request.
+     * @returns A promise that resolves to the current state.
+     */
+    getB2BToken(appClientId: string, options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._b2bTokenActionCreator.loadB2BToken(appClientId, options);
+
+        return this._dispatch(action, { queueId: 'b2bToken' });
     }
 
     /**

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -685,19 +685,19 @@ export default class CheckoutService {
      *
      * The token can be used to authenticate requests to B2B REST and GraphQL
      * endpoints. The customer must be signed in for this method to succeed.
+     * The B2B base URL and client ID are read from the checkout settings config.
      *
      * ```js
-     * const state = await service.getB2BToken('my-app-client-id');
+     * const state = await service.getB2BToken();
      *
      * console.log(state.data.getB2BToken());
      * ```
      *
-     * @param appClientId - The B2B application client ID used to generate the BC JWT.
      * @param options - Options for the request.
      * @returns A promise that resolves to the current state.
      */
-    getB2BToken(appClientId: string, options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._b2bTokenActionCreator.loadB2BToken(appClientId, options);
+    getB2BToken(options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._b2bTokenActionCreator.loadB2BToken(options);
 
         return this._dispatch(action, { queueId: 'b2bToken' });
     }

--- a/packages/core/src/checkout/checkout-store-error-selector.ts
+++ b/packages/core/src/checkout/checkout-store-error-selector.ts
@@ -289,6 +289,13 @@ export default interface CheckoutStoreErrorSelector {
     getSignInEmailError(): Error | undefined;
 
     /**
+     * Returns an error if unable to load the B2B token.
+     *
+     * @returns The error object if unable to load the B2B token, otherwise undefined.
+     */
+    getLoadB2BTokenError(): Error | undefined;
+
+    /**
      * Returns an error if unable to create customer account.
      *
      * @returns The error object if unable to create account, otherwise undefined.
@@ -382,6 +389,7 @@ export function createCheckoutStoreErrorSelectorFactory(): CheckoutStoreErrorSel
             getDeleteInstrumentError: state.instruments.getDeleteError,
             getLoadConfigError: state.config.getLoadError,
             getSignInEmailError: state.signInEmail.getSendError,
+            getLoadB2BTokenError: state.b2bToken.getLoadError,
             getCreateCustomerAccountError: state.customer.getCreateAccountError,
             getCreateCustomerAddressError: state.customer.getCreateAddressError,
             getPickupOptionsError: state.pickupOptions.getLoadError,

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -60,6 +60,13 @@ export default interface CheckoutStoreSelector {
     getSignInEmail(): SignInEmail | undefined;
 
     /**
+     * Gets the B2B authentication token for the current customer.
+     *
+     * @returns The B2B token string if it has been loaded, otherwise undefined.
+     */
+    getB2BToken(): string | undefined;
+
+    /**
      * Gets the shipping address of the current checkout.
      *
      * If the address is partially complete, it may not have shipping options
@@ -495,6 +502,11 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         (getEmail) => clone(getEmail),
     );
 
+    const getB2BToken = createSelector(
+        ({ b2bToken }: InternalCheckoutSelectors) => b2bToken.getToken,
+        (getToken) => clone(getToken),
+    );
+
     const isPaymentDataRequired = createSelector(
         ({ payment }: InternalCheckoutSelectors) => payment.isPaymentDataRequired,
         (isPaymentDataRequired) => clone(isPaymentDataRequired),
@@ -624,6 +636,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             isPaymentDataRequired: isPaymentDataRequired(state),
             isPaymentDataSubmitted: isPaymentDataSubmitted(state),
             getSignInEmail: getSignInEmail(state),
+            getB2BToken: getB2BToken(state),
             getInstruments: getInstruments(state),
             getCustomerAccountFields: getCustomerAccountFields(state),
             getBillingAddressFields: getBillingAddressFields(state),

--- a/packages/core/src/checkout/checkout-store-state.ts
+++ b/packages/core/src/checkout/checkout-store-state.ts
@@ -1,5 +1,5 @@
-import { BillingAddressState } from '../billing';
 import { B2BTokenState } from '../b2b-token';
+import { BillingAddressState } from '../billing';
 import { CartState } from '../cart';
 import { CheckoutButtonState } from '../checkout-buttons';
 import { ConfigState } from '../config';

--- a/packages/core/src/checkout/checkout-store-state.ts
+++ b/packages/core/src/checkout/checkout-store-state.ts
@@ -1,4 +1,5 @@
 import { BillingAddressState } from '../billing';
+import { B2BTokenState } from '../b2b-token';
 import { CartState } from '../cart';
 import { CheckoutButtonState } from '../checkout-buttons';
 import { ConfigState } from '../config';
@@ -26,6 +27,7 @@ import { SubscriptionsState } from '../subscription';
 import CheckoutState from './checkout-state';
 
 export default interface CheckoutStoreState {
+    b2bToken: B2BTokenState;
     billingAddress: BillingAddressState;
     cart: CartState;
     checkout: CheckoutState;

--- a/packages/core/src/checkout/checkout-store-status-selector.ts
+++ b/packages/core/src/checkout/checkout-store-status-selector.ts
@@ -282,6 +282,13 @@ export default interface CheckoutStoreStatusSelector {
     isSendingSignInEmail(): boolean;
 
     /**
+     * Checks whether a B2B token is being loaded.
+     *
+     * @returns True if a B2B token is being loaded, otherwise false.
+     */
+    isLoadingB2BToken(): boolean;
+
+    /**
      * Checks whether the current customer is applying a gift certificate.
      *
      * @returns True if applying a gift certificate, otherwise false.
@@ -507,6 +514,7 @@ export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusS
             isDeletingInstrument: state.instruments.isDeleting,
             isLoadingConfig: state.config.isLoading,
             isSendingSignInEmail: state.signInEmail.isSending,
+            isLoadingB2BToken: state.b2bToken.isLoading,
             isCustomerStepPending: isCustomerStepPending(state),
             isShippingStepPending: isShippingStepPending(state),
             isPaymentStepPending: isPaymentStepPending(state),

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -118,6 +118,7 @@ export function getCheckoutState(): CheckoutState {
 
 export function getCheckoutStoreState(): CheckoutStoreState {
     return {
+        b2bToken: { errors: {}, statuses: {} },
         billingAddress: getBillingAddressState(),
         cart: getCartState(),
         checkout: getCheckoutState(),

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -1,6 +1,7 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
+import { B2BTokenActionCreator, B2BTokenRequestSender } from '../b2b-token';
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { createDataStoreProjection } from '../common/data-store';
 import { ErrorActionCreator, ErrorLogger } from '../common/error';
@@ -168,6 +169,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         storeProjection,
         extensionMessenger,
         createExtensionEventBroadcaster(storeProjection, extensionMessenger),
+        new B2BTokenActionCreator(new B2BTokenRequestSender(requestSender)),
         new BillingAddressActionCreator(
             new BillingAddressRequestSender(requestSender),
             subscriptionsActionCreator,

--- a/packages/core/src/checkout/create-checkout-store-reducer.ts
+++ b/packages/core/src/checkout/create-checkout-store-reducer.ts
@@ -1,5 +1,6 @@
 import { Action, combineReducers, Reducer } from '@bigcommerce/data-store';
 
+import { b2bTokenReducer } from '../b2b-token';
 import { billingAddressReducer } from '../billing';
 import { cartReducer } from '../cart';
 import { checkoutButtonReducer } from '../checkout-buttons';
@@ -30,6 +31,7 @@ import CheckoutStoreState from './checkout-store-state';
 
 export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState, Action> {
     return combineReducers({
+        b2bToken: b2bTokenReducer,
         billingAddress: billingAddressReducer,
         cart: cartReducer,
         checkout: checkoutReducer,

--- a/packages/core/src/checkout/create-internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/create-internal-checkout-selectors.ts
@@ -1,3 +1,4 @@
+import { createB2BTokenSelectorFactory } from '../b2b-token';
 import { createBillingAddressSelectorFactory } from '../billing';
 import { createCartSelectorFactory } from '../cart';
 import { createCheckoutButtonSelectorFactory } from '../checkout-buttons';
@@ -40,6 +41,7 @@ export type InternalCheckoutSelectorsFactory = (
 ) => InternalCheckoutSelectors;
 
 export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
+    const createB2BTokenSelector = createB2BTokenSelectorFactory();
     const createBillingAddressSelector = createBillingAddressSelectorFactory();
     const createCartSelector = createCartSelectorFactory();
     const createCheckoutButtonSelector = createCheckoutButtonSelectorFactory();
@@ -70,6 +72,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createExtensionSelector = createExtensionSelectorFactory();
 
     return (state, options = {}) => {
+        const b2bToken = createB2BTokenSelector(state.b2bToken);
         const billingAddress = createBillingAddressSelector(state.billingAddress);
         const cart = createCartSelector(state.cart);
         const checkoutButton = createCheckoutButtonSelector(state.checkoutButton);
@@ -112,6 +115,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const config = createConfigSelector(state.config, state.formFields);
 
         const selectors = {
+            b2bToken,
             billingAddress,
             cart,
             checkout,

--- a/packages/core/src/checkout/internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/internal-checkout-selectors.ts
@@ -1,4 +1,5 @@
 import { BillingAddressSelector } from '../billing';
+import { B2BTokenSelector } from '../b2b-token';
 import { CartSelector } from '../cart';
 import { CheckoutButtonSelector } from '../checkout-buttons';
 import { ConfigSelector } from '../config';
@@ -27,6 +28,7 @@ import { SubscriptionsSelector } from '../subscription';
 import CheckoutSelector from './checkout-selector';
 
 export default interface InternalCheckoutSelectors {
+    b2bToken: B2BTokenSelector;
     billingAddress: BillingAddressSelector;
     cart: CartSelector;
     checkout: CheckoutSelector;

--- a/packages/core/src/checkout/internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/internal-checkout-selectors.ts
@@ -1,5 +1,5 @@
-import { BillingAddressSelector } from '../billing';
 import { B2BTokenSelector } from '../b2b-token';
+import { BillingAddressSelector } from '../billing';
 import { CartSelector } from '../cart';
 import { CheckoutButtonSelector } from '../checkout-buttons';
 import { ConfigSelector } from '../config';

--- a/packages/core/src/config/capabilities.ts
+++ b/packages/core/src/config/capabilities.ts
@@ -6,6 +6,7 @@ export interface Capabilities {
         disableEditCart: boolean;
         hasCompanyAddressBook: boolean;
         hasExtraAddressFields: boolean;
+        requiresB2BToken: boolean;
     };
     customer: {
         superAdminCompanySelector: boolean;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -102,6 +102,8 @@ export interface UserExperienceSettings {
 
 export interface CheckoutSettings {
     capabilities?: Capabilities;
+    b2bBaseUrl?: string;
+    b2bClientId?: string;
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
     checkoutUserExperienceSettings: UserExperienceSettings;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -100,10 +100,14 @@ export interface UserExperienceSettings {
     floatingLabelEnabled: boolean;
 }
 
+export interface B2BServiceDetails {
+    b2bBaseUrl: string;
+    b2bClientId: string;
+}
+
 export interface CheckoutSettings {
     capabilities?: Capabilities;
-    b2bBaseUrl?: string;
-    b2bClientId?: string;
+    b2bServiceDetails?: B2BServiceDetails;
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
     checkoutUserExperienceSettings: UserExperienceSettings;

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -19,6 +19,8 @@ export function getConfig(): Config {
         storeConfig: {
             cdnPath: 'https://cdn.bcapp.dev/rHEAD',
             checkoutSettings: {
+                b2bBaseUrl: 'https://api-b2b.test.zone',
+                b2bClientId: 'test-b2b-client-id',
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
                 checkoutUserExperienceSettings: {

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -19,8 +19,10 @@ export function getConfig(): Config {
         storeConfig: {
             cdnPath: 'https://cdn.bcapp.dev/rHEAD',
             checkoutSettings: {
-                b2bBaseUrl: 'https://api-b2b.test.zone',
-                b2bClientId: 'test-b2b-client-id',
+                b2bServiceDetails: {
+                    b2bBaseUrl: 'https://api-b2b.test.zone',
+                    b2bClientId: 'test-b2b-client-id',
+                },
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
                 checkoutUserExperienceSettings: {

--- a/packages/payment-integration-api/src/config/capabilities.ts
+++ b/packages/payment-integration-api/src/config/capabilities.ts
@@ -6,6 +6,7 @@ export interface Capabilities {
         disableEditCart: boolean;
         hasCompanyAddressBook: boolean;
         hasExtraAddressFields: boolean;
+        requiresB2BToken: boolean;
     };
     customer: {
         superAdminCompanySelector: boolean;

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -102,6 +102,8 @@ export interface UserExperienceSettings {
 
 export interface CheckoutSettings {
     capabilities?: Capabilities;
+    b2bBaseUrl?: string;
+    b2bClientId?: string;
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
     checkoutUserExperienceSettings: UserExperienceSettings;

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -100,10 +100,14 @@ export interface UserExperienceSettings {
     floatingLabelEnabled: boolean;
 }
 
+export interface B2BServiceDetails {
+    b2bBaseUrl: string;
+    b2bClientId: string;
+}
+
 export interface CheckoutSettings {
     capabilities?: Capabilities;
-    b2bBaseUrl?: string;
-    b2bClientId?: string;
+    b2bServiceDetails?: B2BServiceDetails;
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
     checkoutUserExperienceSettings: UserExperienceSettings;


### PR DESCRIPTION
## What/Why?

Implements the ability to fetch a B2B authentication token for signed-in B2B customers and store it in the checkout SDK state, making it available for downstream use in B2B REST and GraphQL API calls.

**New b2b-token module** — adds the full Redux-style slice for B2B token management:

**B2BTokenRequestSender** — fetches a BC JWT via `/customer/current.jwt`, then exchanges it for a B2B token via the B2B API (`/api/v2/login`)
**B2BTokenActionCreator** — orchestrates the two-step token fetch and dispatches load/success/failure actions
**B2BTokenReducer** — stores the token in state and tracks loading/error status
**B2BTokenSelector** — exposes `getToken()`, `isLoading()`, and `getLoadError()` for consumers
**CheckoutService.getB2BToken()** — new public method that triggers the token fetch. No arguments needed; the B2B base URL and client ID are read from checkout settings config.

**CheckoutSettings** — adds optional b2bBaseUrl and b2bClientId fields, sourced from the `/api/storefront/checkout-settings` response. 

**Capabilities.userJourney** — adds **requiresB2BToken** flag to signal when a B2B token is required for the current shopper journey.

**Usage**

```
const state = await service.getB2BToken();
console.log(state.data.getB2BToken()); // the B2B auth token string

```
## Rollout/Rollback

Revert this PR.

## Testing

CI checks


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new network calls and state plumbing for token retrieval; risk centers on misconfiguration of `b2bServiceDetails`/base URL and downstream reliance on the new token data.
> 
> **Overview**
> Adds a new `b2b-token` module that can fetch a B2B auth token (BC JWT from `/customer/current.jwt` exchanged at `${b2bBaseUrl}/api/v2/login`) and store it in SDK state with loading/error tracking.
> 
> Wires this into checkout by adding `CheckoutService.getB2BToken()` (queued under `b2bToken`), exposing `getB2BToken()` plus related status/error selectors, and extending store state/reducers/selectors to include the new `b2bToken` slice.
> 
> Extends config types and mocks to include `checkoutSettings.b2bServiceDetails` and adds a `capabilities.userJourney.requiresB2BToken` flag in both `core` and `payment-integration-api` type definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257938edc1a88c770d76378acb5ca39993dba158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->