### PR TITLE
feat(checkout): CHECKOUT-9821 Add Loading Company Payment Methods

### DIFF
--- a/packages/core/src/b2b-dev-tools/capabilities-override.spec.ts
+++ b/packages/core/src/b2b-dev-tools/capabilities-override.spec.ts
@@ -1,0 +1,137 @@
+// TODO: CHECKOUT-9979 remove this file before delivery
+import { Capabilities } from '../config/capabilities';
+
+import { applyCapabilitiesOverride } from './capabilities-override';
+
+describe('applyCapabilitiesOverride', () => {
+    const originalLocation = window.location;
+
+    function setSearch(search: string): void {
+        delete (window as { location?: Location }).location;
+        (window as { location: Pick<Location, 'search'> }).location = { search };
+    }
+
+    function baseCapabilities(): Capabilities {
+        return {
+            userJourney: {
+                disableEditCart: false,
+                disableStoreCredit: false,
+                hasCompanyAddressBook: false,
+                hasAddressExtraFields: false,
+                requiresB2BToken: false,
+            },
+            customer: { superAdminCompanySelector: false },
+            shipping: {
+                restrictManualAddressEntry: false,
+                prefillCompanyAddress: false,
+                hideSaveToAddressBookCheck: false,
+                hideBillingSameAsShippingCheck: false,
+            },
+            billing: {
+                restrictManualAddressEntry: false,
+                hideSaveToAddressBookCheck: false,
+            },
+            payment: {
+                paymentMethodFiltering: false,
+                b2bPaymentMethodFilter: false,
+                poPaymentMethod: false,
+                additionalPaymentNotes: false,
+                excludeOfflineForInvoice: false,
+                excludePPSDK: false,
+            },
+            orderConfirmation: {
+                orderSummary: false,
+                persistB2BMetadata: false,
+                storeQuoteId: false,
+                storeInvoiceReference: false,
+                invoiceRedirect: false,
+            },
+        };
+    }
+
+    afterEach(() => {
+        delete (window as { location?: Location }).location;
+        (window as { location: Location }).location = originalLocation;
+    });
+
+    it('returns the input unchanged when no override is present', () => {
+        setSearch('');
+
+        const input = baseCapabilities();
+
+        expect(applyCapabilitiesOverride(input)).toBe(input);
+    });
+
+    it('returns undefined when input is undefined and no override is present', () => {
+        setSearch('');
+
+        expect(applyCapabilitiesOverride(undefined)).toBeUndefined();
+    });
+
+    it('merges a payment override over the base capabilities', () => {
+        const override = encodeURIComponent(
+            JSON.stringify({ payment: { b2bPaymentMethodFilter: true } }),
+        );
+
+        setSearch(`?capabilitiesOverride=${override}`);
+
+        const input = baseCapabilities();
+        const result = applyCapabilitiesOverride(input);
+
+        expect(result?.payment.b2bPaymentMethodFilter).toBe(true);
+        expect(result?.payment.paymentMethodFiltering).toBe(false);
+        expect(result?.userJourney).toEqual(input.userJourney);
+    });
+
+    it('merges multiple groups in one override', () => {
+        const override = encodeURIComponent(
+            JSON.stringify({
+                payment: { b2bPaymentMethodFilter: true },
+                orderConfirmation: { invoiceRedirect: true },
+            }),
+        );
+
+        setSearch(`?capabilitiesOverride=${override}`);
+
+        const result = applyCapabilitiesOverride(baseCapabilities());
+
+        expect(result?.payment.b2bPaymentMethodFilter).toBe(true);
+        expect(result?.orderConfirmation.invoiceRedirect).toBe(true);
+    });
+
+    it('produces an override-only result when the input is undefined', () => {
+        const override = encodeURIComponent(
+            JSON.stringify({ payment: { b2bPaymentMethodFilter: true } }),
+        );
+
+        setSearch(`?capabilitiesOverride=${override}`);
+
+        const result = applyCapabilitiesOverride(undefined);
+
+        expect(result?.payment.b2bPaymentMethodFilter).toBe(true);
+    });
+
+    it('falls back to the input when the override is malformed JSON', () => {
+        setSearch('?capabilitiesOverride=not-json');
+
+        const input = baseCapabilities();
+
+        expect(applyCapabilitiesOverride(input)).toBe(input);
+    });
+
+    it('falls back to the input when the override is a non-object JSON value', () => {
+        setSearch('?capabilitiesOverride=42');
+
+        const input = baseCapabilities();
+
+        expect(applyCapabilitiesOverride(input)).toBe(input);
+    });
+
+    it('falls back to the input when the override is a JSON array', () => {
+        setSearch('?capabilitiesOverride=%5B1%2C2%5D');
+
+        const input = baseCapabilities();
+
+        expect(applyCapabilitiesOverride(input)).toBe(input);
+    });
+});

--- a/packages/core/src/b2b-dev-tools/capabilities-override.ts
+++ b/packages/core/src/b2b-dev-tools/capabilities-override.ts
@@ -1,0 +1,76 @@
+// TODO: CHECKOUT-9979 remove this file before delivery
+//
+// Client-side override for capability flags while the API is pending. Mirrors
+// the helper in the consumer (checkout-js).
+//
+// Usage: append `?capabilitiesOverride=<url-encoded-json>` to the checkout
+// URL, e.g.
+//   ?capabilitiesOverride=%7B%22payment%22%3A%7B%22b2bPaymentMethodFilter%22%3Atrue%7D%7D
+// Only the keys present in the JSON are overridden; all other values come
+// from the API.
+
+import { Capabilities } from '../config/capabilities';
+
+const OVERRIDE_QUERY_PARAM = 'capabilitiesOverride';
+
+type CapabilitiesOverride = {
+    [K in keyof Capabilities]?: Partial<Capabilities[K]>;
+};
+
+function parseOverride(): CapabilitiesOverride | undefined {
+    if (typeof window === 'undefined' || !window.location) {
+        return undefined;
+    }
+
+    let raw: string | null;
+
+    try {
+        raw = new URLSearchParams(window.location.search).get(OVERRIDE_QUERY_PARAM);
+    } catch {
+        return undefined;
+    }
+
+    if (!raw) {
+        return undefined;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(raw);
+
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed as CapabilitiesOverride;
+        }
+    } catch {
+        // Malformed override — fall back to API-provided capabilities.
+    }
+
+    return undefined;
+}
+
+/**
+ * Returns the API-provided capabilities merged with any client-side override
+ * supplied via the `?capabilitiesOverride=<json>` URL param. Only the keys
+ * present in the override are merged; all other values pass through from the
+ * API. Returns the input unchanged when no override is set.
+ */
+export function applyCapabilitiesOverride(
+    capabilities: Capabilities | undefined,
+): Capabilities | undefined {
+    const override = parseOverride();
+
+    if (!override) {
+        return capabilities;
+    }
+
+    return {
+        userJourney: { ...capabilities?.userJourney, ...override.userJourney },
+        customer: { ...capabilities?.customer, ...override.customer },
+        shipping: { ...capabilities?.shipping, ...override.shipping },
+        billing: { ...capabilities?.billing, ...override.billing },
+        payment: { ...capabilities?.payment, ...override.payment },
+        orderConfirmation: {
+            ...capabilities?.orderConfirmation,
+            ...override.orderConfirmation,
+        },
+    } as Capabilities;
+}

--- a/packages/core/src/b2b-dev-tools/index.ts
+++ b/packages/core/src/b2b-dev-tools/index.ts
@@ -1,2 +1,3 @@
 // TODO: CHECKOUT-9979 remove this file before delivery
 export { isB2bDevModeEnabled, resolveB2bAppClientId, resolveB2bBaseUrl } from './b2b-dev-mode';
+export { applyCapabilitiesOverride } from './capabilities-override';

