### PR TITLE
feat(payment): PAYMENTS-11630 Allow manual order payment with tokenized card

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
       "types": "./dist/types/integrations/*.d.ts",
       "import": "./dist/esm/integrations/*.js",
       "require": "./dist/cjs/integrations/*.js"
+    },
+    "./hosted-form-v2-iframe-host": {
+      "types": "./dist/hosted-form-v2-iframe-host.d.ts",
+      "import": "./dist/esm/hosted-form-v2-iframe-host.js",
+      "require": "./dist/cjs/hosted-form-v2-iframe-host.js"
     }
   },
   "files": [

--- a/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.ts
+++ b/packages/hosted-form-v2/src/bundles/hosted-form-v2-iframe-host.ts
@@ -1,2 +1,9 @@
 export { createHostedFormService } from '../create-hosted-form-service';
 export { default as createStoredCardHostedFormService } from '../create-hosted-form-stored-card-service';
+export { default as HostedFormService } from '../hosted-form-service';
+export { HostedCardFieldOptionsMap } from '../hosted-form-options';
+export {
+    HostedInputSubmitManualOrderSuccessEvent,
+    HostedInputValidateErrorDataMap,
+    HostedInputValidateResults,
+} from '../iframe-content';

--- a/packages/hosted-form-v2/src/hosted-form-manual-order-data.ts
+++ b/packages/hosted-form-v2/src/hosted-form-manual-order-data.ts
@@ -1,4 +1,5 @@
 export default interface HostedFormManualOrderData {
     paymentMethodId: string;
     paymentSessionToken: string;
+    token?: string;
 }

--- a/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
+++ b/packages/hosted-form-v2/src/iframe-content/hosted-input-manual-order-payment-handler.spec.ts
@@ -211,4 +211,39 @@ describe('HostedInputManualOrderPaymentHandler', () => {
             },
         });
     });
+
+    it('should forward token to submitPayment and post succeeded event for tokenized card', async () => {
+        const event: HostedFieldSubmitManualOrderRequestEvent = {
+            type: HostedFieldEventType.SubmitManualOrderRequested,
+            payload: {
+                data: {
+                    paymentMethodId: 'squarev2.credit_card',
+                    paymentSessionToken: pstToken,
+                    token: 'cnon:test-token',
+                },
+            },
+        };
+        const response = {
+            body: { type: 'success' },
+        };
+
+        jest.spyOn(inputAggregator, 'getInputValues').mockReturnValue({});
+        jest.spyOn(inputValidator, 'validate').mockResolvedValue({ isValid: true, errors: {} });
+
+        const submitPaymentSpy = jest
+            .spyOn(manualOrderPaymentRequestSender, 'submitPayment')
+            .mockResolvedValue(response as Response<unknown>);
+
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle(event);
+
+        expect(submitPaymentSpy).toHaveBeenCalledWith(event.payload.data, {}, undefined);
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: HostedInputEventType.SubmitManualOrderSucceeded,
+            payload: {
+                response,
+            },
+        });
+    });
 });

--- a/packages/hosted-form-v2/src/payment/Instrument.ts
+++ b/packages/hosted-form-v2/src/payment/Instrument.ts
@@ -1,6 +1,7 @@
 export enum InstrumentType {
     Card = 'card',
     ManualPayment = 'manual_payment',
+    TokenizedCard = 'tokenized_card',
 }
 
 export const manualPaymentMethod = 'bigcommerce.manual_payment';
@@ -50,4 +51,13 @@ interface OfflinePaymentInstrument {
     type: OfflinePaymentMethodTypes;
 }
 
-export type Instrument = CardInstrument | ManualPaymentInstrument | OfflinePaymentInstrument;
+interface TokenizedCardInstrument {
+    type: InstrumentType.TokenizedCard;
+    token: string;
+}
+
+export type Instrument =
+    | CardInstrument
+    | ManualPaymentInstrument
+    | OfflinePaymentInstrument
+    | TokenizedCardInstrument;

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.spec.ts
@@ -147,4 +147,37 @@ describe('ManualOrderPaymentRequestSender', () => {
             }),
         );
     });
+
+    it('submits tokenized card payment', async () => {
+        (requestSender.post as jest.Mock).mockResolvedValue(response);
+
+        requestInitializationData.paymentMethodId = 'squarev2.credit_card';
+        requestInitializationData.token = 'cnon:test-token';
+        instrumentFormData = {} as HostedInputValues;
+
+        const result = await manualOrderPaymentRequestSender.submitPayment(
+            requestInitializationData,
+            instrumentFormData,
+        );
+
+        expect(result).toBe(response);
+        expect(requestSender.post).toHaveBeenCalledWith(
+            `${paymentOrigin}/payments`,
+            expect.objectContaining({
+                headers: {
+                    Accept: ContentType.Json,
+                    'Content-Type': ContentType.Json,
+                    'X-Payment-Session-Token': pstToken,
+                },
+                body: {
+                    instrument: {
+                        type: InstrumentType.TokenizedCard,
+                        token: 'cnon:test-token',
+                    },
+                    payment_method_id: 'squarev2.credit_card',
+                    form_nonce: undefined,
+                },
+            }),
+        );
+    });
 });

--- a/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.ts
+++ b/packages/hosted-form-v2/src/payment/manual-order-payment-request-sender.ts
@@ -24,7 +24,12 @@ export class ManualOrderPaymentRequestSender {
 
         let instrument: Instrument;
 
-        if (paymentMethodId === manualPaymentMethod) {
+        if (requestInitializationData.token) {
+            instrument = {
+                type: InstrumentType.TokenizedCard,
+                token: requestInitializationData.token,
+            };
+        } else if (paymentMethodId === manualPaymentMethod) {
             instrument = {
                 type: InstrumentType.ManualPayment,
                 note: instrumentFormData.note ?? '',


### PR DESCRIPTION
## What/Why?

We want to allow payment of a manual order with Square v2 credit card, which uses Square SDK widget (instead of BigPay hosed form) and passes the card token rather than CC details. 

Also, currently manual-orders-ui access the hosted form components for manual orders via `@bigcommerce/checkout-sdk/dist/hosted-form-v2-iframe-host` path while used v1.693.0 of checkout DSK. In the latest releases, those components are not exposed which will break the microapp. We want to expose those components to be accessed via `@bigcommerce/checkout-sdk/hosted-form-v2-iframe-host` path.

1- Cater for tokenized card payment method
2- Expose in the new releases the components currently used in the new manual orders UI from an old release (1.693.0)

## Rollout/Rollback
Revert

## Testing
Unit tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes manual-order payment submission to send a new `tokenized_card` instrument when a token is provided, which can affect payment processing behavior for manual orders. Also introduces a new public export path, so consumers could be impacted if packaging or types are incorrect.
> 
> **Overview**
> Manual-order payment submission now supports *tokenized cards*: `HostedFormManualOrderData` accepts an optional `token`, `Instrument` adds `InstrumentType.TokenizedCard`, and `ManualOrderPaymentRequestSender.submitPayment` prioritizes sending `{ type: 'tokenized_card', token }` when present (with updated unit coverage).
> 
> The SDK package now exposes a new public entrypoint `@bigcommerce/checkout-sdk/hosted-form-v2-iframe-host` and expands that bundle’s exports (e.g. `HostedFormService` and hosted-input event/types) to preserve access for consumers relying on these hosted-form-v2 iframe-host APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c959410c8921481c96ad6046a0dac9f79bad91c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->