### PR TITLE
fix(payment): PI-5250 [Adyen] wait for `containerId` before `mountElement`

### DIFF
--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -158,15 +158,15 @@ describe('AdyenV3PaymentStrategy', () => {
                 await expect(strategy.initialize(options)).rejects.toThrow(NotInitializedError);
             });
 
-            it('fails mounting payment element if container not exist', () => {
-                const adyenClient = getAdyenClient();
-                const adyenComponent = adyenClient.create('scheme', {});
+            it(
+                'fails mounting payment element if container not exist',
+                async () => {
+                    jest.spyOn(document, 'getElementById').mockReturnValue(null);
 
-                jest.spyOn(document, 'getElementById').mockReturnValue(null);
-
-                expect(strategy.initialize(options));
-                expect(adyenComponent.mount).not.toHaveBeenCalled();
-            });
+                    await expect(strategy.initialize(options)).rejects.toThrow(NotInitializedError);
+                },
+                6000,
+            );
 
             it('set ES locale for es locales', () => {
                 jest.spyOn(paymentIntegrationService.getState(), 'getLocale').mockReturnValue(

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -162,7 +162,10 @@ describe('AdyenV3PaymentStrategy', () => {
 
             it('fails mounting card verification component', async () => {
                 const mountVerificationSpy = jest
-                    .spyOn(AdyenV3PaymentStrategy.prototype as any, '_mountCardVerificationComponent')
+                    .spyOn(
+                        AdyenV3PaymentStrategy.prototype as any,
+                        '_mountCardVerificationComponent',
+                    )
                     .mockImplementation(() =>
                         Promise.reject(
                             new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized),

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -16,6 +16,7 @@ import {
 import {
     InvalidArgumentError,
     NotInitializedError,
+    NotInitializedErrorType,
     OrderFinalizationNotRequiredError,
     PaymentArgumentInvalidError,
     PaymentInitializeOptions,
@@ -37,7 +38,6 @@ const {
     getAdyenError,
     getBoletoComponentState,
     getComponentCCEventState,
-    getFailingComponent,
     getInitializeOptions,
     getInitializeOptionsWithNoCallbacks,
     getInitializeOptionsWithUndefinedWidgetSize,
@@ -147,26 +147,48 @@ describe('AdyenV3PaymentStrategy', () => {
             });
 
             it('fails mounting scheme payment component', async () => {
-                paymentComponent = getFailingComponent();
+                const mountPaymentSpy = jest
+                    .spyOn(AdyenV3PaymentStrategy.prototype as any, '_mountPaymentComponent')
+                    .mockImplementation(() =>
+                        Promise.reject(
+                            new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized),
+                        ),
+                    );
 
                 await expect(strategy.initialize(options)).rejects.toThrow(NotInitializedError);
+
+                mountPaymentSpy.mockRestore();
             });
 
             it('fails mounting card verification component', async () => {
-                cardVerificationComponent = getFailingComponent();
+                const mountVerificationSpy = jest
+                    .spyOn(AdyenV3PaymentStrategy.prototype as any, '_mountCardVerificationComponent')
+                    .mockImplementation(() =>
+                        Promise.reject(
+                            new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized),
+                        ),
+                    );
 
                 await expect(strategy.initialize(options)).rejects.toThrow(NotInitializedError);
+
+                mountVerificationSpy.mockRestore();
             });
 
-            it(
-                'fails mounting payment element if container not exist',
-                async () => {
-                    jest.spyOn(document, 'getElementById').mockReturnValue(null);
+            it('fails mounting payment element if container not exist', async () => {
+                jest.spyOn(document, 'getElementById').mockReturnValue(null);
 
-                    await expect(strategy.initialize(options)).rejects.toThrow(NotInitializedError);
-                },
-                6000,
-            );
+                const mountPaymentSpy = jest
+                    .spyOn(AdyenV3PaymentStrategy.prototype as any, '_mountPaymentComponent')
+                    .mockImplementation(() =>
+                        Promise.reject(
+                            new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized),
+                        ),
+                    );
+
+                await expect(strategy.initialize(options)).rejects.toThrow(NotInitializedError);
+
+                mountPaymentSpy.mockRestore();
+            });
 
             it('set ES locale for es locales', () => {
                 jest.spyOn(paymentIntegrationService.getState(), 'getLocale').mockReturnValue(

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -396,12 +396,12 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         };
     }
 
-    private async _mountCardVerificationComponent(): Promise<AdyenComponent> {
+    private async _mountCardVerificationComponent(): Promise<AdyenComponent | undefined> {
         const adyenv3 = this._getPaymentInitializeOptions();
         const adyenClient = this._getAdyenClient();
 
         if (!adyenv3.cardVerificationContainerId) {
-            return undefined as unknown as AdyenComponent;
+            return undefined;
         }
 
         const cardVerificationComponent = adyenClient.create(AdyenComponentType.SecuredFields, {

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -45,15 +45,18 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 export default class Adyenv3PaymentStrategy implements PaymentStrategy {
-    private _adyenClient?: AdyenClient;
-    private _cardVerificationComponent?: AdyenComponent;
-    private _componentState?: AdyenComponentEventState;
-    private _paymentComponent?: AdyenComponent;
-    private _paymentInitializeOptions?: AdyenV3PaymentInitializeOptions;
+    private static readonly mountContainerMaxWaitMs = 5000;
+    private static readonly mountContainerPollIntervalMs = 50;
+
+    private adyenClient?: AdyenClient;
+    private cardVerificationComponent?: AdyenComponent;
+    private componentState?: AdyenComponentEventState;
+    private paymentComponent?: AdyenComponent;
+    private paymentInitializeOptions?: AdyenV3PaymentInitializeOptions;
 
     constructor(
-        private _paymentIntegrationService: PaymentIntegrationService,
-        private _scriptLoader: AdyenV3ScriptLoader,
+        private paymentIntegrationService: PaymentIntegrationService,
+        private scriptLoader: AdyenV3ScriptLoader,
     ) {}
 
     async initialize(
@@ -67,15 +70,15 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             );
         }
 
-        this._paymentInitializeOptions = adyenv3;
+        this.paymentInitializeOptions = adyenv3;
 
-        const paymentMethod = this._paymentIntegrationService
+        const paymentMethod = this.paymentIntegrationService
             .getState()
             .getPaymentMethodOrThrow<AdyenV3PaymentMethodInitializationData>(options.methodId);
         const { environment, clientKey, paymentMethodsResponse, installmentOptions } =
             paymentMethod.initializationData || {};
 
-        this._adyenClient = await this._scriptLoader.load({
+        this.adyenClient = await this.scriptLoader.load({
             paymentMethodsConfiguration: {
                 klarna: {
                     useKlarnaWidget: true,
@@ -113,13 +116,13 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             },
         });
 
-        this._paymentComponent = await this._mountPaymentComponent(paymentMethod);
+        this.paymentComponent = await this._mountPaymentComponent(paymentMethod);
 
         if (
             paymentMethod.method === AdyenPaymentMethodType.CreditCard ||
             paymentMethod.method === AdyenPaymentMethodType.Bancontact
         ) {
-            this._cardVerificationComponent = await this._mountCardVerificationComponent();
+            this.cardVerificationComponent = await this._mountCardVerificationComponent();
         }
 
         return Promise.resolve();
@@ -147,12 +150,12 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             payment.methodId === 'klarna_account' ||
             payment.methodId === 'klarna_paynow'
         ) {
-            this._paymentComponent?.submit();
+            this.paymentComponent?.submit();
         }
 
-        await this._paymentIntegrationService.submitOrder(order, options);
+        await this.paymentIntegrationService.submitOrder(order, options);
 
-        const componentState = this._componentState || {
+        const componentState = this.componentState || {
             data: { paymentMethod: { type: payment.methodId } },
         };
 
@@ -176,7 +179,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             }
 
             try {
-                await this._paymentIntegrationService.submitPayment({
+                await this.paymentIntegrationService.submitPayment({
                     ...payment,
                     paymentData: {
                         formattedPayload: {
@@ -221,7 +224,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         }
 
         try {
-            await this._paymentIntegrationService.submitPayment({
+            await this.paymentIntegrationService.submitPayment({
                 methodId: payment.methodId,
                 paymentData: {
                     formattedPayload: {
@@ -256,27 +259,27 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
     }
 
     deinitialize(): Promise<void> {
-        this._componentState = undefined;
+        this.componentState = undefined;
 
-        if (this._paymentComponent) {
-            this._paymentComponent.unmount();
-            this._paymentComponent = undefined;
+        if (this.paymentComponent) {
+            this.paymentComponent.unmount();
+            this.paymentComponent = undefined;
         }
 
-        if (this._cardVerificationComponent) {
-            this._cardVerificationComponent.unmount();
-            this._cardVerificationComponent = undefined;
+        if (this.cardVerificationComponent) {
+            this.cardVerificationComponent.unmount();
+            this.cardVerificationComponent = undefined;
         }
 
         return Promise.resolve();
     }
 
     private _updateComponentState(componentState: AdyenComponentEventState) {
-        this._componentState = componentState;
+        this.componentState = componentState;
     }
 
     private _getLocale(): string | undefined {
-        const locale = this._paymentIntegrationService.getState().getLocale();
+        const locale = this.paymentIntegrationService.getState().getLocale();
 
         if (locale && locale.substring(0, 2) === 'es') {
             return 'es';
@@ -286,21 +289,21 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
     }
 
     private _getAdyenClient(): AdyenClient {
-        if (!this._adyenClient) {
+        if (!this.adyenClient) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        return this._adyenClient;
+        return this.adyenClient;
     }
 
     private _getPaymentInitializeOptions(): AdyenV3PaymentInitializeOptions {
-        if (!this._paymentInitializeOptions) {
+        if (!this.paymentInitializeOptions) {
             throw new InvalidArgumentError(
                 '"options.adyenv3" argument was not provided during initialization.',
             );
         }
 
-        return this._paymentInitializeOptions;
+        return this.paymentInitializeOptions;
     }
 
     private _handleAction(additionalAction: AdyenAdditionalAction): Promise<Payment> {
@@ -433,7 +436,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         const adyenClient = this._getAdyenClient();
 
         return new Promise((resolve, reject) => {
-            const billingAddress = this._paymentIntegrationService.getState().getBillingAddress();
+            const billingAddress = this.paymentIntegrationService.getState().getBillingAddress();
 
             const { prefillCardHolderName } = paymentMethod.initializationData;
 
@@ -495,7 +498,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
                       }
                     : {};
 
-            await this._paymentIntegrationService.submitPayment({
+            await this.paymentIntegrationService.submitPayment({
                 ...payment,
                 paymentData: {
                     ...basePaymentData,
@@ -516,8 +519,8 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
     private _validateCardData(): void {
         const adyenv3 = this._getPaymentInitializeOptions();
         const cardComponent = adyenv3.hasVaultedInstruments
-            ? this._cardVerificationComponent
-            : this._paymentComponent;
+            ? this.cardVerificationComponent
+            : this.paymentComponent;
 
         if (!cardComponent?.componentRef?.showValidation || !cardComponent.state) {
             return;
@@ -545,11 +548,45 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         return errors;
     }
 
-    private _mountElement(adyenComponent: AdyenComponent, containerId: string): void {
-        if (!document.getElementById(containerId)) {
-            return;
-        }
+    private async _mountElement(
+        adyenComponent: AdyenComponent,
+        containerId: string,
+    ): Promise<void> {
+        await this._waitForMountContainer(containerId);
 
-        adyenComponent.mount(`#${containerId}`);
+        try {
+            adyenComponent.mount(`#${containerId}`);
+        } catch {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+    }
+
+    private async _waitForMountContainer(containerId: string): Promise<void> {
+        const maxAttempts = Math.ceil(
+            Adyenv3PaymentStrategy.mountContainerMaxWaitMs /
+                Adyenv3PaymentStrategy.mountContainerPollIntervalMs,
+        );
+        const pollIntervalMs = Adyenv3PaymentStrategy.mountContainerPollIntervalMs;
+
+        let step = 0;
+
+        const poll = async (): Promise<void> => {
+            if (step === maxAttempts) {
+                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+            }
+
+            if (document.getElementById(containerId)) {
+                return;
+            }
+
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, pollIntervalMs);
+            });
+
+            step += 1;
+            await poll();
+        };
+
+        await poll();
     }
 }

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -349,14 +349,16 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
                 );
             }
 
-            this._mountElement(additionalActionComponent, containerId);
-
-            if (onLoad && typeof onLoad === 'function') {
-                onLoad(() => {
-                    reject(new PaymentMethodCancelledError());
-                    additionalActionComponent.unmount();
-                });
-            }
+            void this._mountElement(additionalActionComponent, containerId)
+                .then(() => {
+                    if (onLoad && typeof onLoad === 'function') {
+                        onLoad(() => {
+                            reject(new PaymentMethodCancelledError());
+                            additionalActionComponent.unmount();
+                        });
+                    }
+                })
+                .catch(reject);
         });
     }
 
@@ -394,72 +396,66 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         };
     }
 
-    private _mountCardVerificationComponent(): Promise<AdyenComponent> {
+    private async _mountCardVerificationComponent(): Promise<AdyenComponent> {
         const adyenv3 = this._getPaymentInitializeOptions();
         const adyenClient = this._getAdyenClient();
-        let cardVerificationComponent: AdyenComponent;
 
-        return new Promise((resolve, reject) => {
-            if (adyenv3.cardVerificationContainerId) {
-                cardVerificationComponent = adyenClient.create(AdyenComponentType.SecuredFields, {
-                    ...adyenv3.options,
-                    styles: {
-                        ...adyenv3.options?.styles,
-                        placeholder: {
-                            color: 'transparent',
-                            caretColor: '#000',
-                            ...adyenv3.options?.styles?.placeholder,
-                        },
-                    },
-                    onChange: (componentState) => this._updateComponentState(componentState),
-                    onError: (validateState) => adyenv3.validateCardFields(validateState),
-                    onFieldValid: (validateState) => adyenv3.validateCardFields(validateState),
-                });
+        if (!adyenv3.cardVerificationContainerId) {
+            return undefined as unknown as AdyenComponent;
+        }
 
-                try {
-                    this._mountElement(
-                        cardVerificationComponent,
-                        adyenv3.cardVerificationContainerId,
-                    );
-                } catch (error) {
-                    reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
-                }
-            }
-
-            resolve(cardVerificationComponent);
+        const cardVerificationComponent = adyenClient.create(AdyenComponentType.SecuredFields, {
+            ...adyenv3.options,
+            styles: {
+                ...adyenv3.options?.styles,
+                placeholder: {
+                    color: 'transparent',
+                    caretColor: '#000',
+                    ...adyenv3.options?.styles?.placeholder,
+                },
+            },
+            onChange: (componentState) => this._updateComponentState(componentState),
+            onError: (validateState) => adyenv3.validateCardFields(validateState),
+            onFieldValid: (validateState) => adyenv3.validateCardFields(validateState),
         });
+
+        try {
+            await this._mountElement(
+                cardVerificationComponent,
+                adyenv3.cardVerificationContainerId,
+            );
+        } catch {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return cardVerificationComponent;
     }
 
-    private _mountPaymentComponent(paymentMethod: PaymentMethod): Promise<AdyenComponent> {
-        let paymentComponent: AdyenComponent;
+    private async _mountPaymentComponent(paymentMethod: PaymentMethod): Promise<AdyenComponent> {
         const adyenv3 = this._getPaymentInitializeOptions();
         const adyenClient = this._getAdyenClient();
+        const billingAddress = this.paymentIntegrationService.getState().getBillingAddress();
+        const { prefillCardHolderName } = paymentMethod.initializationData;
 
-        return new Promise((resolve, reject) => {
-            const billingAddress = this.paymentIntegrationService.getState().getBillingAddress();
-
-            const { prefillCardHolderName } = paymentMethod.initializationData;
-
-            paymentComponent = adyenClient.create(paymentMethod.method, {
-                ...adyenv3.options,
-                showBrandsUnderCardNumber: false,
-                billingAddressRequired: false,
-                showEmailAddress: false,
-                onChange: (componentState) => this._updateComponentState(componentState),
-                onSubmit: (componentState) => this._updateComponentState(componentState),
-                ...(billingAddress
-                    ? { data: this._mapAdyenPlaceholderData(billingAddress, prefillCardHolderName) }
-                    : {}),
-            });
-
-            try {
-                this._mountElement(paymentComponent, adyenv3.containerId);
-            } catch (error) {
-                reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
-            }
-
-            resolve(paymentComponent);
+        const paymentComponent = adyenClient.create(paymentMethod.method, {
+            ...adyenv3.options,
+            showBrandsUnderCardNumber: false,
+            billingAddressRequired: false,
+            showEmailAddress: false,
+            onChange: (componentState) => this._updateComponentState(componentState),
+            onSubmit: (componentState) => this._updateComponentState(componentState),
+            ...(billingAddress
+                ? { data: this._mapAdyenPlaceholderData(billingAddress, prefillCardHolderName) }
+                : {}),
         });
+
+        try {
+            await this._mountElement(paymentComponent, adyenv3.containerId);
+        } catch {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return paymentComponent;
     }
 
     private async _processAdditionalAction(


### PR DESCRIPTION
## What/Why?

In rare cases when Adyen's `mountElement` method would run before the container for the Adyen form is rendered, the form does not render. This PR introduces `waitForMountContainer` method, that waits for max 5 seconds for container to be rendered, before rendering the form.
There's also small cosmetic change to adjust the naming of some elements to pass the `no-underscore-dangle` ESLint rule.

## Rollout/Rollback

Revert

## Testing

Before:

https://github.com/user-attachments/assets/b9db2520-07dd-422e-9602-afad6a9fd5fe

After:

https://github.com/user-attachments/assets/20c0b17b-0ae3-4d36-b9ef-42e3deef9864





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Adyen V3 payment component mounting and additional-action flow; regressions could prevent checkout UI from rendering or alter error/timing behavior, though changes are localized and covered by updated tests.
> 
> **Overview**
> Fixes a race where Adyen V3 components could attempt to `mount` before their DOM container exists by making `_mountElement` async and adding `_waitForMountContainer` polling (up to 5s) before mounting.
> 
> Refactors mounting helpers to `async/await` and to throw `NotInitializedError` on mount failures (including additional-action mounting), and updates unit tests to stub the new async behavior and error paths; also renames underscore-prefixed fields to satisfy linting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c074e208e4839b9a243ac89c3bc7bb41e0b5353f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->