### PR TITLE
fix(payment): CHECKOUT-9963 Fix error related to container not found for bluesnap

### DIFF
--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-credit-card/bluesnap-direct-credit-card-payment-strategy.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-credit-card/bluesnap-direct-credit-card-payment-strategy.spec.ts
@@ -240,6 +240,16 @@ describe('BlueSnapDirectCreditCardPaymentStrategy', () => {
                 expect(hostedForm.attach).not.toHaveBeenCalled();
             });
         });
+
+        it('should not throw when attach fails due to missing DOM containers (user navigated away)', async () => {
+            jest.spyOn(hostedForm, 'attach').mockRejectedValue(
+                new InvalidArgumentError(
+                    'Unable to create hosted payment fields to invalid HTML container elements.',
+                ),
+            );
+
+            await expect(strategy.initialize(options)).resolves.not.toThrow();
+        });
     });
 
     describe('#execute()', () => {

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-credit-card/bluesnap-direct-credit-card-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-credit-card/bluesnap-direct-credit-card-payment-strategy.ts
@@ -62,11 +62,18 @@ export default class BlueSnapDirectCreditCardPaymentStrategy implements PaymentS
 
         if (this._shouldUseHostedFields) {
             this._blueSnapDirectHostedForm.initialize(this._blueSnapSdk, creditCard.form.fields);
-            await this._blueSnapDirectHostedForm.attach(
-                this._getPaymentFieldsToken(),
-                creditCard,
-                is3dsEnabled,
-            );
+            try {
+                await this._blueSnapDirectHostedForm.attach(
+                    this._getPaymentFieldsToken(),
+                    creditCard,
+                    is3dsEnabled,
+                );
+            } catch (error) {
+                if (error instanceof InvalidArgumentError) {
+                    return;
+                }
+                throw error;
+            }
         }
     }
 


### PR DESCRIPTION
## What/Why?
Fix error related to container not found for bluesnap direct.

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast

https://github.com/user-attachments/assets/46ad499e-e506-4145-8517-65c8f0dafd2f


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment initialization error handling by swallowing `InvalidArgumentError` from hosted-field attachment, which could mask other invalid-argument cases and alter checkout initialization flow.
> 
> **Overview**
> Prevents BlueSnap Direct credit-card initialization from failing when hosted-field `attach` throws an `InvalidArgumentError` (e.g., missing container elements if the shopper navigated away), by catching that error and returning early.
> 
> Adds a unit test asserting `initialize()` resolves without throwing when `attach` rejects due to missing DOM containers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9dc0248bbaa54ace12b78ecdc4dd14f8c4f16b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->