### PR TITLE
feat(checkout): CHECKOUT-9821 Add Loading B2B Payment Methods

### DIFF
--- a/packages/core/src/cart/cart.ts
+++ b/packages/core/src/cart/cart.ts
@@ -9,6 +9,7 @@ import LineItemMap from './line-item-map';
 export default interface Cart {
     id: string;
     customerId: number;
+    companyId?: number | null;
     currency: Currency;
     email: string;
     isTaxIncluded: boolean;

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -62,6 +62,8 @@ import { OrderActionCreator, OrderRequestSender } from '../order';
 import { getCompleteOrderResponseBody, getOrderRequestBody } from '../order/internal-orders.mock';
 import { getOrder } from '../order/orders.mock';
 import {
+    B2BCompanyPaymentMethodActionCreator,
+    B2BCompanyPaymentMethodRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistryV2,
     PaymentMethodActionCreator,
@@ -69,7 +71,6 @@ import {
     PaymentStrategyActionCreator,
     PaymentStrategyRegistry,
 } from '../payment';
-import { createPaymentIntegrationService } from '../payment-integration';
 import { InstrumentActionCreator, InstrumentRequestSender } from '../payment/instrument';
 import { InstrumentActionType } from '../payment/instrument/instrument-actions';
 import {
@@ -83,6 +84,7 @@ import {
     getPaymentMethods,
 } from '../payment/payment-methods.mock';
 import { PaymentStrategyActionType } from '../payment/payment-strategy-actions';
+import { createPaymentIntegrationService } from '../payment-integration';
 import {
     ConsignmentActionCreator,
     ConsignmentActionType,
@@ -420,6 +422,9 @@ describe('CheckoutService', () => {
             extensionMessenger,
             extensionEventBroadcaster,
             new B2BTokenActionCreator(new B2BTokenRequestSender(requestSender)),
+            new B2BCompanyPaymentMethodActionCreator(
+                new B2BCompanyPaymentMethodRequestSender(requestSender),
+            ),
             billingAddressActionCreator,
             checkoutActionCreator,
             configActionCreator,

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -36,6 +36,7 @@ import { FormFieldsActionCreator } from '../form';
 import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
 import {
+    B2BCompanyPaymentMethodActionCreator,
     OrderFinalizeOptions,
     PaymentInitializeOptions,
     PaymentMethodActionCreator,
@@ -88,6 +89,7 @@ export default class CheckoutService {
         private _extensionMessenger: ExtensionMessenger,
         private _extensionEventBroadcaster: ExtensionEventBroadcaster,
         private _b2bTokenActionCreator: B2BTokenActionCreator,
+        private _b2bCompanyPaymentMethodActionCreator: B2BCompanyPaymentMethodActionCreator,
         private _billingAddressActionCreator: BillingAddressActionCreator,
         private _checkoutActionCreator: CheckoutActionCreator,
         private _configActionCreator: ConfigActionCreator,
@@ -700,6 +702,36 @@ export default class CheckoutService {
         const action = this._b2bTokenActionCreator.loadB2BToken(options);
 
         return this._dispatch(action, { queueId: 'b2bToken' });
+    }
+
+    /**
+     * Loads the list of payment methods allowed by the customer's B2B company.
+     *
+     * The customer must be signed in, associated with an approved B2B company,
+     * and a B2B token must already be loaded (via
+     * {@link CheckoutService.getB2BToken}). The result is the company's
+     * allow-list as configured in B2B Edition; storefront consumers intersect
+     * it against the regular payment method list to filter what is offered to
+     * the buyer.
+     *
+     * The returned promise rejects with a `MissingDataError` if the customer
+     * is a guest, has no associated company, or the B2B token / API base URL
+     * is unavailable.
+     *
+     * ```js
+     * const state = await service.loadB2BCompanyPaymentMethods();
+     *
+     * console.log(state.data.getB2BCompanyPaymentMethods());
+     * ```
+     *
+     * @param options - Options for the request.
+     * @returns A promise that resolves to the current state.
+     */
+    loadB2BCompanyPaymentMethods(options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action =
+            this._b2bCompanyPaymentMethodActionCreator.loadB2BCompanyPaymentMethods(options);
+
+        return this._dispatch(action, { queueId: 'b2bCompanyPaymentMethods' });
     }
 
     /**

--- a/packages/core/src/checkout/checkout-store-error-selector.ts
+++ b/packages/core/src/checkout/checkout-store-error-selector.ts
@@ -296,6 +296,14 @@ export default interface CheckoutStoreErrorSelector {
     getLoadB2BTokenError(): Error | undefined;
 
     /**
+     * Returns an error if unable to load company payment methods.
+     *
+     * @returns The error object if unable to load company payment methods,
+     * otherwise undefined.
+     */
+    getLoadB2BCompanyPaymentMethodsError(): Error | undefined;
+
+    /**
      * Returns an error if unable to create customer account.
      *
      * @returns The error object if unable to create account, otherwise undefined.
@@ -390,6 +398,7 @@ export function createCheckoutStoreErrorSelectorFactory(): CheckoutStoreErrorSel
             getLoadConfigError: state.config.getLoadError,
             getSignInEmailError: state.signInEmail.getSendError,
             getLoadB2BTokenError: state.b2bToken.getLoadError,
+            getLoadB2BCompanyPaymentMethodsError: state.b2bCompanyPaymentMethods.getLoadError,
             getCreateCustomerAccountError: state.customer.getCreateAccountError,
             getCreateCustomerAddressError: state.customer.getCreateAddressError,
             getPickupOptionsError: state.pickupOptions.getLoadError,

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -13,7 +13,7 @@ import { Extension, ExtensionRegion } from '../extension';
 import { FormField } from '../form';
 import { Country } from '../geography';
 import { Order } from '../order';
-import { PaymentMethod } from '../payment';
+import { B2BCompanyPaymentMethod, PaymentMethod } from '../payment';
 import { PaymentProviderCustomer } from '../payment-provider-customer';
 import { CardInstrument, PaymentInstrument } from '../payment/instrument';
 import { Consignment, PickupOptionResult, SearchArea, ShippingOption } from '../shipping';
@@ -65,6 +65,14 @@ export default interface CheckoutStoreSelector {
      * @returns The B2B token string if it has been loaded, otherwise undefined.
      */
     getB2BToken(): string | undefined;
+
+    /**
+     * Gets the list of payment methods allowed by the customer's B2B company.
+     *
+     * @returns The list of company payment methods if it has been loaded,
+     * otherwise undefined.
+     */
+    getB2BCompanyPaymentMethods(): B2BCompanyPaymentMethod[] | undefined;
 
     /**
      * Gets the shipping address of the current checkout.
@@ -507,6 +515,12 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         (getToken) => clone(getToken),
     );
 
+    const getB2BCompanyPaymentMethods = createSelector(
+        ({ b2bCompanyPaymentMethods }: InternalCheckoutSelectors) =>
+            b2bCompanyPaymentMethods.getB2BCompanyPaymentMethods,
+        (getB2BCompanyPaymentMethods) => clone(getB2BCompanyPaymentMethods),
+    );
+
     const isPaymentDataRequired = createSelector(
         ({ payment }: InternalCheckoutSelectors) => payment.isPaymentDataRequired,
         (isPaymentDataRequired) => clone(isPaymentDataRequired),
@@ -637,6 +651,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             isPaymentDataSubmitted: isPaymentDataSubmitted(state),
             getSignInEmail: getSignInEmail(state),
             getB2BToken: getB2BToken(state),
+            getB2BCompanyPaymentMethods: getB2BCompanyPaymentMethods(state),
             getInstruments: getInstruments(state),
             getCustomerAccountFields: getCustomerAccountFields(state),
             getBillingAddressFields: getBillingAddressFields(state),

--- a/packages/core/src/checkout/checkout-store-state.ts
+++ b/packages/core/src/checkout/checkout-store-state.ts
@@ -10,7 +10,12 @@ import { FormFieldsState } from '../form';
 import { CountryState } from '../geography';
 import { OrderState } from '../order';
 import { OrderBillingAddressState } from '../order-billing-address';
-import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payment';
+import {
+    B2BCompanyPaymentMethodState,
+    PaymentMethodState,
+    PaymentState,
+    PaymentStrategyState,
+} from '../payment';
 import { PaymentProviderCustomerState } from '../payment-provider-customer';
 import { InstrumentState } from '../payment/instrument';
 import { RemoteCheckoutState } from '../remote-checkout';
@@ -27,6 +32,7 @@ import { SubscriptionsState } from '../subscription';
 import CheckoutState from './checkout-state';
 
 export default interface CheckoutStoreState {
+    b2bCompanyPaymentMethods: B2BCompanyPaymentMethodState;
     b2bToken: B2BTokenState;
     billingAddress: BillingAddressState;
     cart: CartState;

--- a/packages/core/src/checkout/checkout-store-status-selector.ts
+++ b/packages/core/src/checkout/checkout-store-status-selector.ts
@@ -289,6 +289,13 @@ export default interface CheckoutStoreStatusSelector {
     isLoadingB2BToken(): boolean;
 
     /**
+     * Checks whether company payment methods are being loaded.
+     *
+     * @returns True if company payment methods are being loaded, otherwise false.
+     */
+    isLoadingB2BCompanyPaymentMethods(): boolean;
+
+    /**
      * Checks whether the current customer is applying a gift certificate.
      *
      * @returns True if applying a gift certificate, otherwise false.
@@ -515,6 +522,7 @@ export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusS
             isLoadingConfig: state.config.isLoading,
             isSendingSignInEmail: state.signInEmail.isSending,
             isLoadingB2BToken: state.b2bToken.isLoading,
+            isLoadingB2BCompanyPaymentMethods: state.b2bCompanyPaymentMethods.isLoading,
             isCustomerStepPending: isCustomerStepPending(state),
             isShippingStepPending: isShippingStepPending(state),
             isPaymentStepPending: isPaymentStepPending(state),

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -119,6 +119,7 @@ export function getCheckoutState(): CheckoutState {
 
 export function getCheckoutStoreState(): CheckoutStoreState {
     return {
+        b2bCompanyPaymentMethods: { errors: {}, statuses: {} },
         b2bToken: { errors: {}, statuses: {} },
         billingAddress: getBillingAddressState(),
         cart: getCartState(),

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -35,6 +35,8 @@ import * as paymentStrategyFactories from '../generated/payment-strategies';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import {
+    B2BCompanyPaymentMethodActionCreator,
+    B2BCompanyPaymentMethodRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistry,
     createPaymentStrategyRegistryV2,
@@ -42,8 +44,8 @@ import {
     PaymentMethodRequestSender,
     PaymentStrategyActionCreator,
 } from '../payment';
-import { createPaymentIntegrationService } from '../payment-integration';
 import { InstrumentActionCreator, InstrumentRequestSender } from '../payment/instrument';
+import { createPaymentIntegrationService } from '../payment-integration';
 import {
     ConsignmentActionCreator,
     ConsignmentRequestSender,
@@ -175,6 +177,9 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         extensionMessenger,
         createExtensionEventBroadcaster(storeProjection, extensionMessenger),
         new B2BTokenActionCreator(new B2BTokenRequestSender(requestSender)),
+        new B2BCompanyPaymentMethodActionCreator(
+            new B2BCompanyPaymentMethodRequestSender(requestSender),
+        ),
         new BillingAddressActionCreator(
             new BillingAddressRequestSender(experimentRequestSender),
             subscriptionsActionCreator,

--- a/packages/core/src/checkout/create-checkout-store-reducer.ts
+++ b/packages/core/src/checkout/create-checkout-store-reducer.ts
@@ -12,7 +12,12 @@ import { formFieldsReducer } from '../form';
 import { countryReducer } from '../geography';
 import { orderReducer } from '../order';
 import { orderBillingAddressReducer } from '../order-billing-address';
-import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '../payment';
+import {
+    b2bCompanyPaymentMethodReducer,
+    paymentMethodReducer,
+    paymentReducer,
+    paymentStrategyReducer,
+} from '../payment';
 import { paymentProviderCustomerReducer } from '../payment-provider-customer';
 import { instrumentReducer } from '../payment/instrument';
 import { remoteCheckoutReducer } from '../remote-checkout';
@@ -31,6 +36,7 @@ import CheckoutStoreState from './checkout-store-state';
 
 export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState, Action> {
     return combineReducers({
+        b2bCompanyPaymentMethods: b2bCompanyPaymentMethodReducer,
         b2bToken: b2bTokenReducer,
         billingAddress: billingAddressReducer,
         cart: cartReducer,

--- a/packages/core/src/checkout/create-internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/create-internal-checkout-selectors.ts
@@ -12,12 +12,13 @@ import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
 import { createOrderBillingAddressSelectorFactory } from '../order-billing-address';
 import {
+    createB2BCompanyPaymentMethodSelectorFactory,
     createPaymentMethodSelectorFactory,
     createPaymentSelectorFactory,
     createPaymentStrategySelectorFactory,
 } from '../payment';
-import { createPaymentProviderCustomerSelectorFactory } from '../payment-provider-customer';
 import { createInstrumentSelectorFactory } from '../payment/instrument';
+import { createPaymentProviderCustomerSelectorFactory } from '../payment-provider-customer';
 import { createRemoteCheckoutSelectorFactory } from '../remote-checkout';
 import {
     createConsignmentSelectorFactory,
@@ -41,6 +42,7 @@ export type InternalCheckoutSelectorsFactory = (
 ) => InternalCheckoutSelectors;
 
 export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
+    const createB2BCompanyPaymentMethodSelector = createB2BCompanyPaymentMethodSelectorFactory();
     const createB2BTokenSelector = createB2BTokenSelectorFactory();
     const createBillingAddressSelector = createBillingAddressSelectorFactory();
     const createCartSelector = createCartSelectorFactory();
@@ -72,6 +74,9 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createExtensionSelector = createExtensionSelectorFactory();
 
     return (state, options = {}) => {
+        const b2bCompanyPaymentMethods = createB2BCompanyPaymentMethodSelector(
+            state.b2bCompanyPaymentMethods,
+        );
         const b2bToken = createB2BTokenSelector(state.b2bToken);
         const billingAddress = createBillingAddressSelector(state.billingAddress);
         const cart = createCartSelector(state.cart);
@@ -115,6 +120,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const config = createConfigSelector(state.config, state.formFields);
 
         const selectors = {
+            b2bCompanyPaymentMethods,
             b2bToken,
             billingAddress,
             cart,

--- a/packages/core/src/checkout/internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/internal-checkout-selectors.ts
@@ -10,7 +10,12 @@ import { FormSelector } from '../form';
 import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import OrderBillingAddressSelector from '../order-billing-address/order-billing-address-selector';
-import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
+import {
+    B2BCompanyPaymentMethodSelector,
+    PaymentMethodSelector,
+    PaymentSelector,
+    PaymentStrategySelector,
+} from '../payment';
 import { PaymentProviderCustomerSelector } from '../payment-provider-customer';
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
@@ -28,6 +33,7 @@ import { SubscriptionsSelector } from '../subscription';
 import CheckoutSelector from './checkout-selector';
 
 export default interface InternalCheckoutSelectors {
+    b2bCompanyPaymentMethods: B2BCompanyPaymentMethodSelector;
     b2bToken: B2BTokenSelector;
     billingAddress: BillingAddressSelector;
     cart: CartSelector;

--- a/packages/core/src/payment/b2b-company-payment-method-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-action-creator.spec.ts
@@ -1,0 +1,132 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { getCart } from '../cart/carts.mock';
+import { CheckoutStore, createCheckoutStore } from '../checkout';
+import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { getConfig } from '../config/configs.mock';
+
+import B2BCompanyPaymentMethodActionCreator from './b2b-company-payment-method-action-creator';
+import { B2BCompanyPaymentMethodActionType } from './b2b-company-payment-method-actions';
+import B2BCompanyPaymentMethodRequestSender, {
+    B2BCompanyPaymentMethodsResponseBody,
+} from './b2b-company-payment-method-request-sender';
+
+describe('B2BCompanyPaymentMethodActionCreator', () => {
+    let store: CheckoutStore;
+    let requestSender: B2BCompanyPaymentMethodRequestSender;
+    let actionCreator: B2BCompanyPaymentMethodActionCreator;
+
+    const companyId = 42;
+    const b2bToken = 'b2b-auth-token';
+    const b2bBaseUrl = 'https://api-b2b.bigcommerce.com';
+    const responseBody: B2BCompanyPaymentMethodsResponseBody = {
+        data: [
+            { code: 'cheque', name: 'Cheque', isEnabled: '1', paymentId: 1 },
+            { code: 'stripev3', name: 'Stripe', isEnabled: '0', paymentId: 2 },
+        ],
+    };
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = new B2BCompanyPaymentMethodRequestSender(createRequestSender());
+
+        jest.spyOn(requestSender, 'getB2BCompanyPaymentMethods').mockResolvedValue(
+            getResponse(responseBody),
+        );
+
+        jest.spyOn(store.getState().b2bToken, 'getToken').mockReturnValue(b2bToken);
+        jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+            ...getConfig().storeConfig,
+            b2bApiSettings: { baseUrl: b2bBaseUrl, clientId: 'dl7c39mdpul6hyc489yk0vzxl6jesyx' },
+        });
+        jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({
+            ...getCart(),
+            companyId,
+        });
+
+        actionCreator = new B2BCompanyPaymentMethodActionCreator(requestSender);
+    });
+
+    describe('#loadB2BCompanyPaymentMethods()', () => {
+        it('emits load actions and maps the response on success', async () => {
+            const actions = await from(actionCreator.loadB2BCompanyPaymentMethods()(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                {
+                    type: B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsRequested,
+                },
+                {
+                    type: B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsSucceeded,
+                    payload: [
+                        { code: 'cheque', name: 'Cheque', isEnabled: true, paymentId: 1 },
+                        { code: 'stripev3', name: 'Stripe', isEnabled: false, paymentId: 2 },
+                    ],
+                },
+            ]);
+        });
+
+        it('calls getB2BCompanyPaymentMethods with companyId, b2bToken, b2bBaseUrl and options', async () => {
+            const options = { timeout: undefined };
+
+            await from(actionCreator.loadB2BCompanyPaymentMethods(options)(store)).toPromise();
+
+            expect(requestSender.getB2BCompanyPaymentMethods).toHaveBeenCalledWith(
+                companyId,
+                b2bToken,
+                b2bBaseUrl,
+                options,
+            );
+        });
+
+        it('emits error actions if getB2BCompanyPaymentMethods fails', async () => {
+            jest.spyOn(requestSender, 'getB2BCompanyPaymentMethods').mockRejectedValue(
+                getErrorResponse(),
+            );
+
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(actionCreator.loadB2BCompanyPaymentMethods()(store))
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                {
+                    type: B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsRequested,
+                },
+                expect.objectContaining({
+                    type: B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsFailed,
+                    error: true,
+                }),
+            ]);
+        });
+
+        it('emits error actions if required data is missing', async () => {
+            jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({
+                ...getCart(),
+                companyId: undefined,
+            });
+
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(actionCreator.loadB2BCompanyPaymentMethods()(store))
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(requestSender.getB2BCompanyPaymentMethods).not.toHaveBeenCalled();
+            expect(actions).toEqual([
+                {
+                    type: B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsRequested,
+                },
+                expect.objectContaining({
+                    type: B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsFailed,
+                    error: true,
+                }),
+            ]);
+        });
+    });
+});

--- a/packages/core/src/payment/b2b-company-payment-method-action-creator.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-action-creator.ts
@@ -1,0 +1,75 @@
+import { createAction, ThunkAction } from '@bigcommerce/data-store';
+import { concat, defer, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { InternalCheckoutSelectors } from '../checkout';
+import { throwErrorAction } from '../common/error';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { RequestOptions } from '../common/http-request';
+
+import B2BCompanyPaymentMethod from './b2b-company-payment-method';
+import {
+    B2BCompanyPaymentMethodActionType,
+    LoadB2BCompanyPaymentMethodsAction,
+} from './b2b-company-payment-method-actions';
+import B2BCompanyPaymentMethodRequestSender from './b2b-company-payment-method-request-sender';
+
+export default class B2BCompanyPaymentMethodActionCreator {
+    constructor(private _requestSender: B2BCompanyPaymentMethodRequestSender) {}
+
+    loadB2BCompanyPaymentMethods(
+        options?: RequestOptions,
+    ): ThunkAction<LoadB2BCompanyPaymentMethodsAction, InternalCheckoutSelectors> {
+        return (store) => {
+            const state = store.getState();
+            const customer = state.customer.getCustomer();
+            const b2bToken = state.b2bToken.getToken();
+            // TODO: CHECKOUT-9979 revert to const b2bBaseUrl = state.config.getStoreConfig()?.b2bApiSettings?.baseUrl
+            const b2bBaseUrl = resolveB2bBaseUrl(
+                state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
+            );
+            const companyId = store.getState().cart.getCart()?.companyId;
+
+            return concat(
+                of(
+                    createAction(
+                        B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsRequested,
+                    ),
+                ),
+                defer(async () => {
+                    if (!customer || customer.isGuest || !b2bToken || !b2bBaseUrl || !companyId) {
+                        throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+                    }
+
+                    const { body: methodsBody } =
+                        await this._requestSender.getB2BCompanyPaymentMethods(
+                            companyId,
+                            b2bToken,
+                            b2bBaseUrl,
+                            options,
+                        );
+
+                    const methods: B2BCompanyPaymentMethod[] = methodsBody.data.map((method) => ({
+                        code: method.code,
+                        name: method.name,
+                        isEnabled: method.isEnabled === '1',
+                        paymentId: method.paymentId,
+                    }));
+
+                    return createAction(
+                        B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsSucceeded,
+                        methods,
+                    );
+                }),
+            ).pipe(
+                catchError((error) =>
+                    throwErrorAction(
+                        B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsFailed,
+                        error,
+                    ),
+                ),
+            );
+        };
+    }
+}

--- a/packages/core/src/payment/b2b-company-payment-method-actions.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-actions.ts
@@ -1,0 +1,27 @@
+import { Action } from '@bigcommerce/data-store';
+
+import B2BCompanyPaymentMethod from './b2b-company-payment-method';
+
+export enum B2BCompanyPaymentMethodActionType {
+    LoadB2BCompanyPaymentMethodsRequested = 'LOAD_B2B_COMPANY_PAYMENT_METHODS_REQUESTED',
+    LoadB2BCompanyPaymentMethodsSucceeded = 'LOAD_B2B_COMPANY_PAYMENT_METHODS_SUCCEEDED',
+    LoadB2BCompanyPaymentMethodsFailed = 'LOAD_B2B_COMPANY_PAYMENT_METHODS_FAILED',
+}
+
+export type LoadB2BCompanyPaymentMethodsAction =
+    | LoadB2BCompanyPaymentMethodsRequestedAction
+    | LoadB2BCompanyPaymentMethodsSucceededAction
+    | LoadB2BCompanyPaymentMethodsFailedAction;
+
+export interface LoadB2BCompanyPaymentMethodsRequestedAction extends Action {
+    type: B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsRequested;
+}
+
+export interface LoadB2BCompanyPaymentMethodsSucceededAction
+    extends Action<B2BCompanyPaymentMethod[]> {
+    type: B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsSucceeded;
+}
+
+export interface LoadB2BCompanyPaymentMethodsFailedAction extends Action<Error> {
+    type: B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsFailed;
+}

--- a/packages/core/src/payment/b2b-company-payment-method-reducer.spec.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-reducer.spec.ts
@@ -1,0 +1,59 @@
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+
+import B2BCompanyPaymentMethod from './b2b-company-payment-method';
+import { B2BCompanyPaymentMethodActionType } from './b2b-company-payment-method-actions';
+import b2bCompanyPaymentMethodReducer from './b2b-company-payment-method-reducer';
+import B2BCompanyPaymentMethodState, { DEFAULT_STATE } from './b2b-company-payment-method-state';
+
+describe('b2bCompanyPaymentMethodReducer()', () => {
+    let initialState: B2BCompanyPaymentMethodState;
+
+    beforeEach(() => {
+        initialState = DEFAULT_STATE;
+    });
+
+    it('returns loading state on requested', () => {
+        const action = createAction(
+            B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsRequested,
+        );
+        const state = b2bCompanyPaymentMethodReducer(initialState, action);
+
+        expect(state.statuses.isLoading).toBe(true);
+        expect(state.errors.loadError).toBeUndefined();
+    });
+
+    it('stores methods and clears loading state on success', () => {
+        const methods: B2BCompanyPaymentMethod[] = [
+            { code: 'cheque', name: 'Cheque', isEnabled: true, paymentId: 1 },
+        ];
+        const action = createAction(
+            B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsSucceeded,
+            methods,
+        );
+        const state = b2bCompanyPaymentMethodReducer(initialState, action);
+
+        expect(state.data).toEqual(methods);
+        expect(state.statuses.isLoading).toBe(false);
+        expect(state.errors.loadError).toBeUndefined();
+    });
+
+    it('stores error and clears loading state on failure', () => {
+        const error = new Error('Failed to load company payment methods');
+        const action = createErrorAction(
+            B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsFailed,
+            error,
+        );
+        const state = b2bCompanyPaymentMethodReducer(initialState, action);
+
+        expect(state.errors.loadError).toBe(error);
+        expect(state.statuses.isLoading).toBe(false);
+        expect(state.data).toBeUndefined();
+    });
+
+    it('returns previous state for unknown actions', () => {
+        const action = { type: 'UNKNOWN_ACTION' } as any;
+        const state = b2bCompanyPaymentMethodReducer(initialState, action);
+
+        expect(state).toEqual(initialState);
+    });
+});

--- a/packages/core/src/payment/b2b-company-payment-method-reducer.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-reducer.ts
@@ -1,0 +1,75 @@
+import { Action, combineReducers, composeReducers } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
+import { objectSet } from '../common/utility';
+
+import B2BCompanyPaymentMethod from './b2b-company-payment-method';
+import {
+    B2BCompanyPaymentMethodActionType,
+    LoadB2BCompanyPaymentMethodsAction,
+} from './b2b-company-payment-method-actions';
+import B2BCompanyPaymentMethodState, {
+    B2BCompanyPaymentMethodErrorsState,
+    B2BCompanyPaymentMethodStatusesState,
+    DEFAULT_STATE,
+} from './b2b-company-payment-method-state';
+
+export default function b2bCompanyPaymentMethodReducer(
+    state: B2BCompanyPaymentMethodState = DEFAULT_STATE,
+    action: Action,
+): B2BCompanyPaymentMethodState {
+    const reducer = combineReducers<B2BCompanyPaymentMethodState>({
+        data: dataReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
+        statuses: statusesReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: B2BCompanyPaymentMethod[] | undefined,
+    action: LoadB2BCompanyPaymentMethodsAction,
+): B2BCompanyPaymentMethod[] | undefined {
+    switch (action.type) {
+        case B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsSucceeded:
+            return action.payload;
+
+        default:
+            return data;
+    }
+}
+
+function errorsReducer(
+    errors: B2BCompanyPaymentMethodErrorsState = DEFAULT_STATE.errors,
+    action: LoadB2BCompanyPaymentMethodsAction,
+): B2BCompanyPaymentMethodErrorsState {
+    switch (action.type) {
+        case B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsRequested:
+        case B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsSucceeded:
+            return objectSet(errors, 'loadError', undefined);
+
+        case B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsFailed:
+            return objectSet(errors, 'loadError', action.payload);
+
+        default:
+            return errors;
+    }
+}
+
+function statusesReducer(
+    statuses: B2BCompanyPaymentMethodStatusesState = DEFAULT_STATE.statuses,
+    action: LoadB2BCompanyPaymentMethodsAction,
+): B2BCompanyPaymentMethodStatusesState {
+    switch (action.type) {
+        case B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsRequested:
+            return objectSet(statuses, 'isLoading', true);
+
+        case B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsFailed:
+        case B2BCompanyPaymentMethodActionType.LoadB2BCompanyPaymentMethodsSucceeded:
+            return objectSet(statuses, 'isLoading', false);
+
+        default:
+            return statuses;
+    }
+}

--- a/packages/core/src/payment/b2b-company-payment-method-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-request-sender.spec.ts
@@ -1,0 +1,67 @@
+import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
+
+import { getResponse } from '../common/http-request/responses.mock';
+
+import B2BCompanyPaymentMethodRequestSender, {
+    B2BCompanyPaymentMethodsResponseBody,
+} from './b2b-company-payment-method-request-sender';
+
+describe('B2BCompanyPaymentMethodRequestSender', () => {
+    let requestSender: RequestSender;
+    let b2bCompanyPaymentMethodRequestSender: B2BCompanyPaymentMethodRequestSender;
+
+    const b2bToken = 'b2b-token-value';
+    const b2bBaseUrl = 'https://api-b2b.bigcommerce.com';
+    const companyId = 42;
+    const responseBody: B2BCompanyPaymentMethodsResponseBody = {
+        data: [{ code: 'cheque', name: 'Cheque', isEnabled: '1', paymentId: 1 }],
+    };
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        jest.spyOn(requestSender, 'get').mockResolvedValue(getResponse(responseBody));
+
+        b2bCompanyPaymentMethodRequestSender = new B2BCompanyPaymentMethodRequestSender(
+            requestSender,
+        );
+    });
+
+    describe('#getB2BCompanyPaymentMethods()', () => {
+        it('issues a GET to the company payments endpoint with auth headers', async () => {
+            await b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods(
+                companyId,
+                b2bToken,
+                b2bBaseUrl,
+            );
+
+            expect(requestSender.get).toHaveBeenCalledWith(
+                `${b2bBaseUrl}/api/v2/companies/${companyId}/payments`,
+                {
+                    timeout: undefined,
+                    credentials: false,
+                    headers: {
+                        authToken: b2bToken,
+                        Authorization: `Bearer ${b2bToken}`,
+                    },
+                },
+            );
+        });
+
+        it('forwards the timeout option to the underlying request', async () => {
+            const timeout = createTimeout();
+
+            await b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods(
+                companyId,
+                b2bToken,
+                b2bBaseUrl,
+                { timeout },
+            );
+
+            expect(requestSender.get).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({ timeout }),
+            );
+        });
+    });
+});

--- a/packages/core/src/payment/b2b-company-payment-method-request-sender.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-request-sender.ts
@@ -1,0 +1,35 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { RequestOptions } from '../common/http-request';
+
+export interface B2BCompanyPaymentMethodsResponseBody {
+    data: Array<{
+        code: string;
+        name: string;
+        isEnabled: '1' | '0';
+        paymentId: number;
+    }>;
+}
+
+export default class B2BCompanyPaymentMethodRequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    async getB2BCompanyPaymentMethods(
+        companyId: number,
+        b2bToken: string,
+        b2bBaseUrl: string,
+        options?: RequestOptions,
+    ): Promise<Response<B2BCompanyPaymentMethodsResponseBody>> {
+        return this._requestSender.get<B2BCompanyPaymentMethodsResponseBody>(
+            `${b2bBaseUrl}/api/v2/companies/${companyId}/payments`,
+            {
+                timeout: options?.timeout,
+                credentials: false,
+                headers: {
+                    authToken: b2bToken,
+                    Authorization: `Bearer ${b2bToken}`,
+                },
+            },
+        );
+    }
+}

--- a/packages/core/src/payment/b2b-company-payment-method-selector.spec.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-selector.spec.ts
@@ -1,0 +1,59 @@
+import B2BCompanyPaymentMethod from './b2b-company-payment-method';
+import { createB2BCompanyPaymentMethodSelectorFactory } from './b2b-company-payment-method-selector';
+import B2BCompanyPaymentMethodState, { DEFAULT_STATE } from './b2b-company-payment-method-state';
+
+describe('createB2BCompanyPaymentMethodSelectorFactory()', () => {
+    const createSelector = createB2BCompanyPaymentMethodSelectorFactory();
+
+    it('returns undefined for getB2BCompanyPaymentMethods when no data is loaded', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getB2BCompanyPaymentMethods()).toBeUndefined();
+    });
+
+    it('returns the methods array when data is loaded', () => {
+        const methods: B2BCompanyPaymentMethod[] = [
+            { code: 'cheque', name: 'Cheque', isEnabled: true, paymentId: 1 },
+        ];
+        const state: B2BCompanyPaymentMethodState = {
+            ...DEFAULT_STATE,
+            data: methods,
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getB2BCompanyPaymentMethods()).toEqual(methods);
+    });
+
+    it('returns false for isLoading when not loading', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.isLoading()).toBe(false);
+    });
+
+    it('returns true for isLoading when loading', () => {
+        const state: B2BCompanyPaymentMethodState = {
+            ...DEFAULT_STATE,
+            statuses: { isLoading: true },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.isLoading()).toBe(true);
+    });
+
+    it('returns undefined for getLoadError when no error', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getLoadError()).toBeUndefined();
+    });
+
+    it('returns error for getLoadError when there is an error', () => {
+        const error = new Error('Company payment methods load failed');
+        const state: B2BCompanyPaymentMethodState = {
+            ...DEFAULT_STATE,
+            errors: { loadError: error },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getLoadError()).toBe(error);
+    });
+});

--- a/packages/core/src/payment/b2b-company-payment-method-selector.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-selector.ts
@@ -1,0 +1,43 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { createSelector } from '../common/selector';
+
+import B2BCompanyPaymentMethod from './b2b-company-payment-method';
+import B2BCompanyPaymentMethodState, { DEFAULT_STATE } from './b2b-company-payment-method-state';
+
+export default interface B2BCompanyPaymentMethodSelector {
+    getB2BCompanyPaymentMethods(): B2BCompanyPaymentMethod[] | undefined;
+    getLoadError(): Error | undefined;
+    isLoading(): boolean;
+}
+
+export type B2BCompanyPaymentMethodSelectorFactory = (
+    state: B2BCompanyPaymentMethodState,
+) => B2BCompanyPaymentMethodSelector;
+
+export function createB2BCompanyPaymentMethodSelectorFactory(): B2BCompanyPaymentMethodSelectorFactory {
+    const getB2BCompanyPaymentMethods = createSelector(
+        (state: B2BCompanyPaymentMethodState) => state.data,
+        (methods) => () => methods,
+    );
+
+    const getLoadError = createSelector(
+        (state: B2BCompanyPaymentMethodState) => state.errors.loadError,
+        (error) => () => error,
+    );
+
+    const isLoading = createSelector(
+        (state: B2BCompanyPaymentMethodState) => !!state.statuses.isLoading,
+        (status) => () => status,
+    );
+
+    return memoizeOne(
+        (state: B2BCompanyPaymentMethodState = DEFAULT_STATE): B2BCompanyPaymentMethodSelector => {
+            return {
+                getB2BCompanyPaymentMethods: getB2BCompanyPaymentMethods(state),
+                getLoadError: getLoadError(state),
+                isLoading: isLoading(state),
+            };
+        },
+    );
+}

--- a/packages/core/src/payment/b2b-company-payment-method-state.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-state.ts
@@ -1,0 +1,20 @@
+import B2BCompanyPaymentMethod from './b2b-company-payment-method';
+
+export default interface B2BCompanyPaymentMethodState {
+    data?: B2BCompanyPaymentMethod[];
+    errors: B2BCompanyPaymentMethodErrorsState;
+    statuses: B2BCompanyPaymentMethodStatusesState;
+}
+
+export interface B2BCompanyPaymentMethodErrorsState {
+    loadError?: Error;
+}
+
+export interface B2BCompanyPaymentMethodStatusesState {
+    isLoading?: boolean;
+}
+
+export const DEFAULT_STATE: B2BCompanyPaymentMethodState = {
+    errors: {},
+    statuses: {},
+};

--- a/packages/core/src/payment/b2b-company-payment-method.ts
+++ b/packages/core/src/payment/b2b-company-payment-method.ts
@@ -1,0 +1,24 @@
+export default interface B2BCompanyPaymentMethod {
+    /**
+     * Method code as stored by B2B Edition (e.g. "cheque", "stripev3",
+     * "qbmsv2"). Storefront consumers intersect this against the BC payment
+     * list to build the company allow-list.
+     */
+    code: string;
+
+    /**
+     * Display name from the B2B registry. Informational only.
+     */
+    name: string;
+
+    /**
+     * Normalised from the upstream `'1' | '0'` string. Consumers should never
+     * see the raw string form.
+     */
+    isEnabled: boolean;
+
+    /**
+     * B2B Edition's internal payment id. Useful for refresh / debugging.
+     */
+    paymentId: number;
+}

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -4,9 +4,28 @@ export {
     PaymentInitializeOptions,
     PaymentRequestOptions,
 } from './payment-request-options';
+export * from './b2b-company-payment-method-actions';
 export * from './payment-method-actions';
 export * from './payment-method-types';
 export * from './payment-status-types';
+
+export { default as B2BCompanyPaymentMethod } from './b2b-company-payment-method';
+export { default as B2BCompanyPaymentMethodActionCreator } from './b2b-company-payment-method-action-creator';
+export { default as b2bCompanyPaymentMethodReducer } from './b2b-company-payment-method-reducer';
+export {
+    default as B2BCompanyPaymentMethodRequestSender,
+    B2BCompanyPaymentMethodsResponseBody,
+} from './b2b-company-payment-method-request-sender';
+export {
+    default as B2BCompanyPaymentMethodSelector,
+    B2BCompanyPaymentMethodSelectorFactory,
+    createB2BCompanyPaymentMethodSelectorFactory,
+} from './b2b-company-payment-method-selector';
+export {
+    default as B2BCompanyPaymentMethodState,
+    B2BCompanyPaymentMethodErrorsState,
+    B2BCompanyPaymentMethodStatusesState,
+} from './b2b-company-payment-method-state';
 
 export {
     default as PaymentAdditionalAction,


### PR DESCRIPTION
## What/Why?

Key changes:

* New `payment/company-payment-method-action`.
* New `CheckoutService` API.
   * New `loadCompanyPaymentMethods(options?)` method, dispatched on its own `companyPaymentMethods` queue.
   * New selectors: 
     * `getCompanyPaymentMethods()`
     * `getLoadCompanyPaymentMethodsError()`
     * `isLoadingCompanyPaymentMethods()`
* Update `Cart` type
   * Added optional `companyId?: number | null` to the `Cart` interface

## Rollout/Rollback

CI.

## Testing

### Before applying the filter.
<img width="1511" height="829" alt="Screenshot 2026-05-18 at 16 51 25" src="https://github.com/user-attachments/assets/72088832-6858-48e0-ad66-7bb613c955cf" />
<img width="1511" height="841" alt="Screenshot 2026-05-18 at 16 54 14" src="https://github.com/user-attachments/assets/8a1a18c1-f771-4bb2-85de-1ea309fc4045" />


### After applying the filter.
<img width="1511" height="829" alt="Screenshot 2026-05-18 at 16 51 00" src="https://github.com/user-attachments/assets/b610755c-0150-4ea3-a40a-9c9a1ace61e7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new checkout data slice and service API that calls B2B endpoints and gates behavior on customer/company/token presence, which could impact payment method availability and error/loading handling.
> 
> **Overview**
> Adds support for loading a B2B company’s allowed payment-method allow-list into checkout state. This introduces a new `b2bCompanyPaymentMethods` store slice (actions/reducer/selector/state), wires it into `CheckoutService` via `loadB2BCompanyPaymentMethods()` (queued under `b2bCompanyPaymentMethods`), and exposes corresponding data/error/loading selectors.
> 
> Updates the `Cart` type to include optional `companyId` (used to fetch company methods) and adds request-sender logic/tests to call the B2B `/api/v2/companies/{companyId}/payments` endpoint and normalize `isEnabled` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921371e6d24c1f5ce586e23acdb4a8bfff8f9a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->