### PR TITLE
PI-4734 [Adyen][FE] Oney - Hide Oney default inputs

### DIFF
--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -214,6 +214,42 @@ describe('AdyenV3PaymentStrategy', () => {
                     expect.objectContaining({ locale: 'en_US' }),
                 );
             });
+
+            it('does not hide shopper input fields for non-Oney payment methods', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue(getAdyenV3('boletobancario'));
+
+                await strategy.initialize(options);
+
+                expect(adyenCheckout.create).toHaveBeenCalledWith(
+                    'boletobancario',
+                    expect.not.objectContaining({
+                        visibility: expect.anything(),
+                    }),
+                );
+            });
+
+            it('hides shopper input fields for Oney payment methods', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue(getAdyenV3('facilypay_3x'));
+
+                await strategy.initialize(options);
+
+                expect(adyenCheckout.create).toHaveBeenCalledWith(
+                    'facilypay_3x',
+                    expect.objectContaining({
+                        visibility: {
+                            personalDetails: 'hidden',
+                            billingAddress: 'hidden',
+                            deliveryAddress: 'hidden',
+                        },
+                    }),
+                );
+            });
         });
 
         describe('#execute', () => {

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -438,6 +438,15 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         const { prefillCardHolderName } = paymentMethod.initializationData;
 
         const paymentComponent = adyenClient.create(paymentMethod.method, {
+            ...(this._isOneyPaymentMethod(paymentMethod.method)
+                ? {
+                      visibility: {
+                          personalDetails: 'hidden',
+                          billingAddress: 'hidden',
+                          deliveryAddress: 'hidden',
+                      },
+                  }
+                : {}),
             ...adyenv3.options,
             showBrandsUnderCardNumber: false,
             billingAddressRequired: false,
@@ -456,6 +465,10 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         }
 
         return paymentComponent;
+    }
+
+    private _isOneyPaymentMethod(method: string): boolean {
+        return method.startsWith('facilypay');
     }
 
     private async _processAdditionalAction(

--- a/packages/adyen-utils/src/types.ts
+++ b/packages/adyen-utils/src/types.ts
@@ -481,10 +481,19 @@ export interface AdyenIdealComponentOptions
     showImage?: boolean;
 }
 
+export type AdyenComponentFieldVisibility = 'hidden' | 'readOnly' | 'editable';
+
+export interface AdyenOpenInvoiceComponentVisibility {
+    personalDetails?: AdyenComponentFieldVisibility;
+    billingAddress?: AdyenComponentFieldVisibility;
+    deliveryAddress?: AdyenComponentFieldVisibility;
+}
+
 export interface AdyenBoletoComponentOptions extends AdyenComponentEvents {
     personalDetailsRequired?: boolean;
     billingAddressRequired?: boolean;
     showEmailAddress?: boolean;
+    visibility?: AdyenOpenInvoiceComponentVisibility;
 }
 
 export interface AdyenStoredPaymentMethod {


### PR DESCRIPTION
## What/Why?
Hide Oney default inputs

## Rollout/Rollback

Revert this PR

## Testing
before:
<img width="714" height="830" alt="Screenshot 2026-05-12 at 08 54 20" src="https://github.com/user-attachments/assets/2f736ff1-06a6-4492-9d7f-df8a6026bdb9" />
after:
<img width="1572" height="1390" alt="image" src="https://github.com/user-attachments/assets/5b0c94d7-dc71-4375-a36e-dccff70dbd95" />
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped UI/config change to Adyen component initialization for `facilypay*` methods plus unit coverage; main risk is unintended hiding/overriding of fields if other methods share the prefix or rely on these inputs.
> 
> **Overview**
> **Hides Adyen’s default shopper detail fields for Oney payments.** During `AdyenV3PaymentStrategy` initialization, `facilypay*` methods now pass a `visibility` config to the Adyen component to hide `personalDetails`, `billingAddress`, and `deliveryAddress`.
> 
> Updates `adyen-utils` types to model the new `visibility` option and adds unit tests asserting the config is applied only to Oney methods (and not to other methods like `boletobancario`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5d85f1b33484e2d5df96fafc9dc2bfe25907204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->