### PR TITLE
feat(checkout): CHECKOUT-9956 get client id and b2b base url from initial state

### DIFF
--- a/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
@@ -49,21 +49,27 @@ describe('B2BTokenActionCreator', () => {
             ]);
         });
 
-        it('calls getB2BToken with state data and b2bServiceDetails from checkout settings', async () => {
+        it('calls getB2BToken with b2bApiSettings from initial state', async () => {
             const customer = getCustomer();
             const checkout = getCheckout();
-            const { storeHash } = getConfig().storeConfig.storeProfile;
-            const { b2bBaseUrl, b2bClientId } =
-                getConfig().storeConfig.checkoutSettings.b2bServiceDetails!;
+            const b2bApiSettings = {
+                clientId: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
+                baseUrl: 'https://api-b2b.bigcommerce.com',
+            };
+
+            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
 
             await from(actionCreator.loadB2BToken()(store)).toPromise();
 
             expect(requestSender.getB2BToken).toHaveBeenCalledWith(
-                b2bClientId,
+                b2bApiSettings.clientId,
                 customer.id,
-                storeHash,
+                getConfig().storeConfig.storeProfile.storeHash,
                 checkout.channelId,
-                b2bBaseUrl,
+                b2bApiSettings.baseUrl,
                 undefined,
             );
         });

--- a/packages/core/src/b2b-token/b2b-token-action-creator.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.ts
@@ -9,10 +9,6 @@ import { RequestOptions } from '../common/http-request';
 import { B2BTokenActionType, LoadB2BTokenAction } from './b2b-token-actions';
 import B2BTokenRequestSender from './b2b-token-request-sender';
 
-// TODO: Remove once all stores have b2bServiceDetails configured in checkout settings
-const DEFAULT_B2B_BASE_URL = '';
-const DEFAULT_B2B_CLIENT_ID = '';
-
 export default class B2BTokenActionCreator {
     constructor(private _requestSender: B2BTokenRequestSender) {}
 
@@ -21,9 +17,10 @@ export default class B2BTokenActionCreator {
     ): ThunkAction<LoadB2BTokenAction, InternalCheckoutSelectors> {
         return (store) => {
             const state = store.getState();
-            const { storeHash } = state.config.getStoreConfigOrThrow().storeProfile;
-            const { b2bBaseUrl = DEFAULT_B2B_BASE_URL, b2bClientId = DEFAULT_B2B_CLIENT_ID } =
-                state.config.getStoreConfigOrThrow().checkoutSettings.b2bServiceDetails ?? {};
+            const storeConfig = state.config.getStoreConfigOrThrow();
+            const { storeHash } = storeConfig.storeProfile;
+            const { baseUrl: b2bBaseUrl = '', clientId: b2bClientId = '' } =
+                storeConfig.b2bApiSettings ?? {};
             const { id: customerId } = state.customer.getCustomerOrThrow();
             const { channelId } = state.checkout.getCheckoutOrThrow();
 

--- a/packages/core/src/checkout/checkout-initial-state.ts
+++ b/packages/core/src/checkout/checkout-initial-state.ts
@@ -1,4 +1,4 @@
-import { Config } from '../config';
+import { B2BApiSettings, Config } from '../config';
 import { Extension } from '../extension';
 import { ExtraFields, FormFields } from '../form';
 
@@ -10,4 +10,5 @@ export default interface CheckoutInitialState {
     checkout?: Checkout;
     extensions?: Extension[];
     extraFields?: ExtraFields;
+    b2bApiSettings?: B2BApiSettings;
 }

--- a/packages/core/src/config/config-reducer.ts
+++ b/packages/core/src/config/config-reducer.ts
@@ -29,8 +29,24 @@ function dataReducer(
         case ConfigActionType.LoadConfigSucceeded:
             return objectMerge(data, action.payload);
 
-        case CheckoutHydrateActionType.HydrateInitialState:
-            return objectMerge(data, action.payload?.config);
+        case CheckoutHydrateActionType.HydrateInitialState: {
+            const merged = objectMerge(data, action.payload?.config);
+
+            // b2bApiSettings is a top-level field in CheckoutInitialState (separate from config),
+            // so it must be merged into storeConfig manually after the config hydration.
+            // Skip if config data is absent or this is a non-B2B store (no b2bApiSettings).
+            if (!merged || !action.payload?.b2bApiSettings) {
+                return merged;
+            }
+
+            return {
+                ...merged,
+                storeConfig: {
+                    ...merged.storeConfig,
+                    b2bApiSettings: action.payload.b2bApiSettings,
+                },
+            };
+        }
 
         default:
             return data;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -8,9 +8,15 @@ export default interface Config {
     storeConfig: StoreConfig;
 }
 
+export interface B2BApiSettings {
+    clientId: string;
+    baseUrl: string;
+}
+
 export interface StoreConfig {
     cdnPath: string;
     checkoutSettings: CheckoutSettings;
+    b2bApiSettings?: B2BApiSettings;
     currency: StoreCurrency;
     displayDateFormat: string;
     displaySettings: DisplaySettings;
@@ -101,14 +107,8 @@ export interface UserExperienceSettings {
     floatingLabelEnabled: boolean;
 }
 
-export interface B2BServiceDetails {
-    b2bBaseUrl: string;
-    b2bClientId: string;
-}
-
 export interface CheckoutSettings {
     capabilities?: Capabilities;
-    b2bServiceDetails?: B2BServiceDetails;
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
     checkoutUserExperienceSettings: UserExperienceSettings;

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -19,10 +19,6 @@ export function getConfig(): Config {
         storeConfig: {
             cdnPath: 'https://cdn.bcapp.dev/rHEAD',
             checkoutSettings: {
-                b2bServiceDetails: {
-                    b2bBaseUrl: 'https://api-b2b.test.zone',
-                    b2bClientId: 'test-b2b-client-id',
-                },
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
                 checkoutUserExperienceSettings: {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -8,6 +8,7 @@ export {
     FlashMessage,
     FlashMessageType,
     UserExperienceSettings,
+    B2BApiSettings,
 } from './config';
 export { default as ConfigActionCreator } from './config-action-creator';
 export {


### PR DESCRIPTION
## What/Why?

Migrates B2B API configuration from the deprecated `b2bServiceDetails` field in `checkoutSettings` to a new `b2bApiSettings` field delivered via `CheckoutInitialState`.

**What changed:**

- Introduced `B2BApiSettings` interface (`clientId`, `baseUrl`) on `StoreConfig` in `config.ts`, replacing the old `B2BServiceDetails` / `b2bServiceDetails` on `CheckoutSettings`
- Added `b2bApiSettings?: B2BApiSettings` as a top-level field on `CheckoutInitialState` — since it comes in separately from the main `config` payload, the config reducer now manually merges it into `storeConfig` during `HydrateInitialState`
- Updated `B2BTokenActionCreator` to read `clientId` and `baseUrl` from `storeConfig.b2bApiSettings` instead of `checkoutSettings.b2bServiceDetails`
- Removed the temporary `DEFAULT_B2B_BASE_URL` / `DEFAULT_B2B_CLIENT_ID` constants and the `TODO` comment that accompanied them
- Updated tests and mocks accordingly

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config hydration and B2B token acquisition wiring; mis-hydration or missing `b2bApiSettings` could break B2B authentication for affected stores, though changes are localized and default to empty strings.
> 
> **Overview**
> Shifts B2B API configuration from deprecated `checkoutSettings.b2bServiceDetails` to a new `storeConfig.b2bApiSettings` (`clientId`, `baseUrl`) that is provided via `CheckoutInitialState`.
> 
> Updates config hydration to manually merge top-level `b2bApiSettings` into `storeConfig` during `HYDRATE_INITIAL_STATE`, and updates `B2BTokenActionCreator` (plus mocks/tests) to read the B2B client/base URL from this new location, removing the temporary default constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad73c259aab4b239a43dc780c5164affa7d0e54a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->