### PR TITLE
feat(checkout): CHECKOUT-9821 Add B2B Dev Tool

### DIFF
--- a/packages/core/src/b2b-dev-tools/b2b-dev-mode-constants.ts
+++ b/packages/core/src/b2b-dev-tools/b2b-dev-mode-constants.ts
@@ -1,0 +1,8 @@
+// TODO: CHECKOUT-9979 remove this file before delivery
+/**
+ * Dev-only credentials. DO NOT use in production code paths.
+ * Activated only when the `enableB2bDevMode` URL param is present.
+ */
+export const B2B_DEV_MODE_URL_PARAM = 'enableB2bDevMode';
+export const B2B_DEV_MODE_APP_CLIENT_ID = 'dl7c39mdpul6hyc489yk0vzxl6jesyx';
+export const B2B_DEV_MODE_BASE_URL = 'https://api-b2b.bigcommerce.com';

--- a/packages/core/src/b2b-dev-tools/b2b-dev-mode.spec.ts
+++ b/packages/core/src/b2b-dev-tools/b2b-dev-mode.spec.ts
@@ -1,0 +1,84 @@
+// TODO: CHECKOUT-9979 remove this file before delivery
+import { isB2bDevModeEnabled, resolveB2bAppClientId, resolveB2bBaseUrl } from './b2b-dev-mode';
+
+describe('b2b-dev-mode', () => {
+    const originalLocation = window.location;
+
+    function setSearch(search: string) {
+        delete (window as { location?: Location }).location;
+        (window as { location: Pick<Location, 'search'> }).location = { search };
+    }
+
+    afterEach(() => {
+        delete (window as { location?: Location }).location;
+        (window as { location: Location }).location = originalLocation;
+    });
+
+    describe('isB2bDevModeEnabled', () => {
+        it('returns true when enableB2bDevMode is present (no value)', () => {
+            setSearch('?enableB2bDevMode');
+
+            expect(isB2bDevModeEnabled()).toBe(true);
+        });
+
+        it('returns true when enableB2bDevMode=true', () => {
+            setSearch('?enableB2bDevMode=true');
+
+            expect(isB2bDevModeEnabled()).toBe(true);
+        });
+
+        it('returns true when enableB2bDevMode is one of many params', () => {
+            setSearch('?foo=bar&enableB2bDevMode&baz=qux');
+
+            expect(isB2bDevModeEnabled()).toBe(true);
+        });
+
+        it('returns false when param is absent', () => {
+            setSearch('?foo=bar');
+
+            expect(isB2bDevModeEnabled()).toBe(false);
+        });
+
+        it('returns false when search is empty', () => {
+            setSearch('');
+
+            expect(isB2bDevModeEnabled()).toBe(false);
+        });
+    });
+
+    describe('resolveB2bAppClientId', () => {
+        it('returns dev id when dev mode enabled', () => {
+            setSearch('?enableB2bDevMode');
+
+            expect(resolveB2bAppClientId('prod-id')).toBe('dl7c39mdpul6hyc489yk0vzxl6jesyx');
+        });
+
+        it('returns fallback when dev mode disabled', () => {
+            setSearch('');
+
+            expect(resolveB2bAppClientId('prod-id')).toBe('prod-id');
+        });
+
+        it('returns empty fallback when dev mode disabled and fallback is empty', () => {
+            setSearch('');
+
+            expect(resolveB2bAppClientId('')).toBe('');
+        });
+    });
+
+    describe('resolveB2bBaseUrl', () => {
+        it('returns dev url when dev mode enabled', () => {
+            setSearch('?enableB2bDevMode');
+
+            expect(resolveB2bBaseUrl('https://prod.example.com')).toBe(
+                'https://api-b2b.bigcommerce.com',
+            );
+        });
+
+        it('returns fallback when dev mode disabled', () => {
+            setSearch('');
+
+            expect(resolveB2bBaseUrl('https://prod.example.com')).toBe('https://prod.example.com');
+        });
+    });
+});

