### PR TITLE
feat(payment): PAYPAL-6469 wallet-button-integration package with core bundle integration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,6 +80,7 @@
 /packages/paypal-commerce-utils @bigcommerce/team-paypal
 /packages/paypal-pro-integration @bigcommerce/team-paypal
 /packages/paypal-utils @bigcommerce/team-paypal
+/packages/wallet-button-integration @bigcommerce/team-paypal
 
 ## Shared
 

--- a/packages/core/auto-export.config.json
+++ b/packages/core/auto-export.config.json
@@ -17,6 +17,12 @@
             "outputPath": "packages/core/src/generated/checkout-button-strategies.ts",
             "packageOutputPath": "packages/core/src/generated/integrations/<moduleName>/index.ts",
             "memberPattern": "^create.+ButtonStrategy$"
+        },
+        {
+            "inputPath": "packages/*/src/index.ts",
+            "outputPath": "packages/core/src/generated/wallet-button-strategies.ts",
+            "packageOutputPath": "packages/core/src/generated/integrations/<moduleName>/index.ts",
+            "memberPattern": "^create.+WalletStrategy$"
         }
     ],
     "apiExtractorConfig": {

--- a/packages/core/extend-interface.config.json
+++ b/packages/core/extend-interface.config.json
@@ -23,6 +23,14 @@
             "memberPattern": "^With.+ButtonInitializeOptions$",
             "targetPath": "packages/core/src/checkout-buttons/index.ts",
             "targetMemberName": "BaseCheckoutButtonInitializeOptions"
+        },
+        {
+            "inputPath": "packages/*/src/index.ts",
+            "outputPath": "packages/core/src/generated/wallet-button-initialize-options.ts",
+            "outputMemberName": "WalletButtonInitializeOptions",
+            "memberPattern": "^With.+WalletInitializeOptions$",
+            "targetPath": "packages/core/src/wallet-buttons/index.ts",
+            "targetMemberName": "BaseWalletButtonInitializeOptions"
         }
     ]
 }

--- a/packages/core/src/bundles/wallet-button.ts
+++ b/packages/core/src/bundles/wallet-button.ts
@@ -1,0 +1,1 @@
+export { createWalletButtonInitializer } from '../wallet-buttons';

--- a/packages/core/src/loader-cdn.ts
+++ b/packages/core/src/loader-cdn.ts
@@ -5,15 +5,20 @@ import * as checkoutButtonBundle from './bundles/checkout-button';
 import * as mainBundle from './bundles/checkout-sdk';
 import * as embeddedCheckoutBundle from './bundles/embedded-checkout';
 import * as hostedFormBundle from './bundles/hosted-form';
+import * as walletButtonBundle from './bundles/wallet-button';
 import { parseUrl } from './common/url';
 
 export type CheckoutButtonBundle = typeof checkoutButtonBundle & { version: string };
