### PR TITLE
chore(payment): PAYPAL-5902 clean up Braintree Credit Card 3D Secure options

### DIFF
--- a/packages/braintree-integration/src/mocks/braintree.mock.ts
+++ b/packages/braintree-integration/src/mocks/braintree.mock.ts
@@ -138,8 +138,6 @@ export function getThreeDSecureOptionsMock(): BraintreeThreeDSecureOptions {
     return {
         nonce: 'nonce',
         amount: 225,
-        addFrame: jest.fn(),
-        removeFrame: jest.fn(),
         additionalInformation: {
             acsWindowSize: '01',
         },

--- a/packages/braintree-utils/src/braintree-integration-service.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.ts
@@ -3,7 +3,6 @@ import { isEmpty } from 'lodash';
 
 import {
     Address,
-    CancellablePromise,
     CreditCardInstrument,
     LegacyAddress,
     NonceInstrument,
@@ -13,7 +12,6 @@ import {
     PaymentArgumentInvalidError,
     PaymentInvalidFormError,
     PaymentInvalidFormErrorDetails,
-    PaymentMethodCancelledError,
     UnsupportedBrowserError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { Overlay } from '@bigcommerce/checkout-sdk/ui';
@@ -503,47 +501,25 @@ export default class BraintreeIntegrationService {
     ): Promise<BraintreeVerifyPayload> {
         const { nonce, bin } = tokenizationPayload;
 
-        if (!this.threeDSecureOptions || !nonce) {
+        if (!nonce) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        const {
-            addFrame,
-            removeFrame,
-            challengeRequested = true,
-            additionalInformation,
-        } = this.threeDSecureOptions;
-        const cancelVerifyCard = async () => {
-            const response = await threeDSecure.cancelVerifyCard();
-
-            // eslint-disable-next-line @typescript-eslint/no-use-before-define
-            verification.cancel(new PaymentMethodCancelledError());
-
-            return response;
-        };
+        const { challengeRequested = true, additionalInformation = undefined } =
+            this.threeDSecureOptions || {};
 
         const roundedAmount = amount.toFixed(2);
 
-        const verification = new CancellablePromise(
-            threeDSecure.verifyCard({
-                addFrame: (error, iframe) => {
-                    if (addFrame) {
-                        addFrame(error, iframe, cancelVerifyCard);
-                    }
-                },
-                amount: Number(roundedAmount),
-                bin,
-                challengeRequested,
-                nonce,
-                removeFrame,
-                onLookupComplete: (_data, next) => {
-                    next();
-                },
-                collectDeviceData: true,
-                additionalInformation,
-            }),
-        );
-
-        return verification.promise;
+        return threeDSecure.verifyCard({
+            amount: Number(roundedAmount),
+            bin,
+            challengeRequested,
+            nonce,
+            onLookupComplete: (_data, next) => {
+                next();
+            },
+            collectDeviceData: true,
+            additionalInformation,
+        });
     }
 }

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -315,39 +315,6 @@ export interface BraintreePaypal {
     Buttons?(options: PaypalButtonOptions): PaypalButtonRender;
 }
 
-/**
- * A set of options that are required to support 3D Secure authentication flow.
- *
- * If the customer uses a credit card that has 3D Secure enabled, they will be
- * asked to verify their identity when they pay. The verification is done
- * through a web page via an iframe provided by the card issuer.
- */
-// export interface BraintreeThreeDSecureOptions {
-//     /**
-//      * A callback that gets called when the iframe is ready to be added to the
-//      * current page. It is responsible for determining where the iframe should
-//      * be inserted in the DOM.
-//      *
-//      * @param error - Any error raised during the verification process;
-//      * undefined if there is none.
-//      * @param iframe - The iframe element containing the verification web page
-//      * provided by the card issuer.
-//      * @param cancel - A function, when called, will cancel the verification
-//      * process and remove the iframe.
-//      */
-//     addFrame(
-//         error: Error | undefined,
-//         iframe: HTMLIFrameElement,
-//         cancel: () => Promise<BraintreeVerifyPayload> | undefined,
-//     ): void;
-//
-//     /**
-//      * A callback that gets called when the iframe is about to be removed from
-//      * the current page.
-//      */
-//     removeFrame(): void;
-// }
-
 export interface BraintreeFormOptions {
     fields: BraintreeFormFieldsMap | BraintreeStoredCardFieldsMap;
     styles?: BraintreeFormFieldStylesMap;

--- a/packages/braintree-utils/src/types.ts
+++ b/packages/braintree-utils/src/types.ts
@@ -272,12 +272,6 @@ export interface BraintreeThreeDSecureOptions {
         acsWindowSize?: '01' | '02' | '03' | '04' | '05';
     };
     collectDeviceData?: boolean;
-    addFrame?(
-        error: Error | undefined,
-        iframe: HTMLIFrameElement,
-        cancel: () => Promise<BraintreeVerifyPayload> | undefined,
-    ): void;
-    removeFrame?(): void;
     onLookupComplete?(data: BraintreeThreeDSecureVerificationData, next: () => void): void;
 }
 


### PR DESCRIPTION
## What/Why?

Clean up the Braintree Credit Card 3D Secure update. (Remove deprecated options)

## Rollout/Rollback

Revert

## Testing

CI Passed + Manual

https://github.com/user-attachments/assets/b7f6f90f-ecd4-4a7a-b0c3-ae869e4feb00



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches card 3DS verification in a deprecated but still-used integration service; behavior shifts from custom iframe/cancel handling to Braintree’s default challenge UI.
> 
> **Overview**
> Removes deprecated **Braintree credit card 3D Secure** iframe hooks (`addFrame` / `removeFrame`) from `BraintreeThreeDSecureOptions` and related types, mocks, and commented docs.
> 
> **`present3DSChallenge`** in `BraintreeIntegrationService` now calls `threeDSecure.verifyCard` directly instead of wrapping it in `CancellablePromise` with custom frame insertion and `PaymentMethodCancelledError` on cancel. Verification still passes amount, bin, nonce, `challengeRequested`, `additionalInformation`, and `onLookupComplete`; it no longer requires `threeDSecureOptions` to be set up front (only a valid `nonce`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac5fb1f781272bc63733a1a395901ac6ec40b51c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->