### PR TITLE
feat(payment): PAYPAL-6439 fixed loading overlay for venmo

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-payment-strategy.ts
@@ -4,7 +4,10 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
-import { createPayPalIntegrationService } from '@bigcommerce/checkout-sdk/paypal-utils';
+import {
+    createPayPalIntegrationService,
+    LOADING_INDICATOR_STYLES,
+} from '@bigcommerce/checkout-sdk/paypal-utils';
 
 import PayPalCommerceVenmoPaymentStrategy from './paypal-commerce-venmo-payment-strategy';
 
@@ -14,7 +17,10 @@ const createPayPalCommerceVenmoPaymentStrategy: PaymentStrategyFactory<
     new PayPalCommerceVenmoPaymentStrategy(
         paymentIntegrationService,
         createPayPalIntegrationService(paymentIntegrationService),
-        new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
+        new LoadingIndicator({
+            containerStyles: LOADING_INDICATOR_STYLES,
+            styles: { backgroundColor: 'black' },
+        }),
     );
 
 export default toResolvableModule(createPayPalCommerceVenmoPaymentStrategy, [


### PR DESCRIPTION
## What/Why?
Fixed Loading overlay for venmo on checkout page

## Rollout/Rollback
Revert

## Testing
**Before**

https://github.com/user-attachments/assets/e0a7a139-242e-4bde-bd8a-ef14294b3058

**After**

https://github.com/user-attachments/assets/fae60d55-808c-4e23-83a0-19b21dae77cc




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that updates the Venmo checkout loading indicator styling; no payment processing or data flow logic is modified.
> 
> **Overview**
> Fixes the PayPal Commerce Venmo checkout loading overlay by wiring `LOADING_INDICATOR_STYLES` into the `LoadingIndicator` via `containerStyles` when creating the Venmo payment strategy, keeping the existing black indicator styling while ensuring the overlay renders correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a2aa1a90662d06e3c51c17eb3f25f7b0ad9518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->