### PR TITLE
feat(payment): PAYPAL-6436 Fixed an issue with asynchronous behavior during strategy reinitialization

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
@@ -197,6 +197,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
 
     afterEach(() => {
         const buttonContainer = document.getElementById('checkout-button-container');
+
         if (buttonContainer) {
             buttonContainer.remove();
         }
@@ -519,6 +520,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
             const braintreeOptions = {
                 ...options,
                 braintree: {
+                    containerId: '#checkout-button-container',
                     onError: jest.fn(),
                 },
             };

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -50,7 +50,7 @@ import {
 export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
     private paymentMethod?: PaymentMethod<BraintreeInitializationData>;
     private braintreeHostWindow: BraintreeHostWindow = window;
-    private braintree?: BraintreePaypalPaymentInitializeOptions;
+    private braintreeButtonOptions?: BraintreePaypalPaymentInitializeOptions;
     private braintreeTokenizePayload?: BraintreeTokenizePayload;
     private paypalButtonRender?: PaypalButtonRender;
     private loadingIndicatorContainer?: string;
@@ -67,7 +67,9 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
     ) {
         const { braintree: braintreeOptions, methodId } = options;
 
-        this.braintree = braintreeOptions;
+        if (braintreeOptions?.containerId) {
+            this.braintreeButtonOptions = braintreeOptions;
+        }
 
         if (!this.paymentMethod || !this.paymentMethod.nonce) {
             this.paymentMethod = this.paymentIntegrationService
@@ -78,7 +80,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
         if (this.paymentMethod.clientToken && braintreeOptions?.bannerContainerId) {
             await this.loadPaypal();
 
-            return this.loadPaypalCheckoutInstance();
+            return this.loadPaypalCheckoutInstance(braintreeOptions);
         }
 
         if (this.paymentMethod.clientToken) {
@@ -90,7 +92,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
         this.paymentMethod = state.getPaymentMethodOrThrow(methodId);
 
         if (braintreeOptions?.bannerContainerId) {
-            return this.loadPaypalCheckoutInstance();
+            return this.loadPaypalCheckoutInstance(braintreeOptions);
         }
 
         if (!this.paymentMethod.clientToken) {
@@ -103,11 +105,11 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
     async execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
         const { payment, ...order } = orderRequest;
 
-        const { onError } = this.braintree || {};
-
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
         }
+
+        const { onError } = this.braintreeButtonOptions || {};
 
         try {
             const paymentData = await this.preparePaymentData(payment, order.useStoreCredit);
@@ -120,7 +122,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
 
                 this.paypalButtonRender?.close();
 
-                await this.loadPaypalCheckoutInstance();
+                await this.loadPaypalCheckoutInstance(this.braintreeButtonOptions);
 
                 await new Promise((_resolve, reject) => {
                     if (onError && typeof onError === 'function') {
@@ -262,7 +264,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
         };
     }
 
-    private async loadPaypalCheckoutInstance() {
+    private async loadPaypalCheckoutInstance(options?: BraintreePaypalPaymentInitializeOptions) {
         const { clientToken, initializationData, id: paymentMethodId } = this.paymentMethod || {};
 
         if (!clientToken) {
@@ -291,15 +293,12 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                     if (
                         shouldShowPayPalCreditBanner &&
                         paymentMethodId &&
-                        this.braintree?.bannerContainerId
+                        options?.bannerContainerId
                     ) {
-                        this.renderPayPalMessages(
-                            paymentMethodId,
-                            this.braintree.bannerContainerId,
-                        );
+                        this.renderPayPalMessages(paymentMethodId, options.bannerContainerId);
                     }
 
-                    this.renderPayPalButton(braintreePaypalCheckout);
+                    this.renderPayPalButton(braintreePaypalCheckout, options);
                 },
                 this.handleError,
             );
@@ -312,9 +311,11 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
         this.braintreeMessages.render(methodId, containerId, MessagingPlacements.PAYMENT);
     }
 
-    private renderPayPalButton(braintreePaypalCheckout: BraintreePaypalCheckout) {
-        const { onPaymentError, submitForm, onRenderButton, containerId, onError } =
-            this.braintree || {};
+    private renderPayPalButton(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        options?: BraintreePaypalPaymentInitializeOptions,
+    ) {
+        const { onPaymentError, submitForm, onRenderButton, containerId, onError } = options || {};
 
         if (!containerId) {
             return;


### PR DESCRIPTION
## What/Why?

Fixes a race condition in `BraintreePaypalPaymentStrategy` where calling `initialize()` twice in quick succession caused `this.braintree` to be overwritten with stale options from the first call's async callback.

The fix snapshots `this.braintree` before the async call and restores it inside the callback to ensure correct options are used when rendering the PayPal button and banner.

## Rollout/Rollback

Revert

## Testing

https://github.com/user-attachments/assets/1dbc22ec-5b35-4729-a162-c7f008c2dde8

https://github.com/user-attachments/assets/49d14cf5-9b27-4815-9fea-ceeea63e097f


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PayPal/Braintree initialization and rendering timing; a small change, but it can affect whether the PayPal button/messages render under rapid re-initialization scenarios.
> 
> **Overview**
> Fixes a race in `BraintreePaypalPaymentStrategy.loadPaypalCheckoutInstance()` where an earlier async `getPaypalCheckout` callback could read newer `this.braintree` options after a rapid re-`initialize()`, leading to incorrect UI rendering.
> 
> The strategy now snapshots the current `braintree` options before calling `getPaypalCheckout` and restores that snapshot inside the success callback. A new unit test covers the double-initialize timing case to ensure a stale callback does not render the PayPal button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c117123cff90ccc5fc7906a137bf8151c4883d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->