### PR TITLE
feat(checkout): CHECKOUT-10038 Refresh B2B payment methods cache

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -63,6 +63,8 @@ import { getCompleteOrderResponseBody, getOrderRequestBody } from '../order/inte
 import { getOrder } from '../order/orders.mock';
 import {
     B2BCompanyPaymentMethodRequestSender,
+    B2BPaymentsRefreshActionCreator,
+    B2BPaymentsRefreshRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistryV2,
     PaymentMethodActionCreator,
@@ -126,6 +128,8 @@ import { createCheckoutSelectorsFactory } from './create-checkout-selectors';
 import createCheckoutStore from './create-checkout-store';
 
 describe('CheckoutService', () => {
+    let b2bPaymentsRefreshActionCreator: B2BPaymentsRefreshActionCreator;
+    let b2bPaymentsRefreshRequestSender: B2BPaymentsRefreshRequestSender;
     let billingAddressActionCreator: BillingAddressActionCreator;
     let billingAddressRequestSender: BillingAddressRequestSender;
     let checkoutActionCreator: CheckoutActionCreator;
@@ -399,6 +403,14 @@ describe('CheckoutService', () => {
             new B2BCompanyPaymentMethodRequestSender(requestSender),
         );
 
+        b2bPaymentsRefreshRequestSender = new B2BPaymentsRefreshRequestSender(requestSender);
+
+        jest.spyOn(b2bPaymentsRefreshRequestSender, 'refresh').mockResolvedValue(getResponse({}));
+
+        b2bPaymentsRefreshActionCreator = new B2BPaymentsRefreshActionCreator(
+            b2bPaymentsRefreshRequestSender,
+        );
+
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             paymentStrategyRegistry,
             paymentStrategyRegistryV2,
@@ -455,6 +467,7 @@ describe('CheckoutService', () => {
             formFieldsActionCreator,
             extensionActionCreator,
             workerExtensionMessenger,
+            b2bPaymentsRefreshActionCreator,
         );
     });
 
@@ -604,6 +617,25 @@ describe('CheckoutService', () => {
             );
 
             expect(state.data.getCheckout()).toEqual(store.getState().checkout.getCheckout());
+        });
+    });
+
+    describe('#refreshB2BPaymentMethods()', () => {
+        it('exposes the method on the service', () => {
+            expect(typeof checkoutService.refreshB2BPaymentMethods).toBe('function');
+        });
+
+        it('dispatches the action creator and returns a promise', async () => {
+            jest.spyOn(b2bPaymentsRefreshActionCreator, 'refreshB2BPaymentMethods');
+
+            const result = checkoutService.refreshB2BPaymentMethods();
+
+            expect(result).toBeInstanceOf(Promise);
+            expect(b2bPaymentsRefreshActionCreator.refreshB2BPaymentMethods).toHaveBeenCalledWith(
+                undefined,
+            );
+
+            await result.catch(() => undefined);
         });
     });
 

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -36,6 +36,7 @@ import { FormFieldsActionCreator } from '../form';
 import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
 import {
+    B2BPaymentsRefreshActionCreator,
     OrderFinalizeOptions,
     PaymentInitializeOptions,
     PaymentMethodActionCreator,
@@ -112,6 +113,7 @@ export default class CheckoutService {
         private _formFieldsActionCreator: FormFieldsActionCreator,
         private _extensionActionCreator: ExtensionActionCreator,
         private _workerExtensionMessenger: WorkerExtensionMessenger,
+        private _b2bPaymentsRefreshActionCreator: B2BPaymentsRefreshActionCreator,
     ) {
         this._errorTransformer = createCheckoutServiceErrorTransformer();
     }
@@ -700,6 +702,22 @@ export default class CheckoutService {
         const action = this._b2bTokenActionCreator.loadB2BToken(options);
 
         return this._dispatch(action, { queueId: 'b2bToken' });
+    }
+
+    /**
+     * Refreshes the B2B payment methods cache for the current customer.
+     *
+     * ```js
+     * await service.refreshB2BPaymentMethods();
+     * ```
+     *
+     * @param options - Options for the request.
+     * @returns A promise that resolves to the current state.
+     */
+    refreshB2BPaymentMethods(options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._b2bPaymentsRefreshActionCreator.refreshB2BPaymentMethods(options);
+
+        return this._dispatch(action, { queueId: 'b2bPaymentsRefresh' });
     }
 
     /**

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -36,6 +36,8 @@ import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import {
     B2BCompanyPaymentMethodRequestSender,
+    B2BPaymentsRefreshActionCreator,
+    B2BPaymentsRefreshRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistry,
     createPaymentStrategyRegistryV2,
@@ -230,6 +232,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         formFieldsActionCreator,
         extensionActionCreator,
         workerExtensionMessenger,
+        new B2BPaymentsRefreshActionCreator(new B2BPaymentsRefreshRequestSender(requestSender)),
     );
 }
 

--- a/packages/core/src/payment/b2b-payments-refresh-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-action-creator.spec.ts
@@ -1,0 +1,183 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { CheckoutStore, createCheckoutStore } from '../checkout';
+import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { getConfig } from '../config/configs.mock';
+
+import B2BPaymentsRefreshActionCreator from './b2b-payments-refresh-action-creator';
+import { B2BPaymentsRefreshActionType } from './b2b-payments-refresh-actions';
+import B2BPaymentsRefreshRequestSender from './b2b-payments-refresh-request-sender';
+import PaymentMethod from './payment-method';
+
+describe('B2BPaymentsRefreshActionCreator', () => {
+    let store: CheckoutStore;
+    let requestSender: B2BPaymentsRefreshRequestSender;
+    let actionCreator: B2BPaymentsRefreshActionCreator;
+
+    const b2bApiSettings = {
+        clientId: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
+        baseUrl: 'https://api-b2b.bigcommerce.com',
+    };
+
+    const paymentMethods: PaymentMethod[] = [
+        {
+            id: 'cheque',
+            method: 'check',
+            type: 'PAYMENT_TYPE_OFFLINE',
+            supportedCards: [],
+            config: { displayName: 'Check' },
+            skipRedirectConfirmationAlert: false,
+        },
+        {
+            id: 'stripe-card',
+            method: 'credit-card',
+            type: 'PAYMENT_TYPE_API',
+            supportedCards: [],
+            gateway: 'stripev3',
+            config: {},
+            skipRedirectConfirmationAlert: false,
+        },
+        {
+            id: 'no-display-no-gateway',
+            method: 'credit-card',
+            type: 'PAYMENT_TYPE_API',
+            supportedCards: [],
+            config: {},
+            skipRedirectConfirmationAlert: false,
+        },
+    ];
+
+    beforeEach(() => {
+        store = createCheckoutStore({
+            ...getCheckoutStoreState(),
+            b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+            paymentMethods: {
+                data: paymentMethods,
+                errors: {},
+                statuses: {},
+            },
+        });
+
+        requestSender = new B2BPaymentsRefreshRequestSender(createRequestSender());
+
+        jest.spyOn(requestSender, 'refresh').mockResolvedValue(getResponse({}));
+
+        jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+            ...getConfig().storeConfig,
+            b2bApiSettings,
+        });
+
+        actionCreator = new B2BPaymentsRefreshActionCreator(requestSender);
+    });
+
+    describe('#refreshB2BPaymentMethods()', () => {
+        it('emits requested and succeeded actions on success', async () => {
+            const actions = await from(actionCreator.refreshB2BPaymentMethods()(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsRequested },
+                { type: B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsSucceeded },
+            ]);
+        });
+
+        it('calls refresh with payments mapped from payment methods state', async () => {
+            await from(actionCreator.refreshB2BPaymentMethods()(store)).toPromise();
+
+            expect(requestSender.refresh).toHaveBeenCalledWith(
+                [
+                    { code: 'cheque', name: 'Check' },
+                    { code: 'stripe-card', name: 'stripev3' },
+                    { code: 'no-display-no-gateway', name: '' },
+                ],
+                'b2b-auth-token',
+                b2bApiSettings.baseUrl,
+                undefined,
+            );
+        });
+
+        it('sends an empty array when no payment methods are loaded', async () => {
+            store = createCheckoutStore({
+                ...getCheckoutStoreState(),
+                b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+                paymentMethods: { errors: {}, statuses: {} },
+            });
+
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
+
+            await from(actionCreator.refreshB2BPaymentMethods()(store)).toPromise();
+
+            expect(requestSender.refresh).toHaveBeenCalledWith(
+                [],
+                'b2b-auth-token',
+                b2bApiSettings.baseUrl,
+                undefined,
+            );
+        });
+
+        it('forwards request options to the request sender', async () => {
+            const options = { timeout: undefined, params: { foo: 'bar' } };
+
+            await from(actionCreator.refreshB2BPaymentMethods(options)(store)).toPromise();
+
+            expect(requestSender.refresh).toHaveBeenCalledWith(
+                expect.any(Array),
+                'b2b-auth-token',
+                b2bApiSettings.baseUrl,
+                options,
+            );
+        });
+
+        it('throws when the b2b token is missing', () => {
+            store = createCheckoutStore({
+                ...getCheckoutStoreState(),
+                paymentMethods: {
+                    data: paymentMethods,
+                    errors: {},
+                    statuses: {},
+                },
+            });
+
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
+
+            expect(() => actionCreator.refreshB2BPaymentMethods()(store)).toThrow();
+        });
+
+        it('throws when the b2b base url is missing', () => {
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings: { ...b2bApiSettings, baseUrl: '' },
+            });
+
+            expect(() => actionCreator.refreshB2BPaymentMethods()(store)).toThrow();
+        });
+
+        it('emits failed action when the request rejects', async () => {
+            jest.spyOn(requestSender, 'refresh').mockRejectedValue(getErrorResponse());
+
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(actionCreator.refreshB2BPaymentMethods()(store))
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsRequested },
+                expect.objectContaining({
+                    type: B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsFailed,
+                    error: true,
+                }),
+            ]);
+        });
+    });
+});

--- a/packages/core/src/payment/b2b-payments-refresh-action-creator.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-action-creator.ts
@@ -1,0 +1,60 @@
+import { createAction, ThunkAction } from '@bigcommerce/data-store';
+import { concat, defer, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+// TODO: CHECKOUT-9979 remove this import before delivery
+import { resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { InternalCheckoutSelectors } from '../checkout';
+import { throwErrorAction } from '../common/error';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { RequestOptions } from '../common/http-request';
+
+import {
+    B2BPaymentsRefreshActionType,
+    RefreshB2BPaymentMethodsAction,
+} from './b2b-payments-refresh-actions';
+import B2BPaymentsRefreshRequestSender from './b2b-payments-refresh-request-sender';
+
+export default class B2BPaymentsRefreshActionCreator {
+    constructor(private _requestSender: B2BPaymentsRefreshRequestSender) {}
+
+    refreshB2BPaymentMethods(
+        options?: RequestOptions,
+    ): ThunkAction<RefreshB2BPaymentMethodsAction, InternalCheckoutSelectors> {
+        return (store) => {
+            const state = store.getState();
+            const paymentMethods = state.paymentMethods.getPaymentMethods() ?? [];
+            const b2bToken = state.b2bToken.getToken();
+            const b2bBaseUrl = resolveB2bBaseUrl(
+                state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
+            );
+
+            if (!b2bToken || !b2bBaseUrl) {
+                throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+            }
+
+            const payments = paymentMethods.map((method) => ({
+                code: method.id,
+                name: method.config?.displayName || method.gateway || '',
+            }));
+
+            return concat(
+                of(createAction(B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsRequested)),
+                defer(async () => {
+                    await this._requestSender.refresh(payments, b2bToken, b2bBaseUrl, options);
+
+                    return createAction(
+                        B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsSucceeded,
+                    );
+                }),
+            ).pipe(
+                catchError((error) =>
+                    throwErrorAction(
+                        B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsFailed,
+                        error,
+                    ),
+                ),
+            );
+        };
+    }
+}

--- a/packages/core/src/payment/b2b-payments-refresh-actions.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-actions.ts
@@ -1,0 +1,24 @@
+import { Action } from '@bigcommerce/data-store';
+
+export enum B2BPaymentsRefreshActionType {
+    RefreshB2BPaymentMethodsRequested = 'REFRESH_B2B_PAYMENT_METHODS_REQUESTED',
+    RefreshB2BPaymentMethodsSucceeded = 'REFRESH_B2B_PAYMENT_METHODS_SUCCEEDED',
+    RefreshB2BPaymentMethodsFailed = 'REFRESH_B2B_PAYMENT_METHODS_FAILED',
+}
+
+export type RefreshB2BPaymentMethodsAction =
+    | RefreshB2BPaymentMethodsRequestedAction
+    | RefreshB2BPaymentMethodsSucceededAction
+    | RefreshB2BPaymentMethodsFailedAction;
+
+export interface RefreshB2BPaymentMethodsRequestedAction extends Action {
+    type: B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsRequested;
+}
+
+export interface RefreshB2BPaymentMethodsSucceededAction extends Action {
+    type: B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsSucceeded;
+}
+
+export interface RefreshB2BPaymentMethodsFailedAction extends Action<Error> {
+    type: B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsFailed;
+}

--- a/packages/core/src/payment/b2b-payments-refresh-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-request-sender.spec.ts
@@ -1,0 +1,101 @@
+import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
+
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+
+import B2BPaymentsRefreshRequestSender from './b2b-payments-refresh-request-sender';
+
+describe('B2BPaymentsRefreshRequestSender', () => {
+    let requestSender: RequestSender;
+    let b2bPaymentsRefreshRequestSender: B2BPaymentsRefreshRequestSender;
+
+    const payments = [
+        { code: 'cheque', name: 'Check' },
+        { code: 'stripev3', name: 'Stripe' },
+    ];
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        jest.spyOn(requestSender, 'post').mockResolvedValue(getResponse({}));
+
+        b2bPaymentsRefreshRequestSender = new B2BPaymentsRefreshRequestSender(requestSender);
+    });
+
+    describe('#refresh()', () => {
+        it('posts to the payments refresh endpoint with auth headers and payload', async () => {
+            await b2bPaymentsRefreshRequestSender.refresh(
+                payments,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/payments/refresh',
+                {
+                    timeout: undefined,
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                    body: { payments },
+                },
+            );
+        });
+
+        it('forwards the request timeout', async () => {
+            const timeout = createTimeout();
+
+            await b2bPaymentsRefreshRequestSender.refresh(
+                payments,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+                { timeout },
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/payments/refresh',
+                expect.objectContaining({ timeout }),
+            );
+        });
+
+        it('uses the provided b2bBaseUrl for the endpoint', async () => {
+            await b2bPaymentsRefreshRequestSender.refresh(
+                payments,
+                'b2b-token-value',
+                'https://api-b2b.staging.zone',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.staging.zone/api/v2/payments/refresh',
+                expect.any(Object),
+            );
+        });
+
+        it('sends an empty payments array when given one', async () => {
+            await b2bPaymentsRefreshRequestSender.refresh(
+                [],
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/payments/refresh',
+                expect.objectContaining({ body: { payments: [] } }),
+            );
+        });
+
+        it('rejects when the request sender rejects', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
+
+            await expect(
+                b2bPaymentsRefreshRequestSender.refresh(
+                    payments,
+                    'b2b-token-value',
+                    'https://api-b2b.bigcommerce.com',
+                ),
+            ).rejects.toEqual(getErrorResponse());
+        });
+    });
+});

--- a/packages/core/src/payment/b2b-payments-refresh-request-sender.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-request-sender.ts
@@ -1,0 +1,30 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { RequestOptions } from '../common/http-request';
+
+export interface B2BPaymentsRefreshPayment {
+    code: string;
+    name: string;
+}
+
+export default class B2BPaymentsRefreshRequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    async refresh(
+        payments: B2BPaymentsRefreshPayment[],
+        b2bToken: string,
+        b2bBaseUrl: string,
+        options?: RequestOptions,
+    ): Promise<Response<unknown>> {
+        return this._requestSender.post(`${b2bBaseUrl}/api/v2/payments/refresh`, {
+            timeout: options?.timeout,
+            credentials: false,
+            headers: {
+                'Content-Type': 'application/json',
+                authToken: b2bToken,
+                Authorization: `Bearer ${b2bToken}`,
+            },
+            body: { payments },
+        });
+    }
+}

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -38,6 +38,15 @@ export {
     WithMollieIssuerInstrument,
 } from './payment';
 export { default as B2BCompanyPaymentMethodRequestSender } from './b2b-company-payment-method-request-sender';
+export { default as B2BPaymentsRefreshActionCreator } from './b2b-payments-refresh-action-creator';
+export {
+    B2BPaymentsRefreshActionType,
+    RefreshB2BPaymentMethodsAction,
+} from './b2b-payments-refresh-actions';
+export {
+    default as B2BPaymentsRefreshRequestSender,
+    B2BPaymentsRefreshPayment,
+} from './b2b-payments-refresh-request-sender';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';
 export { default as PaymentMethodConfig } from './payment-method-config';


### PR DESCRIPTION
## What/Why?

Syncs payment methods to B2B app, they will be cached for 10 minutes.

### Context
B2B backend is only able to sync part of all available payment methods. Some payment methods can only be seen during checkout. Therefore, we need to use this refresh endpoint for syncing payment methods.

### Timing (the tasks on checkout-js side)
1. On mount of the Payment step (post-redirect after jumping to a third-party payment site).
2. Inside handleSubmit, before placing the order


## Rollout/Rollback

Revert.

## Testing

Tested along with the checkout-js side changes.

<img width="1508" height="824" alt="Screenshot 2026-05-27 at 13 50 18" src="https://github.com/user-attachments/assets/21282ab2-5aa1-48ae-a0b8-8a337a98728a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New outbound B2B API call using auth tokens and payment method payloads; additive and tested, but failures or mis-sync could affect B2B payment visibility at checkout.
> 
> **Overview**
> Adds a **B2B payment methods refresh** path in checkout-sdk so checkout can push the **current loaded payment methods** to the B2B API cache (methods only visible at checkout).
> 
> **`CheckoutService.refreshB2BPaymentMethods()`** dispatches a new thunk (queue `b2bPaymentsRefresh`). **`B2BPaymentsRefreshActionCreator`** reads payment methods from store, maps them to `{ code, name }` (display name or gateway), requires **B2B token** and **base URL** (via `resolveB2bBaseUrl`), then **`B2BPaymentsRefreshRequestSender`** **POST**s to `{baseUrl}/api/v2/payments/refresh` with `authToken` and `Bearer` headers.
> 
> Wiring in **`create-checkout-service`**, public exports from **`payment/index`**, and unit tests for the action creator, request sender, and service method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af67bb065d3d7630bb5a07a6c8f1c8f0fa02849e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->