### PR TITLE
fix(payments): reinitialize expired Stipe checkout session

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -1294,7 +1294,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 ).rejects.toBe(sessionExpiredErrorResponse);
 
                 // Background reinit is fire-and-forget — flush microtasks before asserting.
-                await new Promise((resolve) => setImmediate(resolve));
+                await new Promise((resolve) => setTimeout(resolve, 0));
 
                 expect(deinitializeSpy).toHaveBeenCalledTimes(1);
                 expect(initializeSpy).toHaveBeenCalledTimes(1);
@@ -1313,7 +1313,7 @@ describe('StripeOCSPaymentStrategy', () => {
                     stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
                 ).rejects.toBe(sessionExpiredErrorResponse);
 
-                await new Promise((resolve) => setImmediate(resolve));
+                await new Promise((resolve) => setTimeout(resolve, 0));
 
                 expect(initializeSpy).toHaveBeenCalledWith({
                     gatewayId,
@@ -1338,7 +1338,7 @@ describe('StripeOCSPaymentStrategy', () => {
                     stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
                 ).rejects.toThrow('not a request error');
 
-                await new Promise((resolve) => setImmediate(resolve));
+                await new Promise((resolve) => setTimeout(resolve, 0));
 
                 expect(deinitializeSpy).not.toHaveBeenCalled();
                 expect(initializeSpy).not.toHaveBeenCalled();

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -1249,6 +1249,102 @@ describe('StripeOCSPaymentStrategy', () => {
             ).rejects.toThrow(Error);
         });
 
+        describe('session expired error', () => {
+            let sessionExpiredErrorResponse: RequestError;
+            let initializeSpy: jest.SpyInstance;
+            let deinitializeSpy: jest.SpyInstance;
+
+            beforeEach(() => {
+                sessionExpiredErrorResponse = new RequestError(
+                    getResponse({
+                        ...getErrorPaymentResponseBody(),
+                        errors: [{ code: 'authorization_expired' }],
+                        status: 'error',
+                    }),
+                );
+
+                jest.spyOn(stripeIntegrationService, 'isAdditionalActionError').mockReturnValue(
+                    false,
+                );
+                jest.spyOn(stripeIntegrationService, 'isSessionExpiredError').mockReturnValue(true);
+
+                initializeSpy = jest.spyOn(stripeCSPaymentStrategy, 'initialize');
+                deinitializeSpy = jest.spyOn(stripeCSPaymentStrategy, 'deinitialize');
+            });
+
+            it('rethrows the original error when session is expired', async () => {
+                mockFirstPaymentRequest(sessionExpiredErrorResponse);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).rejects.toBe(sessionExpiredErrorResponse);
+            });
+
+            it('triggers a background reinitialization (deinitialize then initialize) on session expiry', async () => {
+                mockFirstPaymentRequest(sessionExpiredErrorResponse);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+                initializeSpy.mockClear();
+                deinitializeSpy.mockClear();
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).rejects.toBe(sessionExpiredErrorResponse);
+
+                // Background reinit is fire-and-forget — flush microtasks before asserting.
+                await new Promise((resolve) => setImmediate(resolve));
+
+                expect(deinitializeSpy).toHaveBeenCalledTimes(1);
+                expect(initializeSpy).toHaveBeenCalledTimes(1);
+                expect(deinitializeSpy.mock.invocationCallOrder[0]).toBeLessThan(
+                    initializeSpy.mock.invocationCallOrder[0],
+                );
+            });
+
+            it('passes the cached stripe options (cloned) and current gateway/method ids on reinitialization', async () => {
+                mockFirstPaymentRequest(sessionExpiredErrorResponse);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+                initializeSpy.mockClear();
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).rejects.toBe(sessionExpiredErrorResponse);
+
+                await new Promise((resolve) => setImmediate(resolve));
+
+                expect(initializeSpy).toHaveBeenCalledWith({
+                    gatewayId,
+                    methodId,
+                    stripeocs: stripeOptions.stripeocs,
+                });
+
+                // Verify the stripeocs is cloned, not the same reference as what was captured during initial init.
+                const reinitArgs = initializeSpy.mock.calls[0][0];
+
+                expect(reinitArgs.stripeocs).not.toBe(stripeOptions.stripeocs);
+            });
+
+            it('does not invoke session-expired branch when error is not a RequestError', async () => {
+                mockFirstPaymentRequest(new Error('not a request error'));
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+                initializeSpy.mockClear();
+                deinitializeSpy.mockClear();
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).rejects.toThrow('not a request error');
+
+                await new Promise((resolve) => setImmediate(resolve));
+
+                expect(deinitializeSpy).not.toHaveBeenCalled();
+                expect(initializeSpy).not.toHaveBeenCalled();
+            });
+        });
+
         it('throws not initialized error', async () => {
             jest.spyOn(paymentIntegrationService, 'submitPayment').mockImplementationOnce(() => {
                 stripeCSPaymentStrategy.deinitialize();

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import { cloneDeep, merge } from 'lodash';
 
 import {
     InvalidArgumentError,
@@ -48,6 +48,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
     private stripeClient?: StripeClient;
     private stripeCheckout?: StripeCheckoutInstance;
     private selectedMethod?: StripeSelectedPaymentMethod;
+    private stripeInitializationOptions?: StripeOCSPaymentInitializeOptions;
 
     constructor(
         private readonly paymentIntegrationService: PaymentIntegrationService,
@@ -77,6 +78,8 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
                 .getState()
                 .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
         }
+
+        this.stripeInitializationOptions = stripeocs;
 
         try {
             await this._initStripeCheckoutSession(stripeocs, paymentMethod);
@@ -140,6 +143,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         this.stripeCheckout = undefined;
         this.stripeClient = undefined;
         this.selectedMethod = undefined;
+        this.stripeInitializationOptions = undefined;
 
         return Promise.resolve();
     }
@@ -319,10 +323,18 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         gatewayId: string,
         methodId: string,
     ): Promise<PaymentIntegrationSelectors | undefined> {
-        if (
-            !isRequestError(error) ||
-            !this.stripeIntegrationService.isAdditionalActionError(error.body.errors)
-        ) {
+        if (!isRequestError(error)) {
+            throw error;
+        } else if (this.stripeIntegrationService.isSessionExpiredError(error.body.errors)) {
+            // INFO: await is skipped here to not block error propagation and update checkout session in the background
+            this._reinitializeStrategy({
+                gatewayId,
+                methodId,
+                stripeocs: cloneDeep(this.stripeInitializationOptions),
+            });
+
+            throw error;
+        } else if (!this.stripeIntegrationService.isAdditionalActionError(error.body.errors)) {
             throw error;
         }
 
@@ -502,5 +514,12 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
                 customerCurrency: stripeCurrencyCode,
             });
         });
+    }
+
+    private async _reinitializeStrategy(
+        options: PaymentInitializeOptions & WithStripeOCSPaymentInitializeOptions,
+    ): Promise<void> {
+        await this.deinitialize();
+        await this.initialize(options);
     }
 }

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
@@ -109,7 +109,15 @@ describe('StripeLinkV2ButtonStrategy', () => {
         element = {
             mount: jest.fn(),
             on: jest.fn((eventName, callback) => {
-                stripeEventEmitter.on(eventName, callback);
+                stripeEventEmitter.on(eventName, (event: unknown) => {
+                    const result = callback(event);
+
+                    if (result && typeof (result as Promise<unknown>).catch === 'function') {
+                        (result as Promise<unknown>).catch(() => undefined);
+                    }
+
+                    return result;
+                });
             }),
         } as any;
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
@@ -109,7 +109,15 @@ describe('StripeLinkV2CustomerStrategy', () => {
         element = {
             mount: jest.fn(),
             on: jest.fn((eventName, callback) => {
-                stripeEventEmitter.on(eventName, callback);
+                stripeEventEmitter.on(eventName, (event: unknown) => {
+                    const result = callback(event);
+
+                    if (result && typeof (result as Promise<unknown>).catch === 'function') {
+                        (result as Promise<unknown>).catch(() => undefined);
+                    }
+
+                    return result;
+                });
             }),
         } as any;
 

--- a/packages/stripe-utils/src/stripe-integration-service.mock.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.mock.ts
@@ -37,6 +37,7 @@ export const getStripeIntegrationServiceMock = () =>
             },
         })),
         isAdditionalActionError: jest.fn(() => false),
