### PR TITLE
feat(payment): PAYPAL-6472 add wallet button redirect to checkout

### DIFF
--- a/packages/wallet-button-integration/src/billing/billing-address-request-sender.spec.ts
+++ b/packages/wallet-button-integration/src/billing/billing-address-request-sender.spec.ts
@@ -36,8 +36,14 @@ describe('BillingAddressRequestSender', () => {
         id: 'address-1',
     };
 
+    const {
+        id: _ignoredAddressId,
+        shouldSaveAddress: _ignoredShouldSaveAddress,
+        ...billingAddressResponseFields
+    } = updateBillingAddressRequestBody;
+
     const billingAddressResponse: BillingAddressResponse = {
-        ...updateBillingAddressRequestBody,
+        ...billingAddressResponseFields,
         entityId: 'entity-1',
     };
 

--- a/packages/wallet-button-integration/src/billing/billing-address.ts
+++ b/packages/wallet-button-integration/src/billing/billing-address.ts
@@ -1,3 +1,5 @@
+import { Omit } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 export interface AddressRequestBody {
     firstName: string;
     lastName: string;
@@ -14,7 +16,7 @@ export interface AddressRequestBody {
     shouldSaveAddress: boolean;
 }
 
-export interface BillingAddressResponse extends AddressRequestBody {
+export interface BillingAddressResponse extends Omit<AddressRequestBody, 'shouldSaveAddress'> {
     entityId: string;
 }
 

--- a/packages/wallet-button-integration/src/checkout/checkout-redirect-error.spec.ts
+++ b/packages/wallet-button-integration/src/checkout/checkout-redirect-error.spec.ts
@@ -1,0 +1,22 @@
+import CheckoutRedirectError from './checkout-redirect-error';
+
+describe('CheckoutRedirectError', () => {
+    it('creates an error with default message when no message is provided', () => {
+        const error = new CheckoutRedirectError();
+
+        expect(error.message).toBe(
+            'An unexpected error has occurred during checkout redirection process. Please try again later.',
+        );
+        expect(error.name).toBe('CheckoutRedirectError');
+        expect(error.type).toBe('checkout_redirect_error');
+    });
+
+    it('creates an error with a custom message', () => {
+        const customMessage = 'Cart not found';
+        const error = new CheckoutRedirectError(customMessage);
+
+        expect(error.message).toBe(customMessage);
+        expect(error.name).toBe('CheckoutRedirectError');
+        expect(error.type).toBe('checkout_redirect_error');
+    });
+});

--- a/packages/wallet-button-integration/src/checkout/checkout-redirect-error.ts
+++ b/packages/wallet-button-integration/src/checkout/checkout-redirect-error.ts
@@ -1,0 +1,13 @@
+import { StandardError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default class CheckoutRedirectError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message ||
+                'An unexpected error has occurred during checkout redirection process. Please try again later.',
+        );
+
+        this.name = 'CheckoutRedirectError';
+        this.type = 'checkout_redirect_error';
+    }
+}

--- a/packages/wallet-button-integration/src/checkout/checkout-request-sender.spec.ts
+++ b/packages/wallet-button-integration/src/checkout/checkout-request-sender.spec.ts
@@ -1,0 +1,221 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { CreateRedirectToCheckoutResponse, RedirectToCheckoutUrlInputData } from './checkout';
+import CheckoutRedirectError from './checkout-redirect-error';
+import { CheckoutRequestSender } from './checkout-request-sender';
+
+describe('CheckoutRequestSender', () => {
+    let requestSender: RequestSender;
+    let checkoutRequestSender: CheckoutRequestSender;
+
+    const graphQLEndpoint = 'graphql';
+
+    const inputData: RedirectToCheckoutUrlInputData = {
+        paymentWalletData: {
+            providerId: 'paypalcommerce',
+            providerOrderId: 'order-id-123',
+        },
+        cartEntityId: 'cart-entity-id-123',
+        queryParams: [{ key: 'foo', value: 'bar' }],
+    };
+
+    const successResponseBody: CreateRedirectToCheckoutResponse = {
+        data: {
+            cart: {
+                createCartRedirectUrls: {
+                    errors: [],
+                    redirectUrls: {
+                        externalCheckoutUrl: 'https://store.example.com/checkout',
+                    },
+                },
+            },
+        },
+    };
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+        checkoutRequestSender = new CheckoutRequestSender(requestSender);
+    });
+
+    describe('#getRedirectToCheckoutUrl()', () => {
+        it('sends a POST request to the correct endpoint', async () => {
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: successResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            await checkoutRequestSender.getRedirectToCheckoutUrl(graphQLEndpoint, inputData);
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                `${window.location.origin}/${graphQLEndpoint}`,
+                expect.objectContaining({
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+                    },
+                }),
+            );
+        });
+
+        it('includes the correct variables in the request body', async () => {
+            const postSpy = jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: successResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            await checkoutRequestSender.getRedirectToCheckoutUrl(graphQLEndpoint, inputData);
+
+            expect(postSpy.mock.calls[0][1]).toMatchObject({
+                body: { variables: { input: inputData } },
+            });
+        });
+
+        it('returns transformed response body with redirectUrls', async () => {
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: successResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            const response = await checkoutRequestSender.getRedirectToCheckoutUrl(
+                graphQLEndpoint,
+                inputData,
+            );
+
+            expect(response.body).toEqual({
+                redirectUrls: { externalCheckoutUrl: 'https://store.example.com/checkout' },
+            });
+        });
+
+        it('returns null redirectUrls when createCartRedirectUrls has no redirectUrls', async () => {
+            const nullRedirectResponse: CreateRedirectToCheckoutResponse = {
+                data: {
+                    cart: {
+                        createCartRedirectUrls: {
+                            errors: [],
+                            redirectUrls: null,
+                        },
+                    },
+                },
+            };
+
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: nullRedirectResponse,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            const response = await checkoutRequestSender.getRedirectToCheckoutUrl(
+                graphQLEndpoint,
+                inputData,
+            );
+
+            expect(response.body).toEqual({ redirectUrls: null });
+        });
+
+        it('merges custom headers with the required headers', async () => {
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: successResponseBody,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            const customOptions = { headers: { Authorization: 'Bearer token-123' } };
+
+            await checkoutRequestSender.getRedirectToCheckoutUrl(
+                graphQLEndpoint,
+                inputData,
+                customOptions,
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                `${window.location.origin}/${graphQLEndpoint}`,
+                expect.objectContaining({
+                    headers: {
+                        Authorization: 'Bearer token-123',
+                        'Content-Type': 'application/json',
+                        'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+                    },
+                }),
+            );
+        });
+
+        it('rethrows the original error when request fails with an Error instance', async () => {
+            const networkError = new Error('Network error');
+
+            jest.spyOn(requestSender, 'post').mockRejectedValue(networkError);
+
+            await expect(
+                checkoutRequestSender.getRedirectToCheckoutUrl(graphQLEndpoint, inputData),
+            ).rejects.toThrow('Network error');
+        });
+
+        it('throws a generic error when request fails with a non-Error value', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue('unexpected failure');
+
+            await expect(
+                checkoutRequestSender.getRedirectToCheckoutUrl(graphQLEndpoint, inputData),
+            ).rejects.toThrow('Checkout redirection failed');
+        });
+
+        it('throws CheckoutRedirectError when GraphQL mutation returns a message error', async () => {
+            const responseWithMessageError: CreateRedirectToCheckoutResponse = {
+                data: {
+                    cart: {
+                        createCartRedirectUrls: {
+                            errors: [
+                                {
+                                    __typename: 'CreateCartRedirectUrlsError',
+                                    message: 'Cart not found',
+                                },
+                            ],
+                            redirectUrls: null,
+                        },
+                    },
+                },
+            };
+
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: responseWithMessageError,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            await expect(
+                checkoutRequestSender.getRedirectToCheckoutUrl(graphQLEndpoint, inputData),
+            ).rejects.toEqual(expect.any(CheckoutRedirectError));
+        });
+
+        it('throws default CheckoutRedirectError when GraphQL mutation returns a typeless error message', async () => {
+            const responseWithTypenameOnlyError: CreateRedirectToCheckoutResponse = {
+                data: {
+                    cart: {
+                        createCartRedirectUrls: {
+                            errors: [{ __typename: 'NotFoundError' }],
+                            redirectUrls: null,
+                        },
+                    },
+                },
+            };
+
+            jest.spyOn(requestSender, 'post').mockResolvedValue({
+                body: responseWithTypenameOnlyError,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            });
+
+            await expect(
+                checkoutRequestSender.getRedirectToCheckoutUrl(graphQLEndpoint, inputData),
+            ).rejects.toEqual(expect.any(CheckoutRedirectError));
+        });
+    });
+});

