### PR TITLE
feat(paymnet): Remove isButtonMicroTextDisabled for not usage

### DIFF
--- a/packages/amazon-pay-integration/src/amazon-pay-v2-button-strategy.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-button-strategy.ts
@@ -48,7 +48,6 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
         const { getPaymentMethodOrThrow } = this.paymentIntegrationService.getState();
 
         const paymentMethod = getPaymentMethodOrThrow<AmazonPayV2InitializeOptions>(methodId);
-        const { initializationData } = paymentMethod;
 
         await this.amazonPayV2PaymentProcessor.initialize(paymentMethod);
 
@@ -75,7 +74,6 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
             options: initializeAmazonButtonOptions,
             placement: AmazonPayV2Placement.Cart,
             buttonColor,
-            isButtonMicroTextDisabled: initializationData?.isButtonMicroTextDisabled,
         });
 
         if (this._buyNowInitializeOptions) {

--- a/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.ts
+++ b/packages/amazon-pay-integration/src/amazon-pay-v2-payment-strategy.ts
@@ -51,7 +51,7 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
         const { features } = state.getStoreConfigOrThrow().checkoutSettings;
         const paymentMethod = state.getPaymentMethodOrThrow<AmazonPayV2InitializeOptions>(methodId);
         const initializationData = paymentMethod.initializationData || {};
-        const { paymentToken = '', region = '', isButtonMicroTextDisabled } = initializationData;
+        const { paymentToken = '', region = '' } = initializationData;
 
         await this.amazonPayV2PaymentProcessor.initialize(paymentMethod);
 
@@ -76,7 +76,6 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
                 ),
                 methodId,
                 placement: AmazonPayV2Placement.Checkout,
-                isButtonMicroTextDisabled,
             });
 
             if (!this._amazonPayButton) {

--- a/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.spec.ts
@@ -160,18 +160,6 @@ describe('AmazonPayV2PaymentProcessor', () => {
             );
         });
 
