### PR TITLE
feat(payment): PI-4985 [Worldpay Access][FE][B2B checkout] Open Banking

### DIFF
--- a/packages/core/src/payment/payment-request-transformer.ts
+++ b/packages/core/src/payment/payment-request-transformer.ts
@@ -158,8 +158,14 @@ export default class PaymentRequestTransformer {
         // Worldpay Access: sub-methods carry the provider name in `gateway` and the method
         // name in `id`. BigPay's mapToId uses `id` as the gateway field unless
         // `method === 'multi-option'`, so we align with hosted-form-order-data-transformer
-        if (paymentMethod.gateway === 'worldpayaccess' && paymentMethod.id === 'credit_card') {
-            return { ...paymentMethod, id: 'worldpayaccess', method: 'credit-card' };
+        if (paymentMethod.gateway === 'worldpayaccess') {
+            if (paymentMethod.id === 'credit_card') {
+                return { ...paymentMethod, id: 'worldpayaccess', method: 'credit-card' };
+            }
+
+            if (paymentMethod.id === 'open_banking') {
+                return { ...paymentMethod, id: 'worldpayaccess', method: 'open_banking' };
+            }
         }
 
         if (paymentMethod.id === CheckoutButtonMethodType.BRAINTREE_VENMO) {

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
@@ -1,6 +1,5 @@
 import {
     OrderFinalizationNotRequiredError,
-    OrderRequestBody,
     PaymentArgumentInvalidError,
     PaymentIntegrationService,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -37,7 +36,7 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
             };
 
             await strategy.initialize();
-            await strategy.execute(payload as OrderRequestBody);
+            await strategy.execute(payload);
 
             expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
                 methodId: 'open_banking',
@@ -50,20 +49,6 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
                     },
                 },
             });
-        });
-
-        it('submits credit card payment unchanged when not open banking', async () => {
-            const payment = {
-                methodId: 'credit_card',
-                gatewayId: 'worldpayaccess',
-                paymentData: { instrumentId: 'token-123' },
-            };
-            const payload = { payment };
-
-            await strategy.initialize();
-            await strategy.execute(payload as OrderRequestBody);
-
-            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(payment);
         });
 
         it('redirects when additional_action_required with redirect_url is returned', async () => {
@@ -98,7 +83,7 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
                 },
             });
 
-            void strategy.execute(payload as OrderRequestBody);
+            void strategy.execute(payload);
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(window.location.replace).toHaveBeenCalledWith(redirectUrl);

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.spec.ts
@@ -28,6 +28,44 @@ describe('WorldpayAccessOpenBankingPaymentStrategy', () => {
             await expect(strategy.execute({})).rejects.toThrow(PaymentArgumentInvalidError);
         });
 