--- a/packages/wallet-button-integration/src/checkout/checkout-request-sender.ts
+++ b/packages/wallet-button-integration/src/checkout/checkout-request-sender.ts
@@ -1,0 +1,91 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { GraphQLRequestOptions } from '../graphql-request-options';
+
+import {
+    CreateRedirectToCheckoutResponse,
+    CreateRedirectToCheckoutResponseBody,
+    RedirectToCheckoutUrlInputData,
+} from './checkout';
+import CheckoutRedirectError from './checkout-redirect-error';
+
+export class CheckoutRequestSender {
+    constructor(private readonly requestSender: RequestSender) {}
+
+    async getRedirectToCheckoutUrl(
+        graphQLEndpoint: string,
+        inputData: RedirectToCheckoutUrlInputData,
+        options?: GraphQLRequestOptions,
+    ): Promise<Response<CreateRedirectToCheckoutResponseBody>> {
+        const document = `
+            mutation CheckoutRedirectMutation($input: CreateCartRedirectUrlsInput!) {
+                cart {
+                    createCartRedirectUrls(input: $input) {
+                        errors {
+                         __typename
+                        ... on NotFoundError {
+                                message  
+                            }
+                        ... on CreateRedirectUrlsCurrencyNotAllowed {
+                                message
+                            }
+                        }
+                        redirectUrls {
+                            externalCheckoutUrl
+                        }
+                    }
+                }
+            }
+        `;
+
+        const requestOptions: GraphQLRequestOptions = {
+            headers: {
+                ...options?.headers,
+                'Content-Type': 'application/json',
+                'x-catalyst-graphql-proxy-requester': 'checkout-sdk-js',
+            },
+            body: {
+                query: document,
+                variables: {
+                    input: inputData,
+                },
+            },
+        };
+
+        try {
+            const response = await this.requestSender.post<CreateRedirectToCheckoutResponse>(
+                `${window.location.origin}/${graphQLEndpoint}`,
+                requestOptions,
+            );
+
+            const {
+                data: {
+                    cart: { createCartRedirectUrls },
+                },
+            } = response.body;
+
+            const errorMessage = createCartRedirectUrls.errors[0]?.message;
+
+            if (errorMessage) {
+                throw new CheckoutRedirectError(errorMessage);
+            }
+
+            if (createCartRedirectUrls.errors.length > 0) {
+                throw new CheckoutRedirectError();
+            }
+
+            return {
+                ...response,
+                body: {
+                    redirectUrls: createCartRedirectUrls.redirectUrls,
+                },
+            };
+        } catch (error) {
+            if (error instanceof Error) {
+                throw error;
+            }
+
+            throw new Error('Checkout redirection failed');
+        }
+    }
+}

