### PR TITLE
feat(payment): PI-5297 Adyen Sending Extra Payment Details within "paymentData"

### DIFF
--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -115,7 +115,6 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
                 'es-PE': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
             },
         });
-
         this.paymentComponent = await this._mountPaymentComponent(paymentMethod);
 
         if (
@@ -145,11 +144,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
 
         this._validateCardData();
 
-        if (
-            payment.methodId === 'klarna' ||
-            payment.methodId === 'klarna_account' ||
-            payment.methodId === 'klarna_paynow'
-        ) {
+        if (this._isKlarnaPaymentMethod(payment.methodId)) {
             this.paymentComponent?.submit();
         }
 
@@ -208,11 +203,16 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             }
         }
 
-        let paymentToken = JSON.stringify({
+        const tokenPayload = {
             ...componentState.data.paymentMethod,
             type: payment.methodId,
             origin: window.location.origin,
-        });
+        };
+        let paymentToken = JSON.stringify(
+            this._isKlarnaPaymentMethod(payment.methodId)
+                ? this._removeEmptyDetails(tokenPayload)
+                : tokenPayload,
+        );
 
         if (payment.methodId === 'boletobancario' && isBoletoState(componentState)) {
             paymentToken = JSON.stringify({
@@ -324,10 +324,16 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
                     }
                 },
                 onAdditionalDetails: (additionalActionState: AdyenAdditionalActionState) => {
+                    const additionalActionData = this._isKlarnaPaymentMethod(
+                        adyenAction.paymentMethodType,
+                    )
+                        ? this._removeEmptyDetails(additionalActionState.data)
+                        : additionalActionState.data;
+
                     const paymentPayload = {
                         methodId: adyenAction.paymentMethodType,
                         paymentData: {
-                            nonce: JSON.stringify(additionalActionState.data),
+                            nonce: JSON.stringify(additionalActionData),
                         },
                     };
 
@@ -469,6 +475,18 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
 
     private _isOneyPaymentMethod(method: string): boolean {
         return method.startsWith('facilypay');
+    }
+
+    private _isKlarnaPaymentMethod(methodId?: string): boolean {
+        return (
+            methodId === 'klarna' || methodId === 'klarna_account' || methodId === 'klarna_paynow'
+        );
+    }
+
+    private _removeEmptyDetails(payload: object) {
+        const { details, ...rest } = payload as Record<string, unknown>;
+
+        return details && Object.keys(details).length ? payload : rest;
     }
 
     private async _processAdditionalAction(


### PR DESCRIPTION
## What/Why?

Merchant has reached out to report that in Adyen Klarna, the payment will show as authorized but in BigCommerce the order is showing as declined/incomplete.
Additional context: “Adyen responded with error for Authorization requests - Gateway authorize response message = Structure of CardDetails contains the following unknown fields: [paymentData, details] and code = 702, thus we considered it as not successful and the order was declined.
In fact, Authorization did happen and later we received authorization success webhook, but we don't have restore mechanism for declined orders. The issue is that we occasionally send extra `details` data within paymentData, which Adyen rejects to proceed.

The solution: don't send `details` if it's an empty object.


## Rollout/Rollback

Revert this PR

## Testing

TBA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Klarna authorization and additional-action payment submission; scope is limited to three method IDs and only removes empty `details`, but incorrect stripping could break Klarna when `details` is required.
> 
> **Overview**
> Fixes **Adyen Klarna** checkouts where authorization succeeds at Adyen but BigCommerce marks the order declined because the gateway rejects payloads that include an empty **`details`** object inside **`paymentData`**.
> 
> The v3 strategy now centralizes Klarna detection via **`_isKlarnaPaymentMethod`** and strips **`details`** with **`_removeEmptyDetails`** when it is missing or has no keys. That sanitization runs on the initial **`credit_card_token`** payload and on **`onAdditionalDetails`** nonces during extra actions, while non-Klarna flows are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3a444d9295bf4925918503a48b25fdfa492375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->