### PR TITLE
fix(checkout): CHECKOUT-9967 surface invalid_billing_address error on order submission

### DIFF
--- a/packages/core/src/order/errors/invalid-billing-address-error.spec.ts
+++ b/packages/core/src/order/errors/invalid-billing-address-error.spec.ts
@@ -1,0 +1,15 @@
+import InvalidBillingAddressError from './invalid-billing-address-error';
+
+describe('InvalidBillingAddressError', () => {
+    it('returns error name', () => {
+        const error = new InvalidBillingAddressError('error');
+
+        expect(error.name).toBe('InvalidBillingAddressError');
+    });
+
+    it('returns error type', () => {
+        const error = new InvalidBillingAddressError('error');
+
+        expect(error.type).toBe('invalid_billing_address');
+    });
+});

--- a/packages/core/src/order/errors/invalid-billing-address-error.ts
+++ b/packages/core/src/order/errors/invalid-billing-address-error.ts
@@ -1,0 +1,10 @@
+import { StandardError } from '../../common/error/errors';
+
+export default class InvalidBillingAddressError extends StandardError {
+    constructor(message: string) {
+        super(message);
+
+        this.name = 'InvalidBillingAddressError';
+        this.type = 'invalid_billing_address';
+    }
+}

--- a/packages/core/src/order/order-request-sender.spec.ts
+++ b/packages/core/src/order/order-request-sender.spec.ts
@@ -9,6 +9,7 @@ import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import { MissingShippingMethodError, OrderTaxProviderUnavailableError } from './errors';
+import InvalidBillingAddressError from './errors/invalid-billing-address-error';
 import InvalidShippingAddressError from './errors/invalid-shipping-address-error';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import { getCompleteOrderResponseBody } from './internal-orders.mock';
@@ -235,6 +236,52 @@ describe('OrderRequestSender', () => {
             await expect(orderRequestSender.submitOrder(payload)).rejects.toThrow(
                 InvalidShippingAddressError,
             );
+        });
+
+        it('throws `InvalidBillingAddressError` if error type is `invalid_billing_address`', async () => {
+            const error = getErrorResponse(
+                {
+                    status: 400,
+                    title: 'Invalid billing address',
+                    type: 'invalid_billing_address',
+                },
+                undefined,
+                400,
+            );
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
+
+            const payload = {
+                cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                useStoreCredit: false,
+            };
+
+            await expect(orderRequestSender.submitOrder(payload)).rejects.toThrow(
+                InvalidBillingAddressError,
+            );
+        });
+
+        it('throws `InvalidBillingAddressError` carrying `detail` as the message when present', async () => {
+            const detail = 'The billing address is missing a required field.';
+            const error = getErrorResponse(
+                {
+                    status: 400,
+                    title: 'Invalid billing address',
+                    type: 'invalid_billing_address',
+                    detail,
+                } as any,
+                undefined,
+                400,
+            );
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.reject(error));
+
+            const payload = {
+                cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                useStoreCredit: false,
+            };
+
+            await expect(orderRequestSender.submitOrder(payload)).rejects.toThrow(detail);
         });
 
         it('throws `EmptyCartError` if error type is `empty_cart`', async () => {

--- a/packages/core/src/order/order-request-sender.ts
+++ b/packages/core/src/order/order-request-sender.ts
@@ -14,6 +14,7 @@ import {
 } from '../common/http-request';
 
 import { MissingShippingMethodError, OrderTaxProviderUnavailableError } from './errors';
+import InvalidBillingAddressError from './errors/invalid-billing-address-error';
 import InvalidShippingAddressError from './errors/invalid-shipping-address-error';
 import InternalOrderRequestBody from './internal-order-request-body';
 import { InternalOrderResponseBody } from './internal-order-responses';
@@ -93,6 +94,10 @@ export default class OrderRequestSender {
 
                 if (error.body.type === 'invalid_shipping_address') {
                     throw new InvalidShippingAddressError(error.body.detail);
+                }
+
+                if (error.body.type === 'invalid_billing_address') {
+                    throw new InvalidBillingAddressError(error.body.detail || error.body.title);
                 }
 
                 if (error.body.type === 'empty_cart') {


### PR DESCRIPTION
## What/Why?

The order submission endpoint can return `{ type: "invalid_billing_address" }` on a 400, but `OrderRequestSender.submitOrder` had no mapping for it. The raw `RequestError` propagated to checkout-js, which had no way to identify the error type and rendered the generic "Something's gone wrong" modal.

This PR adds an `InvalidBillingAddressError` (mirroring `InvalidShippingAddressError`) and throws it from `submitOrder` when the backend returns `type: "invalid_billing_address"`.

## Rollout/Rollback
Revert

## Testing

- New unit tests for the error class and the `submitOrder` mapping (including `body.detail` propagation).
- `jest order/order-request-sender|order/errors/invalid-(billing|shipping)-address-error` → 20/20 pass.
- Manual: have the order endpoint return `{ status: 400, type: "invalid_billing_address" }` and confirm the SDK rejects with `error.type === "invalid_billing_address"`.