### PR TITLE
feat(checkout): CHECKOUT-10010 Expose order extra fields

### DIFF
--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -273,6 +273,13 @@ export default interface CheckoutStoreSelector {
     getAddressExtraFields(): FormField[];
 
     /**
+     * Gets order extra fields.
+     *
+     * @returns The list of extra fields if available, otherwise an empty array.
+     */
+    getOrderExtraFields(): FormField[];
+
+    /**
      * Gets a list of pickup options for specified parameters.
      *
      * @param consignmentId - Id of consignment.
@@ -571,6 +578,11 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         (getAddressExtraFields) => clone(getAddressExtraFields),
     );
 
+    const getOrderExtraFields = createSelector(
+        ({ form }: InternalCheckoutSelectors) => form.getOrderExtraFields,
+        (getOrderExtraFields) => clone(getOrderExtraFields),
+    );
+
     const getFlashMessages = createSelector(
         ({ config }: InternalCheckoutSelectors) => config.getFlashMessages,
         (getFlashMessages) => clone(getFlashMessages),
@@ -642,6 +654,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             getBillingAddressFields: getBillingAddressFields(state),
             getShippingAddressFields: getShippingAddressFields(state),
             getAddressExtraFields: getAddressExtraFields(state),
+            getOrderExtraFields: getOrderExtraFields(state),
             getPickupOptions: getPickupOptions(state),
             getUserExperienceSettings: getUserExperienceSettings(state),
             getPaymentProviderCustomer: getPaymentProviderCustomer(state),

--- a/packages/core/src/config/capabilities.ts
+++ b/packages/core/src/config/capabilities.ts
@@ -7,6 +7,7 @@ export interface Capabilities {
         disableStoreCredit: boolean;
         hasCompanyAddressBook: boolean;
         hasAddressExtraFields: boolean;
+        hasOrderExtraFields: boolean;
         requiresB2BToken: boolean;
     };
     customer: {

--- a/packages/core/src/form/form-selector.spec.ts
+++ b/packages/core/src/form/form-selector.spec.ts
@@ -8,7 +8,12 @@ import { getShippingCountries } from '../shipping/shipping-countries.mock';
 
 import FormFieldsState from './form-fields-state';
 import FormSelector, { createFormSelectorFactory, FormSelectorFactory } from './form-selector';
-import { getAddressExtraFields, getAddressFormFields, getFormFields } from './form.mock';
+import {
+    getAddressExtraFields,
+    getAddressFormFields,
+    getFormFields,
+    getOrderExtraFields,
+} from './form.mock';
 
 // tslint:disable:no-non-null-assertion
 
@@ -237,6 +242,47 @@ describe('FormSelector', () => {
             const formSelector = createFormSelector(b2bState);
 
             expect(formSelector.getAddressExtraFields()).toEqual([]);
+        });
+    });
+
+    describe('#getOrderExtraFields()', () => {
+        it('returns all mapped B2B extra fields from order extra fields', () => {
+            const b2bState: FormFieldsState = {
+                data: getFormFields(),
+                extraFields: { address: [], order: getOrderExtraFields() },
+                errors: {},
+                statuses: {},
+            };
+
+            const formSelector = createFormSelector(b2bState);
+            const result = formSelector.getOrderExtraFields();
+
+            expect(result).toHaveLength(4);
+            expect(result[0].name).toBe('b2bExtraField_20001');
+            expect(result[0].required).toBe(true);
+            expect(result[0].fieldType).toBe('text');
+            expect(result[1].name).toBe('b2bExtraField_20002');
+            expect(result[1].fieldType).toBe('multiline');
+            expect(result[1].options).toEqual({ rows: 4 });
+            expect(result[2].name).toBe('b2bExtraField_20003');
+            expect(result[2].fieldType).toBe('dropdown');
+            expect(result[2].options?.items).toHaveLength(3);
+            expect(result[3].name).toBe('b2bExtraField_20004');
+            expect(result[3].type).toBe('integer');
+            expect(result[3].max).toBe(100000);
+        });
+
+        it('returns empty array when extraFields.order is an empty array', () => {
+            const b2bState: FormFieldsState = {
+                data: getFormFields(),
+                extraFields: { address: [], order: [] },
+                errors: {},
+                statuses: {},
+            };
+
+            const formSelector = createFormSelector(b2bState);
+
+            expect(formSelector.getOrderExtraFields()).toEqual([]);
         });
     });
 });

--- a/packages/core/src/form/form-selector.ts
+++ b/packages/core/src/form/form-selector.ts
@@ -13,6 +13,7 @@ export default interface FormSelector {
     getBillingAddressFields(countries: Country[] | undefined, countryCode: string): FormField[];
     getCustomerAccountFields(): FormField[];
     getAddressExtraFields(): FormField[];
+    getOrderExtraFields(): FormField[];
     getLoadError(): Error | undefined;
     isLoading(): boolean;
 }
@@ -55,6 +56,17 @@ export function createFormSelectorFactory(): FormSelectorFactory {
             }
 
             return extraFields.address.map(mapExtraFieldToFormField);
+        },
+    );
+
+    const getOrderExtraFields = createSelector(
+        (state: FormFieldsState) => state.extraFields,
+        (extraFields) => () => {
+            if (!extraFields || !extraFields.order.length) {
+                return [];
+            }
+
+            return extraFields.order.map(mapExtraFieldToFormField);
         },
     );
 
@@ -155,6 +167,7 @@ export function createFormSelectorFactory(): FormSelectorFactory {
             getBillingAddressFields: getBillingAddressFields(state),
             getCustomerAccountFields: getCustomerAccountFields(state),
             getAddressExtraFields: getAddressExtraFields(state),
+            getOrderExtraFields: getOrderExtraFields(state),
             getLoadError: getLoadError(state),
             isLoading: isLoading(state),
         };

--- a/packages/core/src/form/form.mock.ts
+++ b/packages/core/src/form/form.mock.ts
@@ -198,3 +198,40 @@ export function getAddressExtraFields(): ExtraField[] {
         },
     ];
 }
+
+export function getOrderExtraFields(): ExtraField[] {
+    return [
+        {
+            id: '20001',
+            name: 'poNumber',
+            visibleToStorefront: true,
+            type: 'text',
+            isRequired: true,
+            config: { maxLength: 30 },
+        },
+        {
+            id: '20002',
+            name: 'deliveryInstructions',
+            visibleToStorefront: true,
+            type: 'multiline_text',
+            isRequired: false,
+            config: { numberOfRows: 4 },
+        },
+        {
+            id: '20003',
+            name: 'orderPriority',
+            visibleToStorefront: true,
+            type: 'dropdown',
+            isRequired: false,
+            config: { options: ['Low', 'Normal', 'High'] },
+        },
+        {
+            id: '20004',
+            name: 'maxBudget',
+            visibleToStorefront: true,
+            type: 'number',
+            isRequired: false,
+            config: { maxValue: 100000 },
+        },
+    ];
+}

--- a/packages/payment-integration-api/src/config/capabilities.ts
+++ b/packages/payment-integration-api/src/config/capabilities.ts
@@ -7,6 +7,7 @@ export interface Capabilities {
         disableStoreCredit: boolean;
         hasCompanyAddressBook: boolean;
         hasAddressExtraFields: boolean;
+        hasOrderExtraFields: boolean;
         requiresB2BToken: boolean;
     };
     customer: {


### PR DESCRIPTION
## What/Why?

Expose order extra fields from `checkout-sdk` to `checkout-js`.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public selector and capability flag, which expands the checkout SDK surface area and may require downstream TypeScript consumers to update typings/feature gating. Logic is straightforward mapping/forwarding, so runtime risk is low.
> 
> **Overview**
> Exposes **order-level B2B extra fields** through the checkout SDK by adding `getOrderExtraFields()` to `FormSelector` and `CheckoutStoreSelector`, returning mapped `FormField` entries (or `[]` when absent).
> 
> Adds a new capabilities flag `userJourney.hasOrderExtraFields` (kept in sync in both `core` and `payment-integration-api`) and extends unit tests/mocks to cover order extra-field mapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e83b5899ca3aa1087ec506e5a536ba31587d2225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->