### PR TITLE
feat(payment): PI-5216 show full list of payment methods when GooglePay direct-pay flow payment is processed

### DIFF
--- a/packages/google-pay-integration/.eslintrc.json
+++ b/packages/google-pay-integration/.eslintrc.json
@@ -27,7 +27,8 @@
                 "jest/no-conditional-expect": "off",
                 "@typescript-eslint/no-unsafe-call": "off",
                 "@typescript-eslint/no-unsafe-return": "off",
-                "@typescript-eslint/no-non-null-assertion": "off"
+                "@typescript-eslint/no-non-null-assertion": "off",
+                "no-underscore-dangle": "off"
             }
         },
         {

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -762,6 +762,8 @@ describe('GooglePayPaymentStrategy', () => {
                 },
             };
 
+            let interactWithPaymentSheetSpy: jest.SpyInstance;
+
             beforeEach(async () => {
                 jest.spyOn(
                     paymentIntegrationService.getState(),
@@ -770,7 +772,15 @@ describe('GooglePayPaymentStrategy', () => {
 
                 jest.spyOn(processor, 'mapToBillingAddressRequestBody').mockReturnValue(undefined);
 
+                interactWithPaymentSheetSpy = jest
+                    .spyOn(Object.getPrototypeOf(strategy), '_interactWithPaymentSheet')
+                    .mockResolvedValue(undefined);
+
                 await strategy.initialize(options);
+            });
+
+            afterEach(() => {
+                interactWithPaymentSheetSpy.mockRestore();
             });
 
             it('should show loading indicator on button click', async () => {
@@ -792,12 +802,22 @@ describe('GooglePayPaymentStrategy', () => {
                 );
             });
 
-            it('should load checkout after receiving payment sheet response', async () => {
+            it('should NOT call loadCheckout on the success path', async () => {
                 button.click();
 
                 await new Promise((resolve) => process.nextTick(resolve));
 
-                expect(paymentIntegrationService.loadCheckout).toHaveBeenCalled();
+                expect(paymentIntegrationService.loadCheckout).not.toHaveBeenCalled();
+            });
+
+            it('should call loadCheckout when execute() throws, to restore UI state', async () => {
+                jest.spyOn(strategy, 'execute').mockRejectedValueOnce(new Error('payment failed'));
+
+                button.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.loadCheckout).toHaveBeenCalledTimes(1);
             });
 
             it('should load payment method with the correct methodId', async () => {
@@ -1069,6 +1089,24 @@ describe('GooglePayPaymentStrategy', () => {
                     useStoreCredit: false,
                     payment: { methodId: options.methodId },
                 });
+            });
+
+            it('should NOT call loadCheckout on the success path', async () => {
+                brandedButton.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.loadCheckout).not.toHaveBeenCalled();
+            });
+
+            it('should call loadCheckout when execute() throws, to restore UI state', async () => {
+                jest.spyOn(strategy, 'execute').mockRejectedValueOnce(new Error('payment failed'));
+
+                brandedButton.click();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.loadCheckout).toHaveBeenCalledTimes(1);
             });
 
             it('should call onError when initializeWidget throws', async () => {

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -818,14 +818,18 @@ describe('GooglePayPaymentStrategy', () => {
                 expect(paymentIntegrationService.loadCheckout).not.toHaveBeenCalled();
             });
 
-            it('should call loadCheckout when execute() throws, to restore UI state', async () => {
-                jest.spyOn(strategy, 'execute').mockRejectedValueOnce(new Error('payment failed'));
+            it('should call loadCheckout and re-throw when execute() throws, to restore UI state', async () => {
+                const paymentError = new Error('payment failed');
+
+                jest.spyOn(strategy, 'execute').mockRejectedValueOnce(paymentError);
 
                 const strategyInternal = strategy as unknown as {
                     _interactWithPaymentSheetAndPay(): Promise<void>;
                 };
 
-                await strategyInternal._interactWithPaymentSheetAndPay();
+                await expect(strategyInternal._interactWithPaymentSheetAndPay()).rejects.toThrow(
+                    paymentError,
+                );
 
                 expect(paymentIntegrationService.loadCheckout).toHaveBeenCalledTimes(1);
             });
@@ -1109,14 +1113,18 @@ describe('GooglePayPaymentStrategy', () => {
                 expect(paymentIntegrationService.loadCheckout).not.toHaveBeenCalled();
             });
 
-            it('should call loadCheckout when execute() throws, to restore UI state', async () => {
-                jest.spyOn(strategy, 'execute').mockRejectedValueOnce(new Error('payment failed'));
+            it('should call loadCheckout, invoke onError, hide loading indicator, and re-throw when execute() throws', async () => {
+                const paymentError = new Error('payment failed');
 
-                brandedButton.click();
+                jest.spyOn(strategy, 'execute').mockRejectedValueOnce(paymentError);
 
-                await new Promise((resolve) => process.nextTick(resolve));
+                await expect(containerButtonOnClick(new MouseEvent('click'))).rejects.toThrow(
+                    paymentError,
+                );
 
                 expect(paymentIntegrationService.loadCheckout).toHaveBeenCalledTimes(1);
+                expect(options.googlepayworldpayaccess?.onError).toHaveBeenCalled();
+                expect(LoadingHide).toHaveBeenCalled();
             });
 
             it('should call onError when initializeWidget throws', async () => {

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -763,6 +763,7 @@ describe('GooglePayPaymentStrategy', () => {
             };
 
             let interactWithPaymentSheetSpy: jest.SpyInstance;
+            let completeCheckoutFlowSpy: jest.SpyInstance;
 
             beforeEach(async () => {
                 jest.spyOn(
@@ -776,11 +777,16 @@ describe('GooglePayPaymentStrategy', () => {
                     .spyOn(Object.getPrototypeOf(strategy), '_interactWithPaymentSheet')
                     .mockResolvedValue(undefined);
 
+                completeCheckoutFlowSpy = jest
+                    .spyOn(Object.getPrototypeOf(strategy), '_completeCheckoutFlow')
+                    .mockImplementation(() => undefined);
+
                 await strategy.initialize(options);
             });
 
             afterEach(() => {
                 interactWithPaymentSheetSpy.mockRestore();
+                completeCheckoutFlowSpy.mockRestore();
             });
 
             it('should show loading indicator on button click', async () => {

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -809,9 +809,11 @@ describe('GooglePayPaymentStrategy', () => {
             });
 
             it('should NOT call loadCheckout on the success path', async () => {
-                button.click();
+                const strategyInternal = strategy as unknown as {
+                    _interactWithPaymentSheetAndPay(): Promise<void>;
+                };
 
-                await new Promise((resolve) => process.nextTick(resolve));
+                await strategyInternal._interactWithPaymentSheetAndPay();
 
                 expect(paymentIntegrationService.loadCheckout).not.toHaveBeenCalled();
             });
@@ -819,9 +821,11 @@ describe('GooglePayPaymentStrategy', () => {
             it('should call loadCheckout when execute() throws, to restore UI state', async () => {
                 jest.spyOn(strategy, 'execute').mockRejectedValueOnce(new Error('payment failed'));
 
-                button.click();
+                const strategyInternal = strategy as unknown as {
+                    _interactWithPaymentSheetAndPay(): Promise<void>;
+                };
 
-                await new Promise((resolve) => process.nextTick(resolve));
+                await strategyInternal._interactWithPaymentSheetAndPay();
 
                 expect(paymentIntegrationService.loadCheckout).toHaveBeenCalledTimes(1);
             });

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -279,6 +279,8 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             this._completeCheckoutFlow();
         } catch (error) {
             await this._paymentIntegrationService.loadCheckout();
+
+            throw error;
         }
     }
 

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -265,7 +265,6 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         await this._googlePayPaymentProcessor.setExternalCheckoutXhr(methodId, response);
 
-        await this._paymentIntegrationService.loadCheckout();
         await this._paymentIntegrationService.loadPaymentMethod(methodId);
 
         const freshPaymentMethod = this._paymentIntegrationService
@@ -274,9 +273,13 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         await this._googlePayPaymentProcessor.initialize(() => freshPaymentMethod);
 
-        await this.execute({ useStoreCredit: false, payment: { methodId } });
+        try {
+            await this.execute({ useStoreCredit: false, payment: { methodId } });
 
-        this._completeCheckoutFlow();
+            this._completeCheckoutFlow();
+        } catch (error) {
+            await this._paymentIntegrationService.loadCheckout();
+        }
     }
 
     protected _completeCheckoutFlow(): void {


### PR DESCRIPTION
## What/Why?

Currently, in direct pay flow for Google Pay, when the shopper clicks 'Pay' in the modal and the payment is being processed, the payment method list collapses and only shows Google Pay (just like it does for sign-in/sign-out flow).
According to the project requirements, we should be showing the whole list of the methods during this step.

## Rollout/Rollback

Revert

## Testing

Before, the payment method list collapses to Google Pay only:

https://github.com/user-attachments/assets/71df1427-7a50-44c2-94c7-1e06f52bad19

After, we keep the whole payment method list:

https://github.com/user-attachments/assets/cd5aa2bc-021a-422e-ae09-3b695695a901



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Google Pay direct-pay checkout path and error recovery; behavior change is localized but affects payment-step UI and post-failure state refresh.
> 
> **Overview**
> Google Pay **direct pay** (`_interactWithPaymentSheetAndPay`) no longer calls `loadCheckout()` before `loadPaymentMethod` and `execute` on the happy path, so the checkout UI keeps showing **all payment methods** while payment is processing instead of collapsing to Google Pay only.
> 
> On failure, `execute` is wrapped in **try/catch**: `loadCheckout()` runs once to refresh checkout state, then the error is rethrown (container flow still surfaces `onError` and hides loading via existing handlers). Specs now assert no `loadCheckout` on success, `loadCheckout` on execute failure, and use spies on internal helpers; ESLint allows `no-underscore-dangle` in `*.spec.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f127eb9a19798a20f80f2a88af56500ace96bd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->