### PR TITLE
feat(order): BACK-392 Add order BO fields to LineItem type

### DIFF
--- a/packages/core/src/cart/line-item.ts
+++ b/packages/core/src/cart/line-item.ts
@@ -66,6 +66,8 @@ export interface LineItem {
     options?: LineItemOption[];
     addedByPromotion: boolean;
     parentId?: string | null;
+    quantityBackordered?: number;
+    backorderMessage?: string | null;
     stockPosition?: StockPosition;
 }
 

--- a/packages/payment-integration-api/src/cart/line-item.ts
+++ b/packages/payment-integration-api/src/cart/line-item.ts
@@ -66,6 +66,8 @@ export interface LineItem {
     options?: LineItemOption[];
     addedByPromotion: boolean;
     parentId?: string | null;
+    quantityBackordered?: number;
+    backorderMessage?: string | null;
     stockPosition?: StockPosition;
 }
 


### PR DESCRIPTION
## What/Why?
`LineItem` type need to be updated to match the response of order API response, so the BO fields can be used in checkout-js

<img width="1494" height="684" alt="Screenshot 2026-04-20 at 7 02 09 am" src="https://github.com/user-attachments/assets/b6818626-8367-44a4-9304-db449db2c3f2" />

## Rollout/Rollback
Revert

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only change: adds optional backorder fields without altering runtime behavior, but may require downstream consumers to handle the new properties if used.
> 
> **Overview**
> Updates the shared `LineItem` TypeScript interfaces in `core` and `payment-integration-api` to include backorder metadata.
> 
> Adds optional `quantityBackordered` and `backorderMessage` fields so checkout/consumers can read backorder information from the order API response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c4d737e3a540d77670b4f2b95c4a72abe9a7242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->