+        isSessionExpiredError: jest.fn(() => false),
         isRedirectAction: jest.fn(() => false),
         isOnPageAdditionalAction: jest.fn(() => false),
         updateStripePaymentIntent: jest.fn(() => Promise.resolve()),

--- a/packages/stripe-utils/src/stripe-integration-service.spec.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.spec.ts
@@ -707,6 +707,35 @@ describe('StripeIntegrationService', () => {
         });
     });
 
+    describe('#isSessionExpiredError', () => {
+        it('should return true if any error has the authorization_expired code', () => {
+            expect(
+                stripeIntegrationService.isSessionExpiredError([{ code: 'authorization_expired' }]),
+            ).toBe(true);
+        });
+
+        it('should return true when authorization_expired is mixed with other codes', () => {
+            expect(
+                stripeIntegrationService.isSessionExpiredError([
+                    { code: 'something_else' },
+                    { code: 'authorization_expired' },
+                ]),
+            ).toBe(true);
+        });
+
+        it('should return false when no error matches the authorization_expired code', () => {
+            expect(
+                stripeIntegrationService.isSessionExpiredError([
+                    { code: 'additional_action_required' },
+                ]),
+            ).toBe(false);
+        });
+
+        it('should return false for an empty errors array', () => {
+            expect(stripeIntegrationService.isSessionExpiredError([])).toBe(false);
+        });
+    });
+
     describe('#isRedirectAction', () => {
         it('should return true if additional action is redirect action', () => {
             expect(

--- a/packages/stripe-utils/src/stripe-integration-service.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.ts
@@ -203,6 +203,10 @@ export default class StripeIntegrationService {
         return some(errors, { code: 'additional_action_required' });
     }
 
+    isSessionExpiredError(errors: Array<{ code: string }>): boolean {
+        return some(errors, { code: 'authorization_expired' });
+    }
+
     isRedirectAction(additionalAction: StripeAdditionalActionRequired): boolean {
         const {
             type,


### PR DESCRIPTION
## What/Why?
When the Stripe Checkout (OCS) session expires, the backend rejects submitPayment with an authorization_expired error code. Previously this bubbled up as a generic payment failure and the strategy stayed bound to the now-dead session, so every subsequent attempt failed the same way until the shopper reloaded the page.

This change detects the expired-session error and silently re-initializes the strategy in the background while still surfacing the original error to the caller, so the next payment attempt uses a fresh Stripe Checkout session.

## Rollout/Rollback
Rollback this PR

## Testing
Before:

https://github.com/user-attachments/assets/b7fb80c3-d641-41da-9f63-e8fb7c07935a

After:

https://github.com/user-attachments/assets/315cedb0-d775-4192-82f2-a03254e086e3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment error handling and async re-init on the Stripe CS path; behavior is scoped to `authorization_expired` but incorrect reinit could affect subsequent payment attempts without a page reload.
> 
> **Overview**
> When Stripe Checkout (OCS) returns **`authorization_expired`** on `submitPayment`, the CS payment strategy now treats it as an expired session instead of a dead-end failure.
> 
> **`StripeIntegrationService`** gains **`isSessionExpiredError`** (matches `authorization_expired`). **`StripeCSPaymentStrategy`** stores **`stripeocs`** init options on initialize and clears them on deinitialize. In **`_processAdditionalAction`**, that error triggers a **fire-and-forget** **`deinitialize` → `initialize`** with **cloned** cached options and the current gateway/method ids, while **still rethrowing** the original error so the shopper sees the failure but the **next** attempt can use a fresh session.
> 
> Specs cover rethrow, background reinit order, cloned options, and non-`RequestError` paths. Link v2 button/customer specs adjust the Stripe element **`on`** mock so async handler rejections are swallowed (test stability).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f4cc588b65128fbf2a17cb75ffcbbbfb34f919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->