### PR TITLE
feat(payment): PAYPAL-6352 implemented server side shipping callbacks logic

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-integration-service.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-integration-service.spec.ts
@@ -232,6 +232,20 @@ describe('BigCommercePaymentsIntegrationService', () => {
             });
         });
 
+        it('successfully updates order when server side shipping callbacks is on', async () => {
+            jest.spyOn(bigCommercePaymentsRequestSender, 'updateOrder').mockResolvedValue({
+                statusCode: 200,
+            });
+
+            await subject.updateOrder(true);
+
+            expect(bigCommercePaymentsRequestSender.updateOrder).toHaveBeenCalledWith({
+                availableShippingOptions: [],
+                cartId: cart.id,
+                selectedShippingOption: null,
+            });
+        });
+
         it('throws an error if something went wrong during order update process', async () => {
             jest.spyOn(bigCommercePaymentsRequestSender, 'updateOrder').mockImplementation(() =>
                 Promise.reject(new Error()),

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-integration-service.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-integration-service.ts
@@ -135,17 +135,21 @@ export default class BigCommercePaymentsIntegrationService {
     async updateOrder(isServerSideShippingCallbacksEnabled?: boolean): Promise<void> {
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
-        const consignment = state.getConsignmentsOrThrow()[0];
+        let consignment;
+
+        if (!isServerSideShippingCallbacksEnabled) {
+            consignment = state.getConsignmentsOrThrow()[0];
+        }
 
         try {
             await this.bigCommercePaymentsRequestSender.updateOrder({
                 availableShippingOptions: isServerSideShippingCallbacksEnabled
                     ? []
-                    : consignment.availableShippingOptions,
+                    : consignment?.availableShippingOptions,
                 cartId: cart.id,
                 selectedShippingOption: isServerSideShippingCallbacksEnabled
                     ? null
-                    : consignment.selectedShippingOption,
+                    : consignment?.selectedShippingOption,
             });
         } catch (_error) {
             throw new RequestError();

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-integration-service.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-integration-service.ts
@@ -132,16 +132,20 @@ export default class BigCommercePaymentsIntegrationService {
         return { orderId, ...(setupToken ? { setupToken } : {}) };
     }
 
-    async updateOrder(): Promise<void> {
+    async updateOrder(isServerSideShippingCallbacksEnabled?: boolean): Promise<void> {
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
         const consignment = state.getConsignmentsOrThrow()[0];
 
         try {
             await this.bigCommercePaymentsRequestSender.updateOrder({
-                availableShippingOptions: consignment.availableShippingOptions,
+                availableShippingOptions: isServerSideShippingCallbacksEnabled
+                    ? []
+                    : consignment.availableShippingOptions,
                 cartId: cart.id,
-                selectedShippingOption: consignment.selectedShippingOption,
+                selectedShippingOption: isServerSideShippingCallbacksEnabled
+                    ? null
+                    : consignment.selectedShippingOption,
             });
         } catch (_error) {
             throw new RequestError();

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-types.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-types.ts
@@ -265,7 +265,7 @@ export interface BigCommercePaymentsInitializationData {
     shouldRenderFields?: boolean;
     shouldRunAcceleratedCheckout?: boolean;
     paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>;
-    isAppSwitchEnabled?: boolean;
+    isServerSideShippingCallbacksEnabled?: boolean;
     paypalBNPLConfiguration?: PayPalBNPLConfigurationItem[];
 }
 
@@ -597,7 +597,7 @@ export interface PayPalOrderData {
 export interface PayPalUpdateOrderRequestBody {
     availableShippingOptions?: ShippingOption[];
     cartId: string;
-    selectedShippingOption?: ShippingOption;
+    selectedShippingOption?: ShippingOption | null;
 }
 
 export interface PayPalUpdateOrderResponse {

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-button-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-button-strategy.spec.ts
@@ -441,57 +441,6 @@ describe('BigCommercePaymentsButtonStrategy', () => {
             expect(bigCommercePaymentsSdkRenderMock).toHaveBeenCalled();
         });
 
-        it('render button with appSwitch flag', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            });
-
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                appSwitchWhenAvailable: true,
-                fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: bigCommercePaymentsOptions.style,
-                createOrder: expect.any(Function),
-                onApprove: expect.any(Function),
-            });
-        });
-
-        it('calls resume when appSwitch enabled and returned from app', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            });
-
-            const resumeMock = jest.fn();
-            const bigCommercePaymentsSdkRenderMock = jest.fn();
-
-            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
-                close: jest.fn(),
-                isEligible: jest.fn(() => true),
-                render: bigCommercePaymentsSdkRenderMock,
-                hasReturned: jest.fn(() => true),
-                resume: resumeMock,
-            }));
-
-            await strategy.initialize(initializationOptions);
-
-            expect(resumeMock).toHaveBeenCalled();
-        });
-
         it('does not render PayPal button if it is not eligible', async () => {
             const bigCommercePaymentsSdkRenderMock = jest.fn();
 

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-button-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-button-strategy.ts
@@ -88,7 +88,7 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
             false,
         );
 
-        this.renderButton(containerId, methodId, bigcommerce_payments, isBuyNowFlow);
+        this.renderButton(containerId, methodId, bigcommerce_payments);
     }
 
     deinitialize(): Promise<void> {
@@ -99,7 +99,6 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
         containerId: string,
         methodId: string,
         bigcommerce_payments: BigCommercePaymentsButtonInitializeOptions,
-        isBuyNowFlow?: boolean,
     ): void {
         const { buyNowInitializeOptions, style, onComplete, onEligibilityFailure } =
             bigcommerce_payments;
@@ -108,14 +107,10 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<BigCommercePaymentsInitializationData>(methodId);
-        const { isHostedCheckoutEnabled, isAppSwitchEnabled } =
+        const { isHostedCheckoutEnabled, isServerSideShippingCallbacksEnabled } =
             paymentMethod.initializationData || {};
 
         const defaultCallbacks = {
-            ...(!isBuyNowFlow &&
-                this.isPaypalCommerceAppSwitchEnabled(methodId) && {
-                    appSwitchWhenAvailable: true,
-                }),
             createOrder: () =>
                 this.bigCommercePaymentsIntegrationService.createOrder('bigcommerce_payments'),
             onApprove: ({ orderID }: ApproveCallbackPayload) =>
@@ -128,7 +123,7 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
         };
 
         const hostedCheckoutCallbacks = {
-            ...(!isAppSwitchEnabled && {
+            ...(!isServerSideShippingCallbacksEnabled && {
                 onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
                     this.onShippingAddressChange(data),
                 onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
@@ -149,11 +144,7 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
         const paypalButton = paypalSdk.Buttons(buttonRenderOptions);
 
         if (paypalButton.isEligible()) {
-            if (paypalButton.hasReturned?.() && this.isPaypalCommerceAppSwitchEnabled(methodId)) {
-                paypalButton.resume?.();
-            } else {
-                paypalButton.render(`#${containerId}`);
-            }
+            paypalButton.render(`#${containerId}`);
         } else if (onEligibilityFailure && typeof onEligibilityFailure === 'function') {
             onEligibilityFailure();
         } else {
@@ -179,6 +170,7 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
         actions: ApproveCallbackActions,
         methodId: string,
         onComplete?: () => void,
+        isServerSideShippingCallbacksEnabled?: boolean,
     ): Promise<boolean> {
         if (!data.orderID) {
             throw new MissingDataError(MissingDataErrorType.MissingOrderId);
@@ -186,32 +178,39 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
 
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
-        const orderDetails = await actions.order.get();
 
         try {
-            const billingAddress =
-                this.bigCommercePaymentsIntegrationService.getBillingAddressFromOrderDetails(
-                    orderDetails,
+            const hasPhysicalItems = cart.lineItems.physicalItems.length > 0;
+
+            if (!isServerSideShippingCallbacksEnabled) {
+                const orderDetails = await actions.order.get();
+
+                const billingAddress =
+                    this.bigCommercePaymentsIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
+
+                await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+
+                if (hasPhysicalItems) {
+                    const shippingAddress =
+                        this.bigCommercePaymentsIntegrationService.getShippingAddressFromOrderDetails(
+                            orderDetails,
+                        );
+
+                    await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
+                }
+            }
+
+            if (hasPhysicalItems) {
+                await this.bigCommercePaymentsIntegrationService.updateOrder(
+                    isServerSideShippingCallbacksEnabled,
                 );
-
-            await this.paymentIntegrationService.updateBillingAddress(billingAddress);
-
-            if (cart.lineItems.physicalItems.length > 0) {
-                const shippingAddress =
-                    this.bigCommercePaymentsIntegrationService.getShippingAddressFromOrderDetails(
-                        orderDetails,
-                    );
-
-                await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
-                await this.bigCommercePaymentsIntegrationService.updateOrder();
             }
 
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
+
             await this.bigCommercePaymentsIntegrationService.submitPayment(methodId, data.orderID);
 
-            if (onComplete && typeof onComplete === 'function') {
-                onComplete();
-            }
+            onComplete?.();
 
             return true; // FIXME: Do we really need to return true here?
         } catch (error) {
@@ -270,18 +269,5 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
 
             throw error;
         }
-    }
-
-    /**
-     *
-     * PayPal AppSwitch enabling handling
-     *
-     */
-    private isPaypalCommerceAppSwitchEnabled(methodId: string): boolean {
-        const state = this.paymentIntegrationService.getState();
-        const paymentMethod =
-            state.getPaymentMethodOrThrow<BigCommercePaymentsInitializationData>(methodId);
-
-        return paymentMethod.initializationData?.isAppSwitchEnabled ?? false;
     }
 }

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-button-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-button-strategy.ts
@@ -130,7 +130,13 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
                     this.onShippingOptionsChange(data),
             }),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
-                this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
+                this.onHostedCheckoutApprove(
+                    data,
+                    actions,
+                    methodId,
+                    onComplete,
+                    isServerSideShippingCallbacksEnabled,
+                ),
         };
 
         const buttonRenderOptions: BigCommercePaymentsButtonsOptions = {
@@ -186,7 +192,9 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
                 const orderDetails = await actions.order.get();
 
                 const billingAddress =
-                    this.bigCommercePaymentsIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
+                    this.bigCommercePaymentsIntegrationService.getBillingAddressFromOrderDetails(
+                        orderDetails,
+                    );
 
                 await this.paymentIntegrationService.updateBillingAddress(billingAddress);
 
@@ -206,11 +214,17 @@ export default class BigCommercePaymentsButtonStrategy implements CheckoutButton
                 );
             }
 
+            if (isServerSideShippingCallbacksEnabled) {
+                await this.paymentIntegrationService.loadCheckout();
+            }
+
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
 
             await this.bigCommercePaymentsIntegrationService.submitPayment(methodId, data.orderID);
 
-            onComplete?.();
+            if (onComplete && typeof onComplete === 'function') {
+                onComplete();
+            }
 
             return true; // FIXME: Do we really need to return true here?
         } catch (error) {

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-customer-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-customer-strategy.spec.ts
@@ -333,62 +333,6 @@ describe('BigCommercePaymentsCustomerStrategy', () => {
             expect(bigCommercePaymentsSdkRenderMock).toHaveBeenCalled();
         });
 
-        it('render button with appSwitch flag', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            });
-
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                appSwitchWhenAvailable: true,
-                fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: {
-                    height: DefaultCheckoutButtonHeight,
-                    color: StyleButtonColor.silver,
-                    label: 'checkout',
-                },
-                createOrder: expect.any(Function),
-                onApprove: expect.any(Function),
-                onClick: expect.any(Function),
-            });
-        });
-
-        it('calls resume when appSwitch enabled and returned from app', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            });
-
-            const resumeMock = jest.fn();
-            const bigCommercePaymentsSdkRenderMock = jest.fn();
-
-            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
-                close: jest.fn(),
-                isEligible: jest.fn(() => true),
-                render: bigCommercePaymentsSdkRenderMock,
-                hasReturned: jest.fn(() => true),
-                resume: resumeMock,
-            }));
-
-            await strategy.initialize(initializationOptions);
-
-            expect(resumeMock).toHaveBeenCalled();
-        });
-
         it('does not render PayPal button if it is not eligible', async () => {
             const bigCommercePaymentsSdkRenderMock = jest.fn();
 

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-customer-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-customer-strategy.ts
@@ -142,7 +142,13 @@ export default class BigCommercePaymentsCustomerStrategy implements CustomerStra
                     this.onShippingOptionsChange(data),
             }),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
