### PR TITLE
feat(payment): PAYPAL-6470 add wallet button billing address

### DIFF
--- a/packages/wallet-button-integration/src/billing/billing-address-request-sender.spec.ts
+++ b/packages/wallet-button-integration/src/billing/billing-address-request-sender.spec.ts
@@ -1,0 +1,157 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { GraphQLRequestOptions } from '../graphql-request-options';
+
+import {
+    AddBillingAddressResponseBody,
+    AddressRequestBody,
+    BillingAddressResponse,
+    BillingAddressUpdateRequestBody,
+    UpdateBillingAddressResponseBody,
+} from './billing-address';
+import BillingAddressRequestSender from './billing-address-request-sender';
+
+describe('BillingAddressRequestSender', () => {
+    let requestSender: RequestSender;
+    let billingAddressRequestSender: BillingAddressRequestSender;
+    const graphQLEndpoint = 'graphql';
+    const checkoutId = 'checkout-123';
+    const address: AddressRequestBody = {
+        firstName: 'John',
+        lastName: 'Doe',
+        company: 'Bigcommerce',
+        address1: '123 Main St',
+        address2: '',
+        city: 'Austin',
+        email: 'john@doe.com',
+        stateOrProvince: 'Texas',
+        stateOrProvinceCode: 'TX',
+        countryCode: 'US',
+        postalCode: '78701',
+        phone: '555-555-5555',
+        shouldSaveAddress: false,
+    };
+    const updateBillingAddressRequestBody: BillingAddressUpdateRequestBody = {
+        ...address,
+        id: 'address-1',
+    };
+
+    const billingAddressResponse: BillingAddressResponse = {
+        ...updateBillingAddressRequestBody,
+        entityId: 'entity-1',
+    };
+
+    const updateResponseBody: UpdateBillingAddressResponseBody = {
+        data: {
+            checkout: {
+                updateCheckoutBillingAddress: {
+                    checkout: {
+                        billingAddress: billingAddressResponse,
+                    },
+                },
+            },
+        },
+    };
+
+    const addResponseBody: AddBillingAddressResponseBody = {
+        data: {
+            checkout: {
+                addCheckoutBillingAddress: {
+                    checkout: {
+                        billingAddress: billingAddressResponse,
+                    },
+                },
+            },
+        },
+    };
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        billingAddressRequestSender = new BillingAddressRequestSender(requestSender);
+    });
+
+    describe('#updateBillingAddress', () => {
+        it('sends a POST request with correct GraphQL mutation and variables', async () => {
+            const postSpy = jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: updateResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            const options: GraphQLRequestOptions = { headers: { 'X-Test': '1' } };
+            const result = await billingAddressRequestSender.updateBillingAddress(
+                graphQLEndpoint,
+                checkoutId,
+                updateBillingAddressRequestBody,
+                options,
+            );
+
+            expect(postSpy).toHaveBeenCalledWith(
+                `${window.location.origin}/${graphQLEndpoint}`,
+                expect.objectContaining({
+                    headers: {
+                        'X-Test': '1',
+                        'Content-Type': 'application/json',
+                        'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+                    },
+                }),
+            );
+
+            expect(postSpy.mock.calls[0][1]).toMatchObject({
+                body: {
+                    variables: {
+                        input: {
+                            checkoutEntityId: checkoutId,
+                            addressEntityId: updateBillingAddressRequestBody.id,
+                        },
+                    },
+                },
+            });
+            expect(result.body).toEqual(billingAddressResponse);
+        });
+    });
+
+    describe('#addBillingAddress', () => {
+        it('sends a POST request with correct GraphQL mutation and variables', async () => {
+            const postSpy = jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: addResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            const options: GraphQLRequestOptions = { headers: { 'X-Test': '2' } };
+            const result = await billingAddressRequestSender.addBillingAddress(
+                graphQLEndpoint,
+                checkoutId,
+                address,
+                options,
+            );
+
+            expect(postSpy).toHaveBeenCalledWith(
+                `${window.location.origin}/${graphQLEndpoint}`,
+                expect.objectContaining({
+                    headers: {
+                        'X-Test': '2',
+                        'Content-Type': 'application/json',
+                        'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+                    },
+                }),
+            );
+
+            expect(postSpy.mock.calls[0][1]).toMatchObject({
+                body: {
+                    variables: {
+                        input: {
+                            checkoutEntityId: checkoutId,
+                            data: { address },
+                        },
+                    },
+                },
+            });
+            expect(result.body).toEqual(billingAddressResponse);
+        });
+    });
+});

