### PR TITLE
Security: Protocol-relative Afterpay SDK URLs may allow insecure script transport

### DIFF
--- a/packages/afterpay-integration/src/afterpay-script-loader.ts
+++ b/packages/afterpay-integration/src/afterpay-script-loader.ts
@@ -9,15 +9,15 @@ import AfterpaySdk from './afterpay-sdk';
 import isAfterpayWindow from './is-afterpay-window';
 
 enum SCRIPTS_DEFAULT {
-    PROD = '//portal.afterpay.com/afterpay-async.js',
-    SANDBOX = '//portal.sandbox.afterpay.com/afterpay.js',
+    PROD = 'https://portal.afterpay.com/afterpay-async.js',
+    SANDBOX = 'https://portal.sandbox.afterpay.com/afterpay.js',
     HTTPS_PROD = 'https://portal.afterpay.com/afterpay-async.js',
     HTTPS_SANDBOX = 'https://portal.sandbox.afterpay.com/afterpay.js',
 }
 
 enum SCRIPTS_US {
-    PROD = '//portal.afterpay.com/afterpay-async.js',
-    SANDBOX = '//portal.sandbox.afterpay.com/afterpay.js',
+    PROD = 'https://portal.afterpay.com/afterpay-async.js',
+    SANDBOX = 'https://portal.sandbox.afterpay.com/afterpay.js',
     HTTPS_PROD = 'https://portal.afterpay.com/afterpay-async.js',
     HTTPS_SANDBOX = 'https://portal.sandbox.afterpay.com/afterpay.js',
 }
@@ -34,7 +34,7 @@ export default class AfterpayScriptLoader {
     async load(
         method: PaymentMethod,
         countryCode: string,
-        withHttps = false,
+        withHttps = true,
     ): Promise<AfterpaySdk> {
         const testMode = method.config.testMode || false;
         const scriptURI = this._getScriptURI(countryCode, testMode, withHttps);
@@ -48,7 +48,7 @@ export default class AfterpayScriptLoader {
         });
     }
 
-    private _getScriptURI(countryCode: string, testMode: boolean, withHttps = false): string {
+    private _getScriptURI(countryCode: string, testMode: boolean, withHttps = true): string {
         if (countryCode === 'US') {
             if (withHttps) {
                 return testMode ? SCRIPTS_US.HTTPS_SANDBOX : SCRIPTS_US.HTTPS_PROD;


### PR DESCRIPTION
## Summary

Security: Protocol-relative Afterpay SDK URLs may allow insecure script transport

## Problem

**Severity**: `Medium` | **File**: `packages/afterpay-integration/src/afterpay-script-loader.ts:L10`

The Afterpay script URL constants use protocol-relative URLs (`//portal...`) and `load()` defaults to `withHttps = false`. If checkout is ever served over HTTP (or through an insecure intermediary), the SDK can be fetched over HTTP, enabling man-in-the-middle script injection.

## Solution

Use HTTPS-only URLs for all script constants and make secure transport the default behavior. Remove protocol-relative variants and set `withHttps` to true by default (or eliminate the flag entirely).

## Changes

- `packages/afterpay-integration/src/afterpay-script-loader.ts` (modified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Afterpay SDK script loading behavior to always prefer HTTPS, which could affect environments relying on protocol-relative/HTTP loading or explicit `withHttps=false` behavior.
> 
> **Overview**
> Forces Afterpay SDK scripts to load over HTTPS by replacing protocol-relative `//portal...` URLs with explicit `https://...` endpoints.
> 
> Also flips the default `withHttps` parameter in `AfterpayScriptLoader.load()` and `_getScriptURI()` to `true`, making secure transport the default without requiring callers to opt in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f7680cdf0e24b89fac9eb1bdecddf0470a7424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->