### PR TITLE
fix(payment): Stripe add second payment request for Stripe declined

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -1583,7 +1583,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 );
             };
 
-            it('sends second submitPayment request when flag is true and stripe returns error', async () => {
+            it('sends second submitPayment request with client_side_error when flag is true and stripe returns error', async () => {
                 const stripeErrorMock = { message: 'Your card was declined' };
 
                 mockPaymentMethodWithFlag(true);
@@ -1598,9 +1598,19 @@ describe('StripeOCSPaymentStrategy', () => {
                 ).rejects.toThrow(PaymentMethodFailedError);
 
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                    2,
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            formattedPayload: expect.objectContaining({
+                                client_side_error: true,
+                            }),
+                        }),
+                    }),
+                );
             });
 
-            it('throws PaymentMethodFailedError with stripe decline message even when second submitPayment fails', async () => {
+            it('throws PaymentMethodFailedError with stripe decline message even when second submitPayment with client_side_error fails', async () => {
                 const stripeErrorMock = { message: 'Your card was declined' };
 
                 mockPaymentMethodWithFlag(true);
@@ -1616,6 +1626,16 @@ describe('StripeOCSPaymentStrategy', () => {
                 ).rejects.toThrow('Your card was declined');
 
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                    2,
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            formattedPayload: expect.objectContaining({
+                                client_side_error: true,
+                            }),
+                        }),
+                    }),
+                );
             });
 
             it('does not send second submitPayment when flag is false and stripe returns error', async () => {
@@ -1635,7 +1655,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
             });
 