-        it('should render the Amazon Pay button to an HTML container element without microtext', async () => {
-            await processor.initialize(amazonPayV2Mock);
-            amazonPayV2ButtonParams = getAmazonPayV2ButtonParamsMock(true);
-
-            processor.createButton(containerId, amazonPayV2ButtonParams);
-
-            expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(
-                `#${containerId}`,
-                amazonPayV2ButtonParams,
-            );
-        });
-
         it('throws an error when amazonPayV2SDK is not initialized', () => {
             const createButton = () => processor.createButton(containerId, amazonPayV2ButtonParams);
 

--- a/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2-payment-processor.ts
@@ -15,7 +15,6 @@ import {
     AmazonPayV2Button,
     AmazonPayV2ButtonColor,
     AmazonPayV2ButtonConfig,
-    AmazonPayV2ButtonDesign,
     AmazonPayV2ButtonParameters,
     AmazonPayV2ButtonRenderingOptions,
     AmazonPayV2ChangeActionType,
@@ -122,7 +121,6 @@ export default class AmazonPayV2PaymentProcessor {
         methodId,
         options,
         placement,
-        isButtonMicroTextDisabled = false,
     }: AmazonPayV2ButtonRenderingOptions): HTMLDivElement | undefined {
         const container = document.querySelector<HTMLElement>(`#${containerId}`);
 
@@ -131,10 +129,6 @@ export default class AmazonPayV2PaymentProcessor {
         }
 
         const { id: parentContainerId } = container.appendChild(this.getButtonParentContainer());
-
-        if (options && isButtonMicroTextDisabled) {
-            options.design = AmazonPayV2ButtonDesign.C0001;
-        }
 
         const amazonPayV2ButtonOptions =
             options ??
@@ -222,7 +216,6 @@ export default class AmazonPayV2PaymentProcessor {
             extractAmazonCheckoutSessionId,
             ledgerCurrency,
             publicKeyId = '',
-            isButtonMicroTextDisabled,
         } = initializationData;
 
         if (!merchantId || !ledgerCurrency) {
@@ -235,7 +228,6 @@ export default class AmazonPayV2PaymentProcessor {
             checkoutLanguage,
             placement,
             buttonColor,
-            ...(isButtonMicroTextDisabled ? { design: AmazonPayV2ButtonDesign.C0001 } : {}),
         };
 
         if (this.isBuyNowFlow) {

--- a/packages/amazon-pay-utils/src/amazon-pay-v2.ts
+++ b/packages/amazon-pay-utils/src/amazon-pay-v2.ts
@@ -99,11 +99,6 @@ export interface AmazonPayV2ButtonConfig {
      * if your `publicKeyId` has an environment prefix. Default is false.
      */
     sandbox?: boolean;
-
-    /**
-     * Sets Amazon Pay button design.
-     */
-    design?: AmazonPayV2ButtonDesign;
 }
 
 export interface AmazonPayV2ButtonParams extends AmazonPayV2ButtonConfig {
@@ -252,10 +247,6 @@ export enum AmazonPayV2ButtonColor {
     DarkGray = 'DarkGray',
 }
 
-export enum AmazonPayV2ButtonDesign {
-    C0001 = 'C0001',
-}
-
 // TODO: after migration AmazonPay strategies to integration package
 // <InternalCheckoutSelectors> should be removed
 // and replaced usage with <PaymentIntegrationService>
@@ -283,7 +274,6 @@ export interface AmazonPayV2InitializeOptions {
     ledgerCurrency?: AmazonPayV2LedgerCurrency;
     publicKeyId?: string;
     region?: string;
-    isButtonMicroTextDisabled?: boolean;
     paymentToken?: string;
 }
 
@@ -295,7 +285,6 @@ export interface AmazonPayV2ButtonRenderingOptions {
     buttonColor?: AmazonPayV2ButtonColor;
     options?: AmazonPayV2ButtonParameters;
     placement: AmazonPayV2Placement;
-    isButtonMicroTextDisabled?: boolean;
 }
 
 export interface AmazonPayAdditionalActionErrorBody {

--- a/packages/amazon-pay-utils/src/mocks/amazon-pay-v2.mock.ts
+++ b/packages/amazon-pay-utils/src/mocks/amazon-pay-v2.mock.ts
@@ -3,7 +3,6 @@ import { PaymentMethod } from '@bigcommerce/checkout-sdk/payment-integration-api
 import {
     AmazonPayV2ButtonColor,
     AmazonPayV2ButtonConfig,
-    AmazonPayV2ButtonDesign,
     AmazonPayV2ButtonParameters,
     AmazonPayV2CheckoutLanguage,
     AmazonPayV2InitializeOptions,
@@ -73,9 +72,7 @@ export function getAmazonPayBaseButtonParamsMock(): AmazonPayV2ButtonConfig {
     };
 }
 
-export function getAmazonPayV2ButtonParamsMock(
-    isButtonMicroTextDisabled = false,
-): AmazonPayV2ButtonParameters {
+export function getAmazonPayV2ButtonParamsMock(): AmazonPayV2ButtonParameters {
     return {
         buttonColor: AmazonPayV2ButtonColor.Gold,
         checkoutLanguage: AmazonPayV2CheckoutLanguage.en_US,
@@ -89,7 +86,6 @@ export function getAmazonPayV2ButtonParamsMock(
         placement: AmazonPayV2Placement.Checkout,
         productType: AmazonPayV2PayOptions.PayAndShip,
         sandbox: true,
-        ...(isButtonMicroTextDisabled ? { design: AmazonPayV2ButtonDesign.C0001 } : {}),
     };
 }
 


### PR DESCRIPTION
## What/Why?

Removes the dead code related to the PI-2061.amazon_pay_button_micro_text_disabled experiment from checkout-sdk.

The experiment controlled whether the Amazon Pay button micro text ("USE YOUR AMAZON ACCOUNT") was hidden by passing design: 'C0001' to the Amazon Pay button config. This value was sourced from initializationData.isButtonMicroTextDisabled, which was set by bcapp based on a LaunchDarkly flag.

The experiment was disabled and fully removed from bcapp in [bigcommerce/bigcommerce#67068](https://github.com/bigcommerce/bigcommerce/pull/67068), meaning isButtonMicroTextDisabled is no longer included in the initializationData response. This PR removes the now-dead handling code from checkout-sdk as a maintenance cleanup.

## Rollout/Rollback

rollback this commit 

## Testing

without changes

https://github.com/user-attachments/assets/765078df-6345-4079-852a-c10a8def4fae

with changes

https://github.com/user-attachments/assets/b34670b5-ede4-45c0-9404-81ad42e02525

<img width="1046" height="841" alt="image" src="https://github.com/user-attachments/assets/9e75c226-8eca-4ebe-ad07-e3aefa6b3292" />
<img width="883" height="772" alt="image" src="https://github.com/user-attachments/assets/702c64b3-dd61-4584-94da-c53d17dd953d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; default Amazon Pay button rendering is unchanged aside from no longer honoring a field that is no longer provided.
> 
> **Overview**
> Removes checkout-sdk support for the retired **PI-2061** Amazon Pay button micro-text experiment. **`initializationData.isButtonMicroTextDisabled`** is no longer read in cart/checkout strategies, and the processor no longer maps it to **`design: C0001`** on Amazon Pay button config.
> 
> Also deletes **`AmazonPayV2ButtonDesign`**, related types/options, the micro-text unit test, and mock helpers—aligned with bcapp no longer sending this flag after LaunchDarkly cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc82d86619d5466f1fe0d39a3d23970cbabd3ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->