-                this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
+                this.onHostedCheckoutApprove(
+                    data,
+                    actions,
+                    methodId,
+                    onComplete,
+                    isServerSideShippingCallbacksEnabled,
+                ),
         };
 
         const buttonRenderOptions: BigCommercePaymentsButtonsOptions = {
@@ -184,7 +190,9 @@ export default class BigCommercePaymentsCustomerStrategy implements CustomerStra
                 const orderDetails = await actions.order.get();
 
                 const billingAddress =
-                    this.bigCommercePaymentsIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
+                    this.bigCommercePaymentsIntegrationService.getBillingAddressFromOrderDetails(
+                        orderDetails,
+                    );
 
                 await this.paymentIntegrationService.updateBillingAddress(billingAddress);
 
@@ -204,11 +212,17 @@ export default class BigCommercePaymentsCustomerStrategy implements CustomerStra
                 );
             }
 
+            if (isServerSideShippingCallbacksEnabled) {
+                await this.paymentIntegrationService.loadCheckout();
+            }
+
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
 
             await this.bigCommercePaymentsIntegrationService.submitPayment(methodId, data.orderID);
 
-            onComplete?.();
+            if (onComplete && typeof onComplete === 'function') {
+                onComplete();
+            }
         } catch (error) {
             this.handleError(error);
         }

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-customer-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-customer-strategy.ts
@@ -122,14 +122,11 @@ export default class BigCommercePaymentsCustomerStrategy implements CustomerStra
         const {
             isHostedCheckoutEnabled,
             paymentButtonStyles,
-            isAppSwitchEnabled = false,
+            isServerSideShippingCallbacksEnabled,
         } = paymentMethod.initializationData || {};
         const { checkoutTopButtonStyles } = paymentButtonStyles || {};
 
         const defaultCallbacks = {
-            ...(isAppSwitchEnabled && {
-                appSwitchWhenAvailable: true,
-            }),
             createOrder: () =>
                 this.bigCommercePaymentsIntegrationService.createOrder('bigcommerce_payments'),
             onApprove: ({ orderID }: ApproveCallbackPayload) =>
@@ -138,7 +135,7 @@ export default class BigCommercePaymentsCustomerStrategy implements CustomerStra
         };
 
         const hostedCheckoutCallbacks = {
-            ...(!isAppSwitchEnabled && {
+            ...(!isServerSideShippingCallbacksEnabled && {
                 onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
                     this.onShippingAddressChange(data),
                 onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
@@ -161,11 +158,7 @@ export default class BigCommercePaymentsCustomerStrategy implements CustomerStra
         const paypalButton = paypalSdk.Buttons(buttonRenderOptions);
 
         if (paypalButton.isEligible()) {
-            if (paypalButton.hasReturned?.() && isAppSwitchEnabled) {
-                paypalButton.resume?.();
-            } else {
-                paypalButton.render(`#${container}`);
-            }
+            paypalButton.render(`#${container}`);
         } else {
             this.bigCommercePaymentsIntegrationService.removeElement(container);
         }
@@ -176,38 +169,46 @@ export default class BigCommercePaymentsCustomerStrategy implements CustomerStra
         actions: ApproveCallbackActions,
         methodId: string,
         onComplete?: () => void,
+        isServerSideShippingCallbacksEnabled?: boolean,
     ): Promise<void> {
         if (!data.orderID) {
             throw new MissingDataError(MissingDataErrorType.MissingOrderId);
         }
 
         const cart = this.paymentIntegrationService.getState().getCartOrThrow();
-        const orderDetails = await actions.order.get();
 
         try {
-            const billingAddress =
-                this.bigCommercePaymentsIntegrationService.getBillingAddressFromOrderDetails(
-                    orderDetails,
+            const hasPhysicalItems = cart.lineItems.physicalItems.length > 0;
+
+            if (!isServerSideShippingCallbacksEnabled) {
+                const orderDetails = await actions.order.get();
+
+                const billingAddress =
+                    this.bigCommercePaymentsIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
+
+                await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+
+                if (hasPhysicalItems) {
+                    const shippingAddress =
+                        this.bigCommercePaymentsIntegrationService.getShippingAddressFromOrderDetails(
+                            orderDetails,
+                        );
+
+                    await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
+                }
+            }
+
+            if (hasPhysicalItems) {
+                await this.bigCommercePaymentsIntegrationService.updateOrder(
+                    isServerSideShippingCallbacksEnabled,
                 );
-
-            await this.paymentIntegrationService.updateBillingAddress(billingAddress);
-
-            if (cart.lineItems.physicalItems.length > 0) {
-                const shippingAddress =
-                    this.bigCommercePaymentsIntegrationService.getShippingAddressFromOrderDetails(
-                        orderDetails,
-                    );
-
-                await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
-                await this.bigCommercePaymentsIntegrationService.updateOrder();
             }
 
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
+
             await this.bigCommercePaymentsIntegrationService.submitPayment(methodId, data.orderID);
 
-            if (onComplete && typeof onComplete === 'function') {
-                onComplete();
-            }
+            onComplete?.();
         } catch (error) {
             this.handleError(error);
         }

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-payment-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-payment-strategy.spec.ts
@@ -239,64 +239,6 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
             });
         });
 
-        it('render button with appSwitch flag', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            });
-
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                appSwitchWhenAvailable: true,
-                fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: {
-                    color: 'black',
-                    height: 55,
-                    label: 'pay',
-                },
-                createOrder: expect.any(Function),
-                onClick: expect.any(Function),
-                onApprove: expect.any(Function),
-                onCancel: expect.any(Function),
-                onError: expect.any(Function),
-            });
-        });
-
-        it('calls resume when appSwitch enabled and returned from app', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isAppSwitchEnabled: true,
-                },
-            });
-
-            const resumeMock = jest.fn();
-            const bigCommercePaymentsSdkRenderMock = jest.fn();
-
-            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
-                close: jest.fn(),
-                isEligible: jest.fn(() => true),
-                render: bigCommercePaymentsSdkRenderMock,
-                hasReturned: jest.fn(() => true),
-                resume: resumeMock,
-            }));
-
-            await strategy.initialize(initializationOptions);
-
-            expect(resumeMock).toHaveBeenCalled();
-        });
-
         it('does not render paypal button if it is not eligible', async () => {
             const bigCommercePaymentsSdkRenderMock = jest.fn();
 

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-payment-strategy.ts
@@ -290,9 +290,6 @@ export default class BigCommercePaymentsPaymentStrategy implements PaymentStrate
         }
 
         const buttonOptions: BigCommercePaymentsButtonsOptions = {
-            ...(this.isAppSwitchEnabled(methodId) && {
-                appSwitchWhenAvailable: true,
-            }),
             fundingSource: paypalSdk.FUNDING.PAYPAL,
             style: this.bigCommercePaymentsIntegrationService.getValidButtonStyle(
                 checkoutPaymentButtonStyles,
@@ -314,11 +311,7 @@ export default class BigCommercePaymentsPaymentStrategy implements PaymentStrate
             onRenderButton();
         }
 
-        if (this.paypalButton.hasReturned?.() && this.isAppSwitchEnabled(methodId)) {
-            this.paypalButton.resume?.();
-        } else {
-            this.paypalButton.render(container);
-        }
+        this.paypalButton.render(container);
     }
 
     private async handleClick(
@@ -454,18 +447,5 @@ export default class BigCommercePaymentsPaymentStrategy implements PaymentStrate
         }
 
         return false;
-    }
-
-    /**
-     *
-     * AppSwitch enabling handling
-     *
-     */
-    private isAppSwitchEnabled(methodId: string): boolean {
-        const state = this.paymentIntegrationService.getState();
-        const paymentMethod =
-            state.getPaymentMethodOrThrow<BigCommercePaymentsInitializationData>(methodId);
-
-        return paymentMethod.initializationData?.isAppSwitchEnabled ?? false;
     }
 }

