### PR TITLE
fix(payment): PAYPAL-6442 double call of loadPayPalSDK to avoid ZOID issues

### DIFF
--- a/packages/paypal-utils/src/create-paypal-sdk-script-loader.ts
+++ b/packages/paypal-utils/src/create-paypal-sdk-script-loader.ts
@@ -1,7 +1,7 @@
-import { createScriptLoader } from '@bigcommerce/script-loader';
+import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import PayPalSdkScriptLoader from './paypal-sdk-script-loader';
 
 export default function createPayPalSdkScriptLoader(): PayPalSdkScriptLoader {
-    return new PayPalSdkScriptLoader(createScriptLoader());
+    return new PayPalSdkScriptLoader(getScriptLoader());
 }


### PR DESCRIPTION
## What/Why?
PayPal wallet buttons not displaying consistently on PDP page. Fixed double call of loadPayPalSDK (async operation from two different places that can lead to such cases as ZOID) to avoid ZOID issues and button display problems.

<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
Manual

<img width="2048" height="682" alt="Screenshot 2026-05-11 at 00 44 09" src="https://github.com/user-attachments/assets/89b37757-a4a3-459f-8cfe-33afae4d6e8a" />

<img width="2353" height="645" alt="Screenshot 2026-05-11 at 00 58 08" src="https://github.com/user-attachments/assets/3529a161-eee3-43d2-85d5-668d0a114d5f" />

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PayPal SDK script loading to use a shared `getScriptLoader()` instance, which can affect how/when scripts are deduped and loaded across the app. Risk is limited in scope but impacts payment UI reliability if the loader behavior differs from `createScriptLoader()`.
> 
> **Overview**
> Switches `createPayPalSdkScriptLoader()` to use `getScriptLoader()` instead of creating a new script loader instance, so PayPal SDK loads go through a shared loader.
> 
> This aims to prevent duplicate/overlapping `loadPayPalSDK` calls that can cause ZOID-related issues and intermittent PayPal button rendering problems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afeda215deda7753ed8abbd1ba6d4ad6df54f51d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->