### PR TITLE
feat(checkout): CHECKOUT-9820 implement fetching b2b checkout config for PO

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -71,6 +71,7 @@ import {
 } from '../payment';
 import { createPaymentIntegrationService } from '../payment-integration';
 import { InstrumentActionCreator, InstrumentRequestSender } from '../payment/instrument';
+import { PoConfigActionCreator, PoConfigRequestSender } from '../po-config';
 import { InstrumentActionType } from '../payment/instrument/instrument-actions';
 import {
     deleteInstrumentResponseBody,
@@ -442,6 +443,7 @@ describe('CheckoutService', () => {
             paymentMethodActionCreator,
             paymentStrategyActionCreator,
             new PickupOptionActionCreator(new PickupOptionRequestSender(requestSender)),
+            new PoConfigActionCreator(new PoConfigRequestSender(requestSender)),
             new ShippingCountryActionCreator(shippingCountryRequestSender, store),
             shippingStrategyActionCreator,
             signInEmailActionCreator,

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -43,6 +43,7 @@ import {
     PaymentStrategyActionCreator,
 } from '../payment';
 import { InstrumentActionCreator } from '../payment/instrument';
+import { PoConfigActionCreator } from '../po-config';
 import {
     ConsignmentActionCreator,
     ConsignmentAssignmentRequestBody,
@@ -103,6 +104,7 @@ export default class CheckoutService {
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _paymentStrategyActionCreator: PaymentStrategyActionCreator,
         private _pickupOptionActionCreator: PickupOptionActionCreator,
+        private _poConfigActionCreator: PoConfigActionCreator,
         private _shippingCountryActionCreator: ShippingCountryActionCreator,
         private _shippingStrategyActionCreator: ShippingStrategyActionCreator,
         private _signInEmailActionCreator: SignInEmailActionCreator,
@@ -700,6 +702,28 @@ export default class CheckoutService {
         const action = this._b2bTokenActionCreator.loadB2BToken(options);
 
         return this._dispatch(action, { queueId: 'b2bToken' });
+    }
+
+    /**
+     * Loads the PO (purchase order) configuration for the current store.
+     *
+     * The configuration is fetched from the B2B store-configs endpoint and
+     * describes whether the PO number field is enabled on checkout, its label,
+     * and whether it is required.
+     *
+     * ```js
+     * const state = await service.loadPoConfig();
+     *
+     * console.log(state.data.getPoConfig());
+     * ```
+     *
+     * @param options - Options for the request.
+     * @returns A promise that resolves to the current state.
+     */
+    loadPoConfig(options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._poConfigActionCreator.loadPoConfig(options);
+
+        return this._dispatch(action, { queueId: 'poConfig' });
     }
 
     /**

--- a/packages/core/src/checkout/checkout-store-error-selector.ts
+++ b/packages/core/src/checkout/checkout-store-error-selector.ts
@@ -296,6 +296,13 @@ export default interface CheckoutStoreErrorSelector {
     getLoadB2BTokenError(): Error | undefined;
 
     /**
+     * Returns an error if unable to load the PO (purchase order) configuration.
+     *
+     * @returns The error object if unable to load the PO config, otherwise undefined.
+     */
+    getLoadPoConfigError(): Error | undefined;
+
+    /**
      * Returns an error if unable to create customer account.
      *
      * @returns The error object if unable to create account, otherwise undefined.
@@ -390,6 +397,7 @@ export function createCheckoutStoreErrorSelectorFactory(): CheckoutStoreErrorSel
             getLoadConfigError: state.config.getLoadError,
             getSignInEmailError: state.signInEmail.getSendError,
             getLoadB2BTokenError: state.b2bToken.getLoadError,
+            getLoadPoConfigError: state.poConfig.getLoadError,
             getCreateCustomerAccountError: state.customer.getCreateAccountError,
             getCreateCustomerAddressError: state.customer.getCreateAddressError,
             getPickupOptionsError: state.pickupOptions.getLoadError,

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -16,6 +16,7 @@ import { Order } from '../order';
 import { PaymentMethod } from '../payment';
 import { PaymentProviderCustomer } from '../payment-provider-customer';
 import { CardInstrument, PaymentInstrument } from '../payment/instrument';
+import { PoConfig } from '../po-config';
 import { Consignment, PickupOptionResult, SearchArea, ShippingOption } from '../shipping';
 import { SignInEmail } from '../signin-email';
 
@@ -65,6 +66,13 @@ export default interface CheckoutStoreSelector {
      * @returns The B2B token string if it has been loaded, otherwise undefined.
      */
     getB2BToken(): string | undefined;
+
+    /**
+     * Gets the PO (purchase order) configuration for the current store.
+     *
+     * @returns The `PoConfig` object if it has been loaded, otherwise undefined.
+     */
+    getPoConfig(): PoConfig | undefined;
 
     /**
      * Gets the shipping address of the current checkout.
@@ -507,6 +515,11 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         (getToken) => clone(getToken),
     );
 
+    const getPoConfig = createSelector(
+        ({ poConfig }: InternalCheckoutSelectors) => poConfig.getConfig,
+        (getConfig) => clone(getConfig),
+    );
+
     const isPaymentDataRequired = createSelector(
         ({ payment }: InternalCheckoutSelectors) => payment.isPaymentDataRequired,
         (isPaymentDataRequired) => clone(isPaymentDataRequired),
@@ -637,6 +650,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             isPaymentDataSubmitted: isPaymentDataSubmitted(state),
             getSignInEmail: getSignInEmail(state),
             getB2BToken: getB2BToken(state),
+            getPoConfig: getPoConfig(state),
             getInstruments: getInstruments(state),
             getCustomerAccountFields: getCustomerAccountFields(state),
             getBillingAddressFields: getBillingAddressFields(state),

--- a/packages/core/src/checkout/checkout-store-state.ts
+++ b/packages/core/src/checkout/checkout-store-state.ts
@@ -13,6 +13,7 @@ import { OrderBillingAddressState } from '../order-billing-address';
 import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payment';
 import { PaymentProviderCustomerState } from '../payment-provider-customer';
 import { InstrumentState } from '../payment/instrument';
+import { PoConfigState } from '../po-config';
 import { RemoteCheckoutState } from '../remote-checkout';
 import {
     ConsignmentState,
@@ -49,6 +50,7 @@ export default interface CheckoutStoreState {
     paymentProviderCustomer: PaymentProviderCustomerState;
     paymentStrategies: PaymentStrategyState;
     pickupOptions: PickupOptionState;
+    poConfig: PoConfigState;
     remoteCheckout: RemoteCheckoutState;
     shippingCountries: ShippingCountryState;
     shippingStrategies: ShippingStrategyState;

--- a/packages/core/src/checkout/checkout-store-status-selector.ts
+++ b/packages/core/src/checkout/checkout-store-status-selector.ts
@@ -289,6 +289,13 @@ export default interface CheckoutStoreStatusSelector {
     isLoadingB2BToken(): boolean;
 
     /**
+     * Checks whether the PO (purchase order) configuration is being loaded.
+     *
+     * @returns True if the PO config is being loaded, otherwise false.
+     */
+    isLoadingPoConfig(): boolean;
+
+    /**
      * Checks whether the current customer is applying a gift certificate.
      *
      * @returns True if applying a gift certificate, otherwise false.
@@ -515,6 +522,7 @@ export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusS
             isLoadingConfig: state.config.isLoading,
             isSendingSignInEmail: state.signInEmail.isSending,
             isLoadingB2BToken: state.b2bToken.isLoading,
+            isLoadingPoConfig: state.poConfig.isLoading,
             isCustomerStepPending: isCustomerStepPending(state),
             isShippingStepPending: isShippingStepPending(state),
             isPaymentStepPending: isPaymentStepPending(state),

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -120,6 +120,7 @@ export function getCheckoutState(): CheckoutState {
 export function getCheckoutStoreState(): CheckoutStoreState {
     return {
         b2bToken: { errors: {}, statuses: {} },
+        poConfig: { errors: {}, statuses: {} },
         billingAddress: getBillingAddressState(),
         cart: getCartState(),
         checkout: getCheckoutState(),

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -44,6 +44,7 @@ import {
 } from '../payment';
 import { createPaymentIntegrationService } from '../payment-integration';
 import { InstrumentActionCreator, InstrumentRequestSender } from '../payment/instrument';
+import { PoConfigActionCreator, PoConfigRequestSender } from '../po-config';
 import {
     ConsignmentActionCreator,
     ConsignmentRequestSender,
@@ -212,6 +213,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
             paymentIntegrationService,
         ),
         new PickupOptionActionCreator(new PickupOptionRequestSender(experimentRequestSender)),
+        new PoConfigActionCreator(new PoConfigRequestSender(requestSender)),
         new ShippingCountryActionCreator(
             new ShippingCountryRequestSender(experimentRequestSender, { locale }),
             store,

--- a/packages/core/src/checkout/create-checkout-store-reducer.ts
+++ b/packages/core/src/checkout/create-checkout-store-reducer.ts
@@ -15,6 +15,7 @@ import { orderBillingAddressReducer } from '../order-billing-address';
 import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '../payment';
 import { paymentProviderCustomerReducer } from '../payment-provider-customer';
 import { instrumentReducer } from '../payment/instrument';
+import { poConfigReducer } from '../po-config';
 import { remoteCheckoutReducer } from '../remote-checkout';
 import {
     consignmentReducer,
@@ -53,6 +54,7 @@ export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState
         paymentStrategies: paymentStrategyReducer,
         pickupOptions: pickupOptionReducer,
         paymentProviderCustomer: paymentProviderCustomerReducer,
+        poConfig: poConfigReducer,
         remoteCheckout: remoteCheckoutReducer,
         shippingCountries: shippingCountryReducer,
         shippingStrategies: shippingStrategyReducer,

--- a/packages/core/src/checkout/create-internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/create-internal-checkout-selectors.ts
@@ -18,6 +18,7 @@ import {
 } from '../payment';
 import { createPaymentProviderCustomerSelectorFactory } from '../payment-provider-customer';
 import { createInstrumentSelectorFactory } from '../payment/instrument';
+import { createPoConfigSelectorFactory } from '../po-config';
 import { createRemoteCheckoutSelectorFactory } from '../remote-checkout';
 import {
     createConsignmentSelectorFactory,
@@ -57,6 +58,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createPaymentStrategySelector = createPaymentStrategySelectorFactory();
     const createPickupOptionSelector = createPickupOptionSelectorFactory();
     const createPaymentProviderCustomerSelector = createPaymentProviderCustomerSelectorFactory();
+    const createPoConfigSelector = createPoConfigSelectorFactory();
     const createRemoteCheckoutSelector = createRemoteCheckoutSelectorFactory();
     const createShippingAddressSelector = createShippingAddressSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
@@ -91,6 +93,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         );
         const paymentStrategies = createPaymentStrategySelector(state.paymentStrategies);
         const pickupOptions = createPickupOptionSelector(state.pickupOptions);
+        const poConfig = createPoConfigSelector(state.poConfig);
         const remoteCheckout = createRemoteCheckoutSelector(state.remoteCheckout);
         const shippingAddress = createShippingAddressSelector(state.consignments);
         const shippingCountries = createShippingCountrySelector(state.shippingCountries);
@@ -137,6 +140,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
             paymentProviderCustomer,
             paymentStrategies,
             pickupOptions,
+            poConfig,
             remoteCheckout,
             shippingAddress,
             shippingCountries,

--- a/packages/core/src/checkout/internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/internal-checkout-selectors.ts
@@ -13,6 +13,7 @@ import OrderBillingAddressSelector from '../order-billing-address/order-billing-
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { PaymentProviderCustomerSelector } from '../payment-provider-customer';
 import { InstrumentSelector } from '../payment/instrument';
+import { PoConfigSelector } from '../po-config';
 import { RemoteCheckoutSelector } from '../remote-checkout';
 import {
     ConsignmentSelector,
@@ -50,6 +51,7 @@ export default interface InternalCheckoutSelectors {
     paymentStrategies: PaymentStrategySelector;
     paymentProviderCustomer: PaymentProviderCustomerSelector;
     pickupOptions: PickupOptionSelector;
+    poConfig: PoConfigSelector;
     remoteCheckout: RemoteCheckoutSelector;
     shippingAddress: ShippingAddressSelector;
     shippingCountries: ShippingCountrySelector;

--- a/packages/core/src/po-config/index.ts
+++ b/packages/core/src/po-config/index.ts
@@ -1,0 +1,15 @@
+export { default as PoConfigActionCreator } from './po-config-action-creator';
+export { LoadPoConfigAction, PoConfigActionType } from './po-config-actions';
+export { default as poConfigReducer } from './po-config-reducer';
+export {
+    default as PoConfigSelector,
+    PoConfigSelectorFactory,
+    createPoConfigSelectorFactory,
+} from './po-config-selector';
+export { PoConfig, default as PoConfigState } from './po-config-state';
+export {
+    default as PoConfigRequestSender,
+    PoConfigResponseBody,
+    PoConfigResponseData,
+    PoConfigStoreSetting,
+} from './po-config-request-sender';

--- a/packages/core/src/po-config/po-config-action-creator.spec.ts
+++ b/packages/core/src/po-config/po-config-action-creator.spec.ts
@@ -1,0 +1,153 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { CheckoutStore, createCheckoutStore } from '../checkout';
+import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { getConfig } from '../config/configs.mock';
+
+import PoConfigActionCreator from './po-config-action-creator';
+import { PoConfigActionType } from './po-config-actions';
+import PoConfigRequestSender from './po-config-request-sender';
+
+describe('PoConfigActionCreator', () => {
+    let store: CheckoutStore;
+    let requestSender: PoConfigRequestSender;
+    let actionCreator: PoConfigActionCreator;
+
+    const responseBody = {
+        code: 200,
+        message: 'SUCCESS',
+        data: {
+            checkoutPaymentPurchaseEnableExtra: { id: 1, value: '1', type: 'checkbox' },
+            checkoutPaymentPurchaseExtraFields: {
+                id: 2,
+                value: 'PO Number / Reference Number',
+                type: 'text',
+            },
+            checkoutPaymentPurchaseExtraFieldsRequired: { id: 3, value: '1', type: 'checkbox' },
+        },
+    };
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = new PoConfigRequestSender(createRequestSender());
+
+        jest.spyOn(requestSender, 'getPoConfig').mockResolvedValue(getResponse(responseBody));
+
+        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
+            getConfig().storeConfig,
+        );
+
+        actionCreator = new PoConfigActionCreator(requestSender);
+    });
+
+    describe('#loadPoConfig()', () => {
+        it('emits load actions on success with a normalised payload', async () => {
+            const actions = await from(actionCreator.loadPoConfig()(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: PoConfigActionType.LoadPoConfigRequested },
+                {
+                    type: PoConfigActionType.LoadPoConfigSucceeded,
+                    payload: {
+                        enabled: true,
+                        label: 'PO Number / Reference Number',
+                        required: true,
+                    },
+                },
+            ]);
+        });
+
+        it('normalises "0"/"1" string flags into booleans', async () => {
+            jest.spyOn(requestSender, 'getPoConfig').mockResolvedValue(
+                getResponse({
+                    code: 200,
+                    message: 'SUCCESS',
+                    data: {
+                        checkoutPaymentPurchaseEnableExtra: {
+                            id: 1,
+                            value: '0',
+                            type: 'checkbox',
+                        },
+                        checkoutPaymentPurchaseExtraFields: {
+                            id: 2,
+                            value: 'PO Number',
+                            type: 'text',
+                        },
+                        checkoutPaymentPurchaseExtraFieldsRequired: {
+                            id: 3,
+                            value: '0',
+                            type: 'checkbox',
+                        },
+                    },
+                }),
+            );
+
+            const actions = await from(actionCreator.loadPoConfig()(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions[1]).toEqual({
+                type: PoConfigActionType.LoadPoConfigSucceeded,
+                payload: { enabled: false, label: 'PO Number', required: false },
+            });
+        });
+
+        it('calls getPoConfig with the B2B clientId, base URL and token from state', async () => {
+            const b2bApiSettings = {
+                clientId: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
+                baseUrl: 'https://api-b2b.bigcommerce.com',
+            };
+
+            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
+            jest.spyOn(store.getState().b2bToken, 'getToken').mockReturnValue('my-b2b-token');
+
+            await from(actionCreator.loadPoConfig()(store)).toPromise();
+
+            expect(requestSender.getPoConfig).toHaveBeenCalledWith(
+                b2bApiSettings.clientId,
+                b2bApiSettings.baseUrl,
+                'my-b2b-token',
+                undefined,
+            );
+        });
+
+        it('passes empty-string token when no B2B token has been loaded', async () => {
+            jest.spyOn(store.getState().b2bToken, 'getToken').mockReturnValue(undefined);
+
+            await from(actionCreator.loadPoConfig()(store)).toPromise();
+
+            expect(requestSender.getPoConfig).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.any(String),
+                '',
+                undefined,
+            );
+        });
+
+        it('emits error actions if getPoConfig fails', async () => {
+            jest.spyOn(requestSender, 'getPoConfig').mockRejectedValue(getErrorResponse());
+
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(actionCreator.loadPoConfig()(store))
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: PoConfigActionType.LoadPoConfigRequested },
+                expect.objectContaining({
+                    type: PoConfigActionType.LoadPoConfigFailed,
+                    error: true,
+                }),
+            ]);
+        });
+    });
+});

--- a/packages/core/src/po-config/po-config-action-creator.ts
+++ b/packages/core/src/po-config/po-config-action-creator.ts
@@ -1,0 +1,58 @@
+import { createAction, ThunkAction } from '@bigcommerce/data-store';
+import { concat, defer, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { InternalCheckoutSelectors } from '../checkout';
+import { throwErrorAction } from '../common/error';
+import { RequestOptions } from '../common/http-request';
+
+import { LoadPoConfigAction, PoConfigActionType } from './po-config-actions';
+import PoConfigRequestSender, { PoConfigResponseBody } from './po-config-request-sender';
+import { PoConfig } from './po-config-state';
+
+export default class PoConfigActionCreator {
+    constructor(private _requestSender: PoConfigRequestSender) {}
+
+    loadPoConfig(
+        options?: RequestOptions,
+    ): ThunkAction<LoadPoConfigAction, InternalCheckoutSelectors> {
+        return (store) => {
+            const state = store.getState();
+            const storeConfig = state.config.getStoreConfigOrThrow();
+            const { baseUrl: b2bBaseUrl = '', clientId: b2bClientId = '' } =
+                storeConfig.b2bApiSettings ?? {};
+            const b2bToken = state.b2bToken.getToken() ?? '';
+
+            return concat(
+                of(createAction(PoConfigActionType.LoadPoConfigRequested)),
+                defer(async () => {
+                    const { body } = await this._requestSender.getPoConfig(
+                        b2bClientId,
+                        b2bBaseUrl,
+                        b2bToken,
+                        options,
+                    );
+
+                    return createAction(
+                        PoConfigActionType.LoadPoConfigSucceeded,
+                        normalisePoConfig(body),
+                    );
+                }),
+            ).pipe(
+                catchError((error) =>
+                    throwErrorAction(PoConfigActionType.LoadPoConfigFailed, error),
+                ),
+            );
+        };
+    }
+}
+
+function normalisePoConfig(body: PoConfigResponseBody): PoConfig {
+    const { data } = body;
+
+    return {
+        enabled: data.checkoutPaymentPurchaseEnableExtra.value === '1',
+        label: data.checkoutPaymentPurchaseExtraFields.value,
+        required: data.checkoutPaymentPurchaseExtraFieldsRequired.value === '1',
+    };
+}

--- a/packages/core/src/po-config/po-config-actions.ts
+++ b/packages/core/src/po-config/po-config-actions.ts
@@ -1,0 +1,26 @@
+import { Action } from '@bigcommerce/data-store';
+
+import { PoConfig } from './po-config-state';
+
+export enum PoConfigActionType {
+    LoadPoConfigRequested = 'LOAD_PO_CONFIG_REQUESTED',
+    LoadPoConfigSucceeded = 'LOAD_PO_CONFIG_SUCCEEDED',
+    LoadPoConfigFailed = 'LOAD_PO_CONFIG_FAILED',
+}
+
+export type LoadPoConfigAction =
+    | LoadPoConfigRequestedAction
+    | LoadPoConfigSucceededAction
+    | LoadPoConfigFailedAction;
+
+export interface LoadPoConfigRequestedAction extends Action {
+    type: PoConfigActionType.LoadPoConfigRequested;
+}
+
+export interface LoadPoConfigSucceededAction extends Action<PoConfig> {
+    type: PoConfigActionType.LoadPoConfigSucceeded;
+}
+
+export interface LoadPoConfigFailedAction extends Action<Error> {
+    type: PoConfigActionType.LoadPoConfigFailed;
+}

--- a/packages/core/src/po-config/po-config-reducer.spec.ts
+++ b/packages/core/src/po-config/po-config-reducer.spec.ts
@@ -1,0 +1,48 @@
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+
+import { PoConfigActionType } from './po-config-actions';
+import poConfigReducer from './po-config-reducer';
+import PoConfigState, { DEFAULT_STATE } from './po-config-state';
+
+describe('poConfigReducer()', () => {
+    let initialState: PoConfigState;
+
+    beforeEach(() => {
+        initialState = DEFAULT_STATE;
+    });
+
+    it('returns loading state on requested', () => {
+        const action = createAction(PoConfigActionType.LoadPoConfigRequested);
+        const state = poConfigReducer(initialState, action);
+
+        expect(state.statuses.isLoading).toBe(true);
+        expect(state.errors.loadError).toBeUndefined();
+    });
+
+    it('stores config and clears loading state on success', () => {
+        const config = { enabled: true, label: 'PO Number', required: false };
+        const action = createAction(PoConfigActionType.LoadPoConfigSucceeded, config);
+        const state = poConfigReducer(initialState, action);
+
+        expect(state.data).toEqual(config);
+        expect(state.statuses.isLoading).toBe(false);
+        expect(state.errors.loadError).toBeUndefined();
+    });
+
+    it('stores error and clears loading state on failure', () => {
+        const error = new Error('Failed to load PO config');
+        const action = createErrorAction(PoConfigActionType.LoadPoConfigFailed, error);
+        const state = poConfigReducer(initialState, action);
+
+        expect(state.errors.loadError).toBe(error);
+        expect(state.statuses.isLoading).toBe(false);
+        expect(state.data).toBeUndefined();
+    });
+
+    it('returns previous state for unknown actions', () => {
+        const action = { type: 'UNKNOWN_ACTION' } as any;
+        const state = poConfigReducer(initialState, action);
+
+        expect(state).toEqual(initialState);
+    });
+});

--- a/packages/core/src/po-config/po-config-reducer.ts
+++ b/packages/core/src/po-config/po-config-reducer.ts
@@ -1,0 +1,69 @@
+import { Action, combineReducers, composeReducers } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
+import { objectSet } from '../common/utility';
+
+import { LoadPoConfigAction, PoConfigActionType } from './po-config-actions';
+import PoConfigState, {
+    DEFAULT_STATE,
+    PoConfig,
+    PoConfigErrorsState,
+    PoConfigStatusesState,
+} from './po-config-state';
+
+export default function poConfigReducer(
+    state: PoConfigState = DEFAULT_STATE,
+    action: Action,
+): PoConfigState {
+    const reducer = combineReducers<PoConfigState>({
+        data: dataReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
+        statuses: statusesReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(data: PoConfig | undefined, action: LoadPoConfigAction): PoConfig | undefined {
+    switch (action.type) {
+        case PoConfigActionType.LoadPoConfigSucceeded:
+            return action.payload;
+
+        default:
+            return data;
+    }
+}
+
+function errorsReducer(
+    errors: PoConfigErrorsState = DEFAULT_STATE.errors,
+    action: LoadPoConfigAction,
+): PoConfigErrorsState {
+    switch (action.type) {
+        case PoConfigActionType.LoadPoConfigRequested:
+        case PoConfigActionType.LoadPoConfigSucceeded:
+            return objectSet(errors, 'loadError', undefined);
+
+        case PoConfigActionType.LoadPoConfigFailed:
+            return objectSet(errors, 'loadError', action.payload);
+
+        default:
+            return errors;
+    }
+}
+
+function statusesReducer(
+    statuses: PoConfigStatusesState = DEFAULT_STATE.statuses,
+    action: LoadPoConfigAction,
+): PoConfigStatusesState {
+    switch (action.type) {
+        case PoConfigActionType.LoadPoConfigRequested:
+            return objectSet(statuses, 'isLoading', true);
+
+        case PoConfigActionType.LoadPoConfigFailed:
+        case PoConfigActionType.LoadPoConfigSucceeded:
+            return objectSet(statuses, 'isLoading', false);
+
+        default:
+            return statuses;
+    }
+}

--- a/packages/core/src/po-config/po-config-request-sender.spec.ts
+++ b/packages/core/src/po-config/po-config-request-sender.spec.ts
@@ -1,0 +1,121 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { SDK_VERSION_HEADERS } from '../common/http-request';
+import { getResponse } from '../common/http-request/responses.mock';
+
+import PoConfigRequestSender, { PoConfigResponseBody } from './po-config-request-sender';
+
+describe('PoConfigRequestSender', () => {
+    let requestSender: RequestSender;
+    let poConfigRequestSender: PoConfigRequestSender;
+
+    const bcJwt = 'bc-jwt-token';
+    const responseBody: PoConfigResponseBody = {
+        code: 200,
+        message: 'SUCCESS',
+        data: {
+            checkoutPaymentPurchaseEnableExtra: { id: 1, value: '1', type: 'checkbox' },
+            checkoutPaymentPurchaseExtraFields: {
+                id: 2,
+                value: 'PO Number / Reference Number',
+                type: 'text',
+            },
+            checkoutPaymentPurchaseExtraFieldsRequired: { id: 3, value: '1', type: 'checkbox' },
+        },
+    };
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        jest.spyOn(requestSender, 'get').mockImplementation(async (url) => {
+            if (url === '/customer/current.jwt') {
+                return getResponse({ token: bcJwt });
+            }
+
+            return getResponse(responseBody);
+        });
+
+        poConfigRequestSender = new PoConfigRequestSender(requestSender);
+    });
+
+    describe('#getPoConfig()', () => {
+        it('GETs the store-configs endpoint at the supplied B2B base URL with auth headers when a B2B token is supplied', async () => {
+            await poConfigRequestSender.getPoConfig(
+                'my-client-id',
+                'https://api-b2b.bigcommerce.com',
+                'my-b2b-token',
+            );
+
+            expect(requestSender.get).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/store-configs/checkout',
+                {
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'my-b2b-token',
+                        Authorization: 'Bearer my-b2b-token',
+                    },
+                    timeout: undefined,
+                },
+            );
+        });
+
+        it('does not fetch the BC JWT when a B2B token is supplied', async () => {
+            await poConfigRequestSender.getPoConfig(
+                'my-client-id',
+                'https://api-b2b.bigcommerce.com',
+                'my-b2b-token',
+            );
+
+            expect(requestSender.get).not.toHaveBeenCalledWith(
+                '/customer/current.jwt',
+                expect.anything(),
+            );
+        });
+
+        it('falls back to the BC JWT for authToken when no B2B token is supplied', async () => {
+            await poConfigRequestSender.getPoConfig(
+                'my-client-id',
+                'https://api-b2b.bigcommerce.com',
+                '',
+            );
+
+            expect(requestSender.get).toHaveBeenCalledWith('/customer/current.jwt', {
+                timeout: undefined,
+                params: { app_client_id: 'my-client-id' },
+                headers: SDK_VERSION_HEADERS,
+            });
+
+            expect(requestSender.get).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/store-configs/checkout',
+                expect.objectContaining({
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: bcJwt,
+                        Authorization: 'Bearer ',
+                    },
+                }),
+            );
+        });
+
+        it('forwards the timeout option to both requests', async () => {
+            const timeout = { promise: Promise.resolve(), token: { aborted: false } } as never;
+
+            await poConfigRequestSender.getPoConfig(
+                'my-client-id',
+                'https://api-b2b.bigcommerce.com',
+                '',
+                { timeout },
+            );
+
+            expect(requestSender.get).toHaveBeenCalledWith(
+                '/customer/current.jwt',
+                expect.objectContaining({ timeout }),
+            );
+            expect(requestSender.get).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/store-configs/checkout',
+                expect.objectContaining({ timeout }),
+            );
+        });
+    });
+});

--- a/packages/core/src/po-config/po-config-request-sender.ts
+++ b/packages/core/src/po-config/po-config-request-sender.ts
@@ -1,0 +1,58 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
+
+export interface PoConfigStoreSetting {
+    id?: number;
+    value: string;
+    type?: string;
+}
+
+export interface PoConfigResponseData {
+    checkoutPaymentPurchaseEnableExtra: PoConfigStoreSetting;
+    checkoutPaymentPurchaseExtraFields: PoConfigStoreSetting;
+    checkoutPaymentPurchaseExtraFieldsRequired: PoConfigStoreSetting;
+    [key: string]: PoConfigStoreSetting | string | undefined;
+}
+
+export interface PoConfigResponseBody {
+    code: number;
+    message: string;
+    data: PoConfigResponseData;
+}
+
+export default class PoConfigRequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    async getPoConfig(
+        appClientId: string,
+        b2bBaseUrl: string,
+        b2bToken: string,
+        options?: RequestOptions,
+    ): Promise<Response<PoConfigResponseBody>> {
+        let bcToken = '';
+
+        if (!b2bToken) {
+            const { body } = await this._requestSender.get<{ token: string }>(
+                '/customer/current.jwt',
+                {
+                    timeout: options?.timeout,
+                    params: { app_client_id: appClientId },
+                    headers: SDK_VERSION_HEADERS,
+                },
+            );
+
+            bcToken = body.token;
+        }
+
+        return this._requestSender.get(`${b2bBaseUrl}/api/v2/store-configs/checkout`, {
+            timeout: options?.timeout,
+            credentials: false,
+            headers: {
+                'Content-Type': 'application/json',
+                authToken: b2bToken || bcToken,
+                Authorization: `Bearer ${b2bToken}`,
+            },
+        });
+    }
+}

--- a/packages/core/src/po-config/po-config-selector.spec.ts
+++ b/packages/core/src/po-config/po-config-selector.spec.ts
@@ -1,0 +1,56 @@
+import { createPoConfigSelectorFactory } from './po-config-selector';
+import PoConfigState, { DEFAULT_STATE } from './po-config-state';
+
+describe('createPoConfigSelectorFactory()', () => {
+    const createSelector = createPoConfigSelectorFactory();
+
+    it('returns undefined config when no data is loaded', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getConfig()).toBeUndefined();
+    });
+
+    it('returns the config object when data is loaded', () => {
+        const config = { enabled: true, label: 'PO Number', required: false };
+        const state: PoConfigState = {
+            ...DEFAULT_STATE,
+            data: config,
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getConfig()).toEqual(config);
+    });
+
+    it('returns false for isLoading when not loading', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.isLoading()).toBe(false);
+    });
+
+    it('returns true for isLoading when loading', () => {
+        const state: PoConfigState = {
+            ...DEFAULT_STATE,
+            statuses: { isLoading: true },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.isLoading()).toBe(true);
+    });
+
+    it('returns undefined for getLoadError when no error', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getLoadError()).toBeUndefined();
+    });
+
+    it('returns error for getLoadError when there is an error', () => {
+        const error = new Error('PO config load failed');
+        const state: PoConfigState = {
+            ...DEFAULT_STATE,
+            errors: { loadError: error },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getLoadError()).toBe(error);
+    });
+});

--- a/packages/core/src/po-config/po-config-selector.ts
+++ b/packages/core/src/po-config/po-config-selector.ts
@@ -1,0 +1,38 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { createSelector } from '../common/selector';
+
+import PoConfigState, { DEFAULT_STATE, PoConfig } from './po-config-state';
+
+export default interface PoConfigSelector {
+    getConfig(): PoConfig | undefined;
+    getLoadError(): Error | undefined;
+    isLoading(): boolean;
+}
+
+export type PoConfigSelectorFactory = (state: PoConfigState) => PoConfigSelector;
+
+export function createPoConfigSelectorFactory(): PoConfigSelectorFactory {
+    const getConfig = createSelector(
+        (state: PoConfigState) => state.data,
+        (data) => () => data,
+    );
+
+    const getLoadError = createSelector(
+        (state: PoConfigState) => state.errors.loadError,
+        (error) => () => error,
+    );
+
+    const isLoading = createSelector(
+        (state: PoConfigState) => !!state.statuses.isLoading,
+        (status) => () => status,
+    );
+
+    return memoizeOne((state: PoConfigState = DEFAULT_STATE): PoConfigSelector => {
+        return {
+            getConfig: getConfig(state),
+            getLoadError: getLoadError(state),
+            isLoading: isLoading(state),
+        };
+    });
+}

--- a/packages/core/src/po-config/po-config-state.ts
+++ b/packages/core/src/po-config/po-config-state.ts
@@ -1,0 +1,24 @@
+export interface PoConfig {
+    enabled: boolean;
+    label: string;
+    required: boolean;
+}
+
+export default interface PoConfigState {
+    data?: PoConfig;
+    errors: PoConfigErrorsState;
+    statuses: PoConfigStatusesState;
+}
+
+export interface PoConfigErrorsState {
+    loadError?: Error;
+}
+
+export interface PoConfigStatusesState {
+    isLoading?: boolean;
+}
+
+export const DEFAULT_STATE: PoConfigState = {
+    errors: {},
+    statuses: {},
+};


### PR DESCRIPTION
## What/Why?

Adds a new `loadPoConfig()` SDK method (plus `getPoConfig(), isLoadingPoConfig(), getLoadPoConfigError()` accessors) so the checkout-js `usePoConfig` hook can read the B2B store's purchase order (PO) configuration — whether the PO field is enabled, its label, and whether it's required.

Fetches from `GET {b2bApiSettings.baseUrl}/api/v2/store-configs/checkout`, authenticated with the B2B token from state (with a BC JWT fallback for the `authToken` header when the B2B token hasn't been loaded yet).

## Rollout/Rollback

Revert this PR

## Testing

- CI checks
