### PR TITLE
feat(checkout): CHECKOUT-9820 add capabilities for b2b checkout config for PO

### DIFF
--- a/packages/core/src/config/capabilities.ts
+++ b/packages/core/src/config/capabilities.ts
@@ -25,7 +25,17 @@ export interface Capabilities {
         paymentMethodFiltering: boolean;
         b2bPaymentMethodFilter: boolean;
         poPaymentMethod: boolean;
+        poConfig: {
+            label: string;
+            required: boolean;
+            creditLimit: number;
+            currency: string;
+        } | null;
         additionalPaymentNotes: boolean;
+        additionalField: {
+            label: string;
+            required: boolean;
+        } | null;
         excludeOfflineForInvoice: boolean;
         excludePPSDK: boolean;
     };

--- a/packages/payment-integration-api/src/config/capabilities.ts
+++ b/packages/payment-integration-api/src/config/capabilities.ts
@@ -25,7 +25,17 @@ export interface Capabilities {
         paymentMethodFiltering: boolean;
         b2bPaymentMethodFilter: boolean;
         poPaymentMethod: boolean;
+        poConfig: {
+            label: string;
+            required: boolean;
+            creditLimit: number;
+            currency: string;
+        } | null;
         additionalPaymentNotes: boolean;
+        additionalField: {
+            label: string;
+            required: boolean;
+        } | null;
         excludeOfflineForInvoice: boolean;
         excludePPSDK: boolean;
     };

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -8,9 +8,14 @@ export default interface Config {
     storeConfig: StoreConfig;
 }
 
+export interface B2BApiSettings {
+    clientId: string;
+    baseUrl: string;
+}
 export interface StoreConfig {
     cdnPath: string;
     checkoutSettings: CheckoutSettings;
+    b2bApiSettings?: B2BApiSettings;
     currency: StoreCurrency;
     displayDateFormat: string;
     displaySettings: DisplaySettings;


### PR DESCRIPTION
## What/Why?

Add capabilities for b2b checkout config interface for poConfig and additionalField

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only expands TypeScript config/capability interfaces (no runtime logic), but it may require downstream consumers to handle the new nullable fields and updated types.
> 
> **Overview**
> Adds new B2B checkout capability metadata for PO payments by extending `Capabilities.payment` with nullable `poConfig` (label/required/creditLimit/currency) and `additionalField` (label/required) in both `core` and `payment-integration-api` copies.
> 
> Extends `payment-integration-api` `StoreConfig` to optionally include `b2bApiSettings` (clientId/baseUrl), aligning its config typing with `core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0457ed622861bb86b4d039482ccb6ccfffea28c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->