### PR TITLE
fix(payments): Update stripe vaultings flow

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -685,6 +685,7 @@ describe('StripeOCSPaymentStrategy', () => {
 
             it('should mount currency selector element when adaptivePricingEnabled is true', async () => {
                 mockPaymentMethodWithAdaptivePricing(true);
+
                 const { currencySelectorMountMock } = mockStripeCheckoutWithCurrencySelector();
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
@@ -696,6 +697,7 @@ describe('StripeOCSPaymentStrategy', () => {
 
             it('should not mount currency selector element when adaptivePricingEnabled is false', async () => {
                 mockPaymentMethodWithAdaptivePricing(false);
+
                 const { currencySelectorMountMock } = mockStripeCheckoutWithCurrencySelector();
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
@@ -1681,29 +1683,33 @@ describe('StripeOCSPaymentStrategy', () => {
             });
         });
 
-        describe('savedPaymentMethods from confirmation session', () => {
-            it('uses savedPaymentMethods from confirmation session instead of calling getSession again', async () => {
-                const existingMethods = [{ id: 'pm_existing', type: 'card', billingDetails: {} }];
-                const newMethods = [
-                    ...existingMethods,
-                    {
-                        id: 'pm_new',
-                        type: 'card',
-                        billingDetails: {},
-                        card: { brand: 'visa', last4: '1234', expMonth: 12, expYear: 2030 },
-                    },
-                ];
+        describe('vaulting via selected payment method', () => {
+            const setupStripeCheckoutWithEvent = (
+                eventValue:
+                    | { type: StripePaymentMethodType | string; savePaymentMethod?: boolean }
+                    | undefined,
+            ) => {
+                const elementMock = {
+                    mount: jest.fn(),
+                    unmount: jest.fn(),
+                    on:
+                        eventValue === undefined
+                            ? jest.fn()
+                            : jest.fn((_, callback) =>
+                                  callback({
+                                      ...StripeEventMock,
+                                      collapsed: false,
+                                      value: eventValue,
+                                  }),
+                              ),
+                    update: jest.fn(),
+                    destroy: jest.fn(),
+                    collapse: jest.fn(),
+                };
 
-                const getSessionMock = jest
-                    .fn()
-                    .mockResolvedValueOnce({}) // initial email check
-                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
-                    .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }); // before confirm
-
-                const confirmPaymentMockLocal = jest.fn().mockResolvedValue({
+                const confirmFn = jest.fn().mockResolvedValue({
                     session: {
                         id: 'checkoutSessionId',
-                        savedPaymentMethods: newMethods,
                         status: {
                             paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
                         },
@@ -1713,95 +1719,24 @@ describe('StripeOCSPaymentStrategy', () => {
                 jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
                     Promise.resolve({
                         ...getStripeCheckoutInstanceMock(),
-                        loadActions: () =>
-                            Promise.resolve({
-                                type: StripeLoadActionsResultType.SUCCESS,
-                                actions: {
-                                    ...getStripeCheckoutSessionActionsMock(),
-                                    confirm: confirmPaymentMockLocal,
-                                    getSession: getSessionMock,
-                                },
-                            }),
-                    }),
-                );
-
-                mockFirstPaymentRequest(errorResponse);
-
-                await stripeCSPaymentStrategy.initialize(stripeOptions);
-                await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
-
-                expect(getSessionMock).toHaveBeenCalledTimes(3);
-                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(2, {
-                    methodId,
-                    paymentData: {
-                        formattedPayload: expect.objectContaining({
-                            vault_payment_instrument: true,
-                        }),
-                    },
-                });
-            });
-        });
-
-        describe('vaultings', () => {
-            let confirmPaymentMockLocal: jest.Mock;
-            let getSessionMock: jest.Mock;
-
-            const mockStripeCheckoutWithSession = (
-                getSessionFn: jest.Mock,
-                confirmFn: jest.Mock,
-            ) => {
-                jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
-                    Promise.resolve({
-                        ...getStripeCheckoutInstanceMock(),
+                        createPaymentElement: jest.fn(() => elementMock),
                         loadActions: () =>
                             Promise.resolve({
                                 type: StripeLoadActionsResultType.SUCCESS,
                                 actions: {
                                     ...getStripeCheckoutSessionActionsMock(),
                                     confirm: confirmFn,
-                                    getSession: getSessionFn,
                                 },
                             }),
                     }),
                 );
             };
 
-            it('should save instrument when new saved payment method is added after confirmation', async () => {
-                const existingMethods = [
-                    {
-                        id: 'pm_existing1',
-                        type: 'card',
-                        billingDetails: {},
-                        card: { brand: 'visa', last4: '4242', expMonth: 12, expYear: 2030 },
-                    },
-                ];
-                const newMethods = [
-                    ...existingMethods,
-                    {
-                        id: 'pm_new1',
-                        type: 'card',
-                        billingDetails: {},
-                        card: { brand: 'mastercard', last4: '5555', expMonth: 6, expYear: 2028 },
-                    },
-                ];
-
-                getSessionMock = jest
-                    .fn()
-                    .mockResolvedValueOnce({}) // initial email check
-                    .mockResolvedValueOnce({}) // initial email check (during execute _updateCheckoutSessionData)
-                    .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }) // before confirm
-                    .mockResolvedValueOnce({ savedPaymentMethods: newMethods }); // after confirm
-
-                confirmPaymentMockLocal = jest.fn().mockResolvedValue({
-                    session: {
-                        id: 'checkoutSessionId',
-                        status: {
-                            paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
-                        },
-                    },
+            it('vaults instrument when savePaymentMethod is true on second payment request', async () => {
+                setupStripeCheckoutWithEvent({
+                    type: StripePaymentMethodType.CreditCard,
+                    savePaymentMethod: true,
                 });
-
-                mockStripeCheckoutWithSession(getSessionMock, confirmPaymentMockLocal);
                 mockFirstPaymentRequest(errorResponse);
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
@@ -1817,33 +1752,11 @@ describe('StripeOCSPaymentStrategy', () => {
                 });
             });
 
-            it('should not save instrument when no new saved payment methods are added after confirmation', async () => {
-                const existingMethods = [
-                    {
-                        id: 'pm_existing1',
-                        type: 'card',
-                        billingDetails: {},
-                        card: { brand: 'visa', last4: '4242', expMonth: 12, expYear: 2030 },
-                    },
-                ];
-
-                getSessionMock = jest
-                    .fn()
-                    .mockResolvedValueOnce({}) // initial email check
-                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
-                    .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }) // before confirm
-                    .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }); // after confirm (same methods)
-
-                confirmPaymentMockLocal = jest.fn().mockResolvedValue({
-                    session: {
-                        id: 'checkoutSessionId',
-                        status: {
-                            paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
-                        },
-                    },
+            it('does not vault instrument when savePaymentMethod is false', async () => {
+                setupStripeCheckoutWithEvent({
+                    type: StripePaymentMethodType.CreditCard,
+                    savePaymentMethod: false,
                 });
-
-                mockStripeCheckoutWithSession(getSessionMock, confirmPaymentMockLocal);
                 mockFirstPaymentRequest(errorResponse);
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
@@ -1859,24 +1772,10 @@ describe('StripeOCSPaymentStrategy', () => {
                 });
             });
 
-            it('should not save instrument when savedPaymentMethods is undefined in session', async () => {
-                getSessionMock = jest
-                    .fn()
-                    .mockResolvedValueOnce({}) // initial email check
-                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
-                    .mockResolvedValueOnce({}) // before confirm (no savedPaymentMethods field)
-                    .mockResolvedValueOnce({}); // after confirm (no savedPaymentMethods field)
-
-                confirmPaymentMockLocal = jest.fn().mockResolvedValue({
-                    session: {
-                        id: 'checkoutSessionId',
-                        status: {
-                            paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
-                        },
-                    },
+            it('does not vault instrument when savePaymentMethod is undefined', async () => {
+                setupStripeCheckoutWithEvent({
+                    type: StripePaymentMethodType.CreditCard,
                 });
-
-                mockStripeCheckoutWithSession(getSessionMock, confirmPaymentMockLocal);
                 mockFirstPaymentRequest(errorResponse);
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
@@ -1892,41 +1791,48 @@ describe('StripeOCSPaymentStrategy', () => {
                 });
             });
 
-            it('should use tokenized_ach when new vaulted instrument is ACH type', async () => {
-                const existingMethods = [
-                    {
-                        id: 'pm_existing1',
-                        type: 'card',
-                        billingDetails: {},
-                        card: { brand: 'visa', last4: '4242', expMonth: 12, expYear: 2030 },
-                    },
-                ];
-                const newMethods = [
-                    ...existingMethods,
-                    {
-                        id: 'pm_new_ach',
-                        type: StripePaymentMethodType.ACH,
-                        billingDetails: {},
-                    },
-                ];
+            it('does not vault instrument when no payment method has been selected', async () => {
+                setupStripeCheckoutWithEvent(undefined);
+                mockFirstPaymentRequest(errorResponse);
 
-                getSessionMock = jest
-                    .fn()
-                    .mockResolvedValueOnce({}) // initial email check
-                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
-                    .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }) // before confirm
-                    .mockResolvedValueOnce({ savedPaymentMethods: newMethods }); // after confirm
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+                await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
 
-                confirmPaymentMockLocal = jest.fn().mockResolvedValue({
-                    session: {
-                        id: 'checkoutSessionId',
-                        status: {
-                            paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
-                        },
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(2, {
+                    methodId,
+                    paymentData: {
+                        formattedPayload: expect.objectContaining({
+                            method: undefined,
+                            vault_payment_instrument: false,
+                        }),
                     },
                 });
+            });
 
-                mockStripeCheckoutWithSession(getSessionMock, confirmPaymentMockLocal);
+            it('does not vault instrument on first payment request even when savePaymentMethod is true', async () => {
+                setupStripeCheckoutWithEvent({
+                    type: StripePaymentMethodType.CreditCard,
+                    savePaymentMethod: true,
+                });
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+                await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                    methodId,
+                    paymentData: {
+                        formattedPayload: expect.objectContaining({
+                            vault_payment_instrument: false,
+                        }),
+                    },
+                });
+            });
+
+            it('uses tokenized_ach payload when ACH is selected and savePaymentMethod is true on second payment request', async () => {
+                setupStripeCheckoutWithEvent({
+                    type: StripePaymentMethodType.ACH,
+                    savePaymentMethod: true,
+                });
                 mockFirstPaymentRequest(errorResponse);
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
@@ -1943,42 +1849,32 @@ describe('StripeOCSPaymentStrategy', () => {
                 });
             });
 
-            it('should use credit_card_token when new vaulted instrument is card type', async () => {
-                const existingMethods = [
-                    {
-                        id: 'pm_existing1',
-                        type: 'card',
-                        billingDetails: {},
-                        card: { brand: 'visa', last4: '4242', expMonth: 12, expYear: 2030 },
-                    },
-                ];
-                const newMethods = [
-                    ...existingMethods,
-                    {
-                        id: 'pm_new_card',
-                        type: StripePaymentMethodType.CreditCard,
-                        billingDetails: {},
-                        card: { brand: 'mastercard', last4: '5555', expMonth: 6, expYear: 2028 },
-                    },
-                ];
+            it('uses credit_card_token payload when ACH is selected but savePaymentMethod is false', async () => {
+                setupStripeCheckoutWithEvent({
+                    type: StripePaymentMethodType.ACH,
+                    savePaymentMethod: false,
+                });
+                mockFirstPaymentRequest(errorResponse);
 
-                getSessionMock = jest
-                    .fn()
-                    .mockResolvedValueOnce({}) // initial email check
-                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
-                    .mockResolvedValueOnce({ savedPaymentMethods: existingMethods }) // before confirm
-                    .mockResolvedValueOnce({ savedPaymentMethods: newMethods }); // after confirm
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+                await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
 
-                confirmPaymentMockLocal = jest.fn().mockResolvedValue({
-                    session: {
-                        id: 'checkoutSessionId',
-                        status: {
-                            paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
-                        },
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(2, {
+                    methodId,
+                    paymentData: {
+                        formattedPayload: expect.objectContaining({
+                            credit_card_token: { token: 'checkoutSessionId' },
+                            vault_payment_instrument: false,
+                        }),
                     },
                 });
+            });
 
-                mockStripeCheckoutWithSession(getSessionMock, confirmPaymentMockLocal);
+            it('uses credit_card_token payload when card is selected and savePaymentMethod is true', async () => {
+                setupStripeCheckoutWithEvent({
+                    type: StripePaymentMethodType.CreditCard,
+                    savePaymentMethod: true,
+                });
                 mockFirstPaymentRequest(errorResponse);
 
                 await stripeCSPaymentStrategy.initialize(stripeOptions);
@@ -1990,39 +1886,6 @@ describe('StripeOCSPaymentStrategy', () => {
                         formattedPayload: expect.objectContaining({
                             credit_card_token: { token: 'checkoutSessionId' },
                             vault_payment_instrument: true,
-                        }),
-                    },
-                });
-            });
-
-            it('should not save instrument when Stripe checkout session returns null', async () => {
-                getSessionMock = jest
-                    .fn()
-                    .mockResolvedValueOnce({}) // initial email check
-                    .mockResolvedValueOnce({}) // during execute _updateCheckoutSessionData
-                    .mockResolvedValueOnce({}) // before confirm
-                    .mockResolvedValueOnce({}); // after confirm
-
-                confirmPaymentMockLocal = jest.fn().mockResolvedValue({
-                    session: {
-                        id: 'checkoutSessionId',
-                        status: {
-                            paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
-                        },
-                    },
-                });
-
-                mockStripeCheckoutWithSession(getSessionMock, confirmPaymentMockLocal);
-                mockFirstPaymentRequest(errorResponse);
-
-                await stripeCSPaymentStrategy.initialize(stripeOptions);
-                await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
-
-                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(2, {
-                    methodId,
-                    paymentData: {
-                        formattedPayload: expect.objectContaining({
-                            vault_payment_instrument: false,
                         }),
                     },
                 });

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -22,7 +22,6 @@ import {
     isStripePaymentEvent,
     StripeAdditionalActionRequired,
     StripeCheckoutInstance,
-    StripeCheckoutSession,
     StripeCheckoutSessionActionResult,
     StripeCheckoutSessionActions,
     StripeCheckoutSessionPaymentStatus,
@@ -36,8 +35,8 @@ import {
     StripeIntegrationService,
     StripeJsVersion,
     StripePaymentMethodType,
-    StripeSavedPaymentMethod,
     StripeScriptLoader,
+    StripeSelectedPaymentMethod,
     StripeStringConstants,
 } from '@bigcommerce/checkout-sdk/stripe-utils';
 
@@ -48,7 +47,7 @@ import StripeOCSPaymentInitializeOptions, {
 export default class StripeCSPaymentStrategy implements PaymentStrategy {
     private stripeClient?: StripeClient;
     private stripeCheckout?: StripeCheckoutInstance;
-    private selectedMethodId?: string;
+    private selectedMethod?: StripeSelectedPaymentMethod;
 
     constructor(
         private readonly paymentIntegrationService: PaymentIntegrationService,
@@ -140,7 +139,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         currencySelectorElement?.destroy();
         this.stripeCheckout = undefined;
         this.stripeClient = undefined;
-        this.selectedMethodId = undefined;
+        this.selectedMethod = undefined;
 
         return Promise.resolve();
     }
@@ -271,7 +270,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
             return;
         }
 
-        this.selectedMethodId = event.value.type;
+        this.selectedMethod = event.value;
         paymentMethodSelect?.(`${gatewayId}-${methodId}`);
     }
 
@@ -293,16 +292,17 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
     private _getPaymentPayload(
         methodId: string,
         token: string,
-        newVaultedStripeInstrument?: StripeSavedPaymentMethod,
+        isSecondPaymentRequest = false,
     ): Payment<StripeFormattedPaymentPayload> {
         const cartId = this.paymentIntegrationService.getState().getCart()?.id || '';
-        const tokenizedOptions = this._getTokenizedOptions(token, newVaultedStripeInstrument);
+        const tokenizedOptions = this._getTokenizedOptions(token, isSecondPaymentRequest);
 
         const formattedPayload = {
             cart_id: cartId,
             confirm: false,
-            method: this.selectedMethodId,
-            vault_payment_instrument: !!newVaultedStripeInstrument,
+            method: this.selectedMethod?.type,
+            vault_payment_instrument:
+                isSecondPaymentRequest && !!this.selectedMethod?.savePaymentMethod,
             ...tokenizedOptions,
         };
 
@@ -328,23 +328,11 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
         const { data: additionalActionData } = error.body?.additional_action_required || {};
         const { token } = additionalActionData || {};
-        const existingStripeSavedPaymentMethods = await this._getStripeSavedPaymentMethodsOrThrow();
         const { session: stripeCheckoutSession, error: stripeError } =
             await this._confirmStripePayment(additionalActionData);
-        const newStripeSavedPaymentMethods = await this._getStripeSavedPaymentMethodsOrThrow(
-            stripeCheckoutSession,
-        );
         const { id: checkoutSessionId, status: checkoutSessionStatus } =
             stripeCheckoutSession || {};
-        const newVaultedStripeInstrument = this._getNewVaultedStripeInstrument(
-            existingStripeSavedPaymentMethods,
-            newStripeSavedPaymentMethods,
-        );
-        const paymentPayload = this._getPaymentPayload(
-            methodId,
-            checkoutSessionId || token,
-            newVaultedStripeInstrument,
-        );
+        const paymentPayload = this._getPaymentPayload(methodId, checkoutSessionId || token, true);
         const { initializationData } = this.paymentIntegrationService
             .getState()
             .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
@@ -452,36 +440,14 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         });
     }
 
-    private async _getStripeSavedPaymentMethodsOrThrow(
-        stripeCheckoutSession?: StripeCheckoutSession,
-    ): Promise<StripeSavedPaymentMethod[]> {
-        if (stripeCheckoutSession?.savedPaymentMethods) {
-            return stripeCheckoutSession.savedPaymentMethods;
-        }
+    private _getTokenizedOptions(token: string, shouldTriggerVaultingFlow: boolean) {
+        const { type, savePaymentMethod } = this.selectedMethod || {};
 
-        const stripeActions = await this._getStripeActionsOrThrow();
-        const { savedPaymentMethods } = await stripeActions.getSession();
-
-        return savedPaymentMethods || [];
-    }
-
-    private _getNewVaultedStripeInstrument(
-        existingStripeSavedPaymentMethods: StripeSavedPaymentMethod[],
-        newStripeSavedPaymentMethods: StripeSavedPaymentMethod[],
-    ): StripeSavedPaymentMethod | undefined {
-        return newStripeSavedPaymentMethods.find(
-            (method: StripeSavedPaymentMethod) =>
-                !existingStripeSavedPaymentMethods.some(
-                    (existingMethod: StripeSavedPaymentMethod) => existingMethod.id === method.id,
-                ),
-        );
-    }
-
-    private _getTokenizedOptions(
-        token: string,
-        newVaultedStripeInstrument?: StripeSavedPaymentMethod,
-    ) {
-        if (newVaultedStripeInstrument?.type === StripePaymentMethodType.ACH) {
+        if (
+            shouldTriggerVaultingFlow &&
+            savePaymentMethod &&
+            type === StripePaymentMethodType.ACH
+        ) {
             return { tokenized_ach: { token } };
         }
 

--- a/packages/stripe-utils/src/index.ts
+++ b/packages/stripe-utils/src/index.ts
@@ -39,7 +39,9 @@ export {
     StripeCheckoutSessionActions,
     StripeCheckoutSessionConfirmationError,
     StripeCheckoutSessionPaymentStatus,
+    StripeSelectedPaymentMethod,
     StripeSavedPaymentMethod,
+    StripePaymentEvent,
 } from './stripe';
 export {
     getStripeJsMock,

--- a/packages/stripe-utils/src/stripe.ts
+++ b/packages/stripe-utils/src/stripe.ts
@@ -228,10 +228,13 @@ export interface StripeShippingEvent extends StripeEvent {
 }
 
 export interface StripePaymentEvent extends StripeEvent {
-    value: {
-        type: StripePaymentMethodType;
-    };
+    value: StripeSelectedPaymentMethod;
     collapsed?: boolean;
+}
+
+export interface StripeSelectedPaymentMethod {
+    type: StripePaymentMethodType;
+    savePaymentMethod?: boolean;
 }
 
 export interface StripeCurrencyEvent extends StripeEvent {
@@ -577,7 +580,7 @@ export interface StripeCheckoutSessionActions {
 
 export interface StripeSavedPaymentMethod {
     id: string;
-    type: string;
+    type: StripePaymentMethodType;
     billingDetails: BillingDetailsOptions;
     card?: StripeCardDetails;
     usBankAccount?: StripeUsBankAccountDetails;


### PR DESCRIPTION
## What/Why?
Refactor the Stripe Checkout-Session (stripe-cs) payment strategy to decide whether to vault the shopper's payment instrument based on the `savePaymentMethod` flag emitted by the Stripe Payment Element change event, instead of diffing Stripe's saved payment methods before and after confirmation.

###Before:
On the second payment request (after the additional-action flow), the strategy called getSession() twice — once before confirm and once after — then compared the `savedPaymentMethods` arrays to detect a newly added instrument. If a new method was present, it sent `vault_payment_instrument: true` to the backend. This was unreliable for cards requiring 3DS: Stripe has a delay before the newly saved card is reflected in the session's savedPaymentMethods array after 3DS confirmation, so legitimate vaultings on 3DS cards could be missed. 

###After:
Stripe's Payment Element change event now exposes `value.savePaymentMethod`, indicating whether the shopper opted in to saving the instrument. The strategy stores the full event value as `selectedMethod` and uses `selectedMethod.savePaymentMethod` to drive the `vault_payment_instrument` flag on the second payment request. No more session diffing or extra `getSession()` calls.

## Rollout/Rollback
Rollback this PR

## Testing

### Guest shopper

https://github.com/user-attachments/assets/d9b1b0fe-3f9e-4fad-8aa4-58605990eb8a


https://github.com/user-attachments/assets/2e483cd7-8ce9-47f6-a73a-3f9f085b4e6d


### Registered shopper

#### With vaulting

https://github.com/user-attachments/assets/76007a48-1eeb-4c9a-9219-96d448a36929


https://github.com/user-attachments/assets/1f92685b-75b8-40aa-a1e7-6b23f423c715


https://github.com/user-attachments/assets/0bc8264b-62a5-4a8f-856f-c9b834ac45b1


#### Without vaultings, payments only

https://github.com/user-attachments/assets/5f328381-e9e7-4a00-994f-a05a359a8a20


https://github.com/user-attachments/assets/617c402a-a110-433f-970f-4e5a10e42d23

<img width="724" height="74" alt="Screenshot 2026-05-28 at 14 20 28" src="https://github.com/user-attachments/assets/4fb33d02-dde4-4c78-aed7-ab8d02e87cec" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when saved instruments are sent to the backend after 3DS/additional-action flows; behavior is more correct for opt-in vaulting but differs from the previous session-diff heuristic.
> 
> **Overview**
> Stripe Checkout Session vaulting no longer infers “save card” by diffing `savedPaymentMethods` before and after `confirm` (and extra `getSession()` calls). The Payment Element **change** event’s `savePaymentMethod` is stored on `selectedMethod`, and the **second** `submitPayment` after additional action sets `vault_payment_instrument` from that flag only.
> 
> `stripe-utils` adds `StripeSelectedPaymentMethod` (`type`, optional `savePaymentMethod`) on `StripePaymentEvent`. Token shape on the retry still uses `tokenized_ach` when vaulting ACH with save enabled; otherwise `credit_card_token`. Specs drop session-diff cases and cover save on/off, missing selection, and first vs second payment request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4455852010486b7d97fc36adfa8d5d7f47cbcda5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->