+export type WalletButtonBundle = typeof walletButtonBundle & {
+    version: string;
+};
 export type EmbeddedCheckoutBundle = typeof embeddedCheckoutBundle & { version: string };
 export type HostedFormBundle = typeof hostedFormBundle & { version: string };
 export type MainBundle = typeof mainBundle & { version: string };
 
 export enum BundleType {
     CheckoutButton = 'checkout-button',
+    WalletButton = 'wallet-button',
     EmbeddedCheckout = 'embedded-checkout',
     HostedForm = 'hosted-form',
     Main = 'checkout-sdk',
@@ -25,12 +30,19 @@ const scriptOrigin = isScriptElement(document.currentScript)
 
 export function load(moduleName?: BundleType.Main): Promise<MainBundle>;
 export function load(moduleName: BundleType.CheckoutButton): Promise<CheckoutButtonBundle>;
+export function load(moduleName: BundleType.WalletButton): Promise<WalletButtonBundle>;
 export function load(moduleName: BundleType.EmbeddedCheckout): Promise<EmbeddedCheckoutBundle>;
 export function load(moduleName: BundleType.HostedForm): Promise<HostedFormBundle>;
 
 export async function load(
     moduleName: string = BundleType.Main,
-): Promise<MainBundle | CheckoutButtonBundle | EmbeddedCheckoutBundle | HostedFormBundle> {
+): Promise<
+    | MainBundle
+    | CheckoutButtonBundle
+    | WalletButtonBundle
+    | EmbeddedCheckoutBundle
+    | HostedFormBundle
+> {
     const { version, js } = MANIFEST_JSON;
     const manifestPath = js.find((path) => path.indexOf(moduleName) !== -1);
 

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -4,14 +4,19 @@ import * as checkoutButtonBundle from './bundles/checkout-button';
 import * as mainBundle from './bundles/checkout-sdk';
 import * as embeddedCheckoutBundle from './bundles/embedded-checkout';
 import * as hostedFormBundle from './bundles/hosted-form';
+import * as walletButtonBundle from './bundles/wallet-button';
 
 export type CheckoutButtonBundle = typeof checkoutButtonBundle & { version: string };
+export type WalletButtonBundle = typeof walletButtonBundle & {
+    version: string;
+};
 export type EmbeddedCheckoutBundle = typeof embeddedCheckoutBundle & { version: string };
 export type HostedFormBundle = typeof hostedFormBundle & { version: string };
 export type MainBundle = typeof mainBundle & { version: string };
 
 export enum BundleType {
     CheckoutButton = 'checkout-button',
+    WalletButton = 'wallet-button',
     EmbeddedCheckout = 'embedded-checkout',
     HostedForm = 'hosted-form',
     Main = 'checkout-sdk',
@@ -19,12 +24,19 @@ export enum BundleType {
 
 export function load(moduleName?: BundleType.Main): Promise<MainBundle>;
 export function load(moduleName: BundleType.CheckoutButton): Promise<CheckoutButtonBundle>;
+export function load(moduleName: BundleType.WalletButton): Promise<WalletButtonBundle>;
 export function load(moduleName: BundleType.EmbeddedCheckout): Promise<EmbeddedCheckoutBundle>;
 export function load(moduleName: BundleType.HostedForm): Promise<HostedFormBundle>;
 
 export async function load(
     moduleName: string = BundleType.Main,
-): Promise<MainBundle | CheckoutButtonBundle | EmbeddedCheckoutBundle | HostedFormBundle> {
+): Promise<
+    | MainBundle
+    | CheckoutButtonBundle
+    | WalletButtonBundle
+    | EmbeddedCheckoutBundle
+    | HostedFormBundle
+> {
     const { version, js } = MANIFEST_JSON;
     const manifestPath = js.find((path) => path.indexOf(moduleName) !== -1);
 

--- a/packages/core/src/wallet-buttons/create-wallet-button-initializer.spec.ts
+++ b/packages/core/src/wallet-buttons/create-wallet-button-initializer.spec.ts
@@ -1,0 +1,23 @@
+import { createWalletButtonIntegrationService } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import createWalletButtonInitializer from './create-wallet-button-initializer';
+import WalletButtonInitializer from './wallet-button-initializer';
+
+jest.mock('@bigcommerce/checkout-sdk/wallet-button-integration');
+jest.mock('../generated/wallet-button-strategies', () => ({}));
+
+describe('createWalletButtonInitializer', () => {
+    beforeEach(() => {
+        (createWalletButtonIntegrationService as jest.Mock).mockReturnValue({
+            getGraphQLEndpoint: () => '/graphql',
+        });
+    });
+
+    it('creates a WalletButtonInitializer instance', () => {
+        const initializer = createWalletButtonInitializer({
+            graphQLEndpoint: '/graphql',
+        });
+
+        expect(initializer).toBeInstanceOf(WalletButtonInitializer);
+    });
+});

--- a/packages/core/src/wallet-buttons/create-wallet-button-initializer.ts
+++ b/packages/core/src/wallet-buttons/create-wallet-button-initializer.ts
@@ -1,0 +1,22 @@
+import { createWalletButtonIntegrationService } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import * as walletButtonStrategyFactories from '../generated/wallet-button-strategies';
+
+import createWalletButtonStrategyRegistry from './create-wallet-button-strategy-registry';
+import WalletButtonInitializer from './wallet-button-initializer';
+import { WalletButtonInitializerOptions } from './wallet-buttons';
+
+export default function createWalletButtonInitializer(
+    options: WalletButtonInitializerOptions,
+): WalletButtonInitializer {
+    const { graphQLEndpoint } = options;
+
+    const walletButtonIntegrationService = createWalletButtonIntegrationService(graphQLEndpoint);
+
+    const registryV2 = createWalletButtonStrategyRegistry(
+        walletButtonIntegrationService,
+        walletButtonStrategyFactories,
+    );
+
+    return new WalletButtonInitializer(registryV2);
+}

--- a/packages/core/src/wallet-buttons/create-wallet-button-strategy-registry.spec.ts
+++ b/packages/core/src/wallet-buttons/create-wallet-button-strategy-registry.spec.ts
@@ -1,0 +1,49 @@
+import {
+    CheckoutButtonStrategy,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { WalletButtonIntegrationService } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import createWalletButtonStrategyRegistry from './create-wallet-button-strategy-registry';
+
+describe('createWalletButtonStrategyRegistry', () => {
+    let walletButtonIntegrationService: WalletButtonIntegrationService;
+    let testStrategy: CheckoutButtonStrategy;
+
+    beforeEach(() => {
+        walletButtonIntegrationService = new WalletButtonIntegrationService('/graphql');
+        testStrategy = {
+            initialize: jest.fn(),
+            deinitialize: jest.fn(),
+        };
+    });
+
+    it('creates registry with factories pre-registered', () => {
+        const registry = createWalletButtonStrategyRegistry(walletButtonIntegrationService, {
+            createTestStrategy: toResolvableModule(() => testStrategy, [{ id: 'test' }]),
+        });
+        const strategy = registry.get({ id: 'test' });
+
+        expect(strategy).toEqual(testStrategy);
+    });
+
+    it('skips non-resolvable modules', () => {
+        const registry = createWalletButtonStrategyRegistry(walletButtonIntegrationService, {
+            notResolvable: (() => ({})) as any,
+        });
+
+        expect(() => registry.get({ id: 'notResolvable' })).toThrow();
+    });
+
+    it('registers multiple resolve IDs for a single factory', () => {
+        const registry = createWalletButtonStrategyRegistry(walletButtonIntegrationService, {
+            createTestStrategy: toResolvableModule(
+                () => testStrategy,
+                [{ id: 'test' }, { id: 'mock' }],
+            ),
+        });
+
+        expect(registry.get({ id: 'test' })).toEqual(testStrategy);
+        expect(registry.get({ id: 'mock' })).toEqual(testStrategy);
+    });
+});

--- a/packages/core/src/wallet-buttons/create-wallet-button-strategy-registry.ts
+++ b/packages/core/src/wallet-buttons/create-wallet-button-strategy-registry.ts
@@ -1,0 +1,44 @@
+import {
+    CheckoutButtonStrategy,
+    CheckoutButtonStrategyResolveId,
+    isResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    WalletButtonIntegrationService,
+    WalletPaymentButtonStrategyFactory,
+} from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import { ResolveIdRegistry } from '../common/registry';
+
+export interface WalletButtonStrategyFactories {
+    [key: string]: WalletPaymentButtonStrategyFactory<CheckoutButtonStrategy>;
+}
+
+export default function createWalletButtonStrategyRegistry(
+    walletButtonIntegrationService: WalletButtonIntegrationService,
+    walletButtonStrategyFactories: WalletButtonStrategyFactories,
+): ResolveIdRegistry<CheckoutButtonStrategy, CheckoutButtonStrategyResolveId> {
+    const registry = new ResolveIdRegistry<
+        CheckoutButtonStrategy,
+        CheckoutButtonStrategyResolveId
+    >();
+
+    for (const [, createWalletButtonStrategy] of Object.entries(walletButtonStrategyFactories)) {
+        if (
+            !isResolvableModule<
+                WalletPaymentButtonStrategyFactory<CheckoutButtonStrategy>,
+                CheckoutButtonStrategyResolveId
+            >(createWalletButtonStrategy)
+        ) {
+            continue;
+        }
+
+        for (const resolverId of createWalletButtonStrategy.resolveIds) {
+            registry.register(resolverId, () =>
+                createWalletButtonStrategy(walletButtonIntegrationService),
+            );
+        }
+    }
+
+    return registry;
+}

--- a/packages/core/src/wallet-buttons/index.ts
+++ b/packages/core/src/wallet-buttons/index.ts
@@ -1,0 +1,6 @@
+export { default as createWalletButtonInitializer } from './create-wallet-button-initializer';
+export {
+    BaseWalletButtonInitializeOptions,
+    WalletButtonMethodType,
+    WalletButtonOptions,
+} from './wallet-button-options';

--- a/packages/core/src/wallet-buttons/wallet-button-initializer.spec.ts
+++ b/packages/core/src/wallet-buttons/wallet-button-initializer.spec.ts
@@ -1,0 +1,78 @@
+import { CheckoutButtonStrategy } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { ResolveIdRegistry } from '../common/registry';
+
+import WalletButtonInitializer from './wallet-button-initializer';
+import {
+    BaseWalletButtonInitializeOptions,
+    WalletButtonMethodType,
+    WalletButtonOptions,
+} from './wallet-button-options';
+import WalletButtonRegistryV2 from './wallet-button-strategy-registry-v2';
+
+describe('WalletButtonInitializer', () => {
+    let initializer: WalletButtonInitializer;
+    let registry: WalletButtonRegistryV2;
+    let strategy: CheckoutButtonStrategy;
+    let baseOptions: BaseWalletButtonInitializeOptions;
+    let baseDeinitializeOptions: WalletButtonOptions;
+
+    beforeEach(() => {
+        strategy = {
+            initialize: jest.fn().mockResolvedValue(undefined),
+            deinitialize: jest.fn().mockResolvedValue(undefined),
+        };
+
+        registry = new ResolveIdRegistry();
+        registry.register({ id: WalletButtonMethodType.PAYPALCOMMERCE }, () => strategy);
+
+        initializer = new WalletButtonInitializer(registry);
+
+        baseOptions = {
+            methodId: WalletButtonMethodType.PAYPALCOMMERCE,
+            containerId: 'wallet-button-container',
+        };
+
+        baseDeinitializeOptions = {
+            methodId: WalletButtonMethodType.PAYPALCOMMERCE,
+        };
+    });
+
+    describe('initializeWalletButton()', () => {
+        it('initializes strategy with provided options', async () => {
+            await initializer.initializeWalletButton(baseOptions);
+
+            expect(strategy.initialize).toHaveBeenCalledWith(baseOptions);
+        });
+
+        it('returns array of promises for multiple containers', async () => {
+            const container = document.createElement('div');
+
+            container.className = 'wallet-button';
+            document.body.appendChild(container);
+
+            const container2 = container.cloneNode() as HTMLElement;
+
+            document.body.appendChild(container2);
+
+            const result = await initializer.initializeWalletButton({
+                ...baseOptions,
+                containerId: '.wallet-button',
+            });
+
+            expect(Array.isArray(result)).toBe(true);
+            expect(strategy.initialize).toHaveBeenCalledTimes(2);
+
+            container.remove();
+            container2.remove();
+        });
+    });
+
+    describe('deinitializeWalletButton()', () => {
+        it('deinitializes strategy', async () => {
+            await initializer.deinitializeWalletButton(baseDeinitializeOptions);
+
+            expect(strategy.deinitialize).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/wallet-buttons/wallet-button-initializer.ts
+++ b/packages/core/src/wallet-buttons/wallet-button-initializer.ts
@@ -1,0 +1,33 @@
+import { bindDecorator as bind } from '@bigcommerce/checkout-sdk/utility';
+
+import { isElementId, setUniqueElementId } from '../common/dom';
+
+import { BaseWalletButtonInitializeOptions, WalletButtonOptions } from './wallet-button-options';
+import WalletButtonRegistryV2 from './wallet-button-strategy-registry-v2';
+
+@bind
+export default class WalletButtonInitializer {
+    constructor(private _registryV2: WalletButtonRegistryV2) {}
+
+    initializeWalletButton(options: BaseWalletButtonInitializeOptions): Promise<void[]> {
+        const containerIds = this.getContainerIds(options);
+
+        return Promise.all(
+            containerIds.map(async (containerId) => {
+                const strategy = this._registryV2.get({ id: options.methodId });
+
+                return strategy.initialize({ ...options, containerId });
+            }),
+        );
+    }
+
+    deinitializeWalletButton(options: WalletButtonOptions): Promise<void> {
+        return this._registryV2.get({ id: options.methodId }).deinitialize();
+    }
+
+    private getContainerIds(options: BaseWalletButtonInitializeOptions) {
+        return isElementId(options.containerId)
+            ? [options.containerId]
+            : setUniqueElementId(options.containerId, `${options.methodId}-container`);
+    }
+}

--- a/packages/core/src/wallet-buttons/wallet-button-options.ts
+++ b/packages/core/src/wallet-buttons/wallet-button-options.ts
@@ -1,0 +1,19 @@
+import { RequestOptions } from '../common/http-request';
+
+export { WalletButtonInitializeOptions } from '../generated/wallet-button-initialize-options';
+
+export enum WalletButtonMethodType {
+    PAYPALCOMMERCE = 'paypalcommercepaypal',
+    PAYPALCOMMERCEVENMO = 'paypalcommercevenmo',
+    PAYPALCOMMERCEPAYPALCREDIT = 'paypalcommercepaypalcredit',
+}
+
+export interface WalletButtonOptions extends RequestOptions {
+    methodId: WalletButtonMethodType;
+}
+
+export interface BaseWalletButtonInitializeOptions extends WalletButtonOptions {
+    [key: string]: unknown;
+
+    containerId: string;
+}

--- a/packages/core/src/wallet-buttons/wallet-button-strategy-registry-v2.ts
+++ b/packages/core/src/wallet-buttons/wallet-button-strategy-registry-v2.ts
@@ -1,0 +1,13 @@
+import {
+    CheckoutButtonStrategy,
+    CheckoutButtonStrategyResolveId,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { ResolveIdRegistry } from '../common/registry';
+
+type WalletButtonRegistry = ResolveIdRegistry<
+    CheckoutButtonStrategy,
+    CheckoutButtonStrategyResolveId
+>;
+
+export default WalletButtonRegistry;

--- a/packages/core/src/wallet-buttons/wallet-buttons.ts
+++ b/packages/core/src/wallet-buttons/wallet-buttons.ts
@@ -1,0 +1,3 @@
+export interface WalletButtonInitializerOptions {
+    graphQLEndpoint: string;
+}

--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -78,3 +78,11 @@ export { WithPayPalCommerceFastlaneCustomerInitializeOptions } from './paypal-co
 
 export { default as createPayPalCommerceFastlanePaymentStrategy } from './paypal-commerce-fastlane/create-paypal-commerce-fastlane-payment-strategy';
 export { WithPayPalCommerceFastlanePaymentInitializeOptions } from './paypal-commerce-fastlane/paypal-commerce-fastlane-payment-initialize-options';
+
+/**
+ *
+ * PayPalCommerce Wallet strategy (headless wallet button integration)
+ *
+ */
+export { default as createPayPalCommerceWalletStrategy } from './paypal-commerce/create-paypal-commerce-wallet-strategy';
+export { WithPayPalCommerceWalletInitializeOptions } from './paypal-commerce/paypal-commerce-wallet-initialize-options';

--- a/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-wallet-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-wallet-strategy.spec.ts
@@ -1,0 +1,21 @@
+import {
+    createWalletButtonIntegrationService,
+    WalletButtonIntegrationService,
+} from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import createPayPalCommerceWalletStrategy from './create-paypal-commerce-wallet-strategy';
+import PayPalCommerceWalletStrategy from './paypal-commerce-wallet-strategy';
+
+describe('createPayPalCommerceWalletStrategy', () => {
+    let walletButtonIntegrationService: WalletButtonIntegrationService;
+
+    beforeEach(() => {
+        walletButtonIntegrationService = createWalletButtonIntegrationService('/graphql');
+    });
+
+    it('creates an instance of PayPalCommerceWalletStrategy', () => {
+        const strategy = createPayPalCommerceWalletStrategy(walletButtonIntegrationService);
+
+        expect(strategy).toBeInstanceOf(PayPalCommerceWalletStrategy);
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-wallet-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-wallet-strategy.ts
@@ -1,0 +1,17 @@
+import { toResolvableModule } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    WalletButtonIntegrationService,
+    WalletPaymentButtonStrategyFactory,
+} from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import PayPalCommerceWalletStrategy from './paypal-commerce-wallet-strategy';
+
+const createPayPalCommerceWalletStrategy: WalletPaymentButtonStrategyFactory<
+    PayPalCommerceWalletStrategy
+> = (walletButtonIntegrationService: WalletButtonIntegrationService) => {
+    return new PayPalCommerceWalletStrategy(walletButtonIntegrationService);
+};
+
+export default toResolvableModule(createPayPalCommerceWalletStrategy, [
+    { id: 'paypalcommercepaypal' },
+]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-initialize-options.ts
@@ -1,0 +1,7 @@
+export default interface PayPalCommerceWalletInitializeOptions {
+    initializationData: string;
+}
+
+export interface WithPayPalCommerceWalletInitializeOptions {
+    paypalcommercepaypal?: PayPalCommerceWalletInitializeOptions;
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-strategy.ts
@@ -1,0 +1,31 @@
+import {
+    CheckoutButtonInitializeOptions,
+    CheckoutButtonStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { WalletButtonIntegrationService } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import { WithPayPalCommerceWalletInitializeOptions } from './paypal-commerce-wallet-initialize-options';
+
+/**
+ * PayPal Commerce Wallet Button Strategy stub for headless wallet button integration.
+ *
+ * This is an empty stub class at this stage. Concrete implementation will be
+ * added in follow-up tickets.
+ */
+export default class PayPalCommerceWalletStrategy implements CheckoutButtonStrategy {
+    constructor(private walletButtonIntegrationService: WalletButtonIntegrationService) {}
+
+    getWalletButtonIntegrationService(): WalletButtonIntegrationService {
+        return this.walletButtonIntegrationService;
+    }
+
+    async initialize(
+        _options: CheckoutButtonInitializeOptions & WithPayPalCommerceWalletInitializeOptions,
+    ): Promise<void> {
+        return Promise.resolve();
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+}

--- a/packages/wallet-button-integration/.eslintrc.json
+++ b/packages/wallet-button-integration/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": ["../../.eslintrc.json"]
+}

--- a/packages/wallet-button-integration/README.md
+++ b/packages/wallet-button-integration/README.md
@@ -1,0 +1,15 @@
+# wallet-button-integration
+
+Integration service for headless wallet button implementations. Provides APIs
+to render wallet payment buttons (PayPal, etc.) without requiring the full
+checkout SDK, communicating directly with BigCommerce via GraphQL.
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test wallet-button-integration` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint wallet-button-integration` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/wallet-button-integration/jest.config.js
+++ b/packages/wallet-button-integration/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+    displayName: 'wallet-button-integration',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+        },
+    },
+    transform: {
+        '^.+\\.[tj]sx?$': 'ts-jest',
+    },
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    coverageDirectory: '../../coverage/packages/wallet-button-integration',
+};

--- a/packages/wallet-button-integration/project.json
+++ b/packages/wallet-button-integration/project.json
@@ -1,0 +1,24 @@
+{
+    "name": "wallet-button-integration",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "packages/wallet-button-integration/src",
+    "projectType": "library",
+    "tags": ["scope:shared"],
+    "targets": {
+        "lint": {
+            "executor": "@nx/eslint:lint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/wallet-button-integration/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nx/jest:jest",
+            "outputs": ["{workspaceRoot}/coverage/packages/wallet-button-integration"],
+            "options": {
+                "jestConfig": "packages/wallet-button-integration/jest.config.js",
+                "passWithNoTests": true
+            }
+        }
+    }
+}

--- a/packages/wallet-button-integration/src/create-wallet-button-integration-service.ts
+++ b/packages/wallet-button-integration/src/create-wallet-button-integration-service.ts
@@ -1,0 +1,9 @@
+import WalletButtonIntegrationService from './wallet-button-integration-service';
+
+const createWalletButtonIntegrationService = (
+    graphQLEndpoint: string,
+): WalletButtonIntegrationService => {
+    return new WalletButtonIntegrationService(graphQLEndpoint);
+};
+
+export default createWalletButtonIntegrationService;

--- a/packages/wallet-button-integration/src/index.ts
+++ b/packages/wallet-button-integration/src/index.ts
@@ -1,0 +1,3 @@
+export { default as createWalletButtonIntegrationService } from './create-wallet-button-integration-service';
+export { default as WalletButtonIntegrationService } from './wallet-button-integration-service';
+export { default as WalletPaymentButtonStrategyFactory } from './wallet-button-factory';

--- a/packages/wallet-button-integration/src/wallet-button-factory.ts
+++ b/packages/wallet-button-integration/src/wallet-button-factory.ts
@@ -1,0 +1,9 @@
+import { CheckoutButtonStrategy } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import WalletButtonIntegrationService from './wallet-button-integration-service';
+
+type WalletPaymentButtonStrategyFactory<TStrategy extends CheckoutButtonStrategy> = (
+    walletButtonIntegrationService: WalletButtonIntegrationService,
+) => TStrategy;
+
+export default WalletPaymentButtonStrategyFactory;

--- a/packages/wallet-button-integration/src/wallet-button-integration-service.ts
+++ b/packages/wallet-button-integration/src/wallet-button-integration-service.ts
@@ -1,0 +1,7 @@
+export default class WalletButtonIntegrationService {
+    constructor(private graphQLEndpoint: string) {}
+
+    getGraphQLEndpoint(): string {
+        return this.graphQLEndpoint;
+    }
+}

--- a/packages/wallet-button-integration/tsconfig.json
+++ b/packages/wallet-button-integration/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ],
+    "compilerOptions": {
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    }
+}

--- a/packages/wallet-button-integration/tsconfig.lib.json
+++ b/packages/wallet-button-integration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": []
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.spec.ts"]
+}

--- a/packages/wallet-button-integration/tsconfig.spec.json
+++ b/packages/wallet-button-integration/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.test.js",
+        "**/*.spec.js",
+        "**/*.test.jsx",
+        "**/*.spec.jsx",
+        "**/*.d.ts"
+    ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -80,7 +80,9 @@
                 "packages/google-pay-integration/src/index.ts"
             ],
             "@bigcommerce/checkout-sdk/hosted-form-v2": ["packages/hosted-form-v2/src/index.ts"],
-            "@bigcommerce/checkout-sdk/humm-integration": ["packages/humm-integration/src/index.ts"],
+            "@bigcommerce/checkout-sdk/humm-integration": [
+                "packages/humm-integration/src/index.ts"
+            ],
             "@bigcommerce/checkout-sdk/klarna-integration": [
                 "packages/klarna-integration/src/index.ts"
             ],
@@ -140,6 +142,9 @@
             ],
             "@bigcommerce/checkout-sdk/ui": ["packages/ui/src/index.ts"],
             "@bigcommerce/checkout-sdk/utility": ["packages/utility/src/index.ts"],
+            "@bigcommerce/checkout-sdk/wallet-button-integration": [
+                "packages/wallet-button-integration/src/index.ts"
+            ],
             "@bigcommerce/checkout-sdk/workspace-tools": ["packages/workspace-tools/src/index.ts"],
             "@bigcommerce/checkout-sdk/worldpayaccess-integration": [
                 "packages/worldpayaccess-integration/src/index.ts"

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -15,6 +15,7 @@ const hostedFormV2SrcPath = path.join(__dirname, 'packages/hosted-form-v2/src');
 const libraryEntries = {
     'checkout-sdk': path.join(coreSrcPath, 'bundles', 'checkout-sdk.ts'),
     'checkout-button': path.join(coreSrcPath, 'bundles', 'checkout-button.ts'),
+    'wallet-button': path.join(coreSrcPath, 'bundles', 'wallet-button.ts'),
     'embedded-checkout': path.join(coreSrcPath, 'bundles', 'embedded-checkout.ts'),
     extension: path.join(coreSrcPath, 'bundles', 'extension.ts'),
     'hosted-form': path.join(coreSrcPath, 'bundles', 'hosted-form.ts'),

--- a/workspace.json
+++ b/workspace.json
@@ -49,6 +49,7 @@
         "td-bank-integration": "packages/td-bank-integration",
         "ui": "packages/ui",
         "utility": "packages/utility",
+        "wallet-button-integration": "packages/wallet-button-integration",
         "workspace-tools": "packages/workspace-tools",
         "worldpayaccess-integration": "packages/worldpayaccess-integration",
         "zip-integration": "packages/zip-integration"


### PR DESCRIPTION
## What/Why?
Scaffolded the @bigcommerce/checkout-sdk/wallet-button-integration package and wire it into the core bundle for wallet buttons. 

- The WalletButtonIntegrationService will be an empty class at this stage — concrete methods will be added in follow-up tickets.
- Empty PaypalCommerceWalletStrategy stub added to packages/paypal-commerce-integration to prevent npm run build-cdn errors on an empty generated file

<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
CI Passed
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CDN bundle/type and new strategy auto-generation paths, which affects build outputs and module loading behavior despite minimal runtime logic.
> 
> **Overview**
> Adds a new `wallet-button` entry point to the core SDK: webpack now builds a dedicated `wallet-button` bundle, and `loader`/`loader-cdn` can load it via the new `BundleType.WalletButton`.
> 
> Introduces a new `wallet-buttons` module in `core` with a `createWalletButtonInitializer` API, registry wiring to auto-generated `create*WalletStrategy` factories, and basic initializer/registry tests (including multi-container initialization).
> 
> Scaffolds a new `@bigcommerce/checkout-sdk/wallet-button-integration` package (Nx project, tsconfig/jest/lint) exposing a minimal `WalletButtonIntegrationService` and factory type, and adds a stub `createPayPalCommerceWalletStrategy`/`PayPalCommerceWalletStrategy` export so wallet strategy generation/builds don’t fail. Also updates `auto-export`/`extend-interface` configs, TS path mappings, workspace registration, and CODEOWNERS accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c83904ee769452b1c3f436aca1e66d0ecf98df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->