--- a/packages/bigcommerce-payments-integration/src/mocks/get-bigcommerce-payments-payment-method.mock.ts
+++ b/packages/bigcommerce-payments-integration/src/mocks/get-bigcommerce-payments-payment-method.mock.ts
@@ -72,7 +72,6 @@ export default function getBigCommercePaymentsPaymentMethod(): PaymentMethod {
                     },
                 },
             ],
-            isAppSwitchEnabled: false,
         },
         skipRedirectConfirmationAlert: false,
         type: 'PAYMENT_TYPE_API',


### PR DESCRIPTION
## What/Why?
Implemented server side shipping callbacks logic for BCP

## Rollout/Rollback
Revert PR

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the PayPal hosted-checkout approval and order-update flow, conditionally skipping client-side shipping callbacks and altering the `updateOrder` payload; mistakes could impact shipping selection/address syncing and order submission timing.
> 
> **Overview**
> Adds a new `isServerSideShippingCallbacksEnabled` flag to BigCommerce Payments initialization data and wires it through PayPal button/customer hosted-checkout flows.
> 
> When enabled, the strategies stop registering PayPal `onShippingAddressChange`/`onShippingOptionsChange` callbacks, adjust the approve path to avoid `actions.order.get()`/address updates, force an `updateOrder` call with empty shipping options + `selectedShippingOption: null`, and reload checkout before submitting order/payment. App-switch rendering/resume logic (and related tests/mocks) is removed, and `PayPalUpdateOrderRequestBody.selectedShippingOption` now allows `null`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7040053005067d649f98bbf08f5602852f3595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->