### PR TITLE
chore(checkout): CHECKOUT-9720 Pass version to api from store credit API

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -1350,7 +1350,7 @@ describe('CheckoutService', () => {
 
             expect(storeCreditRequestSender.applyStoreCredit).toHaveBeenCalledWith(
                 getCheckout().id,
-                options,
+                { ...options, version: getCheckout().version },
             );
         });
 
@@ -1361,7 +1361,7 @@ describe('CheckoutService', () => {
 
             expect(storeCreditRequestSender.removeStoreCredit).toHaveBeenCalledWith(
                 getCheckout().id,
-                options,
+                { ...options, version: getCheckout().version },
             );
         });
     });

--- a/packages/core/src/checkout/checkout.ts
+++ b/packages/core/src/checkout/checkout.ts
@@ -49,6 +49,7 @@ export default interface Checkout {
     channelId: number;
     fees: Fee[];
     totalDiscount: number;
+    version: number;
 }
 
 export interface CheckoutRequestBody {

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -73,6 +73,7 @@ export function getCheckout(): Checkout {
         channelId: 1,
         fees: [],
         totalDiscount: 0,
+        version: 1,
     };
 }
 

--- a/packages/core/src/common/http-request/request-options.ts
+++ b/packages/core/src/common/http-request/request-options.ts
@@ -15,4 +15,9 @@ export default interface RequestOptions<TParams = {}> {
      * The parameters of the request, if required.
      */
     params?: TParams;
+
+    /**
+     * The version of the checkout, used for optimistic concurrency control.
+     */
+    version?: number;
 }

--- a/packages/core/src/store-credit/store-credit-action-creator.ts
+++ b/packages/core/src/store-credit/store-credit-action-creator.ts
@@ -28,9 +28,18 @@ export default class StoreCreditActionCreator {
                         throw new MissingDataError(MissingDataErrorType.MissingCheckout);
                     }
 
+                    const { id } = checkout;
+                    const checkoutVersion = options?.version ?? checkout.version;
+
                     const { body } = await (useStoreCredit
-                        ? this._storeCreditRequestSender.applyStoreCredit(checkout.id, options)
-                        : this._storeCreditRequestSender.removeStoreCredit(checkout.id, options));
+                        ? this._storeCreditRequestSender.applyStoreCredit(id, {
+                              ...options,
+                              version: checkoutVersion,
+                          })
+                        : this._storeCreditRequestSender.removeStoreCredit(id, {
+                              ...options,
+                              version: checkoutVersion,
+                          }));
 
                     return createAction(StoreCreditActionType.ApplyStoreCreditSucceeded, body);
                 }),

--- a/packages/core/src/store-credit/store-credit-request-sender.spec.ts
+++ b/packages/core/src/store-credit/store-credit-request-sender.spec.ts
@@ -37,7 +37,9 @@ describe('StoreCredit Request Sender', () => {
 
             jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve(response));
 
-            const output = await storeCreditRequestSender.applyStoreCredit(checkoutId);
+            const output = await storeCreditRequestSender.applyStoreCredit(checkoutId, {
+                version: 1,
+            });
 
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith(
@@ -50,6 +52,8 @@ describe('StoreCredit Request Sender', () => {
                         Accept: ContentType.JsonV1,
                         ...SDK_VERSION_HEADERS,
                     },
+                    timeout: undefined,
+                    body: { version: 1 },
                 },
             );
         });
@@ -60,7 +64,10 @@ describe('StoreCredit Request Sender', () => {
 
             jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve(response));
 
-            const output = await storeCreditRequestSender.applyStoreCredit(checkoutId, options);
+            const output = await storeCreditRequestSender.applyStoreCredit(checkoutId, {
+                ...options,
+                version: 1,
+            });
 
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith(
@@ -74,6 +81,7 @@ describe('StoreCredit Request Sender', () => {
                         Accept: ContentType.JsonV1,
                         ...SDK_VERSION_HEADERS,
                     },
+                    body: { version: 1 },
                 },
             );
         });
@@ -85,7 +93,9 @@ describe('StoreCredit Request Sender', () => {
 
             jest.spyOn(requestSender, 'delete').mockReturnValue(Promise.resolve(response));
 
-            const output = await storeCreditRequestSender.removeStoreCredit(checkoutId);
+            const output = await storeCreditRequestSender.removeStoreCredit(checkoutId, {
+                version: 1,
+            });
 
             expect(output).toEqual(response);
             expect(requestSender.delete).toHaveBeenCalledWith(
@@ -98,6 +108,8 @@ describe('StoreCredit Request Sender', () => {
                     params: {
                         include: defaultIncludes,
                     },
+                    timeout: undefined,
+                    body: { version: 1 },
                 },
             );
         });
@@ -108,7 +120,10 @@ describe('StoreCredit Request Sender', () => {
 
             jest.spyOn(requestSender, 'delete').mockReturnValue(Promise.resolve(response));
 
-            const output = await storeCreditRequestSender.removeStoreCredit(checkoutId, options);
+            const output = await storeCreditRequestSender.removeStoreCredit(checkoutId, {
+                ...options,
+                version: 1,
+            });
 
             expect(output).toEqual(response);
             expect(requestSender.delete).toHaveBeenCalledWith(
@@ -122,6 +137,7 @@ describe('StoreCredit Request Sender', () => {
                     params: {
                         include: defaultIncludes,
                     },
+                    body: { version: 1 },
                 },
             );
         });

--- a/packages/core/src/store-credit/store-credit-request-sender.ts
+++ b/packages/core/src/store-credit/store-credit-request-sender.ts
@@ -13,7 +13,7 @@ export default class StoreCreditRequestSender {
 
     applyStoreCredit(
         checkoutId: string,
-        { timeout }: RequestOptions = {},
+        { timeout, version }: RequestOptions = {},
     ): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/store-credit`;
         const headers = {
@@ -27,12 +27,13 @@ export default class StoreCreditRequestSender {
             params: {
                 include: joinIncludes(CHECKOUT_DEFAULT_INCLUDES),
             },
+            body: { version },
         });
     }
 
     removeStoreCredit(
         checkoutId: string,
-        { timeout }: RequestOptions = {},
+        { timeout, version }: RequestOptions = {},
     ): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/store-credit`;
         const headers = {
@@ -46,6 +47,7 @@ export default class StoreCreditRequestSender {
             params: {
                 include: joinIncludes(CHECKOUT_DEFAULT_INCLUDES),
             },
+            body: { version },
         });
     }
 }


### PR DESCRIPTION
## What/Why?
Pass version to api from store credit API

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast


#### version not from client

https://github.com/user-attachments/assets/c115e7f3-b092-4a1e-b893-60320722a03d



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the request contract for applying/removing store credit by adding a `version` payload, which could break or alter behavior if the backend/client expectations diverge. Scope is limited to store credit flows and related typings/tests.
> 
> **Overview**
> Adds optimistic concurrency support to store credit operations by introducing `version` on `Checkout` and `RequestOptions`, then sending that version in the request body for `POST`/`DELETE /store-credit`.
> 
> Updates `StoreCreditActionCreator` to default the version from the current checkout state (unless explicitly provided) and adjusts unit tests/mocks to assert the version is propagated through `CheckoutService` → request sender.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8d8336cb9e0fc8913e4d062c690ef7ebd1e0ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->