--- a/packages/core/src/b2b-dev-tools/b2b-dev-mode.ts
+++ b/packages/core/src/b2b-dev-tools/b2b-dev-mode.ts
@@ -1,0 +1,44 @@
+// TODO: CHECKOUT-9979 remove this file before delivery
+import {
+    B2B_DEV_MODE_APP_CLIENT_ID,
+    B2B_DEV_MODE_BASE_URL,
+    B2B_DEV_MODE_URL_PARAM,
+} from './b2b-dev-mode-constants';
+
+/**
+ * Returns true if `enableB2bDevMode` is present in the current URL's query string.
+ * SSR-safe: returns false when `window` is undefined.
+ */
+export function isB2bDevModeEnabled(): boolean {
+    if (typeof window === 'undefined' || !window.location) {
+        return false;
+    }
+
+    try {
+        const params = new URLSearchParams(window.location.search);
+
+        if (params.has(B2B_DEV_MODE_URL_PARAM)) {
+            console.log('B2B Dev Mode Enabled'); // eslint-disable-line no-console
+
+            return true;
+        }
+
+        return false;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Returns the dev-mode app client id if dev mode is enabled, otherwise `fallback`.
+ */
+export function resolveB2bAppClientId(fallback: string): string {
+    return isB2bDevModeEnabled() ? B2B_DEV_MODE_APP_CLIENT_ID : fallback;
+}
+
+/**
+ * Returns the dev-mode B2B base URL if dev mode is enabled, otherwise `fallback`.
+ */
+export function resolveB2bBaseUrl(fallback: string): string {
+    return isB2bDevModeEnabled() ? B2B_DEV_MODE_BASE_URL : fallback;
+}

--- a/packages/core/src/b2b-dev-tools/index.ts
+++ b/packages/core/src/b2b-dev-tools/index.ts
@@ -1,0 +1,2 @@
+// TODO: CHECKOUT-9979 remove this file before delivery
+export { isB2bDevModeEnabled, resolveB2bAppClientId, resolveB2bBaseUrl } from './b2b-dev-mode';

--- a/packages/core/src/b2b-token/b2b-token-action-creator.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.ts
@@ -2,6 +2,8 @@ import { createAction, ThunkAction } from '@bigcommerce/data-store';
 import { concat, defer, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
+// TODO: CHECKOUT-9979 remove this import before delivery
+import { resolveB2bAppClientId, resolveB2bBaseUrl } from '../b2b-dev-tools';
 import { InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { RequestOptions } from '../common/http-request';
@@ -19,8 +21,10 @@ export default class B2BTokenActionCreator {
             const state = store.getState();
             const storeConfig = state.config.getStoreConfigOrThrow();
             const { storeHash } = storeConfig.storeProfile;
-            const { baseUrl: b2bBaseUrl = '', clientId: b2bClientId = '' } =
-                storeConfig.b2bApiSettings ?? {};
+            // TODO: CHECKOUT-9979 revert to `const { baseUrl: b2bBaseUrl = '', clientId: b2bClientId = '' } = storeConfig.b2bApiSettings ?? {};` before delivery
+            const { baseUrl = '', clientId = '' } = storeConfig.b2bApiSettings ?? {};
+            const b2bClientId = resolveB2bAppClientId(clientId);
+            const b2bBaseUrl = resolveB2bBaseUrl(baseUrl);
             const { id: customerId } = state.customer.getCustomerOrThrow();
             const { channelId } = state.checkout.getCheckoutOrThrow();
 


### PR DESCRIPTION
## What/Why?

Add a removable B2B dev tool to enable calling B2B API.

This tool will be removed as part of CHECKOUT-9979.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a dev-only path that can override B2B API base URL and client ID at runtime via a URL param, which risks accidental use in non-dev environments and changes how B2B tokens are requested.
> 
> **Overview**
> Adds a temporary `b2b-dev-tools` module that enables a **dev-only** “B2B Dev Mode” when the `enableB2bDevMode` URL param is present, hardcoding a B2B `baseUrl` and `appClientId` override (with unit tests).
> 
> Updates `B2BTokenActionCreator.loadB2BToken` to resolve `b2bApiSettings.clientId`/`baseUrl` through these helpers before calling `getB2BToken`, so token requests can be redirected to the dev B2B API without changing store config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b73a9f9afc3484312217ec94ca61048de57d42e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->