### PR TITLE
fix(payment): Stripe Link V2 spam protection fix

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
@@ -675,6 +675,42 @@ describe('StripeLinkV2ButtonStrategy', () => {
                 clearAllMocks();
             });
 
+            it('verifies spam protection before updating addresses on confirm', async () => {
+                const verifySpamMock = jest
+                    .spyOn(stripeIntegrationService, 'verifyCheckoutSpamProtection')
+                    .mockResolvedValue();
+
+                await strategy.initialize(initialiseOptions);
+
+                stripeEventEmitter.emit(StripeElementEvent.CONFIRM, mockStripeAddress);
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(verifySpamMock).toHaveBeenCalledTimes(1);
+                expect(verifySpamMock.mock.invocationCallOrder[0]).toBeLessThan(
+                    (paymentIntegrationService.updateBillingAddress as jest.Mock).mock
+                        .invocationCallOrder[0],
+                );
+                expect(verifySpamMock.mock.invocationCallOrder[0]).toBeLessThan(
+                    (paymentIntegrationService.submitOrder as jest.Mock).mock
+                        .invocationCallOrder[0],
+                );
+            });
+
+            it('does not submit order if spam protection rejects', async () => {
+                jest.spyOn(
+                    stripeIntegrationService,
+                    'verifyCheckoutSpamProtection',
+                ).mockRejectedValue(new Error('spam check failed'));
+
+                await strategy.initialize(initialiseOptions);
+
+                stripeEventEmitter.emit(StripeElementEvent.CONFIRM, mockStripeAddress);
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.updateBillingAddress).not.toHaveBeenCalled();
+                expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+            });
+
             it('updates addresses when onConfirm callback event triggered', async () => {
                 await strategy.initialize(initialiseOptions);
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.ts
@@ -261,6 +261,7 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
             this._stripeClient &&
             this._stripeElements
         ) {
+            await this.stripeIntegrationService.verifyCheckoutSpamProtection();
             await this._updateShippingAndBillingAddress(event);
             await this.paymentIntegrationService.submitOrder();
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
@@ -684,6 +684,42 @@ describe('StripeLinkV2CustomerStrategy', () => {
                 clearAllMocks();
             });
 
+            it('verifies spam protection before updating addresses on confirm', async () => {
+                const verifySpamMock = jest
+                    .spyOn(stripeIntegrationService, 'verifyCheckoutSpamProtection')
+                    .mockResolvedValue();
+
+                await strategy.initialize(initialiseOptions);
+
+                stripeEventEmitter.emit(StripeElementEvent.CONFIRM, mockStripeAddress);
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(verifySpamMock).toHaveBeenCalledTimes(1);
+                expect(verifySpamMock.mock.invocationCallOrder[0]).toBeLessThan(
+                    (paymentIntegrationService.updateBillingAddress as jest.Mock).mock
+                        .invocationCallOrder[0],
+                );
+                expect(verifySpamMock.mock.invocationCallOrder[0]).toBeLessThan(
+                    (paymentIntegrationService.submitOrder as jest.Mock).mock
+                        .invocationCallOrder[0],
+                );
+            });
+
+            it('does not submit order if spam protection rejects', async () => {
+                jest.spyOn(
+                    stripeIntegrationService,
+                    'verifyCheckoutSpamProtection',
+                ).mockRejectedValue(new Error('spam check failed'));
+
+                await strategy.initialize(initialiseOptions);
+
+                stripeEventEmitter.emit(StripeElementEvent.CONFIRM, mockStripeAddress);
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.updateBillingAddress).not.toHaveBeenCalled();
+                expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+            });
+
             it('updates addresses when onConfirm callback event triggered', async () => {
                 await strategy.initialize(initialiseOptions);
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
@@ -264,6 +264,7 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
             this._stripeClient &&
             this._stripeElements
         ) {
+            await this.stripeIntegrationService.verifyCheckoutSpamProtection();
             await this._updateShippingAndBillingAddress(event);
             await this.paymentIntegrationService.submitOrder();
 

--- a/packages/stripe-utils/src/stripe-integration-service.mock.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.mock.ts
@@ -55,4 +55,5 @@ export const getStripeIntegrationServiceMock = () =>
         getShopperFullName: jest.fn((address: Address) =>
             `${address?.firstName || ''} ${address?.lastName || ''}`.trim(),
         ),
+        verifyCheckoutSpamProtection: jest.fn(() => Promise.resolve()),
     } as unknown as StripeIntegrationService);

--- a/packages/stripe-utils/src/stripe-integration-service.spec.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBillingAddress,
+    getCheckout,
     getConfig,
     getShippingAddress,
     PaymentIntegrationServiceMock,
@@ -845,6 +846,30 @@ describe('StripeIntegrationService', () => {
 
         it('should return empty string if address is undefined', () => {
             expect(stripeIntegrationService.getShopperFullName(undefined)).toBe('');
+        });
+    });
+
+    describe('#verifyCheckoutSpamProtection', () => {
+        it('runs spam protection when shouldExecuteSpamCheck is true', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCheckoutOrThrow').mockReturnValue({
+                ...getCheckout(),
+                shouldExecuteSpamCheck: true,
+            });
+
+            await stripeIntegrationService.verifyCheckoutSpamProtection();
+
+            expect(paymentIntegrationService.verifyCheckoutSpamProtection).toHaveBeenCalledTimes(1);
+        });
+
+        it('skips spam protection when shouldExecuteSpamCheck is false', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCheckoutOrThrow').mockReturnValue({
+                ...getCheckout(),
+                shouldExecuteSpamCheck: false,
+            });
+
+            await stripeIntegrationService.verifyCheckoutSpamProtection();
+
+            expect(paymentIntegrationService.verifyCheckoutSpamProtection).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/stripe-utils/src/stripe-integration-service.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.ts
@@ -273,7 +273,9 @@ export default class StripeIntegrationService {
     }
 
     async verifyCheckoutSpamProtection(): Promise<void> {
-        const { shouldExecuteSpamCheck } = this.paymentIntegrationService.getState().getCheckoutOrThrow();
+        const { shouldExecuteSpamCheck } = this.paymentIntegrationService
+            .getState()
+            .getCheckoutOrThrow();
 
         if (shouldExecuteSpamCheck) {
             await this.paymentIntegrationService.verifyCheckoutSpamProtection();

--- a/packages/stripe-utils/src/stripe-integration-service.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.ts
@@ -271,4 +271,12 @@ export default class StripeIntegrationService {
 
         return `${firstName} ${lastName}`.trim();
     }
+
+    async verifyCheckoutSpamProtection(): Promise<void> {
+        const { shouldExecuteSpamCheck } = this.paymentIntegrationService.getState().getCheckoutOrThrow();
+
+        if (shouldExecuteSpamCheck) {
+            await this.paymentIntegrationService.verifyCheckoutSpamProtection();
+        }
+    }
 }


### PR DESCRIPTION
## What/Why?
Adds spam-protection verification to the Stripe Link V2 OCS confirm flow so that bot/spam submissions are challenged before the order is created — matching the behavior already
  implemented for Apple Pay.

  **Changes:**
  - New helper `StripeIntegrationService.verifyCheckoutSpamProtection()` that reads `shouldExecuteSpamCheck` from checkout state and calls
  `paymentIntegrationService.verifyCheckoutSpamProtection()` only when required.
  - `StripeLinkV2ButtonStrategy._onConfirm` and `StripeLinkV2CustomerStrategy._onConfirm` now invoke the helper **before** `_updateShippingAndBillingAddress` and `submitOrder`, so a
  failed/cancelled CAPTCHA short-circuits the flow without mutating checkout state.

## Rollout/Rollback
Rollback this PR

## Testing
Before:


https://github.com/user-attachments/assets/b166bac7-aa29-4718-88af-d987766f51ce


After:
Customer Step


https://github.com/user-attachments/assets/2fbfd84d-3f50-4c95-8878-4434346816fa


Cart page

https://github.com/user-attachments/assets/6e832c6d-9a67-4c31-b457-74aea8a7502c



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new gating step in the Stripe Link V2 confirm path that can block address updates and `submitOrder()` when spam verification fails, which could affect checkout completion if misconfigured or if the spam service errors.
> 
> **Overview**
> **Stripe Link V2 confirm now enforces spam checks before order creation.** `StripeLinkV2ButtonStrategy` and `StripeLinkV2CustomerStrategy` call a new `StripeIntegrationService.verifyCheckoutSpamProtection()` at the start of `_onConfirm`, ahead of address updates and `submitOrder()`.
> 
> `StripeIntegrationService` adds the helper to conditionally invoke `paymentIntegrationService.verifyCheckoutSpamProtection()` based on checkout state (`shouldExecuteSpamCheck`), with mocks and unit tests updated to assert call order and that failures prevent address mutation/order submission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e667b750a3bdbc973a4d438c569124f2b4a285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->