### PR TITLE
feat(payment): PAYPAL-6433 implement server side shipping callbacks logic

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -447,13 +447,13 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
             });
         });
 
-        it('initializes PayPal button to render without shipping options when appSwitch enabled', async () => {
+        it('initializes PayPal button to render without shipping options when server side shipping callbacks enabled', async () => {
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
                 initializationData: {
                     ...paymentMethod.initializationData,
                     isHostedCheckoutEnabled: true,
-                    isAppSwitchEnabled: true,
+                    isServerSideShippingCallbacksEnabled: true,
                 },
             };
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -472,6 +472,33 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
             });
         });
 
+        it('initializes PayPal button to render with shipping options when server side shipping callbacks disabled', async () => {
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                    isServerSideShippingCallbacksEnabled: false,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYLATER,
+                style: paypalCommerceCreditOptions.style,
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+                onShippingAddressChange: expect.any(Function),
+                onShippingOptionsChange: expect.any(Function),
+            });
+        });
+
         it('renders PayPal button if it is eligible', async () => {
             const renderMock = jest.fn();
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -220,11 +220,17 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
                 );
             }
 
+            if (isServerSideShippingCallbacksEnabled) {
+                await this.paymentIntegrationService.loadCheckout();
+            }
+
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
 
             await this.paypalIntegrationService.submitPayment(methodId, data.orderID);
 
-            onComplete?.();
+            if (onComplete && typeof onComplete === 'function') {
+                onComplete();
+            }
 
             return true; // FIXME: Do we really need to return true here?
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -104,7 +104,7 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         const paypalSdk = this.paypalIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
         const paymentMethod = state.getPaymentMethodOrThrow<PayPalInitializationData>(methodId);
-        const { isHostedCheckoutEnabled, isAppSwitchEnabled } =
+        const { isHostedCheckoutEnabled, isServerSideShippingCallbacksEnabled } =
             paymentMethod.initializationData || {};
 
         const defaultCallbacks = {
@@ -119,14 +119,20 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         };
 
         const hostedCheckoutCallbacks = {
-            ...(!isAppSwitchEnabled && {
+            ...(!isServerSideShippingCallbacksEnabled && {
                 onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
                     this.onShippingAddressChange(data),
                 onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
                     this.onShippingOptionsChange(data),
             }),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
-                this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
+                this.onHostedCheckoutApprove(
+                    data,
+                    actions,
+                    methodId,
+                    onComplete,
+                    isServerSideShippingCallbacksEnabled,
+                ),
         };
 
         const fundingSources = [paypalSdk.FUNDING.PAYLATER, paypalSdk.FUNDING.CREDIT];
@@ -175,6 +181,7 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         actions: ApproveCallbackActions,
         methodId: string,
         onComplete?: () => void,
+        isServerSideShippingCallbacksEnabled?: boolean,
     ): Promise<boolean> {
         if (!data.orderID) {
             throw new MissingDataError(MissingDataErrorType.MissingOrderId);
@@ -182,28 +189,42 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
 
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
-        const orderDetails = await actions.order.get();
 
         try {
-            const billingAddress =
-                this.paypalIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
+            const hasPhysicalItems = cart.lineItems.physicalItems.length > 0;
 
-            await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+            if (!isServerSideShippingCallbacksEnabled) {
+                const orderDetails = await actions.order.get();
 
-            if (cart.lineItems.physicalItems.length > 0) {
-                const shippingAddress =
-                    this.paypalIntegrationService.getShippingAddressFromOrderDetails(orderDetails);
+                const billingAddress =
+                    this.paypalIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
 
-                await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
-                await this.paypalIntegrationService.updateOrder('paypalcommerce');
+                await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+
+                if (hasPhysicalItems) {
+                    const shippingAddress =
+                        this.paypalIntegrationService.getShippingAddressFromOrderDetails(
+                            orderDetails,
+                        );
+
+                    await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
+                }
+            }
+
+            if (hasPhysicalItems) {
+                await this.paypalIntegrationService.updateOrder(
+                    'paypalcommerce',
+                    undefined,
+                    undefined,
+                    isServerSideShippingCallbacksEnabled,
+                );
             }
 
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
+
             await this.paypalIntegrationService.submitPayment(methodId, data.orderID);
 
-            if (onComplete && typeof onComplete === 'function') {
-                onComplete();
-            }
+            onComplete?.();
 
             return true; // FIXME: Do we really need to return true here?
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -335,7 +335,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
             });
         });
 
-        it('initializes paypal buttons without shipping callbacks when appSwitch enabled', async () => {
+        it('initializes paypal buttons without shipping callbacks when server side shipping callbacks enabled', async () => {
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',
@@ -344,7 +344,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                 initializationData: {
                     ...paymentMethod.initializationData,
                     isHostedCheckoutEnabled: true,
-                    isAppSwitchEnabled: true,
+                    isServerSideShippingCallbacksEnabled: true,
                 },
             });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -217,10 +217,16 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
                 );
             }
 
+            if (isServerSideShippingCallbacksEnabled) {
+                await this.paymentIntegrationService.loadCheckout();
+            }
+
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
             await this.paypalCommerceIntegrationService.submitPayment(methodId, data.orderID);
 
-            onComplete?.();
+            if (onComplete && typeof onComplete === 'function') {
+                onComplete();
+            }
         } catch (error) {
             this.handleError(error);
         }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -114,8 +114,11 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
