### PR TITLE
feat(payment): PAYPAL-5797 Update PayPalCommerceVenmoPaymentStrategy by providing PaypalUtilsService from paypal-utils package

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-payment-strategy.ts
@@ -4,7 +4,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
-import createPayPalCommerceIntegrationService from '../create-paypal-commerce-integration-service';
+import { createPayPalIntegrationService } from '@bigcommerce/checkout-sdk/paypal-utils';
 
 import PayPalCommerceVenmoPaymentStrategy from './paypal-commerce-venmo-payment-strategy';
 
@@ -13,7 +13,7 @@ const createPayPalCommerceVenmoPaymentStrategy: PaymentStrategyFactory<
 > = (paymentIntegrationService) =>
     new PayPalCommerceVenmoPaymentStrategy(
         paymentIntegrationService,
-        createPayPalCommerceIntegrationService(paymentIntegrationService),
+        createPayPalIntegrationService(paymentIntegrationService),
         new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
     );
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.spec.ts
@@ -11,19 +11,16 @@ import {
     PaymentMethodInvalidError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
-import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
-
 import {
-    getPayPalCommerceIntegrationServiceMock,
-    getPayPalCommercePaymentMethod,
+    getPayPalIntegrationServiceMock,
+    getPayPalPaymentMethod,
     getPayPalSDKMock,
-} from '../mocks';
-import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
-import {
-    PayPalCommerceButtonsOptions,
-    PayPalCommerceHostWindow,
+    PayPalButtonsOptions,
+    PayPalHostWindow,
+    PayPalIntegrationService,
     PayPalSDK,
-} from '../paypal-commerce-types';
+} from '@bigcommerce/checkout-sdk/paypal-utils';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import PayPalCommerceVenmoPaymentInitializeOptions from './paypal-commerce-venmo-payment-initialize-options';
 import PayPalCommerceVenmoPaymentStrategy from './paypal-commerce-venmo-payment-strategy';
@@ -33,7 +30,7 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
     let loadingIndicator: LoadingIndicator;
     let paymentIntegrationService: PaymentIntegrationService;
     let paymentMethod: PaymentMethod;
-    let paypalCommerceIntegrationService: PayPalCommerceIntegrationService;
+    let paypalIntegrationService: PayPalIntegrationService;
     let paypalSdk: PayPalSDK;
     let strategy: PayPalCommerceVenmoPaymentStrategy;
 
@@ -58,17 +55,17 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
         eventEmitter = new EventEmitter();
 
         paypalSdk = getPayPalSDKMock();
-        paymentMethod = getPayPalCommercePaymentMethod();
+        paymentMethod = getPayPalPaymentMethod();
         paymentMethod.id = defaultMethodId;
         paymentMethod.initializationData.orderId = undefined;
 
         loadingIndicator = new LoadingIndicator();
-        paypalCommerceIntegrationService = getPayPalCommerceIntegrationServiceMock();
+        paypalIntegrationService = getPayPalIntegrationServiceMock();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
 
         strategy = new PayPalCommerceVenmoPaymentStrategy(
             paymentIntegrationService,
-            paypalCommerceIntegrationService,
+            paypalIntegrationService,
             loadingIndicator,
         );
 
@@ -76,74 +73,70 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
             paymentMethod,
         );
 
-        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockResolvedValue(paypalSdk);
-        jest.spyOn(paypalCommerceIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
-            paypalSdk,
-        );
-        jest.spyOn(paypalCommerceIntegrationService, 'createOrder').mockResolvedValue('');
-        jest.spyOn(paypalCommerceIntegrationService, 'submitPayment').mockResolvedValue(undefined);
+        jest.spyOn(paypalIntegrationService, 'loadPayPalSdk').mockResolvedValue(paypalSdk);
+        jest.spyOn(paypalIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalIntegrationService, 'createOrder').mockResolvedValue('');
+        jest.spyOn(paypalIntegrationService, 'submitPayment').mockResolvedValue(undefined);
 
         jest.spyOn(loadingIndicator, 'show').mockReturnValue(undefined);
         jest.spyOn(loadingIndicator, 'hide').mockReturnValue(undefined);
 
