### PR TITLE
feat(payment): PAYPAL-6471 add wallet button payment

### DIFF
--- a/packages/core/src/wallet-buttons/create-wallet-button-strategy-registry.spec.ts
+++ b/packages/core/src/wallet-buttons/create-wallet-button-strategy-registry.spec.ts
@@ -2,7 +2,10 @@ import {
     CheckoutButtonStrategy,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { WalletButtonIntegrationService } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+import {
+    createWalletButtonIntegrationService,
+    WalletButtonIntegrationService,
+} from '@bigcommerce/checkout-sdk/wallet-button-integration';
 
 import createWalletButtonStrategyRegistry from './create-wallet-button-strategy-registry';
 
@@ -11,7 +14,7 @@ describe('createWalletButtonStrategyRegistry', () => {
     let testStrategy: CheckoutButtonStrategy;
 
     beforeEach(() => {
-        walletButtonIntegrationService = new WalletButtonIntegrationService('/graphql');
+        walletButtonIntegrationService = createWalletButtonIntegrationService('/graphql');
         testStrategy = {
             initialize: jest.fn(),
             deinitialize: jest.fn(),
@@ -29,7 +32,7 @@ describe('createWalletButtonStrategyRegistry', () => {
 
     it('skips non-resolvable modules', () => {
         const registry = createWalletButtonStrategyRegistry(walletButtonIntegrationService, {
-            notResolvable: (() => ({})) as any,
+            notResolvable: () => testStrategy,
         });
 
         expect(() => registry.get({ id: 'notResolvable' })).toThrow();

--- a/packages/wallet-button-integration/jest.config.js
+++ b/packages/wallet-button-integration/jest.config.js
@@ -4,11 +4,14 @@ module.exports = {
     globals: {
         'ts-jest': {
             tsconfig: '<rootDir>/tsconfig.spec.json',
+            diagnostics: false,
         },
     },
     transform: {
         '^.+\\.[tj]sx?$': 'ts-jest',
     },
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    setupFilesAfterEnv: ['../../jest-setup.js'],
+    coveragePathIgnorePatterns: ['<rootDir>/src/index.ts'],
     coverageDirectory: '../../coverage/packages/wallet-button-integration',
 };

--- a/packages/wallet-button-integration/src/create-wallet-button-integration-service.spec.ts
+++ b/packages/wallet-button-integration/src/create-wallet-button-integration-service.spec.ts
@@ -1,0 +1,10 @@
+import createWalletButtonIntegrationService from './create-wallet-button-integration-service';
+import WalletButtonIntegrationService from './wallet-button-integration-service';
+
+describe('createWalletButtonIntegrationService', () => {
+    it('creates a WalletButtonIntegrationService instance', () => {
+        const service = createWalletButtonIntegrationService('graphql');
+
+        expect(service).toBeInstanceOf(WalletButtonIntegrationService);
+    });
+});

--- a/packages/wallet-button-integration/src/create-wallet-button-integration-service.ts
+++ b/packages/wallet-button-integration/src/create-wallet-button-integration-service.ts
@@ -1,9 +1,17 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import { PaymentRequestSender } from './payment/payment-request-sender';
 import WalletButtonIntegrationService from './wallet-button-integration-service';
 
 const createWalletButtonIntegrationService = (
     graphQLEndpoint: string,
 ): WalletButtonIntegrationService => {
-    return new WalletButtonIntegrationService(graphQLEndpoint);
+    const requestSender = createRequestSender();
+
+    return new WalletButtonIntegrationService(
+        graphQLEndpoint,
+        new PaymentRequestSender(requestSender),
+    );
 };
 
 export default createWalletButtonIntegrationService;

--- a/packages/wallet-button-integration/src/graphql-request-options.ts
+++ b/packages/wallet-button-integration/src/graphql-request-options.ts
@@ -1,0 +1,6 @@
+import { RequestOptions } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export interface GraphQLRequestOptions extends RequestOptions {
+    body?: { query: string; variables: Record<string, unknown> };
+    headers?: { [key: string]: string };
+}

--- a/packages/wallet-button-integration/src/index.ts
+++ b/packages/wallet-button-integration/src/index.ts
@@ -1,3 +1,4 @@
 export { default as createWalletButtonIntegrationService } from './create-wallet-button-integration-service';
 export { default as WalletButtonIntegrationService } from './wallet-button-integration-service';
 export { default as WalletPaymentButtonStrategyFactory } from './wallet-button-factory';
+export { GraphQLRequestOptions } from './graphql-request-options';

--- a/packages/wallet-button-integration/src/payment/payment-order-intent-creation-error.spec.ts
+++ b/packages/wallet-button-integration/src/payment/payment-order-intent-creation-error.spec.ts
@@ -1,0 +1,22 @@
+import PaymentOrderCreationError from './payment-order-intent-creation-error';
+
+describe('PaymentOrderCreationError', () => {
+    it('creates an error with default message when no message is provided', () => {
+        const error = new PaymentOrderCreationError();
+
+        expect(error.message).toBe(
+            'An unexpected error has occurred during payment order creation process. Please try again later.',
+        );
+        expect(error.name).toBe('PaymentOrderCreationError');
+        expect(error.type).toBe('payment_order_creation_error');
+    });
+
+    it('creates an error with a custom message', () => {
+        const customMessage = 'Cart not found';
+        const error = new PaymentOrderCreationError(customMessage);
+
+        expect(error.message).toBe(customMessage);
+        expect(error.name).toBe('PaymentOrderCreationError');
+        expect(error.type).toBe('payment_order_creation_error');
+    });
+});

--- a/packages/wallet-button-integration/src/payment/payment-order-intent-creation-error.ts
+++ b/packages/wallet-button-integration/src/payment/payment-order-intent-creation-error.ts
@@ -1,0 +1,13 @@
+import { StandardError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default class PaymentOrderCreationError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message ||
+                'An unexpected error has occurred during payment order creation process. Please try again later.',
+        );
+
+        this.name = 'PaymentOrderCreationError';
+        this.type = 'payment_order_creation_error';
+    }
+}

--- a/packages/wallet-button-integration/src/payment/payment-request-sender.spec.ts
+++ b/packages/wallet-button-integration/src/payment/payment-request-sender.spec.ts
@@ -1,0 +1,196 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { CreatePaymentOrderIntentInputData, CreatePaymentOrderIntentResponse } from './payment';
+import PaymentOrderCreationError from './payment-order-intent-creation-error';
+import { PaymentRequestSender } from './payment-request-sender';
+
+describe('PaymentRequestSender', () => {
+    let requestSender: RequestSender;
+    let paymentRequestSender: PaymentRequestSender;
+
+    const graphQLEndpoint = 'graphql';
+
+    const inputData: CreatePaymentOrderIntentInputData = {
+        cartEntityId: 'cart-entity-id-123',
+        paymentWalletEntityId: 'paypalcommerce',
+    };
+
+    const successResponseBody: CreatePaymentOrderIntentResponse = {
+        data: {
+            payment: {
+                paymentWallet: {
+                    createPaymentWalletIntent: {
+                        errors: [],
+                        paymentWalletIntentData: {
+                            approvalUrl: 'https://www.paypal.com/approve?token=order-123',
+                            orderId: 'order-123',
+                            initializationEntityId: 'init-entity-123',
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+        paymentRequestSender = new PaymentRequestSender(requestSender);
+    });
+
+    describe('#createPaymentOrderIntent()', () => {
+        it('sends a POST request with the correct GraphQL mutation and input variables', async () => {
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: successResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            await paymentRequestSender.createPaymentOrderIntent(graphQLEndpoint, inputData);
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                `${window.location.origin}/${graphQLEndpoint}`,
+                expect.objectContaining({
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+                    },
+                }),
+            );
+        });
+
+        it('includes the correct variables in the request body', async () => {
+            const postSpy = jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: successResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            await paymentRequestSender.createPaymentOrderIntent(graphQLEndpoint, inputData);
+
+            expect(postSpy.mock.calls[0][1]).toMatchObject({
+                body: { variables: { input: inputData } },
+            });
+        });
+
+        it('returns transformed response body with orderId, approvalUrl, and initializationEntityId', async () => {
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: successResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            const response = await paymentRequestSender.createPaymentOrderIntent(
+                graphQLEndpoint,
+                inputData,
+            );
+
+            expect(response.body).toEqual({
+                approvalUrl: 'https://www.paypal.com/approve?token=order-123',
+                orderId: 'order-123',
+                initializationEntityId: 'init-entity-123',
+            });
+        });
+
+        it('throws PaymentOrderCreationError when response contains errors', async () => {
+            const errorResponse: CreatePaymentOrderIntentResponse = {
+                data: {
+                    payment: {
+                        paymentWallet: {
+                            createPaymentWalletIntent: {
+                                errors: [{ message: 'Cart not found' }],
+                                paymentWalletIntentData: {
+                                    approvalUrl: '',
+                                    orderId: '',
+                                    initializationEntityId: '',
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: errorResponse,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            await expect(
+                paymentRequestSender.createPaymentOrderIntent(graphQLEndpoint, inputData),
+            ).rejects.toThrow(PaymentOrderCreationError);
+        });
+
+        it('throws PaymentOrderCreationError with the error message from the response', async () => {
+            const errorMessage = 'Invalid cart entity ID';
+            const errorResponse: CreatePaymentOrderIntentResponse = {
+                data: {
+                    payment: {
+                        paymentWallet: {
+                            createPaymentWalletIntent: {
+                                errors: [{ message: errorMessage }],
+                                paymentWalletIntentData: {
+                                    approvalUrl: '',
+                                    orderId: '',
+                                    initializationEntityId: '',
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: errorResponse,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            await expect(
+                paymentRequestSender.createPaymentOrderIntent(graphQLEndpoint, inputData),
+            ).rejects.toThrow(errorMessage);
+        });
+
+        it('throws PaymentMethodCancelledError when request fails with a non-PaymentOrderCreationError', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(new Error('Network error'));
+
+            await expect(
+                paymentRequestSender.createPaymentOrderIntent(graphQLEndpoint, inputData),
+            ).rejects.toThrow('Payment process was cancelled.');
+        });
+
+        it('merges custom headers with Content-Type header', async () => {
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: successResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            const customOptions = {
+                headers: { Authorization: 'Bearer token-123' },
+            };
+
+            await paymentRequestSender.createPaymentOrderIntent(
+                graphQLEndpoint,
+                inputData,
+                customOptions,
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                `${window.location.origin}/${graphQLEndpoint}`,
+                expect.objectContaining({
+                    headers: {
+                        Authorization: 'Bearer token-123',
+                        'Content-Type': 'application/json',
+                        'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+                    },
+                }),
+            );
+        });
+    });
+});

--- a/packages/wallet-button-integration/src/payment/payment-request-sender.ts
+++ b/packages/wallet-button-integration/src/payment/payment-request-sender.ts
@@ -1,0 +1,102 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { PaymentMethodCancelledError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { GraphQLRequestOptions } from '../graphql-request-options';
+
+import {
+    CreatePaymentOrderIntentInputData,
+    CreatePaymentOrderIntentResponse,
+    CreatePaymentOrderIntentResponseBody,
+} from './payment';
+import PaymentOrderCreationError from './payment-order-intent-creation-error';
+
+export class PaymentRequestSender {
+    constructor(private readonly requestSender: RequestSender) {}
+
+    async createPaymentOrderIntent(
+        graphQLEndpoint: string,
+        inputData: CreatePaymentOrderIntentInputData,
+        options?: GraphQLRequestOptions,
+    ): Promise<Response<CreatePaymentOrderIntentResponseBody>> {
+        const document = `
+            mutation CreatePaymentWalletIntentMutation(
+                $input: CreatePaymentWalletIntentInput!
+            ) {
+                payment {
+                    paymentWallet {
+                        createPaymentWalletIntent(input: $input) {
+                            paymentWalletIntentData {
+                                __typename
+                                ... on PayPalCommercePaymentWalletIntentData {
+                                    orderId
+                                    approvalUrl
+                                    initializationEntityId
+                                }
+                            }
+                            errors {
+                                __typename
+                                ... on CreatePaymentWalletIntentGenericError {
+                                    message
+                                }
+                                ... on Error {
+                                    message
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const requestOptions: GraphQLRequestOptions = {
+            headers: {
+                ...options?.headers,
+                'Content-Type': 'application/json',
+                'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+            },
+            body: {
+                query: document,
+                variables: {
+                    input: inputData,
+                },
+            },
+        };
+
+        try {
+            const response = await this.requestSender.post<CreatePaymentOrderIntentResponse>(
+                `${window.location.origin}/${graphQLEndpoint}`,
+                requestOptions,
+            );
+
+            const {
+                data: {
+                    payment: {
+                        paymentWallet: {
+                            createPaymentWalletIntent: { paymentWalletIntentData, errors },
+                        },
+                    },
+                },
+            } = response.body;
+
+            const errorMessage = errors[0]?.message;
+
+            if (errorMessage) {
+                throw new PaymentOrderCreationError(errorMessage);
+            }
+
+            return {
+                ...response,
+                body: {
+                    ...paymentWalletIntentData,
+                },
+            };
+        } catch (error) {
+            if (!(error instanceof PaymentOrderCreationError)) {
+                throw new PaymentMethodCancelledError();
+            }
+
+            throw error;
+        }
+    }
+}

--- a/packages/wallet-button-integration/src/payment/payment.ts
+++ b/packages/wallet-button-integration/src/payment/payment.ts
@@ -1,0 +1,31 @@
+/**
+ *
+ * Create Payment Order Interfaces
+ *
+ */
+
+export interface CreatePaymentOrderIntentResponse {
+    data: {
+        payment: {
+            paymentWallet: {
+                createPaymentWalletIntent: {
+                    errors: Array<{
+                        message: string;
+                    }>;
+                    paymentWalletIntentData: CreatePaymentOrderIntentResponseBody;
+                };
+            };
+        };
+    };
+}
+
+export interface CreatePaymentOrderIntentResponseBody {
+    approvalUrl: string;
+    orderId: string;
+    initializationEntityId: string;
+}
+
+export interface CreatePaymentOrderIntentInputData {
+    cartEntityId: string;
+    paymentWalletEntityId: string;
+}

--- a/packages/wallet-button-integration/src/wallet-button-integration-service.spec.ts
+++ b/packages/wallet-button-integration/src/wallet-button-integration-service.spec.ts
@@ -1,0 +1,92 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { PaymentRequestSender } from './payment/payment-request-sender';
+import WalletButtonIntegrationService from './wallet-button-integration-service';
+
+describe('WalletButtonIntegrationService', () => {
+    let requestSender: RequestSender;
+    let paymentRequestSender: PaymentRequestSender;
+    let walletButtonIntegrationService: WalletButtonIntegrationService;
+
+    const graphQLEndpoint = 'graphql';
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+        paymentRequestSender = new PaymentRequestSender(requestSender);
+        walletButtonIntegrationService = new WalletButtonIntegrationService(
+            graphQLEndpoint,
+            paymentRequestSender,
+        );
+    });
+
+    describe('#createPaymentOrderIntent()', () => {
+        it('delegates to PaymentRequestSender with the graphQLEndpoint', async () => {
+            const inputData = {
+                cartEntityId: 'cart-id-123',
+                paymentWalletEntityId: 'paypalcommerce',
+            };
+
+            const expectedResponse = {
+                body: {
+                    approvalUrl: 'https://www.paypal.com/approve',
+                    orderId: 'order-id-123',
+                    initializationEntityId: 'init-123',
+                },
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            };
+
+            jest.spyOn(paymentRequestSender, 'createPaymentOrderIntent').mockResolvedValue(
+                expectedResponse,
+            );
+
+            const result = await walletButtonIntegrationService.createPaymentOrderIntent(inputData);
+
+            expect(paymentRequestSender.createPaymentOrderIntent).toHaveBeenCalledWith(
+                graphQLEndpoint,
+                inputData,
+                undefined,
+            );
+            expect(result).toEqual(expectedResponse);
+        });
+
+        it('passes custom options to PaymentRequestSender', async () => {
+            const inputData = {
+                cartEntityId: 'cart-id-456',
+                paymentWalletEntityId: 'paypalcommerce',
+            };
+
+            const customOptions = {
+                headers: { Authorization: 'Bearer token-xyz' },
+            };
+
+            const expectedResponse = {
+                body: {
+                    approvalUrl: 'https://www.paypal.com/approve',
+                    orderId: 'order-id-456',
+                    initializationEntityId: 'init-456',
+                },
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            };
+
+            jest.spyOn(paymentRequestSender, 'createPaymentOrderIntent').mockResolvedValue(
+                expectedResponse,
+            );
+
+            const result = await walletButtonIntegrationService.createPaymentOrderIntent(
+                inputData,
+                customOptions,
+            );
+
+            expect(paymentRequestSender.createPaymentOrderIntent).toHaveBeenCalledWith(
+                graphQLEndpoint,
+                inputData,
+                customOptions,
+            );
+            expect(result).toEqual(expectedResponse);
+        });
+    });
+});

--- a/packages/wallet-button-integration/src/wallet-button-integration-service.ts
+++ b/packages/wallet-button-integration/src/wallet-button-integration-service.ts
@@ -1,7 +1,26 @@
-export default class WalletButtonIntegrationService {
-    constructor(private graphQLEndpoint: string) {}
+import { Response } from '@bigcommerce/request-sender';
 
-    getGraphQLEndpoint(): string {
-        return this.graphQLEndpoint;
+import { GraphQLRequestOptions } from './graphql-request-options';
+import {
+    CreatePaymentOrderIntentInputData,
+    CreatePaymentOrderIntentResponseBody,
+} from './payment/payment';
+import { PaymentRequestSender } from './payment/payment-request-sender';
+
+export default class WalletButtonIntegrationService {
+    constructor(
+        private graphQLEndpoint: string,
+        private paymentRequestSender: PaymentRequestSender,
+    ) {}
+
+    async createPaymentOrderIntent(
+        inputData: CreatePaymentOrderIntentInputData,
+        options?: GraphQLRequestOptions,
+    ): Promise<Response<CreatePaymentOrderIntentResponseBody>> {
+        return this.paymentRequestSender.createPaymentOrderIntent(
+            this.graphQLEndpoint,
+            inputData,
+            options,
+        );
     }
 }


### PR DESCRIPTION
## What/Why?
Adds the payment layer — request sender, CreatePaymentWalletIntent GraphQL mutation, and related types — and wires them into the service.

<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
CI Passed

[screen-capture (4).webm](https://github.com/user-attachments/assets/67d6c624-f0b6-40b4-8984-17e74782ada5)

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new wallet-button loading/bundling and a GraphQL-backed payment intent creation flow; changes touch payment-related request handling and error mapping but are largely additive.
> 
> **Overview**
> Introduces a new **headless wallet button** surface area: adds a `wallet-button` webpack entry/bundle and updates `loader.ts`/`loader-cdn.ts` to support loading `BundleType.WalletButton`.
> 
> Adds a new `wallet-button-integration` package that creates payment wallet intents via a GraphQL mutation (`createPaymentWalletIntent`), including request/response types, header/option handling, and error mapping (`PaymentOrderCreationError` vs `PaymentMethodCancelledError`).
> 
> Extends core codegen configs to auto-export/register `create...WalletStrategy` factories and generate `WalletButtonInitializeOptions`, adds a `WalletButtonInitializer` + registry wiring, and introduces an initial **PayPal Commerce wallet strategy** stub (`createPayPalCommerceWalletStrategy` + init options) to plug into the new registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909ec8e8df55b4b4394480b74ac86c1be3557f83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->