--- a/packages/wallet-button-integration/src/checkout/checkout.ts
+++ b/packages/wallet-button-integration/src/checkout/checkout.ts
@@ -1,0 +1,45 @@
+/**
+ *
+ * Create Redirect To Checkout Interfaces
+ *
+ */
+
+export interface RedirectUrls {
+    externalCheckoutUrl: string;
+}
+
+export interface CreateRedirectToCheckoutResponse {
+    data: {
+        cart: {
+            createCartRedirectUrls: CreateRedirectToCheckoutMutationResult;
+        };
+    };
+}
+
+export interface CreateRedirectToCheckoutMutationResult {
+    errors: CreateRedirectToCheckoutError[];
+    redirectUrls: RedirectUrls | null;
+}
+
+export interface CreateRedirectToCheckoutError {
+    __typename: string;
+    message?: string;
+}
+
+export interface CreateRedirectToCheckoutResponseBody {
+    redirectUrls: RedirectUrls | null;
+}
+
+export interface QueryParams {
+    key: string;
+    value: string;
+}
+
+export interface RedirectToCheckoutUrlInputData {
+    paymentWalletData: {
+        providerId: string;
+        providerOrderId: string;
+    };
+    cartEntityId: string;
+    queryParams: QueryParams[];
+}

--- a/packages/wallet-button-integration/src/create-wallet-button-integration-service.ts
+++ b/packages/wallet-button-integration/src/create-wallet-button-integration-service.ts
@@ -1,6 +1,7 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 
 import BillingAddressRequestSender from './billing/billing-address-request-sender';