-        const { isHostedCheckoutEnabled, paymentButtonStyles, isAppSwitchEnabled } =
-            paymentMethod.initializationData || {};
+        const {
+            isHostedCheckoutEnabled,
+            paymentButtonStyles,
+            isServerSideShippingCallbacksEnabled,
+        } = paymentMethod.initializationData || {};
         const { checkoutTopButtonStyles } = paymentButtonStyles || {};
 
         const defaultCallbacks = {
@@ -127,14 +130,20 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         };
 
         const hostedCheckoutCallbacks = {
-            ...(!isAppSwitchEnabled && {
+            ...(!isServerSideShippingCallbacksEnabled && {
                 onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
                     this.onShippingAddressChange(data),
                 onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
                     this.onShippingOptionsChange(data),
             }),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
-                this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
+                this.onHostedCheckoutApprove(
+                    data,
+                    actions,
+                    methodId,
+                    onComplete,
+                    isServerSideShippingCallbacksEnabled,
+                ),
         };
 
         const fundingSources = [paypalSdk.FUNDING.PAYLATER, paypalSdk.FUNDING.CREDIT];
@@ -171,38 +180,47 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         actions: ApproveCallbackActions,
         methodId: string,
         onComplete?: () => void,
+        isServerSideShippingCallbacksEnabled?: boolean,
     ): Promise<void> {
         if (!data.orderID) {
             throw new MissingDataError(MissingDataErrorType.MissingOrderId);
         }
 
         const cart = this.paymentIntegrationService.getState().getCartOrThrow();
-        const orderDetails = await actions.order.get();
 
         try {
-            const billingAddress =
-                this.paypalCommerceIntegrationService.getBillingAddressFromOrderDetails(
-                    orderDetails,
-                );
+            const hasPhysicalItems = cart.lineItems.physicalItems.length > 0;
 
-            await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+            if (!isServerSideShippingCallbacksEnabled) {
+                const orderDetails = await actions.order.get();
 
-            if (cart.lineItems.physicalItems.length > 0) {
-                const shippingAddress =
-                    this.paypalCommerceIntegrationService.getShippingAddressFromOrderDetails(
+                const billingAddress =
+                    this.paypalCommerceIntegrationService.getBillingAddressFromOrderDetails(
                         orderDetails,
                     );
 
-                await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
-                await this.paypalCommerceIntegrationService.updateOrder();
+                await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+
+                if (hasPhysicalItems) {
+                    const shippingAddress =
+                        this.paypalCommerceIntegrationService.getShippingAddressFromOrderDetails(
+                            orderDetails,
+                        );
+
+                    await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
+                }
+            }
+
+            if (hasPhysicalItems) {
+                await this.paypalCommerceIntegrationService.updateOrder(
+                    isServerSideShippingCallbacksEnabled,
+                );
             }
 
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
             await this.paypalCommerceIntegrationService.submitPayment(methodId, data.orderID);
 
-            if (onComplete && typeof onComplete === 'function') {
-                onComplete();
-            }
+            onComplete?.();
         } catch (error) {
             this.handleError(error);
         }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -133,16 +133,20 @@ export default class PayPalCommerceIntegrationService {
         return { orderId, ...(setupToken ? { setupToken } : {}) };
     }
 
-    async updateOrder(): Promise<void> {
+    async updateOrder(isServerSideShippingCallbacksEnabled?: boolean): Promise<void> {
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
         const consignment = state.getConsignmentsOrThrow()[0];
 
         try {
             await this.paypalCommerceRequestSender.updateOrder({
-                availableShippingOptions: consignment.availableShippingOptions,
+                availableShippingOptions: isServerSideShippingCallbacksEnabled
+                    ? []
+                    : consignment.availableShippingOptions,
                 cartId: cart.id,
-                selectedShippingOption: consignment.selectedShippingOption,
+                selectedShippingOption: isServerSideShippingCallbacksEnabled
+                    ? null
+                    : consignment.selectedShippingOption,
             });
         } catch (_error) {
             throw new RequestError();

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -260,7 +260,7 @@ export interface PayPalCommerceInitializationData {
     shouldRunAcceleratedCheckout?: boolean;
     paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>;
     paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[];
-    isAppSwitchEnabled?: boolean;
+    isServerSideShippingCallbacksEnabled?: boolean;
 }
 
 export interface PayPalBNPLConfigurationItem {
@@ -600,7 +600,7 @@ export interface PayPalOrderData {
 export interface PayPalUpdateOrderRequestBody {
     availableShippingOptions?: ShippingOption[];
     cartId: string;
-    selectedShippingOption?: ShippingOption;
+    selectedShippingOption?: ShippingOption | null;
 }
 
 export interface PayPalUpdateOrderResponse {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -399,30 +399,12 @@ describe('PayPalCommerceButtonStrategy', () => {
             });
         });
 
-        it('calls PayPal button resume', async () => {
-            const paymentMethodWithShippingOptionsFeature = {
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
-            await strategy.initialize(initializationOptions);
-
-            expect(resumeMock).toHaveBeenCalled();
-        });
-
         it('initializes PayPal button to render (buy now flow)', async () => {
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
                 initializationData: {
                     ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
+                    isServerSideShippingCallbacksEnabled: true,
                 },
             };
 
@@ -437,7 +419,6 @@ describe('PayPalCommerceButtonStrategy', () => {
                 expect.objectContaining({
                     fundingSource: paypalSdk.FUNDING.PAYPAL,
                     style: paypalCommerceOptions.style,
-                    appSwitchWhenAvailable: true,
                     createOrder: expect.any(Function),
                     onApprove: expect.any(Function),
                 }),
@@ -484,13 +465,13 @@ describe('PayPalCommerceButtonStrategy', () => {
             });
         });
 
-        it('initializes PayPal button to render without shipping options when appSwitch enabled', async () => {
+        it('initializes PayPal button to render without shipping options when server side shipping callbacks enabled', async () => {
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
                 initializationData: {
                     ...paymentMethod.initializationData,
                     isHostedCheckoutEnabled: true,
-                    isAppSwitchEnabled: true,
+                    isServerSideShippingCallbacksEnabled: true,
                 },
             };
 
@@ -502,7 +483,6 @@ describe('PayPalCommerceButtonStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                appSwitchWhenAvailable: true,
                 createOrder: expect.any(Function),
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
                 onApprove: expect.any(Function),
@@ -572,31 +552,6 @@ describe('PayPalCommerceButtonStrategy', () => {
             expect(paypalCommerceIntegrationService.removeElement).toHaveBeenCalledWith(
                 defaultButtonContainerId,
             );
-        });
-
-        it('initializes PayPal button to render with appSwitch flag', async () => {
-            const paymentMethodWithShippingOptionsFeature = {
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
-            await strategy.initialize(initializationOptions);
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                appSwitchWhenAvailable: true,
-                createOrder: expect.any(Function),
-                fundingSource: paypalSdk.FUNDING.PAYPAL,
-                onApprove: expect.any(Function),
-                style: paypalCommerceOptions.style,
-            });
         });
     });
 
@@ -733,6 +688,20 @@ describe('PayPalCommerceButtonStrategy', () => {
             });
 
             it('updates billing address with valid customers data', async () => {
+                const paymentMethodWithShippingOptionsFeature = {
+                    ...paymentMethod,
+                    initializationData: {
+                        ...paymentMethod.initializationData,
+                        isHostedCheckoutEnabled: true,
+                        isServerSideShippingCallbacksEnabled: false,
+                    },
+                };
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+
                 await strategy.initialize(initializationOptions);
 
                 eventEmitter.emit('onApprove');

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -94,7 +94,7 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
         const paypalSdk = this.paypalIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
         const paymentMethod = state.getPaymentMethodOrThrow<PayPalInitializationData>(methodId);
-        const { isHostedCheckoutEnabled, isAppSwitchEnabled } =
+        const { isHostedCheckoutEnabled, isServerSideShippingCallbacksEnabled } =
             paymentMethod.initializationData || {};
 
         const buyNowFlowCallbacks = {
@@ -104,7 +104,7 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
         const buttonOptions: PayPalButtonOptions = {
             fundingSource: paypalSdk.FUNDING.PAYPAL,
             style: this.paypalIntegrationService.getValidButtonStyle(style),
-            isAppSwitchEnabled,
+            isServerSideShippingCallbacksEnabled,
             isHostedCheckoutEnabled,
             ...(buyNowInitializeOptions && buyNowFlowCallbacks),
             ...(isHostedCheckoutEnabled && onComplete && { onPaymentComplete: () => onComplete() }),
@@ -118,11 +118,7 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
         );
 
         if (paypalButton.isEligible()) {
-            if (paypalButton.hasReturned?.() && isAppSwitchEnabled) {
-                paypalButton.resume?.();
-            } else {
-                paypalButton.render(`#${containerId}`);
-            }
+            paypalButton.render(`#${containerId}`);
         } else if (onEligibilityFailure && typeof onEligibilityFailure === 'function') {
             onEligibilityFailure();
         } else {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -277,24 +277,6 @@ describe('PayPalCommerceCustomerStrategy', () => {
             });
         });
 
-        it('calls PayPal button resume', async () => {
-            const paymentMethodWithAppSwitch = {
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue(paymentMethodWithAppSwitch);
-            await strategy.initialize(initializationOptions);
-
-            expect(resumeMock).toHaveBeenCalled();
-        });
-
         it('initializes paypal buttons with config related to hosted checkout feature', async () => {
             jest.spyOn(
                 paymentIntegrationService.getState(),
@@ -324,7 +306,7 @@ describe('PayPalCommerceCustomerStrategy', () => {
             });
         });
 
-        it('initializes paypal buttons without shipping callbacks what appSwitch enabled', async () => {
+        it('initializes paypal buttons without shipping callbacks what server side shipping callbacks enabled', async () => {
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',
@@ -333,14 +315,13 @@ describe('PayPalCommerceCustomerStrategy', () => {
                 initializationData: {
                     ...paymentMethod.initializationData,
                     isHostedCheckoutEnabled: true,
-                    isAppSwitchEnabled: true,
+                    isServerSideShippingCallbacksEnabled: true,
                 },
             });
 
             await strategy.initialize(initializationOptions);
 
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                appSwitchWhenAvailable: true,
                 createOrder: expect.any(Function),
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
                 style: {
@@ -348,35 +329,6 @@ describe('PayPalCommerceCustomerStrategy', () => {
                     color: StyleButtonColor.silver,
                     label: 'checkout',
                 },
-                onApprove: expect.any(Function),
-                onClick: expect.any(Function),
-            });
-        });
-
-        it('initializes PayPal button to render with appSwitch flag', async () => {
-            const paymentMethodWithAppSwitch = {
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue(paymentMethodWithAppSwitch);
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: {
-                    height: DefaultCheckoutButtonHeight,
-                    color: StyleButtonColor.silver,
-                    label: 'checkout',
-                },
-                appSwitchWhenAvailable: true,
-                createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
             });

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -106,13 +106,16 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         const paypalSdk = this.paypalIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
         const paymentMethod = state.getPaymentMethodOrThrow<PayPalInitializationData>(methodId);
-        const { isHostedCheckoutEnabled, paymentButtonStyles, isAppSwitchEnabled } =
-            paymentMethod.initializationData || {};
+        const {
+            isHostedCheckoutEnabled,
+            paymentButtonStyles,
+            isServerSideShippingCallbacksEnabled,
+        } = paymentMethod.initializationData || {};
         const { checkoutTopButtonStyles } = paymentButtonStyles || {};
 
         const buttonOptions: PayPalButtonOptions = {
             fundingSource: paypalSdk.FUNDING.PAYPAL,
-            isAppSwitchEnabled,
+            isServerSideShippingCallbacksEnabled,
             isHostedCheckoutEnabled,
             style: {
                 ...checkoutTopButtonStyles,
@@ -130,11 +133,7 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         );
 
         if (paypalButton.isEligible()) {
-            if (paypalButton.hasReturned?.() && isAppSwitchEnabled) {
-                paypalButton.resume?.();
-            } else {
-                paypalButton.render(`#${container}`);
-            }
+            paypalButton.render(`#${container}`);
         } else {
             this.paypalIntegrationService.removeElement(container);
         }

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -241,63 +241,6 @@ describe('PayPalCommercePaymentStrategy', () => {
             });
         });
 
-        it('render button with appSwitch flag', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            });
-
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                appSwitchWhenAvailable: true,
-                createOrder: expect.any(Function),
-                fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: {
-                    color: 'black',
-                    height: 55,
-                    label: 'pay',
-                },
-                onClick: expect.any(Function),
-                onApprove: expect.any(Function),
-                onCancel: expect.any(Function),
-                onError: expect.any(Function),
-            });
-        });
-
-        it('calls resume when appSwitch enabled and returned from app', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            });
-
-            const resumeMock = jest.fn();
-
-            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
-                close: jest.fn(),
-                isEligible: jest.fn(() => true),
-                render: paypalCommerceSdkRenderMock,
-                hasReturned: jest.fn(() => true),
-                resume: resumeMock,
-            }));
-
-            await strategy.initialize(initializationOptions);
-
-            expect(resumeMock).toHaveBeenCalled();
-        });
-
         it('does not render paypal button if it is not eligible', async () => {
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
                 close: jest.fn(),

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -302,9 +302,6 @@ export default class PayPalCommercePaymentStrategy implements PaymentStrategy {
         }
 
         const buttonOptions: PayPalButtonsOptions = {
-            ...(this.isPaypalCommerceAppSwitchEnabled(methodId) && {
-                appSwitchWhenAvailable: true,
-            }),
             fundingSource: paypalSdk.FUNDING.PAYPAL,
             style: this.paypalIntegrationService.getValidButtonStyle(checkoutPaymentButtonStyles),
             createOrder: () => this.createOrder(),
@@ -324,11 +321,7 @@ export default class PayPalCommercePaymentStrategy implements PaymentStrategy {
             onRenderButton();
         }
 
-        if (this.paypalButton.hasReturned?.() && this.isPaypalCommerceAppSwitchEnabled(methodId)) {
-            this.paypalButton.resume?.();
-        } else {
-            this.paypalButton.render(container);
-        }
+        this.paypalButton.render(container);
     }
 
     private async handleClick(
@@ -465,18 +458,6 @@ export default class PayPalCommercePaymentStrategy implements PaymentStrategy {
         }
 
         return false;
-    }
-
-    /**
-     *
-     * PayPal AppSwitch enabling handling
-     *
-     */
-    private isPaypalCommerceAppSwitchEnabled(methodId: string): boolean {
-        const state = this.paymentIntegrationService.getState();
-        const paymentMethod = state.getPaymentMethodOrThrow<PayPalInitializationData>(methodId);
-
-        return paymentMethod.initializationData?.isAppSwitchEnabled || false;
     }
 
     private getSmartButtonContainerId(container: string) {

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -40,7 +40,6 @@ export interface PayPalCommerceInitializationData {
     paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>;
     paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[];
     threeDSVerificationMethod?: string;
-    isAppSwitchEnabled?: boolean;
 }
 
 /**

--- a/packages/paypal-utils/src/paypal-button-creation-service.spec.ts
+++ b/packages/paypal-utils/src/paypal-button-creation-service.spec.ts
@@ -256,23 +256,6 @@ describe('PayPalButtonCreationService', () => {
         });
     });
 
-    it('create PayPal button with appSwitchWhenAvailable option enabled', () => {
-        paypalButtonCreationService.createPayPalButton('paypalcommerce', 'paypalcommercecredit', {
-            fundingSource: paypalSdk.FUNDING.PAYLATER,
-            isAppSwitchEnabled: true,
-        });
-
-        expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-            fundingSource: paypalSdk.FUNDING.PAYLATER,
-            createOrder: expect.any(Function),
-            onApprove: expect.any(Function),
-            style: {
-                height: 40,
-            },
-            appSwitchWhenAvailable: true,
-        });
-    });
-
     it('create PayPal button with onCancel callback support', async () => {
         const onCancel = jest.fn();
 

--- a/packages/paypal-utils/src/paypal-button-creation-service.ts
+++ b/packages/paypal-utils/src/paypal-button-creation-service.ts
@@ -33,8 +33,8 @@ class PaypalButtonCreationService {
         const {
             style,
             fundingSource,
-            isAppSwitchEnabled,
             isHostedCheckoutEnabled,
+            isServerSideShippingCallbacksEnabled,
             onClick,
             onCancel,
             onPaymentComplete,
@@ -53,7 +53,7 @@ class PaypalButtonCreationService {
         }
 
         const hostedCheckoutCallbacks = {
-            ...(!isAppSwitchEnabled && {
+            ...(!isServerSideShippingCallbacksEnabled && {
                 onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
                     this.onShippingAddressChange(data, providerId),
                 onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
@@ -72,9 +72,6 @@ class PaypalButtonCreationService {
         return paypalSdk.Buttons({
             fundingSource,
             style: this.paypalIntegrationService.getValidButtonStyle(style),
-            ...(isAppSwitchEnabled && {
-                appSwitchWhenAvailable: true,
-            }),
             createOrder: async () => {
                 if (buyNowInitializeOptions) {
                     const buyNowCart = await this.paypalIntegrationService.createBuyNowCartOrThrow(
@@ -100,6 +97,7 @@ class PaypalButtonCreationService {
         methodId: string,
         providerId: string,
         onComplete?: () => void,
+        isServerSideShippingCallbacksEnabled?: boolean,
     ): Promise<void> {
         if (!data.orderID) {
             throw new MissingDataError(MissingDataErrorType.MissingOrderId);
@@ -107,20 +105,30 @@ class PaypalButtonCreationService {
 
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
-        const orderDetails = await actions.order.get();
+        let orderDetails;
 
         try {
-            const billingAddress =
-                this.paypalIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
-
-            await this.paymentIntegrationService.updateBillingAddress(billingAddress);
-
             if (cart.lineItems.physicalItems.length > 0) {
-                const shippingAddress =
-                    this.paypalIntegrationService.getShippingAddressFromOrderDetails(orderDetails);
+                if (!isServerSideShippingCallbacksEnabled) {
+                    const billingAddress =
+                        this.paypalIntegrationService.getBillingAddressFromOrderDetails(
+                            orderDetails,
+                        );
 
-                await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
-                await this.paypalIntegrationService.updateOrder(providerId);
+                    await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+                    orderDetails = await actions.order.get();
+                    const shippingAddress =
+                        this.paypalIntegrationService.getShippingAddressFromOrderDetails(
+                            orderDetails,
+                        );
+                    await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
+                }
+                await this.paypalIntegrationService.updateOrder(
+                    providerId,
+                    undefined,
+                    undefined,
+                    isServerSideShippingCallbacksEnabled,
+                );
             }
 
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });

--- a/packages/paypal-utils/src/paypal-button-creation-service.ts
+++ b/packages/paypal-utils/src/paypal-button-creation-service.ts
@@ -66,6 +66,7 @@ class PaypalButtonCreationService {
                     methodId,
                     providerId,
                     onPaymentComplete,
+                    isServerSideShippingCallbacksEnabled,
                 ),
         };
 
@@ -105,24 +106,29 @@ class PaypalButtonCreationService {
 
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
-        let orderDetails;
 
         try {
-            if (cart.lineItems.physicalItems.length > 0) {
-                if (!isServerSideShippingCallbacksEnabled) {
-                    const billingAddress =
-                        this.paypalIntegrationService.getBillingAddressFromOrderDetails(
-                            orderDetails,
-                        );
+            const hasPhysicalItems = cart.lineItems.physicalItems.length > 0;
 
-                    await this.paymentIntegrationService.updateBillingAddress(billingAddress);
-                    orderDetails = await actions.order.get();
+            if (!isServerSideShippingCallbacksEnabled) {
+                const orderDetails = await actions.order.get();
+
+                const billingAddress =
+                    this.paypalIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
+
+                await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+
+                if (hasPhysicalItems) {
                     const shippingAddress =
                         this.paypalIntegrationService.getShippingAddressFromOrderDetails(
                             orderDetails,
                         );
+
                     await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
                 }
+            }
+
+            if (hasPhysicalItems) {
                 await this.paypalIntegrationService.updateOrder(
                     providerId,
                     undefined,
@@ -132,11 +138,10 @@ class PaypalButtonCreationService {
             }
 
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
+
             await this.paypalIntegrationService.submitPayment(methodId, data.orderID);
 
-            if (onComplete && typeof onComplete === 'function') {
-                onComplete();
-            }
+            onComplete?.();
         } catch (error) {
             this.handleError(error);
         }

--- a/packages/paypal-utils/src/paypal-button-creation-service.ts
+++ b/packages/paypal-utils/src/paypal-button-creation-service.ts
@@ -137,11 +137,17 @@ class PaypalButtonCreationService {
                 );
             }
 
+            if (isServerSideShippingCallbacksEnabled) {
+                await this.paymentIntegrationService.loadCheckout();
+            }
+
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
 
             await this.paypalIntegrationService.submitPayment(methodId, data.orderID);
 
-            onComplete?.();
+            if (onComplete && typeof onComplete === 'function') {
+                onComplete();
+            }
         } catch (error) {
             this.handleError(error);
         }

--- a/packages/paypal-utils/src/paypal-integration-service.ts
+++ b/packages/paypal-utils/src/paypal-integration-service.ts
@@ -142,15 +142,13 @@ export default class PayPalIntegrationService {
 
         try {
             await this.paypalRequestSender.updateOrder(providerId, {
-                availableShippingOptions:
-                    isServerSideShippingCallbacksEnabled
+                availableShippingOptions: isServerSideShippingCallbacksEnabled
                     ? []
                     : consignment.availableShippingOptions,
                 cartId: cart.id,
-                selectedShippingOption:
-                    isServerSideShippingCallbacksEnabled
-                        ? null
-                        : consignment.selectedShippingOption,
+                selectedShippingOption: isServerSideShippingCallbacksEnabled
+                    ? null
+                    : consignment.selectedShippingOption,
                 ...(methodId ? { methodId } : {}),
                 ...(orderId ? { orderId } : {}),
             });

--- a/packages/paypal-utils/src/paypal-integration-service.ts
+++ b/packages/paypal-utils/src/paypal-integration-service.ts
@@ -138,17 +138,20 @@ export default class PayPalIntegrationService {
     ): Promise<void> {
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
-        const consignment = state.getConsignmentsOrThrow()[0];
+        let consignment;
+        if (!isServerSideShippingCallbacksEnabled) {
+            consignment = state.getConsignmentsOrThrow()[0];
+        }
 
         try {
             await this.paypalRequestSender.updateOrder(providerId, {
                 availableShippingOptions: isServerSideShippingCallbacksEnabled
                     ? []
-                    : consignment.availableShippingOptions,
+                    : consignment?.availableShippingOptions,
                 cartId: cart.id,
                 selectedShippingOption: isServerSideShippingCallbacksEnabled
                     ? null
-                    : consignment.selectedShippingOption,
+                    : consignment?.selectedShippingOption,
                 ...(methodId ? { methodId } : {}),
                 ...(orderId ? { orderId } : {}),
             });

--- a/packages/paypal-utils/src/paypal-integration-service.ts
+++ b/packages/paypal-utils/src/paypal-integration-service.ts
@@ -130,16 +130,27 @@ export default class PayPalIntegrationService {
         return { orderId, ...(setupToken ? { setupToken } : {}) };
     }
 
-    async updateOrder(providerId: string, methodId?: string, orderId?: number): Promise<void> {
+    async updateOrder(
+        providerId: string,
+        methodId?: string,
+        orderId?: number,
+        isServerSideShippingCallbacksEnabled?: boolean,
+    ): Promise<void> {
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
         const consignment = state.getConsignmentsOrThrow()[0];
 
         try {
             await this.paypalRequestSender.updateOrder(providerId, {
-                availableShippingOptions: consignment.availableShippingOptions,
+                availableShippingOptions:
+                    isServerSideShippingCallbacksEnabled
+                    ? []
+                    : consignment.availableShippingOptions,
                 cartId: cart.id,
-                selectedShippingOption: consignment.selectedShippingOption,
+                selectedShippingOption:
+                    isServerSideShippingCallbacksEnabled
+                        ? null
+                        : consignment.selectedShippingOption,
                 ...(methodId ? { methodId } : {}),
                 ...(orderId ? { orderId } : {}),
             });

--- a/packages/paypal-utils/src/paypal-types.ts
+++ b/packages/paypal-utils/src/paypal-types.ts
@@ -67,7 +67,7 @@ export interface PayPalInitializationData {
     paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>;
     paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[];
     threeDSVerificationMethod?: string;
-    isAppSwitchEnabled?: boolean;
+    isServerSideShippingCallbacksEnabled?: boolean;
 }
 
 /**
@@ -542,7 +542,7 @@ export interface PayPalButtonStyleOptions {
 export interface PayPalButtonOptions {
     fundingSource: string;
     style?: PayPalButtonStyleOptions;
-    isAppSwitchEnabled?: boolean;
+    isServerSideShippingCallbacksEnabled?: boolean;
     isHostedCheckoutEnabled?: boolean;
     onClick?: () => void;
     onCancel?: () => void;
@@ -981,7 +981,7 @@ export interface PayPalOrderData {
 export interface PayPalUpdateOrderRequestBody {
     availableShippingOptions?: ShippingOption[];
     cartId: string;
-    selectedShippingOption?: ShippingOption;
+    selectedShippingOption?: ShippingOption | null;
     methodId?: string;
     orderId?: number;
 }


### PR DESCRIPTION
## What/Why?
Implemented server side shipping callbacks logic

## Rollout/Rollback
Revert PR

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PayPal hosted-checkout approval and `updateOrder` behavior around shipping data, which can affect address/shipping selection and order submission for physical carts. Also removes AppSwitch resume/appSwitchWhenAvailable handling, so regressions could impact mobile/app-return flows.
> 
> **Overview**
> Implements a new `isServerSideShippingCallbacksEnabled` initialization flag across PayPal Commerce (PayPal + Credit/PayLater) strategies and shared utils to **toggle client vs server handling of shipping callbacks**.
> 
> When enabled, PayPal button configs omit `onShippingAddressChange`/`onShippingOptionsChange`, approval flows avoid pulling `actions.order.get()` for addresses, `updateOrder` sends no shipping options (`[]`) and `selectedShippingOption: null`, and checkout is reloaded before order submission for physical-item carts.
> 
> Separately, AppSwitch support is removed from these PayPal strategies/utilities (no `appSwitchWhenAvailable`, `hasReturned()`/`resume()` paths), with unit tests updated to reflect the new flag-driven behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 036498d49e7a934504b311077f4d651f132943bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->