### PR TITLE
feat(payment): PI-5215 [FE][Google Pay] Implement container mode in GooglePayPaymentStrategy

### DIFF
--- a/packages/google-pay-integration/src/google-pay-payment-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-initialize-options.ts
@@ -1,3 +1,5 @@
+import { GooglePayButtonColor, GooglePayButtonSizeMode, GooglePayButtonType } from './types';
+
 /**
  * A set of options that are required to initialize the GooglePay payment method
  *
@@ -36,6 +38,25 @@
  *     },
  * });
  * ```
+ *
+ * Alternatively, a container-based Google Pay button can be rendered directly
+ * in the payment step (replacing the Place Order button):
+ *
+ * ```js
+ * service.initializePayment({
+ *     methodId: 'googlepaybraintree',
+ *     googlepaybraintree: {
+ *         container: 'checkout-payment-continue',
+ *         onInit(renderButton) {
+ *             // Hide Place Order, then render the button once container is in DOM
+ *             renderButton();
+ *         },
+ *         onError(error) {
+ *             console.log(error);
+ *         },
+ *     },
+ * });
+ * ```
  */
 export default interface GooglePayPaymentInitializeOptions {
     /**
@@ -49,6 +70,44 @@ export default interface GooglePayPaymentInitializeOptions {
      * It should be an HTML element.
      */
     walletButton?: string;
+
+    /**
+     * The ID of the container element where the Google Pay button will be rendered.
+     * When provided, a branded Google Pay button is created inside this container.
+     * Clicking the button opens the Google Pay payment sheet and, on success, submits
+     * the order and redirects to the order confirmation page directly — no separate
+     * "Place Order" step is needed.
+     */
+    container?: string;
+
+    /**
+     * The color of the Google Pay button rendered into `container`.
+     * Defaults to `'default'`.
+     */
+    buttonColor?: GooglePayButtonColor;
+
+    /**
+     * The size mode of the Google Pay button rendered into `container`.
+     * Defaults to `'fill'`.
+     */
+    buttonSizeMode?: GooglePayButtonSizeMode;
+
+    /**
+     * The type/label of the Google Pay button rendered into `container`.
+     * Defaults to `'pay'`.
+     */
+    buttonType?: GooglePayButtonType;
+
+    /**
+     * Called after the Google Pay processor is fully initialized, with a
+     * `renderButton` function that — when invoked — creates the Google Pay
+     * button inside `container`.  Use this callback to control timing: hide
+     * the Place Order button first, then call `renderButton()` once the
+     * container element is present in the DOM.
+     *
+     * Only used when `container` is provided.
+     */
+    onInit?(renderButton: () => void): void;
 
     /**
      * A callback that gets called when GooglePay fails to initialize or

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -418,15 +418,12 @@ describe('GooglePayPaymentStrategy', () => {
                 jest.spyOn(processor, 'getNonce').mockRejectedValue(
                     new MissingDataError(MissingDataErrorType.MissingConsignments),
                 );
-
-                const execute = () => strategy.execute(payload);
-
                 jest.spyOn(
                     paymentIntegrationService.getState(),
                     'getPaymentMethodOrThrow',
                 ).mockReturnValue(getGeneric());
 
-                await expect(execute()).rejects.toThrow(MissingDataError);
+                await expect(strategy.execute(payload)).rejects.toThrow(MissingDataError);
             });
         });
     });
@@ -451,10 +448,6 @@ describe('GooglePayPaymentStrategy', () => {
             const rejectedInitializeWidgetMock = createInitializeWidgetMock(internalError);
 
             await strategy.initialize(options);
-
-            button.click();
-
-            await new Promise((resolve) => process.nextTick(resolve));
 
             expect(LoadingHide).toHaveBeenCalled();
             expect(rejectedInitializeWidgetMock).toHaveBeenCalledTimes(1);

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -449,6 +449,10 @@ describe('GooglePayPaymentStrategy', () => {
 
             await strategy.initialize(options);
 
+            button.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
             expect(LoadingHide).toHaveBeenCalled();
             expect(rejectedInitializeWidgetMock).toHaveBeenCalledTimes(1);
             expect(options.googlepayworldpayaccess?.onError).toHaveBeenCalled();
@@ -899,12 +903,12 @@ describe('GooglePayPaymentStrategy', () => {
         });
     });
 
-    describe('Container mode', () => {
+    describe('#initialize with container', () => {
         const CONTAINER_ID = 'checkout-payment-continue';
 
         let containerHost: HTMLDivElement;
         let brandedButton: HTMLButtonElement;
-        let capturedOnClick: (event: MouseEvent) => Promise<void>;
+        let containerButtonOnClick: (event: MouseEvent) => Promise<void>;
 
         beforeEach(() => {
             containerHost = document.createElement('div');
@@ -915,11 +919,17 @@ describe('GooglePayPaymentStrategy', () => {
             jest.spyOn(brandedButton, 'remove');
             jest.spyOn(brandedButton, 'removeEventListener');
 
-            jest.spyOn(processor, 'addPaymentButton').mockImplementation((_id, buttonOpts) => {
-                capturedOnClick = buttonOpts.onClick;
+            jest.spyOn(processor, 'addPaymentButton').mockImplementation(
+                (_containerId, buttonOpts) => {
+                    containerButtonOnClick = buttonOpts.onClick;
 
-                return brandedButton;
-            });
+                    brandedButton.onclick = (event: MouseEvent) => {
+                        void buttonOpts.onClick(event);
+                    };
+
+                    return brandedButton;
+                },
+            );
 
             options = {
                 methodId: 'googlepayworldpayaccess',
@@ -932,12 +942,15 @@ describe('GooglePayPaymentStrategy', () => {
         });
 
         afterEach(() => {
+            brandedButton.onclick = null;
             containerHost.remove();
         });
 
         describe('#initialize', () => {
             it('should initialize when only container is provided', async () => {
-                await expect(strategy.initialize(options)).resolves.toBeUndefined();
+                const initialize = strategy.initialize(options);
+
+                await expect(initialize).resolves.toBeUndefined();
 
                 expect(processor.addPaymentButton).toHaveBeenCalledWith(
                     CONTAINER_ID,
@@ -981,7 +994,7 @@ describe('GooglePayPaymentStrategy', () => {
                 expect(processor.addPaymentButton).not.toHaveBeenCalled();
                 expect(onInit).toHaveBeenCalledWith(expect.any(Function));
 
-                const renderButton = onInit.mock.calls[0][0] as () => void;
+                const [[renderButton]] = onInit.mock.calls;
 
                 renderButton();
 
@@ -1007,6 +1020,7 @@ describe('GooglePayPaymentStrategy', () => {
                 };
 
                 await strategy.initialize(options);
+
                 capturedRenderButton();
                 capturedRenderButton();
 
@@ -1017,25 +1031,14 @@ describe('GooglePayPaymentStrategy', () => {
                 test('container element is not in the DOM', async () => {
                     jest.spyOn(processor, 'addPaymentButton').mockReturnValue(undefined);
 
-                    await expect(strategy.initialize(options)).rejects.toThrow(
-                        InvalidArgumentError,
-                    );
-                });
+                    const initialize = strategy.initialize(options);
 
-                test('both walletButton and container are provided', async () => {
-                    options.googlepayworldpayaccess = {
-                        walletButton: 'walletButton',
-                        container: CONTAINER_ID,
-                    };
-
-                    await expect(strategy.initialize(options)).rejects.toThrow(
-                        InvalidArgumentError,
-                    );
+                    await expect(initialize).rejects.toThrow(InvalidArgumentError);
                 });
             });
         });
 
-        describe('container button onClick', () => {
+        describe('when clicking the container payment button', () => {
             let completeCheckoutFlowSpy: jest.SpyInstance;
 
             beforeEach(async () => {
@@ -1055,7 +1058,9 @@ describe('GooglePayPaymentStrategy', () => {
             it('should run direct pay flow via _interactWithPaymentSheetAndPay without PI-5111 experiment', async () => {
                 const executeSpy = jest.spyOn(strategy, 'execute');
 
-                await capturedOnClick(new MouseEvent('click'));
+                brandedButton.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(processor.setShouldRequestShipping).toHaveBeenCalledWith(false);
                 expect(processor.initializeWidget).toHaveBeenCalled();
@@ -1067,12 +1072,12 @@ describe('GooglePayPaymentStrategy', () => {
             });
 
             it('should call onError when initializeWidget throws', async () => {
-                const internalError = new Error('widget failed');
+                const widgetError = new Error('widget failed');
 
-                jest.spyOn(processor, 'initializeWidget').mockRejectedValueOnce(internalError);
+                jest.spyOn(processor, 'initializeWidget').mockRejectedValueOnce(widgetError);
 
-                await expect(capturedOnClick(new MouseEvent('click'))).rejects.toThrow(
-                    internalError,
+                await expect(containerButtonOnClick(new MouseEvent('click'))).rejects.toThrow(
+                    widgetError,
                 );
 
                 expect(options.googlepayworldpayaccess?.onError).toHaveBeenCalled();
@@ -1086,7 +1091,7 @@ describe('GooglePayPaymentStrategy', () => {
 
                 jest.spyOn(processor, 'initializeWidget').mockRejectedValueOnce(canceledError);
 
-                await expect(capturedOnClick(new MouseEvent('click'))).rejects.toThrow(
+                await expect(containerButtonOnClick(new MouseEvent('click'))).rejects.toThrow(
                     PaymentMethodCancelledError,
                 );
             });

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -15,6 +15,7 @@ import {
     PaymentIntegrationSelectors,
     PaymentIntegrationService,
     PaymentMethod,
+    PaymentMethodCancelledError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getCart,
@@ -35,6 +36,7 @@ import { createInitializeImplementationMock } from './mocks/google-pay-processor
 import {
     CallbackTriggerType,
     ErrorReasonType,
+    GooglePayErrorObject,
     GooglePayInitializationData,
     GooglePaymentsClient,
     NewTransactionInfo,
@@ -209,6 +211,16 @@ describe('GooglePayPaymentStrategy', () => {
             test('walletButton is empty', async () => {
                 options.googlepayworldpayaccess = {
                     walletButton: '',
+                };
+
+                const initialize = strategy.initialize(options);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+
+            test('container is empty', async () => {
+                options.googlepayworldpayaccess = {
+                    container: '',
                 };
 
                 const initialize = strategy.initialize(options);
@@ -890,6 +902,210 @@ describe('GooglePayPaymentStrategy', () => {
                 await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(updateAddressSpy).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('Container mode', () => {
+        const CONTAINER_ID = 'checkout-payment-continue';
+
+        let containerHost: HTMLDivElement;
+        let brandedButton: HTMLButtonElement;
+        let capturedOnClick: (event: MouseEvent) => Promise<void>;
+
+        beforeEach(() => {
+            containerHost = document.createElement('div');
+            containerHost.id = CONTAINER_ID;
+            document.body.appendChild(containerHost);
+
+            brandedButton = document.createElement('button');
+            jest.spyOn(brandedButton, 'remove');
+            jest.spyOn(brandedButton, 'removeEventListener');
+
+            jest.spyOn(processor, 'addPaymentButton').mockImplementation((_id, buttonOpts) => {
+                capturedOnClick = buttonOpts.onClick;
+
+                return brandedButton;
+            });
+
+            options = {
+                methodId: 'googlepayworldpayaccess',
+                googlepayworldpayaccess: {
+                    loadingContainerId: 'id',
+                    container: CONTAINER_ID,
+                    onError: jest.fn(),
+                },
+            };
+        });
+
+        afterEach(() => {
+            containerHost.remove();
+        });
+
+        describe('#initialize', () => {
+            it('should initialize when only container is provided', async () => {
+                await expect(strategy.initialize(options)).resolves.toBeUndefined();
+
+                expect(processor.addPaymentButton).toHaveBeenCalledWith(
+                    CONTAINER_ID,
+                    expect.objectContaining({
+                        buttonColor: 'default',
+                        buttonType: 'pay',
+                        buttonSizeMode: 'fill',
+                        onClick: expect.any(Function),
+                    }),
+                );
+            });
+
+            it('should pass custom buttonColor and buttonType to addPaymentButton', async () => {
+                options.googlepayworldpayaccess = {
+                    ...options.googlepayworldpayaccess,
+                    buttonColor: 'black',
+                    buttonType: 'checkout',
+                };
+
+                await strategy.initialize(options);
+
+                expect(processor.addPaymentButton).toHaveBeenCalledWith(
+                    CONTAINER_ID,
+                    expect.objectContaining({
+                        buttonColor: 'black',
+                        buttonType: 'checkout',
+                    }),
+                );
+            });
+
+            it('should defer addPaymentButton until onInit calls renderButton', async () => {
+                const onInit = jest.fn();
+
+                options.googlepayworldpayaccess = {
+                    ...options.googlepayworldpayaccess,
+                    onInit,
+                };
+
+                await strategy.initialize(options);
+
+                expect(processor.addPaymentButton).not.toHaveBeenCalled();
+                expect(onInit).toHaveBeenCalledWith(expect.any(Function));
+
+                const renderButton = onInit.mock.calls[0][0] as () => void;
+
+                renderButton();
+
+                expect(processor.addPaymentButton).toHaveBeenCalledTimes(1);
+            });
+
+            it('should add button only once when initialize is called twice', async () => {
+                await strategy.initialize(options);
+                await strategy.initialize(options);
+
+                expect(processor.addPaymentButton).toHaveBeenCalledTimes(1);
+            });
+
+            it('should add button only once when renderButton is called twice via onInit', async () => {
+                let capturedRenderButton!: () => void;
+                const onInit = jest.fn((renderButton: () => void) => {
+                    capturedRenderButton = renderButton;
+                });
+
+                options.googlepayworldpayaccess = {
+                    ...options.googlepayworldpayaccess,
+                    onInit,
+                };
+
+                await strategy.initialize(options);
+                capturedRenderButton();
+                capturedRenderButton();
+
+                expect(processor.addPaymentButton).toHaveBeenCalledTimes(1);
+            });
+
+            describe('should fail if:', () => {
+                test('container element is not in the DOM', async () => {
+                    jest.spyOn(processor, 'addPaymentButton').mockReturnValue(undefined);
+
+                    await expect(strategy.initialize(options)).rejects.toThrow(
+                        InvalidArgumentError,
+                    );
+                });
+
+                test('both walletButton and container are provided', async () => {
+                    options.googlepayworldpayaccess = {
+                        walletButton: 'walletButton',
+                        container: CONTAINER_ID,
+                    };
+
+                    await expect(strategy.initialize(options)).rejects.toThrow(
+                        InvalidArgumentError,
+                    );
+                });
+            });
+        });
+
+        describe('container button onClick', () => {
+            let completeCheckoutFlowSpy: jest.SpyInstance;
+
+            beforeEach(async () => {
+                jest.spyOn(processor, 'setShouldRequestShipping');
+                jest.spyOn(processor, 'mapToBillingAddressRequestBody').mockReturnValue(undefined);
+                completeCheckoutFlowSpy = jest
+                    .spyOn(Object.getPrototypeOf(strategy), '_completeCheckoutFlow')
+                    .mockImplementation(() => undefined);
+
+                await strategy.initialize(options);
+            });
+
+            afterEach(() => {
+                completeCheckoutFlowSpy.mockRestore();
+            });
+
+            it('should run direct pay flow via _interactWithPaymentSheetAndPay without PI-5111 experiment', async () => {
+                const executeSpy = jest.spyOn(strategy, 'execute');
+
+                await capturedOnClick(new MouseEvent('click'));
+
+                expect(processor.setShouldRequestShipping).toHaveBeenCalledWith(false);
+                expect(processor.initializeWidget).toHaveBeenCalled();
+                expect(processor.showPaymentSheet).toHaveBeenCalled();
+                expect(executeSpy).toHaveBeenCalledWith({
+                    useStoreCredit: false,
+                    payment: { methodId: options.methodId },
+                });
+            });
+
+            it('should call onError when initializeWidget throws', async () => {
+                const internalError = new Error('widget failed');
+
+                jest.spyOn(processor, 'initializeWidget').mockRejectedValueOnce(internalError);
+
+                await expect(capturedOnClick(new MouseEvent('click'))).rejects.toThrow(
+                    internalError,
+                );
+
+                expect(options.googlepayworldpayaccess?.onError).toHaveBeenCalled();
+                expect(LoadingHide).toHaveBeenCalled();
+            });
+
+            it('should throw PaymentMethodCancelledError when Google Pay returns CANCELED', async () => {
+                const canceledError: GooglePayErrorObject = {
+                    statusCode: 'CANCELED',
+                };
+
+                jest.spyOn(processor, 'initializeWidget').mockRejectedValueOnce(canceledError);
+
+                await expect(capturedOnClick(new MouseEvent('click'))).rejects.toThrow(
+                    PaymentMethodCancelledError,
+                );
+            });
+        });
+
+        describe('#deinitialize', () => {
+            it('should remove the branded button instead of removeEventListener', async () => {
+                await strategy.initialize(options);
+                await strategy.deinitialize();
+
+                expect(brandedButton.remove).toHaveBeenCalled();
+                expect(brandedButton.removeEventListener).not.toHaveBeenCalled();
             });
         });
     });

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -215,33 +215,11 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         return async (event: MouseEvent) => {
             event.preventDefault();
 
-            try {
+            await this._runGooglePayWidgetInteractionWithErrorHandling(onError, async () => {
                 this._googlePayPaymentProcessor.setShouldRequestShipping(false);
                 await this._googlePayPaymentProcessor.initializeWidget();
                 await this._interactWithPaymentSheetAndPay();
-            } catch (error) {
-                let err: unknown = error;
-
-                this._toggleLoadingIndicator(false);
-
-                if (isGooglePayErrorObject(error)) {
-                    if (error.statusCode === 'CANCELED') {
-                        throw new PaymentMethodCancelledError();
-                    }
-
-                    err = new PaymentMethodFailedError(JSON.stringify(error));
-                }
-
-                onError?.(
-                    new PaymentMethodFailedError(
-                        'An error occurred while requesting your Google Pay payment details.',
-                    ),
-                );
-
-                throw err;
-            } finally {
-                this._toggleBlockDeinitialization(false);
-            }
+            });
         };
     }
 
@@ -253,7 +231,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             event.preventDefault();
 
             // TODO: Dispatch Widget Actions
-            try {
+            await this._runGooglePayWidgetInteractionWithErrorHandling(onError, async () => {
                 this._googlePayPaymentProcessor.setShouldRequestShipping(false);
                 await this._googlePayPaymentProcessor.initializeWidget();
 
@@ -262,29 +240,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 } else {
                     await this._interactWithPaymentSheet();
                 }
-            } catch (error) {
-                let err: unknown = error;
-
-                this._toggleLoadingIndicator(false);
-
-                if (isGooglePayErrorObject(error)) {
-                    if (error.statusCode === 'CANCELED') {
-                        throw new PaymentMethodCancelledError();
-                    }
-
-                    err = new PaymentMethodFailedError(JSON.stringify(error));
-                }
-
-                onError?.(
-                    new PaymentMethodFailedError(
-                        'An error occurred while requesting your Google Pay payment details.',
-                    ),
-                );
-
-                throw err;
-            } finally {
-                this._toggleBlockDeinitialization(false);
-            }
+            });
 
             onPaymentSelect?.();
         };
@@ -468,6 +424,37 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 },
             },
         };
+    }
+
+    private async _runGooglePayWidgetInteractionWithErrorHandling(
+        onError: GooglePayPaymentInitializeOptions['onError'],
+        interaction: () => Promise<void>,
+    ): Promise<void> {
+        try {
+            await interaction();
+        } catch (error) {
+            let err: unknown = error;
+
+            this._toggleLoadingIndicator(false);
+
+            if (isGooglePayErrorObject(error)) {
+                if (error.statusCode === 'CANCELED') {
+                    throw new PaymentMethodCancelledError();
+                }
+
+                err = new PaymentMethodFailedError(JSON.stringify(error));
+            }
+
+            onError?.(
+                new PaymentMethodFailedError(
+                    'An error occurred while requesting your Google Pay payment details.',
+                ),
+            );
+
+            throw err;
+        } finally {
+            this._toggleBlockDeinitialization(false);
+        }
     }
 
     private _isDirectPayOnClickEnabled(): boolean {

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -99,6 +99,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         if (container) {
             this._isContainerMode = true;
+
             const renderButton = () =>
                 this._addPaymentButtonToContainer(
                     container,

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -100,14 +100,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         if (container) {
             this._isContainerMode = true;
 
-            const renderButton = () =>
-                this._addPaymentButtonToContainer(
-                    container,
-                    buttonColor,
-                    buttonSizeMode,
-                    buttonType,
-                    callbacks.onError,
-                );
+            const renderButton = () => this._addPaymentButtonToContainer(googlePayOptions);
 
             if (onInit) {
                 onInit(renderButton);
@@ -183,17 +176,19 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     }
 
     protected _addPaymentButtonToContainer(
-        containerId: string,
-        buttonColor: GooglePayPaymentInitializeOptions['buttonColor'],
-        buttonSizeMode: GooglePayPaymentInitializeOptions['buttonSizeMode'],
-        buttonType: GooglePayPaymentInitializeOptions['buttonType'],
-        onError: GooglePayPaymentInitializeOptions['onError'],
+        googlePayOptions: GooglePayPaymentInitializeOptions,
     ): void {
         if (this._paymentButton) {
             return;
         }
 
-        const button = this._googlePayPaymentProcessor.addPaymentButton(containerId, {
+        const { container, buttonColor, buttonSizeMode, buttonType, onError } = googlePayOptions;
+
+        if (!container) {
+            throw new InvalidArgumentError('Unable to proceed: container ID is not valid.');
+        }
+
+        const button = this._googlePayPaymentProcessor.addPaymentButton(container, {
             buttonColor: buttonColor ?? 'default',
             buttonSizeMode: buttonSizeMode ?? 'fill',
             buttonType: buttonType ?? 'pay',
@@ -202,7 +197,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         if (!button) {
             throw new InvalidArgumentError(
-                `Unable to proceed: container element "#${containerId}" not found in the DOM.`,
+                `Unable to proceed: container element "#${container}" not found in the DOM.`,
             );
         }
 

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -42,6 +42,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     private _clickListener?: (event: MouseEvent) => unknown;
     private _methodId?: keyof WithGooglePayPaymentInitializeOptions;
     private _isDeinitializationBlocked = false;
+    private _isContainerMode = false;
 
     constructor(
         protected _paymentIntegrationService: PaymentIntegrationService,
@@ -65,11 +66,20 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         const googlePayOptions = options[this._getMethodId()];
 
-        if (!googlePayOptions?.walletButton) {
+        if (!googlePayOptions?.walletButton && !googlePayOptions?.container) {
             throw new InvalidArgumentError('Unable to proceed without valid options.');
         }
 
-        const { walletButton, loadingContainerId, ...callbacks } = googlePayOptions;
+        const {
+            walletButton,
+            loadingContainerId,
+            container,
+            buttonColor,
+            buttonSizeMode,
+            buttonType,
+            onInit,
+            ...callbacks
+        } = googlePayOptions;
 
         this._loadingIndicatorContainer = loadingContainerId;
 
@@ -87,7 +97,25 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             this._getGooglePayClientOptions(paymentMethod.initializationData?.storeCountry),
         );
 
-        this._addPaymentButton(walletButton, callbacks);
+        if (container) {
+            this._isContainerMode = true;
+            const renderButton = () =>
+                this._addPaymentButtonToContainer(
+                    container,
+                    buttonColor,
+                    buttonSizeMode,
+                    buttonType,
+                    callbacks.onError,
+                );
+
+            if (onInit) {
+                onInit(renderButton);
+            } else {
+                renderButton();
+            }
+        } else {
+            this._addPaymentButton(walletButton!, callbacks);
+        }
     }
 
     async execute({ payment }: OrderRequestBody): Promise<void> {
@@ -119,13 +147,16 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             return Promise.resolve();
         }
 
-        if (this._clickListener) {
+        if (this._isContainerMode) {
+            this._paymentButton?.remove();
+        } else if (this._clickListener) {
             this._paymentButton?.removeEventListener('click', this._clickListener);
         }
 
         this._paymentButton = undefined;
         this._clickListener = undefined;
         this._methodId = undefined;
+        this._isContainerMode = false;
 
         return Promise.resolve();
     }
@@ -148,6 +179,69 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         this._clickListener = this._handleClick(callbacks);
 
         this._paymentButton.addEventListener('click', this._clickListener);
+    }
+
+    protected _addPaymentButtonToContainer(
+        containerId: string,
+        buttonColor: GooglePayPaymentInitializeOptions['buttonColor'],
+        buttonSizeMode: GooglePayPaymentInitializeOptions['buttonSizeMode'],
+        buttonType: GooglePayPaymentInitializeOptions['buttonType'],
+        onError: GooglePayPaymentInitializeOptions['onError'],
+    ): void {
+        if (this._paymentButton) {
+            return;
+        }
+
+        const button = this._googlePayPaymentProcessor.addPaymentButton(containerId, {
+            buttonColor: buttonColor ?? 'default',
+            buttonSizeMode: buttonSizeMode ?? 'fill',
+            buttonType: buttonType ?? 'pay',
+            onClick: this._handleContainerButtonClick(onError),
+        });
+
+        if (!button) {
+            throw new InvalidArgumentError(
+                `Unable to proceed: container element "#${containerId}" not found in the DOM.`,
+            );
+        }
+
+        this._paymentButton = button;
+    }
+
+    protected _handleContainerButtonClick(
+        onError: GooglePayPaymentInitializeOptions['onError'],
+    ): (event: MouseEvent) => Promise<void> {
+        return async (event: MouseEvent) => {
+            event.preventDefault();
+
+            try {
+                this._googlePayPaymentProcessor.setShouldRequestShipping(false);
+                await this._googlePayPaymentProcessor.initializeWidget();
+                await this._interactWithPaymentSheetAndPay();
+            } catch (error) {
+                let err: unknown = error;
+
+                this._toggleLoadingIndicator(false);
+
+                if (isGooglePayErrorObject(error)) {
+                    if (error.statusCode === 'CANCELED') {
+                        throw new PaymentMethodCancelledError();
+                    }
+
+                    err = new PaymentMethodFailedError(JSON.stringify(error));
+                }
+
+                onError?.(
+                    new PaymentMethodFailedError(
+                        'An error occurred while requesting your Google Pay payment details.',
+                    ),
+                );
+
+                throw err;
+            } finally {
+                this._toggleBlockDeinitialization(false);
+            }
+        };
     }
 
     protected _handleClick({

--- a/packages/google-pay-integration/src/types.ts
+++ b/packages/google-pay-integration/src/types.ts
@@ -307,6 +307,7 @@ export interface GooglePayButtonOptions {
     onClick: (event: MouseEvent) => Promise<void>;
     allowedPaymentMethods: [GooglePayBaseCardPaymentMethod];
     buttonColor?: GooglePayButtonColor;
+    buttonSizeMode?: GooglePayButtonSizeMode;
     buttonType?: GooglePayButtonType;
 }
 
@@ -519,6 +520,7 @@ export interface ExtraPaymentData {
 }
 
 export type GooglePayButtonColor = 'default' | 'black' | 'white';
+export type GooglePayButtonSizeMode = 'static' | 'fill';
 export type GooglePayButtonType =
     | 'book'
     | 'buy'


### PR DESCRIPTION
## What/Why?

Add container mode support to the Google Pay payment strategy. 
When `container` is provided (instead of walletButton), a Google Pay button is rendered inside the target element, in place of the Place Order button.

Note: this PR only contains changes related to rendering Google Pay button in the SDK; `checkout-js` part is still in progress. Both recordings in Testing section have experiment `PI-5111.google_pay_direct_pay_on_click` on, so stores with disabled experiment won't experience strange behaviour between closing of Google Pay modal and order confirmation.

## Rollout/Rollback

Revert

## Testing

When `container` value is provided:

https://github.com/user-attachments/assets/1c106821-14f3-4fb3-b96f-b59f6bbb560d

When `container` value is not provided (defaults to using current implementation, `walletButton`):

https://github.com/user-attachments/assets/1cf75b6c-07b8-42b0-b4ea-5137b7de89b4



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Google Pay checkout entrypoint by supporting a new container-rendered button and direct-pay flow, affecting initialization, click handling, and teardown paths. Risk is moderate due to new UI/DOM integration and error-handling paths that can impact conversion if misconfigured.
> 
> **Overview**
> Adds an alternative *container mode* to `GooglePayPaymentStrategy`: when `container` is provided (instead of `walletButton`), the strategy renders a branded Google Pay button into the target element and uses that button to launch the payment sheet and proceed with the direct-pay checkout flow.
> 
> Extends `GooglePayPaymentInitializeOptions` with `container`, button styling options (`buttonColor`, `buttonSizeMode`, `buttonType`), and an `onInit(renderButton)` hook to defer rendering until the container exists. Updates deinitialization and centralizes Google Pay widget error handling (including mapping `CANCELED` to `PaymentMethodCancelledError`), with comprehensive new unit coverage for container initialization, click behavior, and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35133aa1add017f08b39489d0d10632feda2f5c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->