-            it('sends second submitPayment and throws when confirmation returns no session and flag is true', async () => {
+            it('sends second submitPayment with client_side_error when confirmation returns no session and flag is true', async () => {
                 mockPaymentMethodWithFlag(true);
                 mockFirstPaymentRequest(errorResponse);
                 confirmPaymentMock = jest.fn().mockResolvedValue({});
@@ -1648,6 +1668,16 @@ describe('StripeOCSPaymentStrategy', () => {
                 ).rejects.toThrow(PaymentMethodFailedError);
 
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                    2,
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            formattedPayload: expect.objectContaining({
+                                client_side_error: true,
+                            }),
+                        }),
+                    }),
+                );
             });
         });
 

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -1,3 +1,5 @@
+import { merge } from 'lodash';
+
 import {
     InvalidArgumentError,
     isRequestError,
@@ -29,6 +31,7 @@ import {
     StripeElementEvent,
     StripeElementsCreateOptions,
     StripeEventType,
+    StripeFormattedPaymentPayload,
     StripeInitializationData,
     StripeIntegrationService,
     StripeJsVersion,
@@ -291,7 +294,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         methodId: string,
         token: string,
         newVaultedStripeInstrument?: StripeSavedPaymentMethod,
-    ): Payment {
+    ): Payment<StripeFormattedPaymentPayload> {
         const cartId = this.paymentIntegrationService.getState().getCart()?.id || '';
         const tokenizedOptions = this._getTokenizedOptions(token, newVaultedStripeInstrument);
 
@@ -352,7 +355,15 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
                 // INFO: even in case when stripe payment confirmation was declined
                 // we need to send submitPayment request to update status of checkout session on BE side.
                 try {
-                    await this.paymentIntegrationService.submitPayment(paymentPayload);
+                    const paymentPayloadWithError = merge({}, paymentPayload, {
+                        paymentData: {
+                            formattedPayload: {
+                                client_side_error: true,
+                            },
+                        },
+                    });
+
+                    await this.paymentIntegrationService.submitPayment(paymentPayloadWithError);
                 } catch {
                     // INFO: additional action should be ignored for this update status request.
                     // will throw Stripe error message to the shopper.

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -1000,7 +1000,7 @@ describe('StripeOCSPaymentStrategy', () => {
 
             await expect(
                 stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
-            ).rejects.toThrow('throw stripe error');
+            ).rejects.toThrow('stripe confirmation error');
         });
 
         it('throw generic stripe error if no confirmation response', async () => {
@@ -1020,7 +1020,7 @@ describe('StripeOCSPaymentStrategy', () => {
 
             await expect(
                 stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
-            ).rejects.toThrow('throw stripe error');
+            ).rejects.toThrow(TypeError);
         });
 
         it('throw generic stripe error if no payment intent response', async () => {
@@ -1235,6 +1235,150 @@ describe('StripeOCSPaymentStrategy', () => {
                         vault_payment_instrument: false,
                     },
                 },
+            });
+        });
+
+        describe('sendSecondPaymentRequestOnStripeError', () => {
+            const mockPaymentMethodWithFlag = (sendSecondPaymentRequestOnStripeError: boolean) => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...getStripeOCSMock(),
+                    initializationData: {
+                        ...getStripeOCSMock().initializationData,
+                        sendSecondPaymentRequestOnStripeError,
+                    },
+                });
+            };
+
+            it('sends second submitPayment request with client_side_error when flag is true and stripe returns error', async () => {
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    error: { message: 'Your card was declined' },
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                    retrievePaymentIntent: jest.fn(),
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow('throw stripe error');
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                    2,
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            formattedPayload: expect.objectContaining({
+                                client_side_error: true,
+                            }),
+                        }),
+                    }),
+                );
+            });
+
+            it('does not send second submitPayment when flag is false and stripe returns error', async () => {
+                mockPaymentMethodWithFlag(false);
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    error: { message: 'Your card was declined' },
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                    retrievePaymentIntent: jest.fn(),
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow('throw stripe error');
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
+            });
+
+            it('sends second submitPayment with client_side_error when flag is true and no payment intent', async () => {
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                confirmPaymentMock = jest.fn().mockResolvedValue({});
+
+                stripeUPEJsMock = {
+                    ...getStripeJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                    retrievePaymentIntent: jest.fn(),
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow('throw stripe error');
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                    2,
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            formattedPayload: expect.objectContaining({
+                                client_side_error: true,
+                            }),
+                        }),
+                    }),
+                );
+            });
+
+            it('throws stripe error even when second submitPayment with client_side_error fails', async () => {
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                mockFirstPaymentRequest(new Error('second payment failed'));
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    error: { message: 'Your card was declined' },
+                });
+
+                stripeUPEJsMock = {
+                    ...getStripeJsMock(),
+                    confirmPayment: confirmPaymentMock,
+                    retrievePaymentIntent: jest.fn(),
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow('throw stripe error');
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                    2,
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            formattedPayload: expect.objectContaining({
+                                client_side_error: true,
+                            }),
+                        }),
+                    }),
+                );
             });
         });
     });

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -1,3 +1,5 @@
+import { merge } from 'lodash';
+
 import {
     InvalidArgumentError,
     isRequestError,
@@ -11,7 +13,6 @@ import {
     PaymentInitializeOptions,
     PaymentIntegrationSelectors,
     PaymentIntegrationService,
-    PaymentMethodFailedError,
     PaymentRequestOptions,
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -24,8 +25,8 @@ import {
     StripeElementEvent,
     StripeElements,
     StripeElementType,
-    StripeError,
     StripeEventType,
+    StripeFormattedPaymentPayload,
     StripeInitializationData,
     StripeInstrumentSetupFutureUsage,
     StripeIntegrationService,
@@ -117,7 +118,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         try {
             await this.paymentIntegrationService.submitPayment(paymentPayload);
         } catch (error) {
-            await this._processAdditionalAction(error, methodId);
+            await this._processAdditionalAction(error, methodId, gatewayId);
         }
     }
 
@@ -265,7 +266,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         methodId: string,
         token: string,
         paymentMethodOptions?: StripePIPaymentMethodOptions,
-    ): Payment {
+    ): Payment<StripeFormattedPaymentPayload> {
         const cartId = this.paymentIntegrationService.getState().getCart()?.id || '';
         const { card, us_bank_account } = paymentMethodOptions || {};
         const shouldSaveInstrument =
@@ -291,6 +292,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
     private async _processAdditionalAction(
         error: unknown,
         methodId: string,
+        gatewayId: string,
     ): Promise<PaymentIntegrationSelectors | undefined> {
         if (
             !isRequestError(error) ||
@@ -306,7 +308,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         const { data: additionalActionData } = error.body.additional_action_required;
         const { token } = additionalActionData;
 
-        const { paymentIntent } = await this._confirmStripePaymentOrThrow(
+        const { paymentIntent, error: stripeError } = await this._confirmStripePaymentOrThrow(
             methodId,
             additionalActionData,
         );
@@ -321,6 +323,34 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
             paymentMethodOptions,
         );
 
+        if (stripeError || !paymentIntent) {
+            const { initializationData } = this.paymentIntegrationService
+                .getState()
+                .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
+            const { sendSecondPaymentRequestOnStripeError } = initializationData || {};
+
+            if (sendSecondPaymentRequestOnStripeError) {
+                // INFO: even in case when stripe payment confirmation was declined
+                // we need to send submitPayment request to update status of checkout session on BE side.
+                try {
+                    const paymentPayloadWithError = merge({}, paymentPayload, {
+                        paymentData: {
+                            formattedPayload: {
+                                client_side_error: true,
+                            },
+                        },
+                    });
+
+                    await this.paymentIntegrationService.submitPayment(paymentPayloadWithError);
+                } catch {
+                    // INFO: additional action should be ignored for this update status request.
+                    // will throw Stripe error message to the shopper.
+                }
+            }
+
+            this.stripeIntegrationService.throwStripeError(stripeError);
+        }
+
         try {
             return await this.paymentIntegrationService.submitPayment(paymentPayload);
         } catch (error) {
@@ -332,33 +362,24 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         methodId: string,
         additionalActionData: StripeAdditionalActionRequired['data'],
     ): Promise<StripeResult | never> {
+        if (!this.stripeClient) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
         const { token, redirect_url } = additionalActionData;
         const stripePaymentData = this.stripeIntegrationService.mapStripePaymentData(
             this.stripeElements,
             redirect_url,
         );
-        let stripeError: StripeError | undefined;
 
-        try {
-            const isPaymentCompleted = await this.stripeIntegrationService.isPaymentCompleted(
-                methodId,
-                this.stripeClient,
-            );
+        const isPaymentCompleted = await this.stripeIntegrationService.isPaymentCompleted(
+            methodId,
+            this.stripeClient,
+        );
 
-            const confirmationResult = !isPaymentCompleted
-                ? await this.stripeClient?.confirmPayment(stripePaymentData)
-                : await this.stripeClient?.retrievePaymentIntent(token || '');
-
-            stripeError = confirmationResult?.error;
-
-            if (stripeError || !confirmationResult?.paymentIntent) {
-                throw new PaymentMethodFailedError();
-            }
-
-            return confirmationResult;
-        } catch (error: unknown) {
-            return this.stripeIntegrationService.throwStripeError(stripeError);
-        }
+        return !isPaymentCompleted
+            ? this.stripeClient.confirmPayment(stripePaymentData)
+            : this.stripeClient.retrievePaymentIntent(token || '');
     }
 
     private _onStripeElementChange(

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -1200,10 +1200,9 @@ describe('StripeUPEPaymentStrategy', () => {
                 );
 
                 await expect(strategy.execute(getStripeUPEOrderRequestBodyMock())).rejects.toThrow(
-                    'throw stripe error',
+                    'stripe confirmation error',
                 );
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
-                expect(stripeUPEIntegrationService.throwStripeError).toHaveBeenCalled();
             });
 
             it('stripe confirms payment returns stripe error', async () => {
@@ -1229,9 +1228,8 @@ describe('StripeUPEPaymentStrategy', () => {
                 );
 
                 await expect(strategy.execute(getStripeUPEOrderRequestBodyMock())).rejects.toThrow(
-                    'throw stripe error',
+                    TypeError,
                 );
-                expect(stripeUPEIntegrationService.throwStripeError).toHaveBeenCalled();
             });
 
             it('stripe confirms payment returns no PI ID', async () => {
@@ -1395,6 +1393,119 @@ describe('StripeUPEPaymentStrategy', () => {
                     stripeUPEIntegrationService.throwPaymentConfirmationProceedMessage,
                 ).toHaveBeenCalled();
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            });
+
+            describe('sendSecondPaymentRequestOnStripeError', () => {
+                const mockPaymentMethodWithFlag = (
+                    sendSecondPaymentRequestOnStripeError: boolean,
+                ) => {
+                    jest.spyOn(
+                        paymentIntegrationService.getState(),
+                        'getPaymentMethodOrThrow',
+                    ).mockReturnValue({
+                        ...getStripeUPEMock(),
+                        initializationData: {
+                            ...getStripeUPEMock().initializationData,
+                            sendSecondPaymentRequestOnStripeError,
+                        },
+                    });
+                };
+
+                it('sends second submitPayment request with client_side_error when flag is true and stripe returns error', async () => {
+                    mockPaymentMethodWithFlag(true);
+                    stripeUPEJsMock.confirmPayment = jest.fn().mockResolvedValue({
+                        error: { message: 'Your card was declined' },
+                    });
+
+                    jest.spyOn(paymentIntegrationService, 'submitPayment').mockRejectedValueOnce(
+                        getAdditionalActionErrorResponse(),
+                    );
+
+                    await expect(
+                        strategy.execute(getStripeUPEOrderRequestBodyMock()),
+                    ).rejects.toThrow('throw stripe error');
+
+                    expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                    expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                        2,
+                        expect.objectContaining({
+                            paymentData: expect.objectContaining({
+                                formattedPayload: expect.objectContaining({
+                                    client_side_error: true,
+                                }),
+                            }),
+                        }),
+                    );
+                });
+
+                it('does not send second submitPayment when flag is false and stripe returns error', async () => {
+                    mockPaymentMethodWithFlag(false);
+                    stripeUPEJsMock.confirmPayment = jest.fn().mockResolvedValue({
+                        error: { message: 'Your card was declined' },
+                    });
+
+                    jest.spyOn(paymentIntegrationService, 'submitPayment').mockRejectedValueOnce(
+                        getAdditionalActionErrorResponse(),
+                    );
+
+                    await expect(
+                        strategy.execute(getStripeUPEOrderRequestBodyMock()),
+                    ).rejects.toThrow('throw stripe error');
+
+                    expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
+                });
+
+                it('sends second submitPayment with client_side_error when flag is true and no payment intent', async () => {
+                    mockPaymentMethodWithFlag(true);
+                    stripeUPEJsMock.confirmPayment = jest.fn().mockResolvedValue({});
+
+                    jest.spyOn(paymentIntegrationService, 'submitPayment').mockRejectedValueOnce(
+                        getAdditionalActionErrorResponse(),
+                    );
+
+                    await expect(
+                        strategy.execute(getStripeUPEOrderRequestBodyMock()),
+                    ).rejects.toThrow('throw stripe error');
+
+                    expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                    expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                        2,
+                        expect.objectContaining({
+                            paymentData: expect.objectContaining({
+                                formattedPayload: expect.objectContaining({
+                                    client_side_error: true,
+                                }),
+                            }),
+                        }),
+                    );
+                });
+
+                it('throws stripe error even when second submitPayment with client_side_error fails', async () => {
+                    mockPaymentMethodWithFlag(true);
+                    stripeUPEJsMock.confirmPayment = jest.fn().mockResolvedValue({
+                        error: { message: 'Your card was declined' },
+                    });
+
+                    jest.spyOn(paymentIntegrationService, 'submitPayment')
+                        .mockRejectedValueOnce(getAdditionalActionErrorResponse())
+                        .mockRejectedValueOnce(new Error('second payment failed'));
+
+                    await expect(
+                        strategy.execute(getStripeUPEOrderRequestBodyMock()),
+                    ).rejects.toThrow('throw stripe error');
+
+                    expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                    expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                        2,
+                        expect.objectContaining({
+                            paymentData: expect.objectContaining({
+                                formattedPayload: expect.objectContaining({
+                                    client_side_error: true,
+                                }),
+                            }),
+                        }),
+                    );
+                });
             });
         });
     });

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.ts
@@ -1,4 +1,4 @@
-import { some } from 'lodash';
+import { merge, some } from 'lodash';
 
 import {
     FormattedHostedInstrument,
@@ -17,7 +17,6 @@ import {
     PaymentInitializeOptions,
     PaymentIntegrationSelectors,
     PaymentIntegrationService,
-    PaymentMethodFailedError,
     PaymentRequestOptions,
     PaymentStrategy,
     RequestError,
@@ -37,8 +36,8 @@ import {
     StripeElementsCreateOptions,
     StripeElementType,
     StripeElementUpdateOptions,
-    StripeError,
     StripeEventType,
+    StripeFormattedPaymentPayload,
     StripeInitializationData,
     StripeIntegrationService,
     StripeJsVersion,
@@ -151,6 +150,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
 
         await this._executeWithStripeConfirmation(
             payment.methodId,
+            payment.gatewayId,
             stripeLinkAuthenticationState ? false : shouldSaveInstrument,
             shouldSetAsDefaultInstrument,
         );
@@ -171,6 +171,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
 
     private async _executeWithStripeConfirmation(
         methodId: string,
+        gatewayId?: string,
         shouldSaveInstrument?: boolean,
         shouldSetAsDefaultInstrument?: boolean,
     ): Promise<void> {
@@ -189,6 +190,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             await this._processAdditionalActionWithStripeConfirmation(
                 error,
                 methodId,
+                gatewayId,
                 shouldSaveInstrument,
                 shouldSetAsDefaultInstrument,
             );
@@ -326,6 +328,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
     private async _processAdditionalActionWithStripeConfirmation(
         error: unknown,
         methodId: string,
+        gatewayId?: string,
         shouldSaveInstrument = false,
         shouldSetAsDefaultInstrument = false,
     ): Promise<void> {
@@ -343,7 +346,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         const { data: additionalActionData } = error.body.additional_action_required;
         const { token } = additionalActionData;
 
-        const { paymentIntent } = await this._confirmStripePaymentOrThrow(
+        const { paymentIntent, error: stripeError } = await this._confirmStripePaymentOrThrow(
             methodId,
             additionalActionData,
         );
@@ -354,6 +357,34 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             shouldSaveInstrument,
             shouldSetAsDefaultInstrument,
         );
+
+        if (stripeError || !paymentIntent) {
+            const { initializationData } = this.paymentIntegrationService
+                .getState()
+                .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
+            const { sendSecondPaymentRequestOnStripeError } = initializationData || {};
+
+            if (sendSecondPaymentRequestOnStripeError) {
+                // INFO: even in case when stripe payment confirmation was declined
+                // we need to send submitPayment request to update status of checkout session on BE side.
+                try {
+                    const paymentPayloadWithError = merge({}, paymentPayload, {
+                        paymentData: {
+                            formattedPayload: {
+                                client_side_error: true,
+                            },
+                        },
+                    });
+
+                    await this.paymentIntegrationService.submitPayment(paymentPayloadWithError);
+                } catch {
+                    // INFO: additional action should be ignored for this update status request.
+                    // will throw Stripe error message to the shopper.
+                }
+            }
+
+            this.stripeIntegrationService.throwStripeError(stripeError);
+        }
 
         try {
             await this.paymentIntegrationService.submitPayment(paymentPayload);
@@ -366,34 +397,25 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         methodId: string,
         additionalActionData: StripeAdditionalActionRequired['data'],
     ): Promise<StripeResult | never> {
+        if (!this._stripeUPEClient) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
         const { token, redirect_url } = additionalActionData;
         const stripePaymentData = this.stripeIntegrationService.mapStripePaymentData(
             this._stripeElements,
             redirect_url,
             !!this._allowRedisplayForStoredInstruments,
         );
-        let stripeError: StripeError | undefined;
 
-        try {
-            const isPaymentCompleted = await this.stripeIntegrationService.isPaymentCompleted(
-                methodId,
-                this._stripeUPEClient,
-            );
+        const isPaymentCompleted = await this.stripeIntegrationService.isPaymentCompleted(
+            methodId,
+            this._stripeUPEClient,
+        );
 
-            const confirmationResult = !isPaymentCompleted
-                ? await this._stripeUPEClient?.confirmPayment(stripePaymentData)
-                : await this._stripeUPEClient?.retrievePaymentIntent(token || '');
-
-            stripeError = confirmationResult?.error;
-
-            if (stripeError || !confirmationResult?.paymentIntent) {
-                throw new PaymentMethodFailedError();
-            }
-
-            return confirmationResult;
-        } catch (error: unknown) {
-            this.stripeIntegrationService.throwStripeError(stripeError);
-        }
+        return !isPaymentCompleted
+            ? this._stripeUPEClient.confirmPayment(stripePaymentData)
+            : this._stripeUPEClient.retrievePaymentIntent(token || '');
     }
 
     private async _processVaultedAdditionalAction(
@@ -468,7 +490,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         token: string,
         shouldSaveInstrument = false,
         shouldSetAsDefaultInstrument = false,
-    ): Payment {
+    ): Payment<StripeFormattedPaymentPayload> {
         const cartId = this.paymentIntegrationService.getState().getCart()?.id || '';
         const formattedPayload: StripeUPEIntent & FormattedHostedInstrument = {
             cart_id: cartId,

--- a/packages/stripe-utils/src/index.ts
+++ b/packages/stripe-utils/src/index.ts
@@ -12,6 +12,7 @@ export {
     StripeElementUpdateOptions,
     StripeError,
     StripeEventType,
+    StripeFormattedPaymentPayload,
     StripeFormMode,
     StripeInitializationData,
     StripeInstrumentSetupFutureUsage,

--- a/packages/stripe-utils/src/stripe.ts
+++ b/packages/stripe-utils/src/stripe.ts
@@ -910,3 +910,14 @@ export interface StripeLinkV2Options {
     captureMethod?: 'automatic' | 'manual';
     amount?: number;
 }
+
+export interface StripeFormattedPaymentPayload {
+    cart_id: string;
+    confirm: boolean;
+    method?: string;
+    credit_card_token?: { token: string };
+    tokenized_ach?: { token: string };
+    vault_payment_instrument?: boolean;
+    set_as_default_stored_instrument?: boolean;
+    client_side_error?: boolean;
+}


### PR DESCRIPTION
## What/Why?
  - When Stripe payment confirmation is declined or fails, a second submitPayment request is now sent with sdk_error: true in the formatted payload so the backend can update the session status accordingly
  - Added this error-handling flow to OCS and UPE strategies (CS already had it), controlled by the sendSecondPaymentRequestOnStripeError feature flag from initializationData
  - Refactored _confirmStripePaymentOrThrow in OCS and UPE to return the raw Stripe result instead of catching errors internally, moving error handling to the caller for clearer control flow
  - Added StripeFormattedPaymentPayload type to stripe-utils for shared payment payload typing across all three strategies


## Rollout/Rollback
Rollback this PR or turn off experiments `STRIPE-1391.update_payment_status_after_stripe_decline`

## Testing
Stripe UPE

https://github.com/user-attachments/assets/fe57f04a-1fc2-44c6-bd12-1a91e1fdb2df

Stripe OCS

https://github.com/user-attachments/assets/3b9e7033-0ca0-4c8f-98ba-ca667d6f002d

Stripe CS

https://github.com/user-attachments/assets/db1f5003-e1b0-490f-984f-bfe8a5fdc134


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment execution error-handling and adds an extra backend call path on failures; mistakes could change how declined/errored Stripe checkouts are reported or retried.
> 
> **Overview**
> Adds an optional error-recovery path for Stripe *additional_action_required* flows: when Stripe confirmation returns an error or no session/PI, the strategies can issue a **second** `submitPayment` call with `paymentData.formattedPayload.client_side_error: true` (gated by `initializationData.sendSecondPaymentRequestOnStripeError`) to let the backend update the checkout/session status.
> 
> Refactors OCS/UPE confirmation handling to return the raw Stripe result and move error decisions to the caller (and updates tests/expectations accordingly), and introduces a shared `StripeFormattedPaymentPayload` type used by CS/OCS/UPE payload builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1086189d714cde584efa3bf2edd1feb23669bb8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->