### PR TITLE
fix(payments): STRIPE-1517 continue success flow when second submitPayment succeeds after stripe error

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -1681,7 +1681,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 );
             };
 
-            it('sends second submitPayment request with client_side_error when flag is true and stripe returns error', async () => {
+            it('completes successfully when second submitPayment with client_side_error returns success after stripe error', async () => {
                 const stripeErrorMock = { message: 'Your card was declined' };
 
                 mockPaymentMethodWithFlag(true);
@@ -1693,7 +1693,7 @@ describe('StripeOCSPaymentStrategy', () => {
 
                 await expect(
                     stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
-                ).rejects.toThrow(PaymentMethodFailedError);
+                ).resolves.not.toThrow();
 
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
                 expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
@@ -1753,7 +1753,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(1);
             });
 
-            it('sends second submitPayment with client_side_error when confirmation returns no session and flag is true', async () => {
+            it('completes successfully when second submitPayment with client_side_error returns success after confirmation returns no session', async () => {
                 mockPaymentMethodWithFlag(true);
                 mockFirstPaymentRequest(errorResponse);
                 confirmPaymentMock = jest.fn().mockResolvedValue({});
@@ -1763,7 +1763,7 @@ describe('StripeOCSPaymentStrategy', () => {
 
                 await expect(
                     stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
-                ).rejects.toThrow(PaymentMethodFailedError);
+                ).resolves.not.toThrow();
 
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
                 expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -363,7 +363,9 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
                         },
                     });
 
-                    await this.paymentIntegrationService.submitPayment(paymentPayloadWithError);
+                    return await this.paymentIntegrationService.submitPayment(
+                        paymentPayloadWithError,
+                    );
                 } catch {
                     // INFO: additional action should be ignored for this update status request.
                     // will throw Stripe error message to the shopper.


### PR DESCRIPTION
## What/Why?
In the Stripe CS payment flow, when Stripe-side confirmation returns an error and `sendSecondPaymentRequestOnStripeError` is enabled, the strategy sends a second `submitPayment` request with `client_side_error: true` so the backend can update the checkout session status.

Previously, the result of that second request was discarded — the strategy **always** threw `PaymentMethodFailedError` with the original Stripe message, regardless of how the BE responded.

**Edge case:** the BE can legitimately accept the second request (success status, no errors), meaning the order is actually paid even though Stripe surfaced an intermediate error to the client. In that case we were incorrectly showing the shopper a payment failure for a completed order.

With this change, the result of the second `submitPayment` is now respected: if the BE returns success, the strategy returns that result and the success payment flow continues. If the second request still fails, behavior is unchanged — the BE error is swallowed and `PaymentMethodFailedError` is thrown with the original Stripe message so the shopper sees the Stripe decline rather than the BE error.

## Rollout/Rollback
Rollback this PR

## Testing


https://github.com/user-attachments/assets/6a641077-515b-4aa6-960c-7944f1235e38

<img width="722" height="73" alt="Screenshot 2026-06-03 at 19 29 59" src="https://github.com/user-attachments/assets/f0a5eb3b-5599-4d48-8f00-c0c2aabb8320" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout payment completion behavior when Stripe errors but the backend accepts the recovery request; wrong handling could still mis-report paid vs failed orders.
> 
> **Overview**
> When Stripe Checkout Session confirmation fails but **`sendSecondPaymentRequestOnStripeError`** is on, the strategy still sends a follow-up **`submitPayment`** with **`client_side_error: true`** so the backend can sync session state. That second call’s outcome was **ignored**—the code always surfaced **`PaymentMethodFailedError`** with Stripe’s message, so shoppers could see a decline after the backend had already accepted payment.
> 
> **`stripe-cs-payment-strategy`** now **`return`s** the result of that recovery **`submitPayment`** on success, so **`execute`** can finish normally. If the recovery request still fails, behavior is unchanged: the backend error is swallowed and the original Stripe decline is thrown. Specs under **`sendSecondPaymentRequestOnStripeError`** were updated to expect success when the mocked second payment succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9afd5221958bceecdecc309c19db9e88e5c5dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->