-        jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-            (options: PayPalCommerceButtonsOptions) => {
-                eventEmitter.on('createOrder', () => {
-                    if (options.createOrder) {
-                        options.createOrder();
-                    }
-                });
+        jest.spyOn(paypalSdk, 'Buttons').mockImplementation((options: PayPalButtonsOptions) => {
+            eventEmitter.on('createOrder', () => {
+                if (options.createOrder) {
+                    options.createOrder();
+                }
+            });
 
-                eventEmitter.on('onClick', () => {
-                    if (options.onClick) {
-                        options.onClick(
-                            { fundingSource: 'venmo' },
-                            {
-                                reject: jest.fn(),
-                                resolve: jest.fn(),
+            eventEmitter.on('onClick', () => {
+                if (options.onClick) {
+                    options.onClick(
+                        { fundingSource: 'venmo' },
+                        {
+                            reject: jest.fn(),
+                            resolve: jest.fn(),
+                        },
+                    );
+                }
+            });
+
+            eventEmitter.on('onApprove', () => {
+                if (options.onApprove) {
+                    options.onApprove(
+                        { orderID: paypalOrderId },
+                        {
+                            order: {
+                                get: jest.fn(),
                             },
-                        );
-                    }
-                });
+                        },
+                    );
+                }
+            });
 
-                eventEmitter.on('onApprove', () => {
-                    if (options.onApprove) {
-                        options.onApprove(
-                            { orderID: paypalOrderId },
-                            {
-                                order: {
-                                    get: jest.fn(),
-                                },
-                            },
-                        );
-                    }
-                });
+            eventEmitter.on('onCancel', () => {
+                if (options.onCancel) {
+                    options.onCancel();
+                }
+            });
 
-                eventEmitter.on('onCancel', () => {
-                    if (options.onCancel) {
-                        options.onCancel();
-                    }
-                });
+            eventEmitter.on('onError', () => {
+                if (options.onError) {
+                    options.onError(new Error());
+                }
+            });
 
-                eventEmitter.on('onError', () => {
-                    if (options.onError) {
-                        options.onError(new Error());
-                    }
-                });
-
-                return {
-                    isEligible: jest.fn(() => true),
-                    render: jest.fn(),
-                    close: jest.fn(),
-                };
-            },
-        );
+            return {
+                isEligible: jest.fn(() => true),
+                render: jest.fn(),
+                close: jest.fn(),
+            };
+        });
     });
 
     afterEach(() => {
         jest.clearAllMocks();
 
-        delete (window as PayPalCommerceHostWindow).paypal;
+        delete (window as PayPalHostWindow).paypal;
     });
 
     it('creates an instance of the PayPal Commerce Venmo payment strategy', () => {
@@ -178,15 +171,13 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            expect(paypalCommerceIntegrationService.loadPayPalSdk).not.toHaveBeenCalled();
+            expect(paypalIntegrationService.loadPayPalSdk).not.toHaveBeenCalled();
         });
 
         it('loads paypal sdk', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(
-                defaultMethodId,
-            );
+            expect(paypalIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(defaultMethodId);
         });
     });
 
@@ -248,7 +239,7 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
 
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(paypalCommerceIntegrationService.createOrder).toHaveBeenCalledWith(
+            expect(paypalIntegrationService.createOrder).toHaveBeenCalledWith(
                 'paypalcommercevenmocheckout',
             );
         });
@@ -411,7 +402,7 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
 
             await strategy.execute(payload);
 
