### PR TITLE
chore(checkout): CHECKOUT-9950 Add experiment aware request sender to payment integration service

### DIFF
--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -144,7 +144,10 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         configActionCreator,
         formFieldsActionCreator,
     );
-    const paymentIntegrationService = createPaymentIntegrationService(store);
+    const paymentIntegrationService = createPaymentIntegrationService(
+        store,
+        experimentRequestSender,
+    );
 
     // NO_PAYMENT_DATA_REQUIRED must always be available regardless of build mode — it handles
     // free orders / full store credit checkouts and cannot be lazily loaded via integrations.

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -1,4 +1,4 @@
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -50,12 +50,15 @@ import PaymentIntegrationStoreProjectionFactory from './payment-integration-stor
 
 export default function createPaymentIntegrationService(
     store: CheckoutStore,
+    requestSender?: RequestSender,
 ): PaymentIntegrationService {
     const {
         config: { getHost, getLocale },
     } = store.getState();
 
-    const requestSender = createRequestSender({ host: getHost() });
+    if (!requestSender) {
+        requestSender = createRequestSender({ host: getHost() });
+    }
 
     const storeProjectionFactory = new PaymentIntegrationStoreProjectionFactory(
         createPaymentIntegrationSelectors,


### PR DESCRIPTION
## What/Why?
Add experiment aware request sender to payment integration service. Fix https://github.com/bigcommerce/checkout-sdk-js/pull/3217#discussion_r3084731429

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment-integration networking by changing which `RequestSender` is used, which could affect payment-related API calls and experiment routing/headers if miswired.
> 
> **Overview**
> Routes payment-integration API traffic through the *experiment-aware* request sender.
> 
> `createPaymentIntegrationService` now accepts an optional `RequestSender` and only creates its own default sender when none is provided, and `createCheckoutService` is updated to pass the existing `experimentRequestSender` into the payment integration service instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db70e16ab8ee2a9530f0566423d9c1534aee223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->