### PR TITLE
feat(checkout) PI-5213 Affirm orderSubmit only after payment complete

### DIFF
--- a/packages/affirm-integration/src/affirm-payment-strategy.spec.ts
+++ b/packages/affirm-integration/src/affirm-payment-strategy.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBillingAddress,
+    getConfig,
     getOrderRequestBody,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
@@ -166,10 +167,6 @@ describe('AffirmPaymentStrategy', () => {
                     phone_number: '555-555-5555',
                 },
                 discounts: {
-                    '279F507D817E3E7': {
-                        discount_amount: 500,
-                        discount_display_name: '$5.00 off the shipping total',
-                    },
                     DISCOUNTED_AMOUNT: {
                         discount_amount: 1000,
                         discount_display_name: 'discount',
@@ -190,12 +187,29 @@ describe('AffirmPaymentStrategy', () => {
                         unit_price: 19000,
                     },
                     {
+                        categories: [['Cat 1'], ['Cat 2'], ['Cat 3']],
+                        display_name: 'Digital Book',
+                        item_image_url: '/images/digital-book.jpg',
+                        item_url: '/digital-book/',
+                        qty: 1,
+                        sku: 'CLX',
+                        unit_price: 20000,
+                    },
+                    {
                         display_name: '$100 Gift Certificate',
                         item_image_url: '',
                         item_url: '',
                         qty: 1,
                         sku: '',
                         unit_price: 10000,
+                    },
+                    {
+                        display_name: 'Custom item',
+                        item_image_url: '',
+                        item_url: '',
+                        qty: 2,
+                        sku: 'custom-sku',
+                        unit_price: 1000,
                     },
                 ],
                 merchant: {
@@ -342,10 +356,6 @@ describe('AffirmPaymentStrategy', () => {
                     phone_number: '555-555-5555',
                 },
                 discounts: {
-                    '279F507D817E3E7': {
-                        discount_amount: 500,
-                        discount_display_name: '$5.00 off the shipping total',
-                    },
                     DISCOUNTED_AMOUNT: {
                         discount_amount: 1000,
                         discount_display_name: 'discount',
@@ -366,12 +376,29 @@ describe('AffirmPaymentStrategy', () => {
                         unit_price: 19000,
                     },
                     {
+                        categories: [['Cat 1'], ['Cat 2'], ['Cat 3']],
+                        display_name: 'Digital Book',
+                        item_image_url: '/images/digital-book.jpg',
+                        item_url: '/digital-book/',
+                        qty: 1,
+                        sku: 'CLX',
+                        unit_price: 20000,
+                    },
+                    {
                         display_name: '$100 Gift Certificate',
                         item_image_url: '',
                         item_url: '',
                         qty: 1,
                         sku: '',
                         unit_price: 10000,
+                    },
+                    {
+                        display_name: 'Custom item',
+                        item_image_url: '',
+                        item_url: '',
+                        qty: 2,
+                        sku: 'custom-sku',
+                        unit_price: 1000,
                     },
                 ],
                 merchant: {
@@ -453,15 +480,60 @@ describe('AffirmPaymentStrategy', () => {
             await expect(strategy.execute(payload)).rejects.toThrow(MissingDataError);
         });
 
-        it('does not create affirm object if order does not exist', async () => {
-            jest.spyOn(paymentIntegrationService.getState(), 'getOrder').mockReturnValue(undefined);
+        it('opens Affirm modal before submitting order when experiment is enabled', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue(
+                getConfig().storeConfig,
+            );
 
-            await strategy.initialize({
-                methodId: paymentMethod.id,
-                gatewayId: paymentMethod.gateway,
+            const callOrder: string[] = [];
+
+            jest.spyOn(paymentIntegrationService, 'submitOrder').mockImplementation(() => {
+                callOrder.push('submitOrder');
+
+                return Promise.resolve(paymentIntegrationService.getState());
+            });
+            jest.spyOn(affirm.checkout, 'open').mockImplementation(({ onSuccess }) => {
+                callOrder.push('affirmOpen');
+                onSuccess({ checkout_token: '1234', created: '1234' });
             });
 
-            await expect(strategy.execute(payload)).rejects.toThrow(MissingDataError);
+            await strategy.initialize({ methodId: paymentMethod.id });
+            await strategy.execute(payload);
+
+            expect(callOrder).toEqual(['affirmOpen', 'submitOrder']);
+        });
+
+        it('submits order before opening Affirm modal when experiment is disabled', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue(
+                getConfig().storeConfig,
+            );
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue({
+                ...getConfig().storeConfig,
+                checkoutSettings: {
+                    ...getConfig().storeConfig.checkoutSettings,
+                    features: { 'PI-5213.affirm_submit_order_after_submit_payment': false },
+                },
+            });
+
+            const callOrder: string[] = [];
+
+            jest.spyOn(paymentIntegrationService, 'submitOrder').mockImplementation(() => {
+                callOrder.push('submitOrder');
+
+                return Promise.resolve(paymentIntegrationService.getState());
+            });
+            jest.spyOn(affirm.checkout, 'open').mockImplementation(({ onSuccess }) => {
+                callOrder.push('affirmOpen');
+                onSuccess({ checkout_token: '1234', created: '1234' });
+            });
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+            await strategy.execute(payload);
+
+            expect(callOrder).toEqual(['submitOrder', 'affirmOpen']);
         });
     });
 

--- a/packages/affirm-integration/src/affirm-payment-strategy.spec.ts
+++ b/packages/affirm-integration/src/affirm-payment-strategy.spec.ts
@@ -480,10 +480,17 @@ describe('AffirmPaymentStrategy', () => {
             await expect(strategy.execute(payload)).rejects.toThrow(MissingDataError);
         });
 
-        it('opens Affirm modal before submitting order when experiment is enabled', async () => {
+        it('opens Affirm modal before submitting order when postponeOrderCreation is enabled', async () => {
             jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue(
                 getConfig().storeConfig,
             );
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: { postponeOrderCreation: true },
+            });
 
             const callOrder: string[] = [];
 
@@ -503,19 +510,16 @@ describe('AffirmPaymentStrategy', () => {
             expect(callOrder).toEqual(['affirmOpen', 'submitOrder']);
         });
 
-        it('submits order before opening Affirm modal when experiment is disabled', async () => {
+        it('submits order before opening Affirm modal when postponeOrderCreation is disabled', async () => {
             jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValue(
                 getConfig().storeConfig,
             );
             jest.spyOn(
                 paymentIntegrationService.getState(),
-                'getStoreConfigOrThrow',
+                'getPaymentMethodOrThrow',
             ).mockReturnValue({
-                ...getConfig().storeConfig,
-                checkoutSettings: {
-                    ...getConfig().storeConfig.checkoutSettings,
-                    features: { 'PI-5213.affirm_submit_order_after_submit_payment': false },
-                },
+                ...paymentMethod,
+                initializationData: { postponeOrderCreation: false },
             });
 
             const callOrder: string[] = [];

--- a/packages/affirm-integration/src/affirm-payment-strategy.ts
+++ b/packages/affirm-integration/src/affirm-payment-strategy.ts
@@ -1,13 +1,14 @@
 import {
     AmountTransformer,
     Consignment,
+    Coupon,
     itemsRequireShipping,
     LineItemCategory,
+    LineItemMap,
     MissingDataError,
     MissingDataErrorType,
     NotInitializedError,
     NotInitializedErrorType,
-    Order,
     OrderFinalizationNotRequiredError,
     OrderRequestBody,
     PaymentArgumentInvalidError,
@@ -18,6 +19,7 @@ import {
     PaymentRequestOptions,
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
 
 import {
     Affirm,
@@ -67,7 +69,17 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             throw new PaymentArgumentInvalidError(['payment.methodId']);
         }
 
-        await this.paymentIntegrationService.submitOrder({ useStoreCredit }, options);
+        const { checkoutSettings } = this.paymentIntegrationService
+            .getState()
+            .getStoreConfigOrThrow();
+        const isSubmitOrderAfterPaymentEnabled = isExperimentEnabled(
+            checkoutSettings.features,
+            'PI-5213.affirm_submit_order_after_submit_payment',
+        );
+
+        if (!isSubmitOrderAfterPaymentEnabled) {
+            await this.paymentIntegrationService.submitOrder({ useStoreCredit }, options);
+        }
 
         const affirmCheckout = await this.initializeAffirmCheckout();
 
@@ -75,6 +87,10 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             methodId,
             paymentData: { nonce: affirmCheckout.checkout_token },
         };
+
+        if (isSubmitOrderAfterPaymentEnabled) {
+            await this.paymentIntegrationService.submitOrder({ useStoreCredit }, options);
+        }
 
         await this.paymentIntegrationService.submitPayment(paymentPayload);
     }
@@ -117,18 +133,18 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
         const state = this.paymentIntegrationService.getState();
         const config = state.getStoreConfig();
         const consignments = state.getConsignments();
-        const order = state.getOrder();
         const cart = state.getCart();
+        const checkout = state.getCheckoutOrThrow();
 
         if (!config) {
             throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
         }
 
-        if (!order) {
-            throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+        if (!cart) {
+            throw new MissingDataError(MissingDataErrorType.MissingCart);
         }
 
-        const amountTransformer = new AmountTransformer(order.currency.decimalPlaces);
+        const amountTransformer = new AmountTransformer(cart.currency.decimalPlaces);
         const billingAddress = this.getBillingAddress();
 
         const retrievedShippingAddress = this.getShippingAddress();
@@ -145,7 +161,7 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             },
             shipping: shippingAddress,
             billing: billingAddress,
-            items: this.getItems(amountTransformer, order),
+            items: this.getItems(amountTransformer, cart.lineItems),
             metadata: {
                 shipping_type: this.getShippingType(consignments),
                 mode: 'modal',
@@ -153,11 +169,11 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
                 platform_version: '',
                 platform_affirm: '',
             },
-            discounts: this.getDiscounts(amountTransformer, order),
-            order_id: order.orderId ? order.orderId.toString() : '',
-            shipping_amount: amountTransformer.toInteger(order.shippingCostTotal),
-            tax_amount: amountTransformer.toInteger(order.taxTotal),
-            total: amountTransformer.toInteger(order.orderAmount),
+            discounts: this.getDiscounts(amountTransformer, cart.coupons, cart.discountAmount),
+            order_id: checkout.orderId ? checkout.orderId.toString() : '',
+            shipping_amount: amountTransformer.toInteger(checkout.shippingCostTotal),
+            tax_amount: amountTransformer.toInteger(checkout.taxTotal),
+            total: amountTransformer.toInteger(checkout.grandTotal),
         };
     }
 
@@ -229,10 +245,10 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
         return shippingInformation;
     }
 
-    private getItems(amountTransformer: AmountTransformer, order: Order): AffirmItem[] {
+    private getItems(amountTransformer: AmountTransformer, lineItems: LineItemMap): AffirmItem[] {
         const items: AffirmItem[] = [];
 
-        order.lineItems.physicalItems.forEach((item) => {
+        lineItems.physicalItems.forEach((item) => {
             items.push({
                 display_name: item.name,
                 sku: item.sku,
@@ -244,7 +260,7 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             });
         });
 
-        order.lineItems.digitalItems.forEach((item) => {
+        lineItems.digitalItems.forEach((item) => {
             items.push({
                 display_name: item.name,
                 sku: item.sku,
@@ -256,7 +272,7 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             });
         });
 
-        order.lineItems.giftCertificates.forEach((item) => {
+        lineItems.giftCertificates.forEach((item) => {
             items.push({
                 display_name: item.name,
                 sku: '',
@@ -267,8 +283,8 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             });
         });
 
-        if (order.lineItems.customItems) {
-            order.lineItems.customItems.forEach((item) => {
+        if (lineItems.customItems) {
+            lineItems.customItems.forEach((item) => {
                 items.push({
                     display_name: item.name,
                     sku: item.sku,
@@ -283,10 +299,14 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
         return items;
     }
 
-    private getDiscounts(amountTransformer: AmountTransformer, order: Order): AffirmDiscount {
+    private getDiscounts(
+        amountTransformer: AmountTransformer,
+        coupons: Coupon[],
+        discountAmount: number,
+    ): AffirmDiscount {
         const discounts: AffirmDiscount = {};
 
-        order.coupons.forEach((line) => {
+        coupons.forEach((line) => {
             if (line.discountedAmount > 0) {
                 discounts[line.code] = {
                     discount_amount: amountTransformer.toInteger(line.discountedAmount),
@@ -295,9 +315,9 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             }
         });
 
-        if (order.discountAmount > 0) {
+        if (discountAmount > 0) {
             discounts.DISCOUNTED_AMOUNT = {
-                discount_amount: amountTransformer.toInteger(order.discountAmount),
+                discount_amount: amountTransformer.toInteger(discountAmount),
                 discount_display_name: 'discount',
             };
         }

--- a/packages/affirm-integration/src/affirm-payment-strategy.ts
+++ b/packages/affirm-integration/src/affirm-payment-strategy.ts
@@ -19,13 +19,13 @@ import {
     PaymentRequestOptions,
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
 
 import {
     Affirm,
     AffirmAddress,
     AffirmDiscount,
     AffirmFailResponse,
+    AffirmInitializationData,
     AffirmItem,
     AffirmRequestData,
     AffirmSuccessResponse,
@@ -69,15 +69,12 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             throw new PaymentArgumentInvalidError(['payment.methodId']);
         }
 
-        const { checkoutSettings } = this.paymentIntegrationService
+        const { initializationData } = this.paymentIntegrationService
             .getState()
-            .getStoreConfigOrThrow();
-        const isSubmitOrderAfterPaymentEnabled = isExperimentEnabled(
-            checkoutSettings.features,
-            'PI-5213.affirm_submit_order_after_submit_payment',
-        );
+            .getPaymentMethodOrThrow<AffirmInitializationData>(methodId);
+        const postponeOrderCreation = initializationData?.postponeOrderCreation ?? false;
 
-        if (!isSubmitOrderAfterPaymentEnabled) {
+        if (!postponeOrderCreation) {
             await this.paymentIntegrationService.submitOrder({ useStoreCredit }, options);
         }
 
@@ -88,7 +85,7 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             paymentData: { nonce: affirmCheckout.checkout_token },
         };
 
-        if (isSubmitOrderAfterPaymentEnabled) {
+        if (postponeOrderCreation) {
             await this.paymentIntegrationService.submitOrder({ useStoreCredit }, options);
         }
 

--- a/packages/affirm-integration/src/affirm.ts
+++ b/packages/affirm-integration/src/affirm.ts
@@ -93,6 +93,10 @@ export interface AffirmAddress {
     email?: string;
 }
 
+export interface AffirmInitializationData {
+    postponeOrderCreation?: boolean;
+}
+
 export enum AFFIRM_SCRIPTS {
     PROD = '//cdn1.affirm.com/js/v2/affirm.js',
     SANDBOX = '//cdn1-sandbox.affirm.com/js/v2/affirm.js',


### PR DESCRIPTION
## What/Why?
Affirm Order Submitting only after payment is complete.

## Rollout/Rollback
Revert PR, OR experiment disable.

## Testing
Manual testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the order submission timing in the Affirm payment flow and switches data sources for the Affirm checkout payload, which could affect totals/discounts and sequencing around payment authorization.
> 
> **Overview**
> **Affirm checkout can now postpone order creation.** `AffirmPaymentStrategy.execute` reads `initializationData.postponeOrderCreation` and conditionally calls `submitOrder` *before* or *after* the Affirm modal succeeds, while still submitting the payment nonce afterwards.
> 
> **Affirm payload generation now uses cart/checkout data instead of order data.** `getCheckoutInformation` pulls totals and `order_id` from `checkout`, and items/discounts from `cart` (`lineItems`, `coupons`, `discountAmount`), with tests updated to cover both sequencing modes and expanded item expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2008804a78ad36481abcc29a18312a29a1bfac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->