-            expect(paypalCommerceIntegrationService.submitPayment).toHaveBeenCalledWith(
+            expect(paypalIntegrationService.submitPayment).toHaveBeenCalledWith(
                 payload.payment.methodId,
                 paypalOrderId,
             );

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
@@ -10,16 +10,15 @@ import {
     PaymentRequestOptions,
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
-
-import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
 import {
     ApproveCallbackPayload,
     ClickCallbackActions,
-    PayPalCommerceButtons,
-    PayPalCommerceButtonsOptions,
-    PayPalCommerceInitializationData,
-} from '../paypal-commerce-types';
+    PayPalButtons,
+    PayPalButtonsOptions,
+    PayPalInitializationData,
+    PayPalIntegrationService,
+} from '@bigcommerce/checkout-sdk/paypal-utils';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import PayPalCommerceVenmoPaymentInitializeOptions, {
     WithPayPalCommerceVenmoPaymentInitializeOptions,
@@ -28,11 +27,11 @@ import PayPalCommerceVenmoPaymentInitializeOptions, {
 export default class PayPalCommerceVenmoPaymentStrategy implements PaymentStrategy {
     private loadingIndicatorContainer?: string;
     private orderId?: string;
-    private paypalButton?: PayPalCommerceButtons;
+    private paypalButton?: PayPalButtons;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
-        private paypalCommerceIntegrationService: PayPalCommerceIntegrationService,
+        private paypalIntegrationService: PayPalIntegrationService,
         private loadingIndicator: LoadingIndicator,
     ) {}
 
@@ -58,8 +57,7 @@ export default class PayPalCommerceVenmoPaymentStrategy implements PaymentStrate
         await this.paymentIntegrationService.loadPaymentMethod(methodId);
 
         const state = this.paymentIntegrationService.getState();
-        const paymentMethod =
-            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const paymentMethod = state.getPaymentMethodOrThrow<PayPalInitializationData>(methodId);
 
         // Info:
         // The PayPal button and fields should not be rendered when shopper was redirected to Checkout page
@@ -71,7 +69,7 @@ export default class PayPalCommerceVenmoPaymentStrategy implements PaymentStrate
             return;
         }
 
-        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+        await this.paypalIntegrationService.loadPayPalSdk(methodId);
 
         this.loadingIndicatorContainer = paypalOptions.container.split('#')[1];
 
@@ -90,7 +88,7 @@ export default class PayPalCommerceVenmoPaymentStrategy implements PaymentStrate
         }
 
         await this.paymentIntegrationService.submitOrder(order, options);
-        await this.paypalCommerceIntegrationService.submitPayment(payment.methodId, this.orderId);
+        await this.paypalIntegrationService.submitPayment(payment.methodId, this.orderId);
     }
 
     finalize(): Promise<void> {
@@ -114,23 +112,20 @@ export default class PayPalCommerceVenmoPaymentStrategy implements PaymentStrate
         methodId: string,
         paypalcommercevenmo: PayPalCommerceVenmoPaymentInitializeOptions,
     ): void {
-        const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
+        const paypalSdk = this.paypalIntegrationService.getPayPalSdkOrThrow();
 
         const state = this.paymentIntegrationService.getState();
-        const paymentMethod =
-            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const paymentMethod = state.getPaymentMethodOrThrow<PayPalInitializationData>(methodId);
         const { paymentButtonStyles } = paymentMethod.initializationData || {};
         const { checkoutPaymentButtonStyles } = paymentButtonStyles || {};
 
         const { container, onError, onRenderButton, onValidate, submitForm } = paypalcommercevenmo;
 
-        const buttonOptions: PayPalCommerceButtonsOptions = {
+        const buttonOptions: PayPalButtonsOptions = {
             fundingSource: paypalSdk.FUNDING.VENMO,
-            style: this.paypalCommerceIntegrationService.getValidButtonStyle(
-                checkoutPaymentButtonStyles,
-            ),
+            style: this.paypalIntegrationService.getValidButtonStyle(checkoutPaymentButtonStyles),
             createOrder: () =>
-                this.paypalCommerceIntegrationService.createOrder('paypalcommercevenmocheckout'),
+                this.paypalIntegrationService.createOrder('paypalcommercevenmocheckout'),
             onClick: (_, actions) => this.handleClick(actions, onValidate),
             onApprove: (data) => this.handleApprove(data, submitForm),
             onCancel: () => this.toggleLoadingIndicator(false),


### PR DESCRIPTION
## What/Why?

Replace PayPalCommerceIntegrationService with PaypalUtilsService from paypal-utils package

## Rollout/Rollback

Revert

## Testing

https://github.com/user-attachments/assets/452ced3b-4316-4ba6-9892-b97d83c561a7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Venmo payment initialization/execution by swapping the underlying PayPal service/types, which could affect SDK loading, button rendering, and order submission behavior if the utility service differs from the prior implementation.
> 
> **Overview**
> Updates the PayPal Commerce Venmo checkout flow to use `@bigcommerce/checkout-sdk/paypal-utils` (`createPayPalIntegrationService` / `PayPalIntegrationService`) instead of the local `PayPalCommerceIntegrationService`.
> 
> The Venmo payment strategy and its tests are refactored to the new shared PayPal types (`PayPalButtonsOptions`, `PayPalInitializationData`, `PayPalHostWindow`) and route all SDK load, order creation, button style validation, and payment submission calls through the paypal-utils service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576538a3e6ee585be61547c5a08445c1dd6e0df3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->