### PR TITLE
chore(checkout): CHECKOUT-9450 Remove experiment check to roll out strategies

### DIFF
--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -94,8 +94,6 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         );
     }
 
-    const rollOutLazyPaymentStrategies = options?.rollOutLazyPaymentStrategies ?? false;
-
     if (getEnvironment() !== 'production') {
         getDefaultLogger().warn(
             'Note that the development build is not optimized. To create a production build, set process\u200b.env.NODE_ENV to `production`.',
@@ -157,14 +155,12 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     };
     const registryV2 = createPaymentStrategyRegistryV2(
         paymentIntegrationService,
-        // TODO: Replace once CHECKOUT-9450.lazy_load_payment_strategies experiment is rolled out
-        // process.env.ESSENTIAL_BUILD ? essentialPaymentStrategyFactories : paymentStrategyFactories,
-        rollOutLazyPaymentStrategies ? essentialPaymentStrategyFactories : paymentStrategyFactories,
+        process.env.ESSENTIAL_BUILD ? essentialPaymentStrategyFactories : paymentStrategyFactories,
         { useFallback: true },
     );
     const customerRegistryV2 = createCustomerStrategyRegistryV2(
         paymentIntegrationService,
-        rollOutLazyPaymentStrategies ? {} : customerStrategyFactories,
+        process.env.ESSENTIAL_BUILD ? {} : customerStrategyFactories,
     );
     const extensionActionCreator = new ExtensionActionCreator(
         new ExtensionRequestSender(experimentRequestSender),
@@ -239,5 +235,4 @@ export interface CheckoutServiceOptions {
     shouldWarnMutation?: boolean;
     externalSource?: string;
     errorLogger?: ErrorLogger;
-    rollOutLazyPaymentStrategies?: boolean;
 }

--- a/packages/core/src/payment/payment-strategy-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.spec.ts
@@ -261,21 +261,7 @@ describe('PaymentStrategyActionCreator', () => {
 
                 mockStrategyFactory = jest.fn().mockReturnValue(mockStrategy);
 
-                store = createCheckoutStore(
-                    merge({}, state, {
-                        config: {
-                            data: {
-                                storeConfig: {
-                                    checkoutSettings: {
-                                        features: {
-                                            'CHECKOUT-9450.lazy_load_payment_strategies': true,
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    }),
-                );
+                store = createCheckoutStore(state);
 
                 actionCreator = new PaymentStrategyActionCreator(
                     registry,


### PR DESCRIPTION
## What/Why?
Remove experiment check to roll out strategies since the experiment has been rolled out successfully.

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how payment/customer strategies are registered at runtime by removing an option/experiment gate and relying solely on `process.env.ESSENTIAL_BUILD`, which could affect which strategies are available in production builds.
> 
> **Overview**
> Removes the `rollOutLazyPaymentStrategies` option/experiment path and always selects payment/customer strategy factories based on `process.env.ESSENTIAL_BUILD` (only `NO_PAYMENT_DATA_REQUIRED` is included in essential builds).
> 
> Updates the `PaymentStrategyActionCreator` spec to stop stubbing the `CHECKOUT-9450.lazy_load_payment_strategies` feature flag now that it no longer influences store setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df0c13a01530750af4c6177d7f7337303e0bccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->