--- a/packages/core/src/cart/cart.ts
+++ b/packages/core/src/cart/cart.ts
@@ -9,6 +9,7 @@ import LineItemMap from './line-item-map';
 export default interface Cart {
     id: string;
     customerId: number;
+    companyId: number | null;
     currency: Currency;
     email: string;
     isTaxIncluded: boolean;

--- a/packages/core/src/cart/carts.mock.ts
+++ b/packages/core/src/cart/carts.mock.ts
@@ -10,6 +10,7 @@ export function getCart(): Cart {
     return {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         customerId: 4,
+        companyId: null,
         currency: getCurrency(),
         email: 'foo@bar.com',
         isTaxIncluded: false,

--- a/packages/core/src/checkout-buttons/checkout-button-initializer.spec.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-initializer.spec.ts
@@ -4,7 +4,11 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { of } from 'rxjs';
 
 import { CheckoutStore, createCheckoutStore } from '../checkout';
-import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
+import {
+    B2BCompanyPaymentMethodRequestSender,
+    PaymentMethodActionCreator,
+    PaymentMethodRequestSender,
+} from '../payment';
 import { createPaymentIntegrationService } from '../payment-integration';
 
 import { CheckoutButtonActionType } from './checkout-button-actions';
@@ -27,7 +31,10 @@ describe('CheckoutButtonInitializer', () => {
         buttonActionCreator = new CheckoutButtonStrategyActionCreator(
             createCheckoutButtonRegistry(store, createRequestSender(), createFormPoster()),
             createCheckoutButtonRegistryV2(createPaymentIntegrationService(store), {}),
-            new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender())),
+            new PaymentMethodActionCreator(
+                new PaymentMethodRequestSender(createRequestSender()),
+                new B2BCompanyPaymentMethodRequestSender(createRequestSender()),
+            ),
         );
 
         jest.spyOn(store, 'dispatch');

--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.spec.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.spec.ts
@@ -8,6 +8,7 @@ import { CheckoutStore, createCheckoutStore } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { Registry } from '../common/registry';
 import {
+    B2BCompanyPaymentMethodRequestSender,
     PaymentMethodActionCreator,
     PaymentMethodActionType,
     PaymentMethodRequestSender,
@@ -45,6 +46,7 @@ describe('CheckoutButtonStrategyActionCreator', () => {
         registry = new Registry<CheckoutButtonStrategy>();
         paymentMethodActionCreator = new PaymentMethodActionCreator(
             new PaymentMethodRequestSender(createRequestSender()),
+            new B2BCompanyPaymentMethodRequestSender(createRequestSender()),
         );
         strategy = new MockButtonStrategy();
         store = createCheckoutStore();

--- a/packages/core/src/checkout-buttons/create-checkout-button-initializer.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-initializer.ts
@@ -4,7 +4,11 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { createCheckoutStore } from '../checkout';
 import { ConfigState } from '../config';
 import * as defaultCheckoutButtonStrategyFactories from '../generated/checkout-button-strategies';
-import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
+import {
+    B2BCompanyPaymentMethodRequestSender,
+    PaymentMethodActionCreator,
+    PaymentMethodRequestSender,
+} from '../payment';
 import { createPaymentIntegrationService } from '../payment-integration';
 
 import CheckoutButtonInitializer from './checkout-button-initializer';
@@ -64,7 +68,10 @@ export default function createCheckoutButtonInitializer(
         new CheckoutButtonStrategyActionCreator(
             createCheckoutButtonRegistry(store, requestSender, formPoster, host),
             registryV2,
-            new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
+            new PaymentMethodActionCreator(
+                new PaymentMethodRequestSender(requestSender),
+                new B2BCompanyPaymentMethodRequestSender(requestSender),
+            ),
         ),
     );
 }

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -62,6 +62,7 @@ import { OrderActionCreator, OrderRequestSender } from '../order';
 import { getCompleteOrderResponseBody, getOrderRequestBody } from '../order/internal-orders.mock';
 import { getOrder } from '../order/orders.mock';
 import {
+    B2BCompanyPaymentMethodRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistryV2,
     PaymentMethodActionCreator,
@@ -393,7 +394,10 @@ describe('CheckoutService', () => {
 
         orderActionCreator = new OrderActionCreator(orderRequestSender, checkoutValidator);
 
-        paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            paymentMethodRequestSender,
+            new B2BCompanyPaymentMethodRequestSender(requestSender),
+        );
 
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             paymentStrategyRegistry,

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -39,7 +39,6 @@ import {
     OrderFinalizeOptions,
     PaymentInitializeOptions,
     PaymentMethodActionCreator,
-    PaymentMethodsRequestOptions,
     PaymentRequestOptions,
     PaymentStrategyActionCreator,
 } from '../payment';
@@ -390,28 +389,28 @@ export default class CheckoutService {
      * console.log(state.data.getPaymentMethods());
      * ```
      *
-     * If `options.useCompanyAllowList` is `true`, the returned list is filtered
-     * against the authenticated customer's B2B company allow-list. The caller
-     * **must** await `service.getB2BToken()` first so the token is in state
-     * when this method runs — there is no automatic token load.
+     * When the store's `b2bPaymentMethodFilter` capability is enabled, the returned
+     * list is automatically filtered against the authenticated customer's B2B company
+     * allow-list. The caller **must** await `service.getB2BToken()` before this method
+     * so the token is in state.
      *
      * ```js
      * await service.getB2BToken();
-     * await service.loadPaymentMethods({ useCompanyAllowList: true });
+     * await service.loadPaymentMethods();
      * const methods = service.getState().data.getPaymentMethods();
      * ```
      *
-     * When `useCompanyAllowList` is set, the call fails with a
-     * `MissingDataError` if the customer is a guest, the B2B token is missing
-     * from state, the B2B API base URL is unavailable, or `cart.companyId` is
-     * missing. Any failure of the B2B endpoint itself also fails the whole
-     * `loadPaymentMethods` call (no fallback to the unfiltered list).
+     * When filtering is active, the call fails with a `MissingDataError` if
+     * the customer is a guest, the B2B token is missing from state, the B2B
+     * API base URL is unavailable, or `cart.companyId` is missing. Any failure
+     * of the B2B endpoint itself also fails the whole `loadPaymentMethods`
+     * call (no fallback to the unfiltered list).
      *
      * @param options - Options for loading the payment methods that are
      * available to the current customer.
      * @returns A promise that resolves to the current state.
      */
-    loadPaymentMethods(options?: PaymentMethodsRequestOptions): Promise<CheckoutSelectors> {
+    loadPaymentMethods(options?: RequestOptions): Promise<CheckoutSelectors> {
         const action = this._paymentMethodActionCreator.loadPaymentMethods(options);
 
         return this._dispatch(action, { queueId: 'paymentMethods' });

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -389,23 +389,6 @@ export default class CheckoutService {
      * console.log(state.data.getPaymentMethods());
      * ```
      *
-     * When the store's `b2bPaymentMethodFilter` capability is enabled, the returned
-     * list is automatically filtered against the authenticated customer's B2B company
-     * allow-list. The caller **must** await `service.getB2BToken()` before this method
-     * so the token is in state.
-     *
-     * ```js
-     * await service.getB2BToken();
-     * await service.loadPaymentMethods();
-     * const methods = service.getState().data.getPaymentMethods();
-     * ```
-     *
-     * When filtering is active, the call fails with a `MissingDataError` if
-     * the customer is a guest, the B2B token is missing from state, the B2B
-     * API base URL is unavailable, or `cart.companyId` is missing. Any failure
-     * of the B2B endpoint itself also fails the whole `loadPaymentMethods`
-     * call (no fallback to the unfiltered list).
-     *
      * @param options - Options for loading the payment methods that are
      * available to the current customer.
      * @returns A promise that resolves to the current state.

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -39,6 +39,7 @@ import {
     OrderFinalizeOptions,
     PaymentInitializeOptions,
     PaymentMethodActionCreator,
+    PaymentMethodsRequestOptions,
     PaymentRequestOptions,
     PaymentStrategyActionCreator,
 } from '../payment';
@@ -389,11 +390,28 @@ export default class CheckoutService {
      * console.log(state.data.getPaymentMethods());
      * ```
      *
+     * If `options.useCompanyAllowList` is `true`, the returned list is filtered
+     * against the authenticated customer's B2B company allow-list. The caller
+     * **must** await `service.getB2BToken()` first so the token is in state
+     * when this method runs — there is no automatic token load.
+     *
+     * ```js
+     * await service.getB2BToken();
+     * await service.loadPaymentMethods({ useCompanyAllowList: true });
+     * const methods = service.getState().data.getPaymentMethods();
+     * ```
+     *
+     * When `useCompanyAllowList` is set, the call fails with a
+     * `MissingDataError` if the customer is a guest, the B2B token is missing
+     * from state, the B2B API base URL is unavailable, or `cart.companyId` is
+     * missing. Any failure of the B2B endpoint itself also fails the whole
+     * `loadPaymentMethods` call (no fallback to the unfiltered list).
+     *
      * @param options - Options for loading the payment methods that are
      * available to the current customer.
      * @returns A promise that resolves to the current state.
      */
-    loadPaymentMethods(options?: RequestOptions): Promise<CheckoutSelectors> {
+    loadPaymentMethods(options?: PaymentMethodsRequestOptions): Promise<CheckoutSelectors> {
         const action = this._paymentMethodActionCreator.loadPaymentMethods(options);
 
         return this._dispatch(action, { queueId: 'paymentMethods' });

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -35,6 +35,7 @@ import * as paymentStrategyFactories from '../generated/payment-strategies';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import {
+    B2BCompanyPaymentMethodRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistry,
     createPaymentStrategyRegistryV2,
@@ -203,7 +204,10 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
             new InstrumentRequestSender(paymentClient, experimentRequestSender),
         ),
         orderActionCreator,
-        new PaymentMethodActionCreator(new PaymentMethodRequestSender(experimentRequestSender)),
+        new PaymentMethodActionCreator(
+            new PaymentMethodRequestSender(experimentRequestSender),
+            new B2BCompanyPaymentMethodRequestSender(requestSender),
+        ),
         new PaymentStrategyActionCreator(
             createPaymentStrategyRegistry(store, paymentClient, experimentRequestSender),
             registryV2,

--- a/packages/core/src/config/capabilities.ts
+++ b/packages/core/src/config/capabilities.ts
@@ -4,6 +4,7 @@
 export interface Capabilities {
     userJourney: {
         disableEditCart: boolean;
+        disableStoreCredit: boolean;
         hasCompanyAddressBook: boolean;
         hasAddressExtraFields: boolean;
         requiresB2BToken: boolean;

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -19,6 +19,7 @@ import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import {
+    B2BCompanyPaymentMethodRequestSender,
     createPaymentClient,
     PaymentActionCreator,
     PaymentMethodActionCreator,
@@ -91,6 +92,7 @@ export default function createPaymentIntegrationService(
 
     const paymentMethodActionCreator = new PaymentMethodActionCreator(
         new PaymentMethodRequestSender(requestSender),
+        new B2BCompanyPaymentMethodRequestSender(requestSender),
     );
 
     const paymentActionCreator = new PaymentActionCreator(

--- a/packages/core/src/payment/apply-b2b-company-payment-method-filter.spec.ts
+++ b/packages/core/src/payment/apply-b2b-company-payment-method-filter.spec.ts
@@ -1,0 +1,151 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import { InternalCheckoutSelectors } from '../checkout';
+import { CheckoutStore, createCheckoutStore } from '../checkout';
+import { getCheckout, getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { MissingDataError } from '../common/error/errors';
+import { getResponse } from '../common/http-request/responses.mock';
+
+import applyB2bCompanyPaymentMethodFilter from './apply-b2b-company-payment-method-filter';
+import B2BCompanyPaymentMethodRequestSender, {
+    B2BCompanyPaymentMethodsResponseBody,
+} from './b2b-company-payment-method-request-sender';
+import { getPaymentMethod } from './payment-methods.mock';
+
+describe('applyB2bCompanyPaymentMethodFilter', () => {
+    const companyId = 42;
+    const b2bToken = 'b2b-token-value';
+    const b2bBaseUrl = 'https://api-b2b.bigcommerce.com';
+
+    const allowListResponseBody: B2BCompanyPaymentMethodsResponseBody = {
+        data: [
+            {
+                code: getPaymentMethod().id,
+                name: getPaymentMethod().id,
+                isEnabled: '1',
+                paymentId: 1,
+            },
+        ],
+    };
+
+    let store: CheckoutStore;
+    let state: InternalCheckoutSelectors;
+    let requestSender: B2BCompanyPaymentMethodRequestSender;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        state = store.getState();
+
+        jest.spyOn(state.cart, 'getCart').mockReturnValue({
+            ...getCheckout().cart,
+            companyId,
+        });
+        jest.spyOn(state.customer, 'getCustomer').mockReturnValue({
+            ...getCheckout().customer,
+            isGuest: false,
+        });
+        jest.spyOn(state.b2bToken, 'getToken').mockReturnValue(b2bToken);
+        jest.spyOn(state.config, 'getStoreConfig').mockReturnValue({
+            ...state.config.getStoreConfig()!,
+            b2bApiSettings: { baseUrl: b2bBaseUrl, clientId: 'cid' },
+        });
+
+        requestSender = new B2BCompanyPaymentMethodRequestSender(createRequestSender());
+
+        jest.spyOn(requestSender, 'getB2BCompanyPaymentMethods').mockResolvedValue(
+            getResponse(allowListResponseBody),
+        );
+    });
+
+    it('fetches the allow-list and returns the filtered subset', async () => {
+        const methods = [getPaymentMethod()];
+
+        const result = await applyB2bCompanyPaymentMethodFilter(methods, state, requestSender);
+
+        expect(requestSender.getB2BCompanyPaymentMethods).toHaveBeenCalledWith(
+            companyId,
+            b2bToken,
+            b2bBaseUrl,
+            undefined,
+        );
+        expect(result).toEqual([getPaymentMethod()]);
+    });
+
+    it('forwards request options to the B2B request sender', async () => {
+        const methods = [getPaymentMethod()];
+        const options = { timeout: undefined };
+
+        await applyB2bCompanyPaymentMethodFilter(methods, state, requestSender, options);
+
+        expect(requestSender.getB2BCompanyPaymentMethods).toHaveBeenCalledWith(
+            companyId,
+            b2bToken,
+            b2bBaseUrl,
+            options,
+        );
+    });
+
+    it('throws MissingDataError when the customer is missing', async () => {
+        jest.spyOn(state.customer, 'getCustomer').mockReturnValue(undefined);
+
+        await expect(
+            applyB2bCompanyPaymentMethodFilter([getPaymentMethod()], state, requestSender),
+        ).rejects.toBeInstanceOf(MissingDataError);
+        expect(requestSender.getB2BCompanyPaymentMethods).not.toHaveBeenCalled();
+    });
+
+    it('throws MissingDataError when the customer is a guest', async () => {
+        jest.spyOn(state.customer, 'getCustomer').mockReturnValue({
+            ...getCheckout().customer,
+            isGuest: true,
+        });
+
+        await expect(
+            applyB2bCompanyPaymentMethodFilter([getPaymentMethod()], state, requestSender),
+        ).rejects.toBeInstanceOf(MissingDataError);
+        expect(requestSender.getB2BCompanyPaymentMethods).not.toHaveBeenCalled();
+    });
+
+    it('throws MissingDataError when the B2B token is missing from state', async () => {
+        jest.spyOn(state.b2bToken, 'getToken').mockReturnValue(undefined);
+
+        await expect(
+            applyB2bCompanyPaymentMethodFilter([getPaymentMethod()], state, requestSender),
+        ).rejects.toBeInstanceOf(MissingDataError);
+        expect(requestSender.getB2BCompanyPaymentMethods).not.toHaveBeenCalled();
+    });
+
+    it('throws MissingDataError when companyId is missing', async () => {
+        jest.spyOn(state.cart, 'getCart').mockReturnValue({
+            ...getCheckout().cart,
+            companyId: null,
+        });
+
+        await expect(
+            applyB2bCompanyPaymentMethodFilter([getPaymentMethod()], state, requestSender),
+        ).rejects.toBeInstanceOf(MissingDataError);
+        expect(requestSender.getB2BCompanyPaymentMethods).not.toHaveBeenCalled();
+    });
+
+    it('throws MissingDataError when the B2B base URL is unavailable', async () => {
+        jest.spyOn(state.config, 'getStoreConfig').mockReturnValue({
+            ...state.config.getStoreConfig()!,
+            b2bApiSettings: { baseUrl: '', clientId: '' },
+        });
+
+        await expect(
+            applyB2bCompanyPaymentMethodFilter([getPaymentMethod()], state, requestSender),
+        ).rejects.toBeInstanceOf(MissingDataError);
+        expect(requestSender.getB2BCompanyPaymentMethods).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors from the B2B request sender', async () => {
+        const b2bError = new Error('B2B endpoint unavailable');
+
+        jest.spyOn(requestSender, 'getB2BCompanyPaymentMethods').mockRejectedValue(b2bError);
+
+        await expect(
+            applyB2bCompanyPaymentMethodFilter([getPaymentMethod()], state, requestSender),
+        ).rejects.toBe(b2bError);
+    });
+});

--- a/packages/core/src/payment/apply-b2b-company-payment-method-filter.ts
+++ b/packages/core/src/payment/apply-b2b-company-payment-method-filter.ts
@@ -1,0 +1,36 @@
+// TODO: CHECKOUT-9979 remove this import before delivery
+import { resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { InternalCheckoutSelectors } from '../checkout';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { RequestOptions } from '../common/http-request';
+
+import B2BCompanyPaymentMethodRequestSender from './b2b-company-payment-method-request-sender';
+import filterPaymentMethodsByB2BCompanyAllowList from './b2b-company-payment-method-filter-transformer';
+import PaymentMethod from './payment-method';
+
+export default async function applyB2bCompanyPaymentMethodFilter(
+    methods: PaymentMethod[],
+    state: InternalCheckoutSelectors,
+    b2bCompanyPaymentMethodRequestSender: B2BCompanyPaymentMethodRequestSender,
+    options?: RequestOptions,
+): Promise<PaymentMethod[]> {
+    const customer = state.customer.getCustomer();
+    const b2bToken = state.b2bToken.getToken();
+    const b2bBaseUrl = resolveB2bBaseUrl(
+        state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
+    );
+    const companyId = state.cart.getCart()?.companyId;
+
+    if (!customer || customer.isGuest || !b2bToken || !b2bBaseUrl || !companyId) {
+        throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+    }
+
+    const { body } = await b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods(
+        companyId,
+        b2bToken,
+        b2bBaseUrl,
+        options,
+    );
+
+    return filterPaymentMethodsByB2BCompanyAllowList(methods, body);
+}

--- a/packages/core/src/payment/b2b-company-payment-method-filter-transformer.spec.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-filter-transformer.spec.ts
@@ -1,0 +1,76 @@
+import filterPaymentMethodsByB2BCompanyAllowList from './b2b-company-payment-method-filter-transformer';
+import { B2BCompanyPaymentMethodsResponseBody } from './b2b-company-payment-method-request-sender';
+import PaymentMethod from './payment-method';
+
+function makeMethod(id: string): PaymentMethod {
+    return {
+        id,
+        config: {},
+        method: 'credit-card',
+        supportedCards: [],
+        type: 'PAYMENT_TYPE_API',
+        skipRedirectConfirmationAlert: false,
+    };
+}
+
+describe('filterPaymentMethodsByB2BCompanyAllowList', () => {
+    it('returns only methods whose id is in the allow-list', () => {
+        const methods = [makeMethod('cheque'), makeMethod('stripev3'), makeMethod('braintree')];
+        const body: B2BCompanyPaymentMethodsResponseBody = {
+            data: [
+                { code: 'cheque', name: 'Check', isEnabled: '1', paymentId: 1 },
+                { code: 'stripev3', name: 'Stripe', isEnabled: '1', paymentId: 2 },
+            ],
+        };
+
+        expect(filterPaymentMethodsByB2BCompanyAllowList(methods, body)).toEqual([
+            makeMethod('cheque'),
+            makeMethod('stripev3'),
+        ]);
+    });
+
+    it('drops methods whose B2B entry is disabled', () => {
+        const methods = [makeMethod('cheque'), makeMethod('stripev3')];
+        const body: B2BCompanyPaymentMethodsResponseBody = {
+            data: [
+                { code: 'cheque', name: 'Check', isEnabled: '1', paymentId: 1 },
+                { code: 'stripev3', name: 'Stripe', isEnabled: '0', paymentId: 2 },
+            ],
+        };
+
+        expect(filterPaymentMethodsByB2BCompanyAllowList(methods, body)).toEqual([
+            makeMethod('cheque'),
+        ]);
+    });
+
+    it('returns an empty list when the allow-list is empty', () => {
+        const methods = [makeMethod('cheque'), makeMethod('stripev3')];
+        const body: B2BCompanyPaymentMethodsResponseBody = { data: [] };
+
+        expect(filterPaymentMethodsByB2BCompanyAllowList(methods, body)).toEqual([]);
+    });
+
+    it('returns an empty list when the intersection is empty', () => {
+        const methods = [makeMethod('cheque'), makeMethod('stripev3')];
+        const body: B2BCompanyPaymentMethodsResponseBody = {
+            data: [{ code: 'braintree', name: 'Braintree', isEnabled: '1', paymentId: 1 }],
+        };
+
+        expect(filterPaymentMethodsByB2BCompanyAllowList(methods, body)).toEqual([]);
+    });
+
+    it('preserves the order of the input methods', () => {
+        const methods = [makeMethod('stripev3'), makeMethod('braintree'), makeMethod('cheque')];
+        const body: B2BCompanyPaymentMethodsResponseBody = {
+            data: [
+                { code: 'cheque', name: 'Check', isEnabled: '1', paymentId: 1 },
+                { code: 'stripev3', name: 'Stripe', isEnabled: '1', paymentId: 2 },
+            ],
+        };
+
+        expect(filterPaymentMethodsByB2BCompanyAllowList(methods, body)).toEqual([
+            makeMethod('stripev3'),
+            makeMethod('cheque'),
+        ]);
+    });
+});

--- a/packages/core/src/payment/b2b-company-payment-method-filter-transformer.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-filter-transformer.ts
@@ -5,8 +5,6 @@ import PaymentMethod from './payment-method';
  * Intersects the storefront payment method list against a B2B company's
  * allow-list. Matches on `PaymentMethod.id === b2bMethod.code` and drops
  * disabled methods (`isEnabled !== '1'`).
- *
- * Temporary ACL: remove once the B2B Storefront API returns a pre-filtered list.
  */
 export default function filterPaymentMethodsByB2BCompanyAllowList(
     methods: PaymentMethod[],

--- a/packages/core/src/payment/b2b-company-payment-method-filter-transformer.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-filter-transformer.ts
@@ -1,0 +1,18 @@
+import { B2BCompanyPaymentMethodsResponseBody } from './b2b-company-payment-method-request-sender';
+import PaymentMethod from './payment-method';
+
+/**
+ * Intersects the storefront payment method list against a B2B company's
+ * allow-list. Matches on `PaymentMethod.id === b2bMethod.code` and drops
+ * disabled methods (`isEnabled !== '1'`).
+ *
+ * Temporary ACL: remove once the B2B Storefront API returns a pre-filtered list.
+ */
+export default function filterPaymentMethodsByB2BCompanyAllowList(
+    methods: PaymentMethod[],
+    body: B2BCompanyPaymentMethodsResponseBody,
+): PaymentMethod[] {
+    const allowedCodes = new Set(body.data.filter((m) => m.isEnabled === '1').map((m) => m.code));
+
+    return methods.filter((method) => allowedCodes.has(method.id));
+}

--- a/packages/core/src/payment/b2b-company-payment-method-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-request-sender.spec.ts
@@ -1,0 +1,90 @@
+import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
+
+import { getResponse } from '../common/http-request/responses.mock';
+
+import B2BCompanyPaymentMethodRequestSender, {
+    B2BCompanyPaymentMethodsResponseBody,
+} from './b2b-company-payment-method-request-sender';
+
+describe('B2BCompanyPaymentMethodRequestSender', () => {
+    let requestSender: RequestSender;
+    let b2bCompanyPaymentMethodRequestSender: B2BCompanyPaymentMethodRequestSender;
+
+    const responseBody: B2BCompanyPaymentMethodsResponseBody = {
+        data: [
+            { code: 'cheque', name: 'Check', isEnabled: '1', paymentId: 1 },
+            { code: 'stripev3', name: 'Stripe', isEnabled: '1', paymentId: 2 },
+        ],
+    };
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        jest.spyOn(requestSender, 'get').mockResolvedValue(getResponse(responseBody));
+
+        b2bCompanyPaymentMethodRequestSender = new B2BCompanyPaymentMethodRequestSender(
+            requestSender,
+        );
+    });
+
+    describe('#getB2BCompanyPaymentMethods()', () => {
+        it('calls the company payments endpoint with auth headers', async () => {
+            await b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods(
+                42,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.get).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/companies/42/payments',
+                {
+                    timeout: undefined,
+                    credentials: false,
+                    headers: {
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                },
+            );
+        });
+
+        it('forwards the request timeout', async () => {
+            const timeout = createTimeout();
+
+            await b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods(
+                42,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+                { timeout },
+            );
+
+            expect(requestSender.get).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/companies/42/payments',
+                expect.objectContaining({ timeout }),
+            );
+        });
+
+        it('uses the provided b2bBaseUrl for the endpoint', async () => {
+            await b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods(
+                7,
+                'b2b-token-value',
+                'https://api-b2b.staging.zone',
+            );
+
+            expect(requestSender.get).toHaveBeenCalledWith(
+                'https://api-b2b.staging.zone/api/v2/companies/7/payments',
+                expect.any(Object),
+            );
+        });
+
+        it('returns the response from the request sender', async () => {
+            const result = await b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods(
+                42,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(result.body).toEqual(responseBody);
+        });
+    });
+});

--- a/packages/core/src/payment/b2b-company-payment-method-request-sender.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-request-sender.ts
@@ -1,0 +1,32 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { RequestOptions } from '../common/http-request';
+
+export interface B2BCompanyPaymentMethodsResponseBody {
+    data: Array<{
+        code: string;
+        name: string;
+        isEnabled: '1' | '0';
+        paymentId: number;
+    }>;
+}
+
+export default class B2BCompanyPaymentMethodRequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    async getB2BCompanyPaymentMethods(
+        companyId: number,
+        b2bToken: string,
+        b2bBaseUrl: string,
+        options?: RequestOptions,
+    ): Promise<Response<B2BCompanyPaymentMethodsResponseBody>> {
+        return this._requestSender.get(`${b2bBaseUrl}/api/v2/companies/${companyId}/payments`, {
+            timeout: options?.timeout,
+            credentials: false,
+            headers: {
+                authToken: b2bToken,
+                Authorization: `Bearer ${b2bToken}`,
+            },
+        });
+    }
+}

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -46,10 +46,7 @@ export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';
 export { default as PaymentMethodConfig } from './payment-method-config';
 export { default as InitializationStrategy } from './payment-method-initialization-strategy';
-export {
-    default as PaymentMethodActionCreator,
-    PaymentMethodsRequestOptions,
-} from './payment-method-action-creator';
+export { default as PaymentMethodActionCreator } from './payment-method-action-creator';
 export { default as paymentMethodReducer } from './payment-method-reducer';
 export { default as PaymentMethodRequestSender } from './payment-method-request-sender';
 export {

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -37,11 +37,19 @@ export {
     WithDocumentInstrument,
     WithMollieIssuerInstrument,
 } from './payment';
+export {
+    default as B2BCompanyPaymentMethodRequestSender,
+    B2BCompanyPaymentMethodsResponseBody,
+} from './b2b-company-payment-method-request-sender';
+export { default as filterPaymentMethodsByB2BCompanyAllowList } from './b2b-company-payment-method-filter-transformer';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';
 export { default as PaymentMethodConfig } from './payment-method-config';
 export { default as InitializationStrategy } from './payment-method-initialization-strategy';
-export { default as PaymentMethodActionCreator } from './payment-method-action-creator';
+export {
+    default as PaymentMethodActionCreator,
+    PaymentMethodsRequestOptions,
+} from './payment-method-action-creator';
 export { default as paymentMethodReducer } from './payment-method-reducer';
 export { default as PaymentMethodRequestSender } from './payment-method-request-sender';
 export {

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -37,11 +37,7 @@ export {
     WithDocumentInstrument,
     WithMollieIssuerInstrument,
 } from './payment';
-export {
-    default as B2BCompanyPaymentMethodRequestSender,
-    B2BCompanyPaymentMethodsResponseBody,
-} from './b2b-company-payment-method-request-sender';
-export { default as filterPaymentMethodsByB2BCompanyAllowList } from './b2b-company-payment-method-filter-transformer';
+export { default as B2BCompanyPaymentMethodRequestSender } from './b2b-company-payment-method-request-sender';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';
 export { default as PaymentMethodConfig } from './payment-method-config';

--- a/packages/core/src/payment/payment-method-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-method-action-creator.spec.ts
@@ -158,9 +158,7 @@ describe('PaymentMethodActionCreator', () => {
             });
 
             it('applies the filter automatically when the capability is enabled', async () => {
-                const actions = await from(
-                    paymentMethodActionCreator.loadPaymentMethods()(store),
-                )
+                const actions = await from(paymentMethodActionCreator.loadPaymentMethods()(store))
                     .pipe(toArray())
                     .toPromise();
 

--- a/packages/core/src/payment/payment-method-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-method-action-creator.spec.ts
@@ -6,8 +6,12 @@ import { ErrorResponseBody } from '@bigcommerce/checkout-sdk/payment-integration
 
 import { CheckoutStore, createCheckoutStore } from '../checkout';
 import { getCheckout, getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { MissingDataError } from '../common/error/errors';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
+import B2BCompanyPaymentMethodRequestSender, {
+    B2BCompanyPaymentMethodsResponseBody,
+} from './b2b-company-payment-method-request-sender';
 import PaymentMethod from './payment-method';
 import PaymentMethodActionCreator from './payment-method-action-creator';
 import { PaymentMethodActionType } from './payment-method-actions';
@@ -18,6 +22,7 @@ describe('PaymentMethodActionCreator', () => {
     let errorResponse: Response<ErrorResponseBody>;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
     let paymentMethodRequestSender: PaymentMethodRequestSender;
+    let b2bCompanyPaymentMethodRequestSender: B2BCompanyPaymentMethodRequestSender;
     let paymentMethodResponse: Response<PaymentMethod>;
     let paymentMethodsResponse: Response<PaymentMethod[]>;
     let store: CheckoutStore;
@@ -32,7 +37,13 @@ describe('PaymentMethodActionCreator', () => {
         store = createCheckoutStore(getCheckoutStoreState());
 
         paymentMethodRequestSender = new PaymentMethodRequestSender(createRequestSender());
-        paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
+        b2bCompanyPaymentMethodRequestSender = new B2BCompanyPaymentMethodRequestSender(
+            createRequestSender(),
+        );
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            paymentMethodRequestSender,
+            b2bCompanyPaymentMethodRequestSender,
+        );
 
         jest.spyOn(paymentMethodRequestSender, 'loadPaymentMethod').mockReturnValue(
             Promise.resolve(paymentMethodResponse),
@@ -89,6 +100,214 @@ describe('PaymentMethodActionCreator', () => {
                     error: true,
                 },
             ]);
+        });
+
+        describe('with useCompanyAllowList', () => {
+            const companyId = 42;
+            const b2bToken = 'b2b-token-value';
+            const b2bBaseUrl = 'https://api-b2b.bigcommerce.com';
+
+            const allowListResponseBody: B2BCompanyPaymentMethodsResponseBody = {
+                data: [
+                    {
+                        code: getPaymentMethod().id,
+                        name: getPaymentMethod().id,
+                        isEnabled: '1',
+                        paymentId: 1,
+                    },
+                ],
+            };
+
+            beforeEach(() => {
+                const state = store.getState();
+
+                jest.spyOn(state.cart, 'getCart').mockReturnValue({
+                    ...getCheckout().cart,
+                    companyId,
+                });
+                jest.spyOn(state.customer, 'getCustomer').mockReturnValue({
+                    ...getCheckout().customer,
+                    isGuest: false,
+                });
+                jest.spyOn(state.b2bToken, 'getToken').mockReturnValue(b2bToken);
+                jest.spyOn(state.config, 'getStoreConfig').mockReturnValue({
+                    ...state.config.getStoreConfig()!,
+                    b2bApiSettings: { baseUrl: b2bBaseUrl, clientId: 'cid' },
+                });
+
+                jest.spyOn(
+                    b2bCompanyPaymentMethodRequestSender,
+                    'getB2BCompanyPaymentMethods',
+                ).mockResolvedValue(getResponse(allowListResponseBody));
+            });
+
+            it('does not call the B2B request sender when option is omitted', async () => {
+                await from(paymentMethodActionCreator.loadPaymentMethods()(store)).toPromise();
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('does not call the B2B request sender when option is false', async () => {
+                await from(
+                    paymentMethodActionCreator.loadPaymentMethods({
+                        useCompanyAllowList: false,
+                    })(store),
+                ).toPromise();
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('fetches the B2B allow-list and emits the filtered subset', async () => {
+                const actions = await from(
+                    paymentMethodActionCreator.loadPaymentMethods({
+                        useCompanyAllowList: true,
+                    })(store),
+                )
+                    .pipe(toArray())
+                    .toPromise();
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).toHaveBeenCalledWith(
+                    companyId,
+                    b2bToken,
+                    b2bBaseUrl,
+                    expect.objectContaining({ useCompanyAllowList: true }),
+                );
+
+                expect(actions).toEqual([
+                    { type: PaymentMethodActionType.LoadPaymentMethodsRequested },
+                    {
+                        type: PaymentMethodActionType.LoadPaymentMethodsSucceeded,
+                        payload: [getPaymentMethod()],
+                        meta: {
+                            deviceSessionId: paymentMethodsResponse.headers['x-device-session-id'],
+                            sessionHash: paymentMethodsResponse.headers['x-session-hash'],
+                        },
+                    },
+                ]);
+            });
+
+            it('emits LoadPaymentMethodsFailed when the B2B fetch errors', async () => {
+                const b2bError = new Error('B2B endpoint unavailable');
+
+                jest.spyOn(
+                    b2bCompanyPaymentMethodRequestSender,
+                    'getB2BCompanyPaymentMethods',
+                ).mockRejectedValue(b2bError);
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    paymentMethodActionCreator.loadPaymentMethods({
+                        useCompanyAllowList: true,
+                    })(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(errorHandler).toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: PaymentMethodActionType.LoadPaymentMethodsRequested },
+                    {
+                        type: PaymentMethodActionType.LoadPaymentMethodsFailed,
+                        payload: b2bError,
+                        error: true,
+                    },
+                ]);
+            });
+
+            it('fails with MissingDataError when the B2B token is missing from state', async () => {
+                jest.spyOn(store.getState().b2bToken, 'getToken').mockReturnValue(undefined);
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    paymentMethodActionCreator.loadPaymentMethods({
+                        useCompanyAllowList: true,
+                    })(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(errorHandler).toHaveBeenCalled();
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
+                expect(actions[0]).toEqual({
+                    type: PaymentMethodActionType.LoadPaymentMethodsRequested,
+                });
+                expect(actions[1]).toMatchObject({
+                    type: PaymentMethodActionType.LoadPaymentMethodsFailed,
+                    error: true,
+                });
+                expect(actions[1].payload).toBeInstanceOf(MissingDataError);
+            });
+
+            it('fails with MissingDataError when companyId is missing', async () => {
+                jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({
+                    ...getCheckout().cart,
+                    companyId: null,
+                });
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    paymentMethodActionCreator.loadPaymentMethods({
+                        useCompanyAllowList: true,
+                    })(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
+                expect(actions[1].payload).toBeInstanceOf(MissingDataError);
+            });
+
+            it('fails with MissingDataError when the customer is a guest', async () => {
+                jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue({
+                    ...getCheckout().customer,
+                    isGuest: true,
+                });
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    paymentMethodActionCreator.loadPaymentMethods({
+                        useCompanyAllowList: true,
+                    })(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
+                expect(actions[1].payload).toBeInstanceOf(MissingDataError);
+            });
+
+            it('fails with MissingDataError when the B2B base URL is unavailable', async () => {
+                jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                    ...store.getState().config.getStoreConfig()!,
+                    b2bApiSettings: { baseUrl: '', clientId: '' },
+                });
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    paymentMethodActionCreator.loadPaymentMethods({
+                        useCompanyAllowList: true,
+                    })(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
+                expect(actions[1].payload).toBeInstanceOf(MissingDataError);
+            });
         });
     });
 

--- a/packages/core/src/payment/payment-method-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-method-action-creator.spec.ts
@@ -102,7 +102,7 @@ describe('PaymentMethodActionCreator', () => {
             ]);
         });
 
-        describe('with useCompanyAllowList', () => {
+        describe('with B2B company allow-list filtering', () => {
             const companyId = 42;
             const b2bToken = 'b2b-token-value';
             const b2bBaseUrl = 'https://api-b2b.bigcommerce.com';
@@ -118,6 +118,25 @@ describe('PaymentMethodActionCreator', () => {
                 ],
             };
 
+            function setCapability(value: boolean): void {
+                const baseConfig = store.getState().config.getStoreConfig()!;
+
+                jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                    ...baseConfig,
+                    checkoutSettings: {
+                        ...baseConfig.checkoutSettings,
+                        capabilities: {
+                            ...baseConfig.checkoutSettings.capabilities,
+                            payment: {
+                                ...baseConfig.checkoutSettings.capabilities?.payment,
+                                b2bPaymentMethodFilter: value,
+                            },
+                        },
+                    } as typeof baseConfig.checkoutSettings,
+                    b2bApiSettings: { baseUrl: b2bBaseUrl, clientId: 'cid' },
+                });
+            }
+
             beforeEach(() => {
                 const state = store.getState();
 
@@ -130,10 +149,7 @@ describe('PaymentMethodActionCreator', () => {
                     isGuest: false,
                 });
                 jest.spyOn(state.b2bToken, 'getToken').mockReturnValue(b2bToken);
-                jest.spyOn(state.config, 'getStoreConfig').mockReturnValue({
-                    ...state.config.getStoreConfig()!,
-                    b2bApiSettings: { baseUrl: b2bBaseUrl, clientId: 'cid' },
-                });
+                setCapability(true);
 
                 jest.spyOn(
                     b2bCompanyPaymentMethodRequestSender,
@@ -141,43 +157,16 @@ describe('PaymentMethodActionCreator', () => {
                 ).mockResolvedValue(getResponse(allowListResponseBody));
             });
 
-            it('does not call the B2B request sender when option is omitted', async () => {
-                await from(paymentMethodActionCreator.loadPaymentMethods()(store)).toPromise();
-
-                expect(
-                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
-                ).not.toHaveBeenCalled();
-            });
-
-            it('does not call the B2B request sender when option is false', async () => {
-                await from(
-                    paymentMethodActionCreator.loadPaymentMethods({
-                        useCompanyAllowList: false,
-                    })(store),
-                ).toPromise();
-
-                expect(
-                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
-                ).not.toHaveBeenCalled();
-            });
-
-            it('fetches the B2B allow-list and emits the filtered subset', async () => {
+            it('applies the filter automatically when the capability is enabled', async () => {
                 const actions = await from(
-                    paymentMethodActionCreator.loadPaymentMethods({
-                        useCompanyAllowList: true,
-                    })(store),
+                    paymentMethodActionCreator.loadPaymentMethods()(store),
                 )
                     .pipe(toArray())
                     .toPromise();
 
                 expect(
                     b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
-                ).toHaveBeenCalledWith(
-                    companyId,
-                    b2bToken,
-                    b2bBaseUrl,
-                    expect.objectContaining({ useCompanyAllowList: true }),
-                );
+                ).toHaveBeenCalledWith(companyId, b2bToken, b2bBaseUrl, undefined);
 
                 expect(actions).toEqual([
                     { type: PaymentMethodActionType.LoadPaymentMethodsRequested },
@@ -192,6 +181,31 @@ describe('PaymentMethodActionCreator', () => {
                 ]);
             });
 
+            it('does not call the B2B request sender when the capability is disabled', async () => {
+                setCapability(false);
+
+                await from(paymentMethodActionCreator.loadPaymentMethods()(store)).toPromise();
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('fails with MissingDataError when the B2B token is missing from state', async () => {
+                jest.spyOn(store.getState().b2bToken, 'getToken').mockReturnValue(undefined);
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(paymentMethodActionCreator.loadPaymentMethods()(store))
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(errorHandler).toHaveBeenCalled();
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
+                expect(actions[1].payload).toBeInstanceOf(MissingDataError);
+            });
+
             it('emits LoadPaymentMethodsFailed when the B2B fetch errors', async () => {
                 const b2bError = new Error('B2B endpoint unavailable');
 
@@ -201,11 +215,7 @@ describe('PaymentMethodActionCreator', () => {
                 ).mockRejectedValue(b2bError);
 
                 const errorHandler = jest.fn((action) => of(action));
-                const actions = await from(
-                    paymentMethodActionCreator.loadPaymentMethods({
-                        useCompanyAllowList: true,
-                    })(store),
-                )
+                const actions = await from(paymentMethodActionCreator.loadPaymentMethods()(store))
                     .pipe(catchError(errorHandler), toArray())
                     .toPromise();
 
@@ -220,32 +230,6 @@ describe('PaymentMethodActionCreator', () => {
                 ]);
             });
 
-            it('fails with MissingDataError when the B2B token is missing from state', async () => {
-                jest.spyOn(store.getState().b2bToken, 'getToken').mockReturnValue(undefined);
-
-                const errorHandler = jest.fn((action) => of(action));
-                const actions = await from(
-                    paymentMethodActionCreator.loadPaymentMethods({
-                        useCompanyAllowList: true,
-                    })(store),
-                )
-                    .pipe(catchError(errorHandler), toArray())
-                    .toPromise();
-
-                expect(errorHandler).toHaveBeenCalled();
-                expect(
-                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
-                ).not.toHaveBeenCalled();
-                expect(actions[0]).toEqual({
-                    type: PaymentMethodActionType.LoadPaymentMethodsRequested,
-                });
-                expect(actions[1]).toMatchObject({
-                    type: PaymentMethodActionType.LoadPaymentMethodsFailed,
-                    error: true,
-                });
-                expect(actions[1].payload).toBeInstanceOf(MissingDataError);
-            });
-
             it('fails with MissingDataError when companyId is missing', async () => {
                 jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({
                     ...getCheckout().cart,
@@ -253,11 +237,7 @@ describe('PaymentMethodActionCreator', () => {
                 });
 
                 const errorHandler = jest.fn((action) => of(action));
-                const actions = await from(
-                    paymentMethodActionCreator.loadPaymentMethods({
-                        useCompanyAllowList: true,
-                    })(store),
-                )
+                const actions = await from(paymentMethodActionCreator.loadPaymentMethods()(store))
                     .pipe(catchError(errorHandler), toArray())
                     .toPromise();
 
@@ -274,11 +254,7 @@ describe('PaymentMethodActionCreator', () => {
                 });
 
                 const errorHandler = jest.fn((action) => of(action));
-                const actions = await from(
-                    paymentMethodActionCreator.loadPaymentMethods({
-                        useCompanyAllowList: true,
-                    })(store),
-                )
+                const actions = await from(paymentMethodActionCreator.loadPaymentMethods()(store))
                     .pipe(catchError(errorHandler), toArray())
                     .toPromise();
 
@@ -289,17 +265,15 @@ describe('PaymentMethodActionCreator', () => {
             });
 
             it('fails with MissingDataError when the B2B base URL is unavailable', async () => {
+                const baseConfig = store.getState().config.getStoreConfig()!;
+
                 jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
-                    ...store.getState().config.getStoreConfig()!,
+                    ...baseConfig,
                     b2bApiSettings: { baseUrl: '', clientId: '' },
                 });
 
                 const errorHandler = jest.fn((action) => of(action));
-                const actions = await from(
-                    paymentMethodActionCreator.loadPaymentMethods({
-                        useCompanyAllowList: true,
-                    })(store),
-                )
+                const actions = await from(paymentMethodActionCreator.loadPaymentMethods()(store))
                     .pipe(catchError(errorHandler), toArray())
                     .toPromise();
 

--- a/packages/core/src/payment/payment-method-action-creator.ts
+++ b/packages/core/src/payment/payment-method-action-creator.ts
@@ -1,15 +1,12 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { Observable, Observer } from 'rxjs';
 
-// TODO: CHECKOUT-9979 remove this import before delivery
-import { resolveB2bBaseUrl } from '../b2b-dev-tools';
 import { InternalCheckoutSelectors } from '../checkout';
 import { ActionOptions, cachableAction } from '../common/data-store';
-import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 
+import applyB2bCompanyPaymentMethodFilter from './apply-b2b-company-payment-method-filter';
 import B2BCompanyPaymentMethodRequestSender from './b2b-company-payment-method-request-sender';
-import filterPaymentMethodsByB2BCompanyAllowList from './b2b-company-payment-method-filter-transformer';
 import {
     LoadPaymentMethodAction,
     LoadPaymentMethodsAction,
@@ -22,10 +19,6 @@ import { PaymentMethod } from '.';
 const isPaymentMethod = (value: PaymentMethod | undefined): value is PaymentMethod => {
     return !!value;
 };
-
-export interface PaymentMethodsRequestOptions extends RequestOptions {
-    useCompanyAllowList?: boolean;
-}
 
 export default class PaymentMethodActionCreator {
     constructor(
@@ -83,7 +76,7 @@ export default class PaymentMethodActionCreator {
     }
 
     loadPaymentMethods(
-        options?: PaymentMethodsRequestOptions,
+        options?: RequestOptions,
     ): ThunkAction<LoadPaymentMethodsAction, InternalCheckoutSelectors> {
         return (store) =>
             Observable.create((observer: Observer<LoadPaymentMethodsAction>) => {
@@ -104,35 +97,17 @@ export default class PaymentMethodActionCreator {
                         };
                         let methods = response.body;
 
-                        if (options?.useCompanyAllowList) {
-                            const customer = state.customer.getCustomer();
-                            const b2bToken = state.b2bToken.getToken();
-                            const b2bBaseUrl = resolveB2bBaseUrl(
-                                state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
+                        const isB2bPaymentMethodFilterEnabled =
+                            state.config.getStoreConfig()?.checkoutSettings.capabilities?.payment
+                                ?.b2bPaymentMethodFilter ?? false;
+
+                        if (isB2bPaymentMethodFilterEnabled) {
+                            methods = await applyB2bCompanyPaymentMethodFilter(
+                                methods,
+                                state,
+                                this._b2bCompanyPaymentMethodRequestSender,
+                                options,
                             );
-                            const companyId = state.cart.getCart()?.companyId;
-
-                            if (
-                                !customer ||
-                                customer.isGuest ||
-                                !b2bToken ||
-                                !b2bBaseUrl ||
-                                !companyId
-                            ) {
-                                throw new MissingDataError(
-                                    MissingDataErrorType.MissingCheckoutConfig,
-                                );
-                            }
-
-                            const { body: b2bBody } =
-                                await this._b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods(
-                                    companyId,
-                                    b2bToken,
-                                    b2bBaseUrl,
-                                    options,
-                                );
-
-                            methods = filterPaymentMethodsByB2BCompanyAllowList(methods, b2bBody);
                         }
 
                         observer.next(

--- a/packages/core/src/payment/payment-method-action-creator.ts
+++ b/packages/core/src/payment/payment-method-action-creator.ts
@@ -1,10 +1,15 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { Observable, Observer } from 'rxjs';
 
+// TODO: CHECKOUT-9979 remove this import before delivery
+import { resolveB2bBaseUrl } from '../b2b-dev-tools';
 import { InternalCheckoutSelectors } from '../checkout';
 import { ActionOptions, cachableAction } from '../common/data-store';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 
+import B2BCompanyPaymentMethodRequestSender from './b2b-company-payment-method-request-sender';
+import filterPaymentMethodsByB2BCompanyAllowList from './b2b-company-payment-method-filter-transformer';
 import {
     LoadPaymentMethodAction,
     LoadPaymentMethodsAction,
@@ -18,8 +23,15 @@ const isPaymentMethod = (value: PaymentMethod | undefined): value is PaymentMeth
     return !!value;
 };
 
+export interface PaymentMethodsRequestOptions extends RequestOptions {
+    useCompanyAllowList?: boolean;
+}
+
 export default class PaymentMethodActionCreator {
-    constructor(private _requestSender: PaymentMethodRequestSender) {}
+    constructor(
+        private _requestSender: PaymentMethodRequestSender,
+        private _b2bCompanyPaymentMethodRequestSender: B2BCompanyPaymentMethodRequestSender,
+    ) {}
 
     loadPaymentMethodsById(
         methodIds: string[],
@@ -71,7 +83,7 @@ export default class PaymentMethodActionCreator {
     }
 
     loadPaymentMethods(
-        options?: RequestOptions,
+        options?: PaymentMethodsRequestOptions,
     ): ThunkAction<LoadPaymentMethodsAction, InternalCheckoutSelectors> {
         return (store) =>
             Observable.create((observer: Observer<LoadPaymentMethodsAction>) => {
@@ -85,12 +97,43 @@ export default class PaymentMethodActionCreator {
                         ...options,
                         params: { ...options?.params, cartId: cart.id },
                     })
-                    .then((response) => {
+                    .then(async (response) => {
                         const meta = {
                             deviceSessionId: response.headers['x-device-session-id'],
                             sessionHash: response.headers['x-session-hash'],
                         };
-                        const methods = response.body;
+                        let methods = response.body;
+
+                        if (options?.useCompanyAllowList) {
+                            const customer = state.customer.getCustomer();
+                            const b2bToken = state.b2bToken.getToken();
+                            const b2bBaseUrl = resolveB2bBaseUrl(
+                                state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
+                            );
+                            const companyId = state.cart.getCart()?.companyId;
+
+                            if (
+                                !customer ||
+                                customer.isGuest ||
+                                !b2bToken ||
+                                !b2bBaseUrl ||
+                                !companyId
+                            ) {
+                                throw new MissingDataError(
+                                    MissingDataErrorType.MissingCheckoutConfig,
+                                );
+                            }
+
+                            const { body: b2bBody } =
+                                await this._b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods(
+                                    companyId,
+                                    b2bToken,
+                                    b2bBaseUrl,
+                                    options,
+                                );
+
+                            methods = filterPaymentMethodsByB2BCompanyAllowList(methods, b2bBody);
+                        }
 
                         observer.next(
                             createAction(

--- a/packages/core/src/payment/payment-method-action-creator.ts
+++ b/packages/core/src/payment/payment-method-action-creator.ts
@@ -1,6 +1,8 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { Observable, Observer } from 'rxjs';
 
+// TODO: CHECKOUT-9979 remove this import before delivery
+import { applyCapabilitiesOverride } from '../b2b-dev-tools';
 import { InternalCheckoutSelectors } from '../checkout';
 import { ActionOptions, cachableAction } from '../common/data-store';
 import { RequestOptions } from '../common/http-request';
@@ -98,8 +100,9 @@ export default class PaymentMethodActionCreator {
                         let methods = response.body;
 
                         const isB2bPaymentMethodFilterEnabled =
-                            state.config.getStoreConfig()?.checkoutSettings.capabilities?.payment
-                                ?.b2bPaymentMethodFilter ?? false;
+                            applyCapabilitiesOverride(
+                                state.config.getStoreConfig()?.checkoutSettings.capabilities,
+                            )?.payment?.b2bPaymentMethodFilter ?? false;
 
                         if (isB2bPaymentMethodFilterEnabled) {
                             methods = await applyB2bCompanyPaymentMethodFilter(

--- a/packages/core/src/shipping/create-shipping-strategy-registry.ts
+++ b/packages/core/src/shipping/create-shipping-strategy-registry.ts
@@ -69,10 +69,7 @@ export default function createShippingStrategyRegistry(
             new AmazonPayV2ShippingStrategy(
                 store,
                 consignmentActionCreator,
-                new PaymentMethodActionCreator(
-                    new PaymentMethodRequestSender(requestSender),
-                    new B2BCompanyPaymentMethodRequestSender(requestSender),
-                ),
+                paymentMethodActionCreator,
                 createAmazonPayV2PaymentProcessor(),
                 new ShippingStrategyActionCreator(registry),
             ),

--- a/packages/core/src/shipping/create-shipping-strategy-registry.ts
+++ b/packages/core/src/shipping/create-shipping-strategy-registry.ts
@@ -17,7 +17,11 @@ import { StripeScriptLoader } from '@bigcommerce/checkout-sdk/stripe-utils';
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
-import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
+import {
+    B2BCompanyPaymentMethodRequestSender,
+    PaymentMethodActionCreator,
+    PaymentMethodRequestSender,
+} from '../payment';
 import { createPaymentIntegrationService } from '../payment-integration';
 import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
 import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subscription';
@@ -46,6 +50,7 @@ export default function createShippingStrategyRegistry(
     );
     const paymentMethodActionCreator = new PaymentMethodActionCreator(
         new PaymentMethodRequestSender(requestSender),
+        new B2BCompanyPaymentMethodRequestSender(requestSender),
     );
     const scriptLoader = getScriptLoader();
     const subscriptionsActionCreator = new SubscriptionsActionCreator(
@@ -64,7 +69,10 @@ export default function createShippingStrategyRegistry(
             new AmazonPayV2ShippingStrategy(
                 store,
                 consignmentActionCreator,
-                new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
+                new PaymentMethodActionCreator(
+                    new PaymentMethodRequestSender(requestSender),
+                    new B2BCompanyPaymentMethodRequestSender(requestSender),
+                ),
                 createAmazonPayV2PaymentProcessor(),
                 new ShippingStrategyActionCreator(registry),
             ),

--- a/packages/core/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.spec.ts
@@ -21,6 +21,7 @@ import { CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../..
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import {
+    B2BCompanyPaymentMethodRequestSender,
     PaymentMethod,
     PaymentMethodActionCreator,
     PaymentMethodRequestSender,
@@ -64,7 +65,10 @@ describe('AmazonPayV2ShippingStrategy', () => {
         const paymentMethodRequestSender: PaymentMethodRequestSender =
             new PaymentMethodRequestSender(requestSender);
 
-        paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            paymentMethodRequestSender,
+            new B2BCompanyPaymentMethodRequestSender(requestSender),
+        );
         paymentMethodMock = getAmazonPayV2('us');
 
         container = document.createElement('div');

--- a/packages/core/src/shipping/strategies/bigcommerce-payments/bigcommerce-payments-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/bigcommerce-payments/bigcommerce-payments-fastlane-shipping-strategy.spec.ts
@@ -31,6 +31,7 @@ import BillingAddressRequestSender from '../../../billing/billing-address-reques
 import { CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { InvalidArgumentError } from '../../../common/error/errors';
 import {
+    B2BCompanyPaymentMethodRequestSender,
     PaymentMethod,
     PaymentMethodActionCreator,
     PaymentMethodRequestSender,
@@ -120,6 +121,7 @@ describe('BigCommercePaymentsFastlaneShippingStrategy', () => {
         );
         paymentMethodActionCreator = new PaymentMethodActionCreator(
             new PaymentMethodRequestSender(requestSender),
+            new B2BCompanyPaymentMethodRequestSender(requestSender),
         );
         paymentProviderCustomerActionCreator = new PaymentProviderCustomerActionCreator();
         payPalSdkHelper = createBigCommercePaymentsSdk();

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
@@ -31,6 +31,7 @@ import BillingAddressRequestSender from '../../../billing/billing-address-reques
 import { CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { InvalidArgumentError } from '../../../common/error/errors';
 import {
+    B2BCompanyPaymentMethodRequestSender,
     PaymentMethod,
     PaymentMethodActionCreator,
     PaymentMethodRequestSender,
@@ -120,6 +121,7 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
         );
         paymentMethodActionCreator = new PaymentMethodActionCreator(
             new PaymentMethodRequestSender(requestSender),
+            new B2BCompanyPaymentMethodRequestSender(requestSender),
         );
         paymentProviderCustomerActionCreator = new PaymentProviderCustomerActionCreator();
         paypalCommerceSdkScriptLoader = createPayPalSdkScriptLoader();

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
@@ -24,6 +24,7 @@ import {
 import { getGuestCustomer } from '../../../customer/customers.mock';
 import { getAddressFormFields } from '../../../form/form.mock';
 import {
+    B2BCompanyPaymentMethodRequestSender,
     LoadPaymentMethodAction,
     PaymentMethod,
     PaymentMethodActionCreator,
@@ -101,6 +102,7 @@ describe('StripeUPEShippingStrategy', () => {
         );
         paymentMethodActionCreator = new PaymentMethodActionCreator(
             new PaymentMethodRequestSender(requestSender),
+            new B2BCompanyPaymentMethodRequestSender(requestSender),
         );
 
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));

--- a/packages/payment-integration-api/src/cart/cart.ts
+++ b/packages/payment-integration-api/src/cart/cart.ts
@@ -8,6 +8,7 @@ import LineItemMap from './line-item-map';
 export default interface Cart {
     id: string;
     customerId: number;
+    companyId: number | null;
     currency: Currency;
     email: string;
     isTaxIncluded: boolean;

--- a/packages/payment-integration-api/src/config/capabilities.ts
+++ b/packages/payment-integration-api/src/config/capabilities.ts
@@ -4,6 +4,7 @@
 export interface Capabilities {
     userJourney: {
         disableEditCart: boolean;
+        disableStoreCredit: boolean;
         hasCompanyAddressBook: boolean;
         hasAddressExtraFields: boolean;
         requiresB2BToken: boolean;

--- a/packages/payment-integration-api/src/mocks/carts.mock.ts
+++ b/packages/payment-integration-api/src/mocks/carts.mock.ts
@@ -14,6 +14,7 @@ export default function getCart(): Cart {
     return {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         customerId: 4,
+        companyId: null,
         currency: getCurrency(),
         email: 'foo@bar.com',
         isTaxIncluded: false,

--- a/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
@@ -14,6 +14,7 @@ export default function getCart(): Cart {
     return {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         customerId: 4,
+        companyId: null,
         currency: getCurrency(),
         email: 'foo@bar.com',
         isTaxIncluded: false,


### PR DESCRIPTION
## What/Why?

Load b2b-allowed payment methods.

## Rollout/Rollback

Revert.

## Testing

### Before the filter
<img width="1511" height="826" alt="Screenshot 2026-05-20 at 10 24 35" src="https://github.com/user-attachments/assets/36535ba8-71c6-41e0-845a-65ba6957308b" />

### After the filter (tested with this PR)
<img width="1511" height="826" alt="Screenshot 2026-05-20 at 10 24 44" src="https://github.com/user-attachments/assets/e9cdad24-984e-4bf2-a8bd-3196be1b24c5" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the payment-method loading path and introduces an additional B2B API call whose failures now surface as `LoadPaymentMethodsFailed` when the capability is enabled.
> 
> **Overview**
> **B2B payment method filtering:** when `capabilities.payment.b2bPaymentMethodFilter` is enabled, `PaymentMethodActionCreator.loadPaymentMethods()` now fetches a company-specific allow-list from the B2B API and filters the storefront payment methods to the enabled intersection.
> 
> Adds a `B2BCompanyPaymentMethodRequestSender` plus helpers/tests for fetching and applying the allow-list, and threads the new request sender through checkout/checkout-button/shipping initializers.
> 
> Also extends `Cart` with `companyId` and adds a temporary `?capabilitiesOverride=<json>` dev-tool to override capability flags client-side (plus `disableStoreCredit` added to `Capabilities` in both core and `payment-integration-api`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 480a0c9bb4fad893ded04b70ee78707cbe2aaf98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->