+import { CheckoutRequestSender } from './checkout/checkout-request-sender';
 import { PaymentRequestSender } from './payment/payment-request-sender';
 import WalletButtonIntegrationService from './wallet-button-integration-service';
 
@@ -13,6 +14,7 @@ const createWalletButtonIntegrationService = (
         graphQLEndpoint,
         new BillingAddressRequestSender(requestSender),
         new PaymentRequestSender(requestSender),
+        new CheckoutRequestSender(requestSender),
     );
 };
 

--- a/packages/wallet-button-integration/src/wallet-button-integration-service.spec.ts
+++ b/packages/wallet-button-integration/src/wallet-button-integration-service.spec.ts
@@ -1,6 +1,7 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import BillingAddressRequestSender from './billing/billing-address-request-sender';
+import { CheckoutRequestSender } from './checkout/checkout-request-sender';
 import { PaymentRequestSender } from './payment/payment-request-sender';
 import WalletButtonIntegrationService from './wallet-button-integration-service';
 
@@ -8,6 +9,7 @@ describe('WalletButtonIntegrationService', () => {
     let requestSender: RequestSender;
     let paymentRequestSender: PaymentRequestSender;
     let billingAddressRequestSender: BillingAddressRequestSender;
+    let checkoutRequestSender: CheckoutRequestSender;
     let walletButtonIntegrationService: WalletButtonIntegrationService;
 
     const graphQLEndpoint = 'graphql';
@@ -16,11 +18,13 @@ describe('WalletButtonIntegrationService', () => {
         requestSender = createRequestSender();
         paymentRequestSender = new PaymentRequestSender(requestSender);
         billingAddressRequestSender = new BillingAddressRequestSender(requestSender);
+        checkoutRequestSender = new CheckoutRequestSender(requestSender);
 
         walletButtonIntegrationService = new WalletButtonIntegrationService(
             graphQLEndpoint,
             billingAddressRequestSender,
             paymentRequestSender,
+            checkoutRequestSender,
         );
     });
 
@@ -155,6 +159,61 @@ describe('WalletButtonIntegrationService', () => {
                 graphQLEndpoint,
                 checkoutId,
                 address,
+                customOptions,
+            );
+            expect(result).toEqual(expectedResponse);
+        });
+    });
+
+    describe('#getRedirectToCheckoutUrl()', () => {
+        const inputData = {
+            paymentWalletData: {
+                providerId: 'paypalcommerce',
+                providerOrderId: 'order-id-123',
+            },
+            cartEntityId: 'cart-id-123',
+            queryParams: [{ key: 'foo', value: 'bar' }],
+        };
+
+        const expectedResponse = {
+            body: {
+                redirectUrls: { externalCheckoutUrl: 'https://store.example.com/checkout' },
+            },
+            status: 200,
+            statusText: 'OK',
+            headers: { 'content-type': 'application/json' },
+        };
+
+        it('delegates to CheckoutRequestSender with the graphQLEndpoint', async () => {
+            jest.spyOn(checkoutRequestSender, 'getRedirectToCheckoutUrl').mockResolvedValue(
+                expectedResponse,
+            );
+
+            const result = await walletButtonIntegrationService.getRedirectToCheckoutUrl(inputData);
+
+            expect(checkoutRequestSender.getRedirectToCheckoutUrl).toHaveBeenCalledWith(
+                graphQLEndpoint,
+                inputData,
+                undefined,
+            );
+            expect(result).toEqual(expectedResponse);
+        });
+
+        it('passes custom options to CheckoutRequestSender', async () => {
+            const customOptions = { headers: { Authorization: 'Bearer token-xyz' } };
+
+            jest.spyOn(checkoutRequestSender, 'getRedirectToCheckoutUrl').mockResolvedValue(
+                expectedResponse,
+            );
+
+            const result = await walletButtonIntegrationService.getRedirectToCheckoutUrl(
+                inputData,
+                customOptions,
+            );
+
+            expect(checkoutRequestSender.getRedirectToCheckoutUrl).toHaveBeenCalledWith(
+                graphQLEndpoint,
+                inputData,
                 customOptions,
             );
             expect(result).toEqual(expectedResponse);

--- a/packages/wallet-button-integration/src/wallet-button-integration-service.ts
+++ b/packages/wallet-button-integration/src/wallet-button-integration-service.ts
@@ -6,6 +6,11 @@ import {
     BillingAddressUpdateRequestBody,
 } from './billing/billing-address';
 import BillingAddressRequestSender from './billing/billing-address-request-sender';
+import {
+    CreateRedirectToCheckoutResponseBody,
+    RedirectToCheckoutUrlInputData,
+} from './checkout/checkout';
+import { CheckoutRequestSender } from './checkout/checkout-request-sender';
 import { GraphQLRequestOptions } from './graphql-request-options';
 import {
     CreatePaymentOrderIntentInputData,
@@ -18,6 +23,7 @@ export default class WalletButtonIntegrationService {
         private graphQLEndpoint: string,
         private billingAddressRequestSender: BillingAddressRequestSender,
         private paymentRequestSender: PaymentRequestSender,
+        private checkoutRequestSender: CheckoutRequestSender,
     ) {}
 
     async addBillingAddress(
@@ -51,6 +57,17 @@ export default class WalletButtonIntegrationService {
         options?: GraphQLRequestOptions,
     ): Promise<Response<CreatePaymentOrderIntentResponseBody>> {
         return this.paymentRequestSender.createPaymentOrderIntent(
+            this.graphQLEndpoint,
+            inputData,
+            options,
+        );
+    }
+
+    async getRedirectToCheckoutUrl(
+        inputData: RedirectToCheckoutUrlInputData,
+        options?: GraphQLRequestOptions,
+    ): Promise<Response<CreateRedirectToCheckoutResponseBody>> {
+        return this.checkoutRequestSender.getRedirectToCheckoutUrl(
             this.graphQLEndpoint,
             inputData,
             options,


### PR DESCRIPTION
## What/Why?
Added checkout redirect layer — a dedicated CheckoutRequestSender class under a new checkout module, the CheckoutRedirectMutation GraphQL mutation, and related types — and wires them into the service. 
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
CI pass
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New checkout redirect API touches cart/checkout handoff for wallet flows; mistakes could break redirects or mis-handle GraphQL errors, though scope is isolated to wallet-button-integration with solid test coverage.
> 
> **Overview**
> Adds a **checkout redirect** path for wallet buttons: callers can obtain an **external checkout URL** after wallet payment data is attached to a cart.
> 
> A new **`CheckoutRequestSender`** posts the **`createCartRedirectUrls`** GraphQL mutation (cart, wallet provider/order IDs, optional query params) and returns a slim **`redirectUrls`** payload. GraphQL and network failures surface as **`CheckoutRedirectError`** (typed `checkout_redirect_error`) or a generic failure when the rejection is not an `Error`.
> 
> **`WalletButtonIntegrationService`** and **`createWalletButtonIntegrationService`** are extended with **`getRedirectToCheckoutUrl`**, following the same delegate pattern as billing and payment senders.
> 
> **`BillingAddressResponse`** no longer includes **`shouldSaveAddress`** (request-only); billing address tests build mock responses without `id` / `shouldSaveAddress`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44bbf841f002caddcfd8a4b576c5d81250548587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->