--- a/packages/wallet-button-integration/src/billing/billing-address-request-sender.ts
+++ b/packages/wallet-button-integration/src/billing/billing-address-request-sender.ts
@@ -1,0 +1,155 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { GraphQLRequestOptions } from '../graphql-request-options';
+
+import {
+    AddBillingAddressResponseBody,
+    AddressRequestBody,
+    BillingAddressResponse,
+    BillingAddressUpdateRequestBody,
+    UpdateBillingAddressResponseBody,
+} from './billing-address';
+
+export default class BillingAddressRequestSender {
+    constructor(private readonly requestSender: RequestSender) {}
+
+    async updateBillingAddress(
+        graphQLEndpoint: string,
+        checkoutId: string,
+        address: BillingAddressUpdateRequestBody,
+        options?: GraphQLRequestOptions,
+    ): Promise<Response<BillingAddressResponse>> {
+        const document = `
+            mutation UpdateCheckoutBillingAddressMutation(
+                $input: UpdateCheckoutBillingAddressInput!
+            ) {
+                checkout {
+                    updateCheckoutBillingAddress(input: $input) {
+                        checkout {
+                            billingAddress {
+                                address1
+                                address2
+                                city
+                                company
+                                countryCode
+                                email
+                                entityId
+                                firstName
+                                lastName
+                                phone
+                                postalCode
+                                stateOrProvince
+                                stateOrProvinceCode
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const { id, ...billingAddressFields } = address;
+
+        const requestOptions: GraphQLRequestOptions = {
+            headers: {
+                ...options?.headers,
+                'Content-Type': 'application/json',
+                'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+            },
+            body: {
+                query: document,
+                variables: {
+                    input: {
+                        checkoutEntityId: checkoutId,
+                        addressEntityId: address.id,
+                        data: {
+                            address: {
+                                ...billingAddressFields,
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const response = await this.requestSender.post<UpdateBillingAddressResponseBody>(
+            `${window.location.origin}/${graphQLEndpoint}`,
+            requestOptions,
+        );
+
+        const { billingAddress } =
+            response.body.data.checkout.updateCheckoutBillingAddress.checkout;
+
+        return {
+            ...response,
+            body: billingAddress,
+        };
+    }
+
+    async addBillingAddress(
+        graphQLEndpoint: string,
+        checkoutId: string,
+        address: AddressRequestBody,
+        options?: GraphQLRequestOptions,
+    ): Promise<Response<BillingAddressResponse>> {
+        const document = `
+            mutation AddCheckoutBillingAddressMutation(
+                $input: AddCheckoutBillingAddressInput!
+            ) {
+                checkout {
+                    addCheckoutBillingAddress(input: $input) {
+                        checkout {
+                            billingAddress {
+                                address1
+                                address2
+                                city
+                                company
+                                countryCode
+                                email
+                                entityId
+                                firstName
+                                lastName
+                                phone
+                                postalCode
+                                stateOrProvince
+                                stateOrProvinceCode
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const requestOptions: GraphQLRequestOptions = {
+            headers: {
+                ...options?.headers,
+                'Content-Type': 'application/json',
+                'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+            },
+            body: {
+                query: document,
+                variables: {
+                    input: {
+                        checkoutEntityId: checkoutId,
+                        data: {
+                            address: {
+                                ...address,
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const response = await this.requestSender.post<AddBillingAddressResponseBody>(
+            `${window.location.origin}/${graphQLEndpoint}`,
+            requestOptions,
+        );
+
+        const { billingAddress } = response.body.data.checkout.addCheckoutBillingAddress.checkout;
+
+        return {
+            ...response,
+            body: billingAddress,
+        };
+    }
+}

--- a/packages/wallet-button-integration/src/billing/billing-address.ts
+++ b/packages/wallet-button-integration/src/billing/billing-address.ts
@@ -1,0 +1,47 @@
+export interface AddressRequestBody {
+    firstName: string;
+    lastName: string;
+    company: string;
+    address1: string;
+    address2: string;
+    city: string;
+    email: string;
+    stateOrProvince: string;
+    stateOrProvinceCode: string;
+    countryCode: string;
+    postalCode: string;
+    phone: string;
+    shouldSaveAddress: boolean;
+}
+
+export interface BillingAddressResponse extends AddressRequestBody {
+    entityId: string;
+}
+
+export interface BillingAddressUpdateRequestBody extends AddressRequestBody {
+    id: string;
+}
+
+export interface AddBillingAddressResponseBody {
+    data: {
+        checkout: {
+            addCheckoutBillingAddress: {
+                checkout: {
+                    billingAddress: BillingAddressResponse;
+                };
+            };
+        };
+    };
+}
+
+export interface UpdateBillingAddressResponseBody {
+    data: {
+        checkout: {
+            updateCheckoutBillingAddress: {
+                checkout: {
+                    billingAddress: BillingAddressResponse;
+                };
+            };
+        };
+    };
+}

--- a/packages/wallet-button-integration/src/create-wallet-button-integration-service.ts
+++ b/packages/wallet-button-integration/src/create-wallet-button-integration-service.ts
@@ -1,5 +1,6 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 
+import BillingAddressRequestSender from './billing/billing-address-request-sender';
 import { PaymentRequestSender } from './payment/payment-request-sender';
 import WalletButtonIntegrationService from './wallet-button-integration-service';
 
@@ -10,6 +11,7 @@ const createWalletButtonIntegrationService = (
 
     return new WalletButtonIntegrationService(
         graphQLEndpoint,
+        new BillingAddressRequestSender(requestSender),
         new PaymentRequestSender(requestSender),
     );
 };

--- a/packages/wallet-button-integration/src/wallet-button-integration-service.spec.ts
+++ b/packages/wallet-button-integration/src/wallet-button-integration-service.spec.ts
@@ -1,11 +1,13 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
+import BillingAddressRequestSender from './billing/billing-address-request-sender';
 import { PaymentRequestSender } from './payment/payment-request-sender';
 import WalletButtonIntegrationService from './wallet-button-integration-service';
 
 describe('WalletButtonIntegrationService', () => {
     let requestSender: RequestSender;
     let paymentRequestSender: PaymentRequestSender;
+    let billingAddressRequestSender: BillingAddressRequestSender;
     let walletButtonIntegrationService: WalletButtonIntegrationService;
 
     const graphQLEndpoint = 'graphql';
@@ -13,8 +15,11 @@ describe('WalletButtonIntegrationService', () => {
     beforeEach(() => {
         requestSender = createRequestSender();
         paymentRequestSender = new PaymentRequestSender(requestSender);
+        billingAddressRequestSender = new BillingAddressRequestSender(requestSender);
+
         walletButtonIntegrationService = new WalletButtonIntegrationService(
             graphQLEndpoint,
+            billingAddressRequestSender,
             paymentRequestSender,
         );
     });
@@ -84,6 +89,72 @@ describe('WalletButtonIntegrationService', () => {
             expect(paymentRequestSender.createPaymentOrderIntent).toHaveBeenCalledWith(
                 graphQLEndpoint,
                 inputData,
+                customOptions,
+            );
+            expect(result).toEqual(expectedResponse);
+        });
+    });
+
+    describe('#updateBillingAddress()', () => {
+        const checkoutId = 'checkout-123';
+        const address = {
+            id: 'address-1',
+            firstName: 'John',
+            lastName: 'Doe',
+            company: '',
+            address1: '',
+            address2: '',
+            city: '',
+            email: '',
+            stateOrProvince: '',
+            stateOrProvinceCode: '',
+            countryCode: '',
+            postalCode: '',
+            phone: '',
+        };
+        const expectedResponse = {
+            body: { ...address, entityId: 'entity-1' },
+            status: 200,
+            statusText: 'OK',
+            headers: { 'content-type': 'application/json' },
+        };
+
+        it('delegates to BillingAddressRequestSender with the graphQLEndpoint', async () => {
+            jest.spyOn(billingAddressRequestSender, 'updateBillingAddress').mockResolvedValue(
+                expectedResponse,
+            );
+
+            const result = await walletButtonIntegrationService.updateBillingAddress(
+                checkoutId,
+                address,
+            );
+
+            expect(billingAddressRequestSender.updateBillingAddress).toHaveBeenCalledWith(
+                graphQLEndpoint,
+                checkoutId,
+                address,
+                undefined,
+            );
+            expect(result).toEqual(expectedResponse);
+        });
+
+        it('passes custom options to BillingAddressRequestSender', async () => {
+            const customOptions = { headers: { Authorization: 'Bearer token-abc' } };
+
+            jest.spyOn(billingAddressRequestSender, 'updateBillingAddress').mockResolvedValue(
+                expectedResponse,
+            );
+
+            const result = await walletButtonIntegrationService.updateBillingAddress(
+                checkoutId,
+                address,
+                customOptions,
+            );
+
+            expect(billingAddressRequestSender.updateBillingAddress).toHaveBeenCalledWith(
+                graphQLEndpoint,
+                checkoutId,
+                address,
                 customOptions,
             );
             expect(result).toEqual(expectedResponse);

--- a/packages/wallet-button-integration/src/wallet-button-integration-service.ts
+++ b/packages/wallet-button-integration/src/wallet-button-integration-service.ts
@@ -1,5 +1,11 @@
 import { Response } from '@bigcommerce/request-sender';
 
+import {
+    AddressRequestBody,
+    BillingAddressResponse,
+    BillingAddressUpdateRequestBody,
+} from './billing/billing-address';
+import BillingAddressRequestSender from './billing/billing-address-request-sender';
 import { GraphQLRequestOptions } from './graphql-request-options';
 import {
     CreatePaymentOrderIntentInputData,
@@ -10,8 +16,35 @@ import { PaymentRequestSender } from './payment/payment-request-sender';
 export default class WalletButtonIntegrationService {
     constructor(
         private graphQLEndpoint: string,
+        private billingAddressRequestSender: BillingAddressRequestSender,
         private paymentRequestSender: PaymentRequestSender,
     ) {}
+
+    async addBillingAddress(
+        checkoutId: string,
+        address: AddressRequestBody,
+        options?: GraphQLRequestOptions,
+    ): Promise<Response<BillingAddressResponse>> {
+        return this.billingAddressRequestSender.addBillingAddress(
+            this.graphQLEndpoint,
+            checkoutId,
+            address,
+            options,
+        );
+    }
+
+    async updateBillingAddress(
+        checkoutId: string,
+        address: BillingAddressUpdateRequestBody,
+        options?: GraphQLRequestOptions,
+    ): Promise<Response<BillingAddressResponse>> {
+        return this.billingAddressRequestSender.updateBillingAddress(
+            this.graphQLEndpoint,
+            checkoutId,
+            address,
+            options,
+        );
+    }
 
     async createPaymentOrderIntent(
         inputData: CreatePaymentOrderIntentInputData,


### PR DESCRIPTION
## What/Why?
Adds the billing address layer — request sender, GraphQL mutations, and related types — and wires them into the WalletButtonIntegrationService.
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
CI Passed
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout billing and payment-wallet GraphQL paths and changes WalletButtonIntegrationService construction/API (removed getGraphQLEndpoint); add billing is not yet on the public service surface.
> 
> **Overview**
> Adds **GraphQL-backed billing and payment wallet flows** to `wallet-button-integration`, and wires them through a factory-built `WalletButtonIntegrationService` instead of constructing the service with only an endpoint.
> 
> **Billing:** New `BillingAddressRequestSender` posts add/update checkout billing address mutations (Catalyst proxy headers, response flattened to `BillingAddressResponse`). The integration service exposes **`updateBillingAddress`** only; **`addBillingAddress`** exists on the sender but is not delegated from the service yet.
> 
> **Payment:** New `PaymentRequestSender` creates payment wallet intents (e.g. PayPal Commerce `orderId`, `approvalUrl`, `initializationEntityId`), maps GraphQL errors to `PaymentOrderCreationError`, and maps other failures to `PaymentMethodCancelledError`. **`createPaymentOrderIntent`** is exposed on the service.
> 
> **Composition:** `createWalletButtonIntegrationService` now builds a shared `RequestSender` and injects billing and payment senders. **`getGraphQLEndpoint()`** is removed from the service. **`GraphQLRequestOptions`** is exported. Core registry tests use the factory; wallet-button Jest gets shared setup and coverage tweaks. Broad unit test coverage accompanies the new senders and service delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c25d96d4870e7b4641a9d8000f5e24fb36eb446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->