+        it('submits open banking payment with formattedPayload for BigPay mapping', async () => {
+            const payload = {
+                payment: {
+                    methodId: 'open_banking',
+                    gatewayId: 'worldpayaccess',
+                },
+            };
+
+            await strategy.initialize();
+            await strategy.execute(payload as OrderRequestBody);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: 'open_banking',
+                gatewayId: 'worldpayaccess',
+                paymentData: {
+                    formattedPayload: {
+                        open_banking: {},
+                        vault_payment_instrument: false,
+                        set_as_default_stored_instrument: false,
+                    },
+                },
+            });
+        });
+
+        it('submits credit card payment unchanged when not open banking', async () => {
+            const payment = {
+                methodId: 'credit_card',
+                gatewayId: 'worldpayaccess',
+                paymentData: { instrumentId: 'token-123' },
+            };
+            const payload = { payment };
+
+            await strategy.initialize();
+            await strategy.execute(payload as OrderRequestBody);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(payment);
+        });
+
         it('redirects when additional_action_required with redirect_url is returned', async () => {
             const payload = {
                 payment: {

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
@@ -1,6 +1,9 @@
 import {
+    isHostedInstrumentLike,
     OrderFinalizationNotRequiredError,
+    OrderPaymentRequestBody,
     OrderRequestBody,
+    Payment,
     PaymentArgumentInvalidError,
     PaymentIntegrationService,
     PaymentStrategy,
@@ -19,7 +22,11 @@ export default class WorldpayAccessOpenBankingPaymentStrategy implements Payment
         await this._paymentIntegrationService.submitOrder();
 
         try {
-            await this._paymentIntegrationService.submitPayment(payment);
+            if (this._isWorldpayAccessOpenBankingPayment(payment)) {
+                await this._executeWorldpayAccessOpenBankingPayment(payment);
+            } else {
+                await this._executeWorldpayAccessCreditCardPayment(payment);
+            }
         } catch (error) {
             if (this._isWorldpayAccessRedirectResponse(error)) {
                 const redirectUrl = error.body.additional_action_required.data.redirect_url;
@@ -41,6 +48,43 @@ export default class WorldpayAccessOpenBankingPaymentStrategy implements Payment
 
     deinitialize(): Promise<void> {
         return Promise.resolve();
+    }
+
+    private async _executeWorldpayAccessOpenBankingPayment(
+        payment: OrderPaymentRequestBody,
+    ): Promise<void> {
+        await this._paymentIntegrationService.submitPayment(
+            this._buildOpenBankingSubmitPayment(payment),
+        );
+    }
+
+    private async _executeWorldpayAccessCreditCardPayment(
+        payment: OrderPaymentRequestBody,
+    ): Promise<void> {
+        await this._paymentIntegrationService.submitPayment(payment);
+    }
+
+    private _buildOpenBankingSubmitPayment(payment: OrderPaymentRequestBody): Payment {
+        const { shouldSaveInstrument, shouldSetAsDefaultInstrument } = isHostedInstrumentLike(
+            payment.paymentData,
+        )
+            ? payment.paymentData
+            : { shouldSaveInstrument: false, shouldSetAsDefaultInstrument: false };
+
+        return {
+            ...payment,
+            paymentData: {
+                formattedPayload: {
+                    open_banking: {},
+                    vault_payment_instrument: shouldSaveInstrument || false,
+                    set_as_default_stored_instrument: shouldSetAsDefaultInstrument || false,
+                },
+            },
+        };
+    }
+
+    private _isWorldpayAccessOpenBankingPayment(payment: OrderPaymentRequestBody): boolean {
+        return payment.gatewayId === 'worldpayaccess' && payment.methodId === 'open_banking';
     }
 
     private _isWorldpayAccessRedirectResponse(

--- a/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
+++ b/packages/worldpayaccess-integration/src/worldpayaccess-open-banking-payment-strategy.ts
@@ -22,11 +22,9 @@ export default class WorldpayAccessOpenBankingPaymentStrategy implements Payment
         await this._paymentIntegrationService.submitOrder();
 
         try {
-            if (this._isWorldpayAccessOpenBankingPayment(payment)) {
-                await this._executeWorldpayAccessOpenBankingPayment(payment);
-            } else {
-                await this._executeWorldpayAccessCreditCardPayment(payment);
-            }
+            await this._paymentIntegrationService.submitPayment(
+                this._buildOpenBankingSubmitPayment(payment),
+            );
         } catch (error) {
             if (this._isWorldpayAccessRedirectResponse(error)) {
                 const redirectUrl = error.body.additional_action_required.data.redirect_url;
@@ -50,20 +48,6 @@ export default class WorldpayAccessOpenBankingPaymentStrategy implements Payment
         return Promise.resolve();
     }
 
-    private async _executeWorldpayAccessOpenBankingPayment(
-        payment: OrderPaymentRequestBody,
-    ): Promise<void> {
-        await this._paymentIntegrationService.submitPayment(
-            this._buildOpenBankingSubmitPayment(payment),
-        );
-    }
-
-    private async _executeWorldpayAccessCreditCardPayment(
-        payment: OrderPaymentRequestBody,
-    ): Promise<void> {
-        await this._paymentIntegrationService.submitPayment(payment);
-    }
-
     private _buildOpenBankingSubmitPayment(payment: OrderPaymentRequestBody): Payment {
         const { shouldSaveInstrument, shouldSetAsDefaultInstrument } = isHostedInstrumentLike(
             payment.paymentData,
@@ -81,10 +65,6 @@ export default class WorldpayAccessOpenBankingPaymentStrategy implements Payment
                 },
             },
         };
-    }
-
-    private _isWorldpayAccessOpenBankingPayment(payment: OrderPaymentRequestBody): boolean {
-        return payment.gatewayId === 'worldpayaccess' && payment.methodId === 'open_banking';
     }
 
     private _isWorldpayAccessRedirectResponse(


### PR DESCRIPTION
## What/Why?
This PR is direct continuation of this one https://github.com/bigcommerce/checkout-sdk-js/pull/3187
- added mapping for Open Banking in payment-request-transformer
- changed payload for paymentSubmit method in Open Banking payment strategy

## Rollout/Rollback

Revert this PR
Disable experiment - PI-4975.worldpay_access_enable_open_banking

## Testing
Payment doesn't pass yet because there are still pending work on BE side.

https://github.com/user-attachments/assets/737de785-c84e-40c4-9944-bffe829548bf

Below test from CC flow

https://github.com/user-attachments/assets/17d6cd1f-c144-473f-9379-c9e6b9027d3a




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes payment method ID/gateway mapping and alters `submitPayment` payload construction for Worldpay Access Open Banking, which can affect payment routing and vaulted-instrument flags.
> 
> **Overview**
> Adds Worldpay Access **Open Banking** support by mapping the `open_banking` sub-method to the `worldpayaccess` gateway in `PaymentRequestTransformer` (similar to the existing credit-card mapping).
> 
> Updates `WorldpayAccessOpenBankingPaymentStrategy` to conditionally wrap Open Banking payments in a `paymentData.formattedPayload` (including vault/default-instrument flags derived from hosted-instrument data) while leaving non-Open-Banking payments unchanged, and adds unit tests to cover both paths and the redirect flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f99a450fa77f34927d2e26f2ee4b9617a49322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->