### PR TITLE
feat(checkout): CHECKOUT-9813 Add persistB2BMetadata Method

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -65,6 +65,8 @@ import {
     B2BCompanyPaymentMethodRequestSender,
     B2BPaymentsRefreshActionCreator,
     B2BPaymentsRefreshRequestSender,
+    B2BPostOrderActionCreator,
+    B2BPostOrderRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistryV2,
     PaymentMethodActionCreator,
@@ -130,6 +132,8 @@ import createCheckoutStore from './create-checkout-store';
 describe('CheckoutService', () => {
     let b2bPaymentsRefreshActionCreator: B2BPaymentsRefreshActionCreator;
     let b2bPaymentsRefreshRequestSender: B2BPaymentsRefreshRequestSender;
+    let b2bPostOrderActionCreator: B2BPostOrderActionCreator;
+    let b2bPostOrderRequestSender: B2BPostOrderRequestSender;
     let billingAddressActionCreator: BillingAddressActionCreator;
     let billingAddressRequestSender: BillingAddressRequestSender;
     let checkoutActionCreator: CheckoutActionCreator;
@@ -411,6 +415,14 @@ describe('CheckoutService', () => {
             b2bPaymentsRefreshRequestSender,
         );
 
+        b2bPostOrderRequestSender = new B2BPostOrderRequestSender(requestSender);
+
+        jest.spyOn(b2bPostOrderRequestSender, 'closeInvoice').mockResolvedValue(
+            getResponse({ data: { paymentId: 'pay_1', receiptId: 'rcpt_1' }, code: 200 }),
+        );
+
+        b2bPostOrderActionCreator = new B2BPostOrderActionCreator(b2bPostOrderRequestSender);
+
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             paymentStrategyRegistry,
             paymentStrategyRegistryV2,
@@ -468,6 +480,7 @@ describe('CheckoutService', () => {
             extensionActionCreator,
             workerExtensionMessenger,
             b2bPaymentsRefreshActionCreator,
+            b2bPostOrderActionCreator,
         );
     });
 
@@ -634,6 +647,29 @@ describe('CheckoutService', () => {
             expect(b2bPaymentsRefreshActionCreator.refreshB2BPaymentMethods).toHaveBeenCalledWith(
                 undefined,
             );
+
+            await result.catch(() => undefined);
+        });
+    });
+
+    describe('#persistB2BMetadata()', () => {
+        it('exposes the method on the service', () => {
+            expect(typeof checkoutService.persistB2BMetadata).toBe('function');
+        });
+
+        it('dispatches the action creator and returns a promise', async () => {
+            jest.spyOn(b2bPostOrderActionCreator, 'persistB2BMetadata');
+
+            const result = checkoutService.persistB2BMetadata({
+                isInvoice: true,
+                invoiceComment: 'Invoice comment',
+            });
+
+            expect(result).toBeInstanceOf(Promise);
+            expect(b2bPostOrderActionCreator.persistB2BMetadata).toHaveBeenCalledWith({
+                isInvoice: true,
+                invoiceComment: 'Invoice comment',
+            });
 
             await result.catch(() => undefined);
         });

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -417,7 +417,7 @@ describe('CheckoutService', () => {
 
         b2bPostOrderRequestSender = new B2BPostOrderRequestSender(requestSender);
 
-        jest.spyOn(b2bPostOrderRequestSender, 'closeInvoice').mockResolvedValue(
+        jest.spyOn(b2bPostOrderRequestSender, 'submitInvoice').mockResolvedValue(
             getResponse({ data: { paymentId: 'pay_1', receiptId: 'rcpt_1' }, code: 200 }),
         );
 

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -37,12 +37,14 @@ import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
 import {
     B2BPaymentsRefreshActionCreator,
+    B2BPostOrderActionCreator,
     OrderFinalizeOptions,
     PaymentInitializeOptions,
     PaymentMethodActionCreator,
     PaymentRequestOptions,
     PaymentStrategyActionCreator,
 } from '../payment';
+import { PersistB2BMetadataOptions } from '../payment/b2b-post-order-actions';
 import { InstrumentActionCreator } from '../payment/instrument';
 import {
     ConsignmentActionCreator,
@@ -114,6 +116,7 @@ export default class CheckoutService {
         private _extensionActionCreator: ExtensionActionCreator,
         private _workerExtensionMessenger: WorkerExtensionMessenger,
         private _b2bPaymentsRefreshActionCreator: B2BPaymentsRefreshActionCreator,
+        private _b2bPostOrderActionCreator: B2BPostOrderActionCreator,
     ) {
         this._errorTransformer = createCheckoutServiceErrorTransformer();
     }
@@ -718,6 +721,28 @@ export default class CheckoutService {
         const action = this._b2bPaymentsRefreshActionCreator.refreshB2BPaymentMethods(options);
 
         return this._dispatch(action, { queueId: 'b2bPaymentsRefresh' });
+    }
+
+    /**
+     * Persists B2B order metadata (e.g. invoice comment) after an order is placed
+     *
+     * ```js
+     * const state = await service.persistB2BMetadata(comment);
+     * ```
+     *
+     * @param PersistB2BMetadataOptions - Passing an object to prepare the payload for the request.
+     * @returns A promise that resolves to the current state.
+     */
+    persistB2BMetadata({
+        isInvoice = false,
+        invoiceComment = '',
+    }: PersistB2BMetadataOptions): Promise<CheckoutSelectors> {
+        const action = this._b2bPostOrderActionCreator.persistB2BMetadata({
+            isInvoice,
+            invoiceComment,
+        });
+
+        return this._dispatch(action, { queueId: 'b2bPostOrder' });
     }
 
     /**

--- a/packages/core/src/checkout/checkout-store-error-selector.ts
+++ b/packages/core/src/checkout/checkout-store-error-selector.ts
@@ -296,6 +296,13 @@ export default interface CheckoutStoreErrorSelector {
     getLoadB2BTokenError(): Error | undefined;
 
     /**
+     * Returns an error if unable to persist B2B order metadata.
+     *
+     * @returns The error object if unable to persist B2B metadata, otherwise undefined.
+     */
+    getPersistB2BMetadataError(): Error | undefined;
+
+    /**
      * Returns an error if unable to create customer account.
      *
      * @returns The error object if unable to create account, otherwise undefined.
@@ -390,6 +397,7 @@ export function createCheckoutStoreErrorSelectorFactory(): CheckoutStoreErrorSel
             getLoadConfigError: state.config.getLoadError,
             getSignInEmailError: state.signInEmail.getSendError,
             getLoadB2BTokenError: state.b2bToken.getLoadError,
+            getPersistB2BMetadataError: state.b2bPostOrder.getPersistError,
             getCreateCustomerAccountError: state.customer.getCreateAccountError,
             getCreateCustomerAddressError: state.customer.getCreateAddressError,
             getPickupOptionsError: state.pickupOptions.getLoadError,

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -67,6 +67,13 @@ export default interface CheckoutStoreSelector {
     getB2BToken(): string | undefined;
 
     /**
+     * Gets the B2B receipt id produced after persisting order metadata.
+     *
+     * @returns The B2B receipt id string if it has been persisted, otherwise undefined.
+     */
+    getB2BReceiptId(): string | undefined;
+
+    /**
      * Gets the shipping address of the current checkout.
      *
      * If the address is partially complete, it may not have shipping options
@@ -514,6 +521,11 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         (getToken) => clone(getToken),
     );
 
+    const getB2BReceiptId = createSelector(
+        ({ b2bPostOrder }: InternalCheckoutSelectors) => b2bPostOrder.getReceiptId,
+        (getReceiptId) => clone(getReceiptId),
+    );
+
     const isPaymentDataRequired = createSelector(
         ({ payment }: InternalCheckoutSelectors) => payment.isPaymentDataRequired,
         (isPaymentDataRequired) => clone(isPaymentDataRequired),
@@ -649,6 +661,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             isPaymentDataSubmitted: isPaymentDataSubmitted(state),
             getSignInEmail: getSignInEmail(state),
             getB2BToken: getB2BToken(state),
+            getB2BReceiptId: getB2BReceiptId(state),
             getInstruments: getInstruments(state),
             getCustomerAccountFields: getCustomerAccountFields(state),
             getBillingAddressFields: getBillingAddressFields(state),

--- a/packages/core/src/checkout/checkout-store-state.ts
+++ b/packages/core/src/checkout/checkout-store-state.ts
@@ -10,7 +10,12 @@ import { FormFieldsState } from '../form';
 import { CountryState } from '../geography';
 import { OrderState } from '../order';
 import { OrderBillingAddressState } from '../order-billing-address';
-import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payment';
+import {
+    B2BPostOrderState,
+    PaymentMethodState,
+    PaymentState,
+    PaymentStrategyState,
+} from '../payment';
 import { InstrumentState } from '../payment/instrument';
 import { PaymentProviderCustomerState } from '../payment-provider-customer';
 import { RemoteCheckoutState } from '../remote-checkout';
@@ -27,6 +32,7 @@ import { SubscriptionsState } from '../subscription';
 import CheckoutState from './checkout-state';
 
 export default interface CheckoutStoreState {
+    b2bPostOrder: B2BPostOrderState;
     b2bToken: B2BTokenState;
     billingAddress: BillingAddressState;
     cart: CartState;

--- a/packages/core/src/checkout/checkout-store-status-selector.ts
+++ b/packages/core/src/checkout/checkout-store-status-selector.ts
@@ -289,6 +289,13 @@ export default interface CheckoutStoreStatusSelector {
     isLoadingB2BToken(): boolean;
 
     /**
+     * Checks whether B2B order metadata is being persisted.
+     *
+     * @returns True if B2B order metadata is being persisted, otherwise false.
+     */
+    isPersistingB2BMetadata(): boolean;
+
+    /**
      * Checks whether the current customer is applying a gift certificate.
      *
      * @returns True if applying a gift certificate, otherwise false.
@@ -515,6 +522,7 @@ export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusS
             isLoadingConfig: state.config.isLoading,
             isSendingSignInEmail: state.signInEmail.isSending,
             isLoadingB2BToken: state.b2bToken.isLoading,
+            isPersistingB2BMetadata: state.b2bPostOrder.isPersisting,
             isCustomerStepPending: isCustomerStepPending(state),
             isShippingStepPending: isShippingStepPending(state),
             isPaymentStepPending: isPaymentStepPending(state),

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -119,6 +119,7 @@ export function getCheckoutState(): CheckoutState {
 
 export function getCheckoutStoreState(): CheckoutStoreState {
     return {
+        b2bPostOrder: { errors: {}, statuses: {} },
         b2bToken: { errors: {}, statuses: {} },
         billingAddress: getBillingAddressState(),
         cart: getCartState(),

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -38,6 +38,8 @@ import {
     B2BCompanyPaymentMethodRequestSender,
     B2BPaymentsRefreshActionCreator,
     B2BPaymentsRefreshRequestSender,
+    B2BPostOrderActionCreator,
+    B2BPostOrderRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistry,
     createPaymentStrategyRegistryV2,
@@ -233,6 +235,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         extensionActionCreator,
         workerExtensionMessenger,
         new B2BPaymentsRefreshActionCreator(new B2BPaymentsRefreshRequestSender(requestSender)),
+        new B2BPostOrderActionCreator(new B2BPostOrderRequestSender(requestSender)),
     );
 }
 

--- a/packages/core/src/checkout/create-checkout-store-reducer.ts
+++ b/packages/core/src/checkout/create-checkout-store-reducer.ts
@@ -12,7 +12,12 @@ import { formFieldsReducer } from '../form';
 import { countryReducer } from '../geography';
 import { orderReducer } from '../order';
 import { orderBillingAddressReducer } from '../order-billing-address';
-import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '../payment';
+import {
+    b2bPostOrderReducer,
+    paymentMethodReducer,
+    paymentReducer,
+    paymentStrategyReducer,
+} from '../payment';
 import { instrumentReducer } from '../payment/instrument';
 import { paymentProviderCustomerReducer } from '../payment-provider-customer';
 import { remoteCheckoutReducer } from '../remote-checkout';
@@ -31,6 +36,7 @@ import CheckoutStoreState from './checkout-store-state';
 
 export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState, Action> {
     return combineReducers({
+        b2bPostOrder: b2bPostOrderReducer,
         b2bToken: b2bTokenReducer,
         billingAddress: billingAddressReducer,
         cart: cartReducer,

--- a/packages/core/src/checkout/create-internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/create-internal-checkout-selectors.ts
@@ -12,6 +12,7 @@ import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
 import { createOrderBillingAddressSelectorFactory } from '../order-billing-address';
 import {
+    createB2BPostOrderSelectorFactory,
     createPaymentMethodSelectorFactory,
     createPaymentSelectorFactory,
     createPaymentStrategySelectorFactory,
@@ -41,6 +42,7 @@ export type InternalCheckoutSelectorsFactory = (
 ) => InternalCheckoutSelectors;
 
 export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
+    const createB2BPostOrderSelector = createB2BPostOrderSelectorFactory();
     const createB2BTokenSelector = createB2BTokenSelectorFactory();
     const createBillingAddressSelector = createBillingAddressSelectorFactory();
     const createCartSelector = createCartSelectorFactory();
@@ -72,6 +74,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createExtensionSelector = createExtensionSelectorFactory();
 
     return (state, options = {}) => {
+        const b2bPostOrder = createB2BPostOrderSelector(state.b2bPostOrder);
         const b2bToken = createB2BTokenSelector(state.b2bToken);
         const billingAddress = createBillingAddressSelector(state.billingAddress);
         const cart = createCartSelector(state.cart);
@@ -115,6 +118,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const config = createConfigSelector(state.config, state.formFields);
 
         const selectors = {
+            b2bPostOrder,
             b2bToken,
             billingAddress,
             cart,

--- a/packages/core/src/checkout/internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/internal-checkout-selectors.ts
@@ -10,7 +10,12 @@ import { FormSelector } from '../form';
 import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import OrderBillingAddressSelector from '../order-billing-address/order-billing-address-selector';
-import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
+import {
+    B2BPostOrderSelector,
+    PaymentMethodSelector,
+    PaymentSelector,
+    PaymentStrategySelector,
+} from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { PaymentProviderCustomerSelector } from '../payment-provider-customer';
 import { RemoteCheckoutSelector } from '../remote-checkout';
@@ -28,6 +33,7 @@ import { SubscriptionsSelector } from '../subscription';
 import CheckoutSelector from './checkout-selector';
 
 export default interface InternalCheckoutSelectors {
+    b2bPostOrder: B2BPostOrderSelector;
     b2bToken: B2BTokenSelector;
     billingAddress: BillingAddressSelector;
     cart: CartSelector;

--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -1,0 +1,139 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { CheckoutStore, createCheckoutStore } from '../checkout';
+import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { getConfig } from '../config/configs.mock';
+
+import B2BPostOrderActionCreator from './b2b-post-order-action-creator';
+import { B2BPostOrderActionType } from './b2b-post-order-actions';
+import B2BPostOrderRequestSender from './b2b-post-order-request-sender';
+
+describe('B2BPostOrderActionCreator', () => {
+    let store: CheckoutStore;
+    let requestSender: B2BPostOrderRequestSender;
+    let actionCreator: B2BPostOrderActionCreator;
+
+    const comment = 'Invoice comment';
+    const invoiceOptions = { isInvoice: true, invoiceComment: comment };
+    const nonInvoiceOptions = { isInvoice: false, invoiceComment: '' };
+    const b2bApiSettings = {
+        clientId: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
+        baseUrl: 'https://api-b2b.bigcommerce.com',
+    };
+
+    beforeEach(() => {
+        store = createCheckoutStore({
+            ...getCheckoutStoreStateWithOrder(),
+            b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+        });
+
+        requestSender = new B2BPostOrderRequestSender(createRequestSender());
+
+        jest.spyOn(requestSender, 'closeInvoice').mockResolvedValue(
+            getResponse({ data: { paymentId: 'pay_1', receiptId: 'rcpt_1' }, code: 200 }),
+        );
+
+        jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+            ...getConfig().storeConfig,
+            b2bApiSettings,
+        });
+
+        actionCreator = new B2BPostOrderActionCreator(requestSender);
+    });
+
+    describe('#persistB2BMetadata()', () => {
+        it('emits requested and succeeded actions on success', async () => {
+            const actions = await from(actionCreator.persistB2BMetadata(invoiceOptions)(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                {
+                    type: B2BPostOrderActionType.PersistB2BMetadataSucceeded,
+                    payload: { receiptId: 'rcpt_1' },
+                },
+            ]);
+        });
+
+        it('calls closeInvoice with the order id, comment, token and base url', async () => {
+            await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
+
+            expect(requestSender.closeInvoice).toHaveBeenCalledWith(
+                { orderId: '295', comment },
+                'b2b-auth-token',
+                b2bApiSettings.baseUrl,
+            );
+        });
+
+        it('does not call closeInvoice when isInvoice is false', async () => {
+            const actions = await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(requestSender.closeInvoice).not.toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                {
+                    type: B2BPostOrderActionType.PersistB2BMetadataSucceeded,
+                    payload: { receiptId: '' },
+                },
+            ]);
+        });
+
+        it('throws when the order id is missing', () => {
+            store = createCheckoutStore({
+                ...getCheckoutStoreState(),
+                b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+            });
+
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
+
+            expect(() => actionCreator.persistB2BMetadata(invoiceOptions)(store)).toThrow();
+        });
+
+        it('throws when the b2b token is missing', () => {
+            store = createCheckoutStore(getCheckoutStoreStateWithOrder());
+
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
+
+            expect(() => actionCreator.persistB2BMetadata(invoiceOptions)(store)).toThrow();
+        });
+
+        it('throws when the b2b base url is missing', () => {
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings: { ...b2bApiSettings, baseUrl: '' },
+            });
+
+            expect(() => actionCreator.persistB2BMetadata(invoiceOptions)(store)).toThrow();
+        });
+
+        it('emits failed action when the request rejects', async () => {
+            jest.spyOn(requestSender, 'closeInvoice').mockRejectedValue(getErrorResponse());
+
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(actionCreator.persistB2BMetadata(invoiceOptions)(store))
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                expect.objectContaining({
+                    type: B2BPostOrderActionType.PersistB2BMetadataFailed,
+                    error: true,
+                }),
+            ]);
+        });
+    });
+});

--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -32,7 +32,7 @@ describe('B2BPostOrderActionCreator', () => {
 
         requestSender = new B2BPostOrderRequestSender(createRequestSender());
 
-        jest.spyOn(requestSender, 'closeInvoice').mockResolvedValue(
+        jest.spyOn(requestSender, 'submitInvoice').mockResolvedValue(
             getResponse({ data: { paymentId: 'pay_1', receiptId: 'rcpt_1' }, code: 200 }),
         );
 
@@ -62,7 +62,7 @@ describe('B2BPostOrderActionCreator', () => {
         it('calls closeInvoice with the order id, comment, token and base url', async () => {
             await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
 
-            expect(requestSender.closeInvoice).toHaveBeenCalledWith(
+            expect(requestSender.submitInvoice).toHaveBeenCalledWith(
                 { orderId: '295', comment },
                 'b2b-auth-token',
                 b2bApiSettings.baseUrl,
@@ -74,7 +74,7 @@ describe('B2BPostOrderActionCreator', () => {
                 .pipe(toArray())
                 .toPromise();
 
-            expect(requestSender.closeInvoice).not.toHaveBeenCalled();
+            expect(requestSender.submitInvoice).not.toHaveBeenCalled();
             expect(actions).toEqual([
                 { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
                 {
@@ -119,7 +119,7 @@ describe('B2BPostOrderActionCreator', () => {
         });
 
         it('emits failed action when the request rejects', async () => {
-            jest.spyOn(requestSender, 'closeInvoice').mockRejectedValue(getErrorResponse());
+            jest.spyOn(requestSender, 'submitInvoice').mockRejectedValue(getErrorResponse());
 
             const errorHandler = jest.fn((action) => of(action));
             const actions = await from(actionCreator.persistB2BMetadata(invoiceOptions)(store))

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -1,0 +1,67 @@
+import { createAction, ThunkAction } from '@bigcommerce/data-store';
+import { concat, defer, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+// TODO: CHECKOUT-9979 remove this import before delivery
+import { resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { InternalCheckoutSelectors } from '../checkout';
+import { throwErrorAction } from '../common/error';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+
+import {
+    B2BPostOrderActionType,
+    PersistB2BMetadataAction,
+    PersistB2BMetadataOptions,
+} from './b2b-post-order-actions';
+import B2BPostOrderRequestSender from './b2b-post-order-request-sender';
+
+export default class B2BPostOrderActionCreator {
+    constructor(private _requestSender: B2BPostOrderRequestSender) {}
+
+    persistB2BMetadata({
+        isInvoice,
+        invoiceComment,
+    }: PersistB2BMetadataOptions): ThunkAction<
+        PersistB2BMetadataAction,
+        InternalCheckoutSelectors
+    > {
+        return (store) => {
+            const state = store.getState();
+            const orderId = state.order.getOrder()?.orderId;
+            const b2bToken = state.b2bToken.getToken();
+            const b2bBaseUrl = resolveB2bBaseUrl(
+                state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
+            );
+
+            if (!orderId || !b2bToken || !b2bBaseUrl) {
+                throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+            }
+
+            return concat(
+                of(createAction(B2BPostOrderActionType.PersistB2BMetadataRequested)),
+                defer(async () => {
+                    let payload = { receiptId: '' };
+
+                    if (isInvoice) {
+                        const { body } = await this._requestSender.closeInvoice(
+                            { orderId: `${orderId}`, comment: invoiceComment ?? '' },
+                            b2bToken,
+                            b2bBaseUrl,
+                        );
+
+                        payload = { receiptId: body.data.receiptId };
+                    }
+
+                    return createAction(
+                        B2BPostOrderActionType.PersistB2BMetadataSucceeded,
+                        payload,
+                    );
+                }),
+            ).pipe(
+                catchError((error) =>
+                    throwErrorAction(B2BPostOrderActionType.PersistB2BMetadataFailed, error),
+                ),
+            );
+        };
+    }
+}

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -34,7 +34,7 @@ export default class B2BPostOrderActionCreator {
             );
 
             if (!orderId || !b2bToken || !b2bBaseUrl) {
-                throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+                throw new MissingDataError(MissingDataErrorType.MissingOrder);
             }
 
             return concat(

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -27,7 +27,7 @@ export default class B2BPostOrderActionCreator {
     > {
         return (store) => {
             const state = store.getState();
-            const orderId = state.order.getOrder()?.orderId;
+            const orderId = state.order.getOrderOrThrow().orderId;
             const b2bToken = state.b2bToken.getToken();
             const b2bBaseUrl = resolveB2bBaseUrl(
                 state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
@@ -43,7 +43,7 @@ export default class B2BPostOrderActionCreator {
                     let payload = { receiptId: '' };
 
                     if (isInvoice) {
-                        const { body } = await this._requestSender.closeInvoice(
+                        const { body } = await this._requestSender.submitInvoice(
                             { orderId: `${orderId}`, comment: invoiceComment ?? '' },
                             b2bToken,
                             b2bBaseUrl,

--- a/packages/core/src/payment/b2b-post-order-actions.ts
+++ b/packages/core/src/payment/b2b-post-order-actions.ts
@@ -1,0 +1,31 @@
+import { Action } from '@bigcommerce/data-store';
+
+import { B2BPostOrderData } from './b2b-post-order-state';
+
+export interface PersistB2BMetadataOptions {
+    isInvoice: boolean;
+    invoiceComment: string;
+}
+
+export enum B2BPostOrderActionType {
+    PersistB2BMetadataRequested = 'PERSIST_B2B_METADATA_REQUESTED',
+    PersistB2BMetadataSucceeded = 'PERSIST_B2B_METADATA_SUCCEEDED',
+    PersistB2BMetadataFailed = 'PERSIST_B2B_METADATA_FAILED',
+}
+
+export type PersistB2BMetadataAction =
+    | PersistB2BMetadataRequestedAction
+    | PersistB2BMetadataSucceededAction
+    | PersistB2BMetadataFailedAction;
+
+export interface PersistB2BMetadataRequestedAction extends Action {
+    type: B2BPostOrderActionType.PersistB2BMetadataRequested;
+}
+
+export interface PersistB2BMetadataSucceededAction extends Action<B2BPostOrderData> {
+    type: B2BPostOrderActionType.PersistB2BMetadataSucceeded;
+}
+
+export interface PersistB2BMetadataFailedAction extends Action<Error> {
+    type: B2BPostOrderActionType.PersistB2BMetadataFailed;
+}

--- a/packages/core/src/payment/b2b-post-order-reducer.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-reducer.spec.ts
@@ -16,7 +16,7 @@ describe('b2bPostOrderReducer()', () => {
         const state = b2bPostOrderReducer(initialState, action);
 
         expect(state.statuses.isPersisting).toBe(true);
-        expect(state.errors.persistError).toBeUndefined();
+        expect(state.errors.persistB2bMetadataError).toBeUndefined();
     });
 
     it('stores receipt id and clears persisting state on success', () => {
@@ -26,7 +26,7 @@ describe('b2bPostOrderReducer()', () => {
 
         expect(state.data).toEqual(data);
         expect(state.statuses.isPersisting).toBe(false);
-        expect(state.errors.persistError).toBeUndefined();
+        expect(state.errors.persistB2bMetadataError).toBeUndefined();
     });
 
     it('stores error and clears persisting state on failure', () => {
@@ -34,7 +34,7 @@ describe('b2bPostOrderReducer()', () => {
         const action = createErrorAction(B2BPostOrderActionType.PersistB2BMetadataFailed, error);
         const state = b2bPostOrderReducer(initialState, action);
 
-        expect(state.errors.persistError).toBe(error);
+        expect(state.errors.persistB2bMetadataError).toBe(error);
         expect(state.statuses.isPersisting).toBe(false);
         expect(state.data).toBeUndefined();
     });

--- a/packages/core/src/payment/b2b-post-order-reducer.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-reducer.spec.ts
@@ -1,0 +1,48 @@
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+
+import { B2BPostOrderActionType } from './b2b-post-order-actions';
+import b2bPostOrderReducer from './b2b-post-order-reducer';
+import B2BPostOrderState, { DEFAULT_STATE } from './b2b-post-order-state';
+
+describe('b2bPostOrderReducer()', () => {
+    let initialState: B2BPostOrderState;
+
+    beforeEach(() => {
+        initialState = DEFAULT_STATE;
+    });
+
+    it('returns persisting state on requested', () => {
+        const action = createAction(B2BPostOrderActionType.PersistB2BMetadataRequested);
+        const state = b2bPostOrderReducer(initialState, action);
+
+        expect(state.statuses.isPersisting).toBe(true);
+        expect(state.errors.persistError).toBeUndefined();
+    });
+
+    it('stores receipt id and clears persisting state on success', () => {
+        const data = { receiptId: 'rcpt_1' };
+        const action = createAction(B2BPostOrderActionType.PersistB2BMetadataSucceeded, data);
+        const state = b2bPostOrderReducer(initialState, action);
+
+        expect(state.data).toEqual(data);
+        expect(state.statuses.isPersisting).toBe(false);
+        expect(state.errors.persistError).toBeUndefined();
+    });
+
+    it('stores error and clears persisting state on failure', () => {
+        const error = new Error('Failed to persist B2B metadata');
+        const action = createErrorAction(B2BPostOrderActionType.PersistB2BMetadataFailed, error);
+        const state = b2bPostOrderReducer(initialState, action);
+
+        expect(state.errors.persistError).toBe(error);
+        expect(state.statuses.isPersisting).toBe(false);
+        expect(state.data).toBeUndefined();
+    });
+
+    it('returns previous state for unknown actions', () => {
+        const action = { type: 'UNKNOWN_ACTION' } as any;
+        const state = b2bPostOrderReducer(initialState, action);
+
+        expect(state).toEqual(initialState);
+    });
+});

--- a/packages/core/src/payment/b2b-post-order-reducer.ts
+++ b/packages/core/src/payment/b2b-post-order-reducer.ts
@@ -1,0 +1,72 @@
+import { Action, combineReducers, composeReducers } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
+import { objectSet } from '../common/utility';
+
+import { B2BPostOrderActionType, PersistB2BMetadataAction } from './b2b-post-order-actions';
+import B2BPostOrderState, {
+    B2BPostOrderData,
+    B2BPostOrderErrorsState,
+    B2BPostOrderStatusesState,
+    DEFAULT_STATE,
+} from './b2b-post-order-state';
+
+export default function b2bPostOrderReducer(
+    state: B2BPostOrderState = DEFAULT_STATE,
+    action: Action,
+): B2BPostOrderState {
+    const reducer = combineReducers<B2BPostOrderState>({
+        data: dataReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
+        statuses: statusesReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: B2BPostOrderData | undefined,
+    action: PersistB2BMetadataAction,
+): B2BPostOrderData | undefined {
+    switch (action.type) {
+        case B2BPostOrderActionType.PersistB2BMetadataSucceeded:
+            return action.payload;
+
+        default:
+            return data;
+    }
+}
+
+function errorsReducer(
+    errors: B2BPostOrderErrorsState = DEFAULT_STATE.errors,
+    action: PersistB2BMetadataAction,
+): B2BPostOrderErrorsState {
+    switch (action.type) {
+        case B2BPostOrderActionType.PersistB2BMetadataRequested:
+        case B2BPostOrderActionType.PersistB2BMetadataSucceeded:
+            return objectSet(errors, 'persistError', undefined);
+
+        case B2BPostOrderActionType.PersistB2BMetadataFailed:
+            return objectSet(errors, 'persistError', action.payload);
+
+        default:
+            return errors;
+    }
+}
+
+function statusesReducer(
+    statuses: B2BPostOrderStatusesState = DEFAULT_STATE.statuses,
+    action: PersistB2BMetadataAction,
+): B2BPostOrderStatusesState {
+    switch (action.type) {
+        case B2BPostOrderActionType.PersistB2BMetadataRequested:
+            return objectSet(statuses, 'isPersisting', true);
+
+        case B2BPostOrderActionType.PersistB2BMetadataFailed:
+        case B2BPostOrderActionType.PersistB2BMetadataSucceeded:
+            return objectSet(statuses, 'isPersisting', false);
+
+        default:
+            return statuses;
+    }
+}

--- a/packages/core/src/payment/b2b-post-order-reducer.ts
+++ b/packages/core/src/payment/b2b-post-order-reducer.ts
@@ -44,10 +44,10 @@ function errorsReducer(
     switch (action.type) {
         case B2BPostOrderActionType.PersistB2BMetadataRequested:
         case B2BPostOrderActionType.PersistB2BMetadataSucceeded:
-            return objectSet(errors, 'persistError', undefined);
+            return objectSet(errors, 'persistB2bMetadataError', undefined);
 
         case B2BPostOrderActionType.PersistB2BMetadataFailed:
-            return objectSet(errors, 'persistError', action.payload);
+            return objectSet(errors, 'persistB2bMetadataError', action.payload);
 
         default:
             return errors;

--- a/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
@@ -1,0 +1,77 @@
+import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
+
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+
+import B2BPostOrderRequestSender, { CloseInvoicePayload } from './b2b-post-order-request-sender';
+
+describe('B2BPostOrderRequestSender', () => {
+    let requestSender: RequestSender;
+    let b2bPostOrderRequestSender: B2BPostOrderRequestSender;
+
+    const payload: CloseInvoicePayload = {
+        orderId: '295',
+        comment: 'Invoice comment',
+    };
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        jest.spyOn(requestSender, 'post').mockResolvedValue(
+            getResponse({ paymentId: 'pay_1', receiptId: 'rcpt_1' }),
+        );
+
+        b2bPostOrderRequestSender = new B2BPostOrderRequestSender(requestSender);
+    });
+
+    describe('#persistMetadata()', () => {
+        it('posts to the IP orders endpoint with auth headers and payload', async () => {
+            await b2bPostOrderRequestSender.closeInvoice(
+                payload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v1/ip/storefront/payments/bigcommerce/orders',
+                {
+                    timeout: undefined,
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                    body: payload,
+                },
+            );
+        });
+
+        it('forwards the request timeout', async () => {
+            const timeout = createTimeout();
+
+            await b2bPostOrderRequestSender.closeInvoice(
+                payload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+                { timeout },
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v1/ip/storefront/payments/bigcommerce/orders',
+                expect.objectContaining({ timeout }),
+            );
+        });
+
+        it('rejects when the request sender rejects', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
+
+            await expect(
+                b2bPostOrderRequestSender.closeInvoice(
+                    payload,
+                    'b2b-token-value',
+                    'https://api-b2b.bigcommerce.com',
+                ),
+            ).rejects.toEqual(getErrorResponse());
+        });
+    });
+});

--- a/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
@@ -25,7 +25,7 @@ describe('B2BPostOrderRequestSender', () => {
 
     describe('#persistMetadata()', () => {
         it('posts to the IP orders endpoint with auth headers and payload', async () => {
-            await b2bPostOrderRequestSender.closeInvoice(
+            await b2bPostOrderRequestSender.submitInvoice(
                 payload,
                 'b2b-token-value',
                 'https://api-b2b.bigcommerce.com',
@@ -49,7 +49,7 @@ describe('B2BPostOrderRequestSender', () => {
         it('forwards the request timeout', async () => {
             const timeout = createTimeout();
 
-            await b2bPostOrderRequestSender.closeInvoice(
+            await b2bPostOrderRequestSender.submitInvoice(
                 payload,
                 'b2b-token-value',
                 'https://api-b2b.bigcommerce.com',
@@ -66,7 +66,7 @@ describe('B2BPostOrderRequestSender', () => {
             jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
 
             await expect(
-                b2bPostOrderRequestSender.closeInvoice(
+                b2bPostOrderRequestSender.submitInvoice(
                     payload,
                     'b2b-token-value',
                     'https://api-b2b.bigcommerce.com',

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -1,0 +1,41 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { RequestOptions } from '../common/http-request';
+
+export interface CloseInvoicePayload {
+    orderId: string;
+    comment: string;
+}
+
+export interface CloseInvoiceResponseBody {
+    data: {
+        paymentId: string;
+        receiptId: string;
+    };
+    code: number;
+}
+
+export default class B2BPostOrderRequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    async closeInvoice(
+        payload: CloseInvoicePayload,
+        b2bToken: string,
+        b2bBaseUrl: string,
+        options?: RequestOptions,
+    ): Promise<Response<CloseInvoiceResponseBody>> {
+        return this._requestSender.post(
+            `${b2bBaseUrl}/api/v1/ip/storefront/payments/bigcommerce/orders`,
+            {
+                timeout: options?.timeout,
+                credentials: false,
+                headers: {
+                    'Content-Type': 'application/json',
+                    authToken: b2bToken,
+                    Authorization: `Bearer ${b2bToken}`,
+                },
+                body: payload,
+            },
+        );
+    }
+}

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -18,7 +18,7 @@ export interface CloseInvoiceResponseBody {
 export default class B2BPostOrderRequestSender {
     constructor(private _requestSender: RequestSender) {}
 
-    async closeInvoice(
+    async submitInvoice(
         payload: CloseInvoicePayload,
         b2bToken: string,
         b2bBaseUrl: string,

--- a/packages/core/src/payment/b2b-post-order-selector.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-selector.spec.ts
@@ -1,0 +1,55 @@
+import { createB2BPostOrderSelectorFactory } from './b2b-post-order-selector';
+import B2BPostOrderState, { DEFAULT_STATE } from './b2b-post-order-state';
+
+describe('createB2BPostOrderSelectorFactory()', () => {
+    const createSelector = createB2BPostOrderSelectorFactory();
+
+    it('returns undefined receipt id when no data is loaded', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getReceiptId()).toBeUndefined();
+    });
+
+    it('returns the receipt id string when data is loaded', () => {
+        const state: B2BPostOrderState = {
+            ...DEFAULT_STATE,
+            data: { receiptId: 'rcpt_1' },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getReceiptId()).toBe('rcpt_1');
+    });
+
+    it('returns false for isPersisting when not persisting', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.isPersisting()).toBe(false);
+    });
+
+    it('returns true for isPersisting when persisting', () => {
+        const state: B2BPostOrderState = {
+            ...DEFAULT_STATE,
+            statuses: { isPersisting: true },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.isPersisting()).toBe(true);
+    });
+
+    it('returns undefined for getPersistError when no error', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getPersistError()).toBeUndefined();
+    });
+
+    it('returns error for getPersistError when there is an error', () => {
+        const error = new Error('B2B metadata persist failed');
+        const state: B2BPostOrderState = {
+            ...DEFAULT_STATE,
+            errors: { persistError: error },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getPersistError()).toBe(error);
+    });
+});

--- a/packages/core/src/payment/b2b-post-order-selector.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-selector.spec.ts
@@ -46,7 +46,7 @@ describe('createB2BPostOrderSelectorFactory()', () => {
         const error = new Error('B2B metadata persist failed');
         const state: B2BPostOrderState = {
             ...DEFAULT_STATE,
-            errors: { persistError: error },
+            errors: { persistB2bMetadataError: error },
         };
         const selector = createSelector(state);
 

--- a/packages/core/src/payment/b2b-post-order-selector.ts
+++ b/packages/core/src/payment/b2b-post-order-selector.ts
@@ -19,7 +19,7 @@ export function createB2BPostOrderSelectorFactory(): B2BPostOrderSelectorFactory
     );
 
     const getPersistError = createSelector(
-        (state: B2BPostOrderState) => state.errors.persistError,
+        (state: B2BPostOrderState) => state.errors.persistB2bMetadataError,
         (error) => () => error,
     );
 

--- a/packages/core/src/payment/b2b-post-order-selector.ts
+++ b/packages/core/src/payment/b2b-post-order-selector.ts
@@ -1,0 +1,38 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { createSelector } from '../common/selector';
+
+import B2BPostOrderState, { DEFAULT_STATE } from './b2b-post-order-state';
+
+export default interface B2BPostOrderSelector {
+    getReceiptId(): string | undefined;
+    getPersistError(): Error | undefined;
+    isPersisting(): boolean;
+}
+
+export type B2BPostOrderSelectorFactory = (state: B2BPostOrderState) => B2BPostOrderSelector;
+
+export function createB2BPostOrderSelectorFactory(): B2BPostOrderSelectorFactory {
+    const getReceiptId = createSelector(
+        (state: B2BPostOrderState) => state.data?.receiptId,
+        (receiptId) => () => receiptId,
+    );
+
+    const getPersistError = createSelector(
+        (state: B2BPostOrderState) => state.errors.persistError,
+        (error) => () => error,
+    );
+
+    const isPersisting = createSelector(
+        (state: B2BPostOrderState) => !!state.statuses.isPersisting,
+        (status) => () => status,
+    );
+
+    return memoizeOne((state: B2BPostOrderState = DEFAULT_STATE): B2BPostOrderSelector => {
+        return {
+            getReceiptId: getReceiptId(state),
+            getPersistError: getPersistError(state),
+            isPersisting: isPersisting(state),
+        };
+    });
+}

--- a/packages/core/src/payment/b2b-post-order-state.ts
+++ b/packages/core/src/payment/b2b-post-order-state.ts
@@ -1,0 +1,22 @@
+export interface B2BPostOrderData {
+    receiptId: string;
+}
+
+export default interface B2BPostOrderState {
+    data?: B2BPostOrderData;
+    errors: B2BPostOrderErrorsState;
+    statuses: B2BPostOrderStatusesState;
+}
+
+export interface B2BPostOrderErrorsState {
+    persistError?: Error;
+}
+
+export interface B2BPostOrderStatusesState {
+    isPersisting?: boolean;
+}
+
+export const DEFAULT_STATE: B2BPostOrderState = {
+    errors: {},
+    statuses: {},
+};

--- a/packages/core/src/payment/b2b-post-order-state.ts
+++ b/packages/core/src/payment/b2b-post-order-state.ts
@@ -9,7 +9,7 @@ export default interface B2BPostOrderState {
 }
 
 export interface B2BPostOrderErrorsState {
-    persistError?: Error;
+    persistB2bMetadataError?: Error;
 }
 
 export interface B2BPostOrderStatusesState {

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -47,6 +47,14 @@ export {
     default as B2BPaymentsRefreshRequestSender,
     B2BPaymentsRefreshPayment,
 } from './b2b-payments-refresh-request-sender';
+export { default as B2BPostOrderActionCreator } from './b2b-post-order-action-creator';
+export { default as B2BPostOrderRequestSender } from './b2b-post-order-request-sender';
+export { default as b2bPostOrderReducer } from './b2b-post-order-reducer';
+export {
+    default as B2BPostOrderSelector,
+    createB2BPostOrderSelectorFactory,
+} from './b2b-post-order-selector';
+export { default as B2BPostOrderState } from './b2b-post-order-state';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';
 export { default as PaymentMethodConfig } from './payment-method-config';


### PR DESCRIPTION
## What/Why?

- Add a shareable B2B post-order action creator in chekcout-sdk.
- Add a B2B API call to support end-to-end B2B invoice flow.

## Rollout/Rollback

Revert.

## Testing
### Close Invoice Flow

https://github.com/user-attachments/assets/19f437ff-f954-4b69-a123-3485f9b940c5



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Post-order calls hit the B2B payments API with auth tokens and depend on order/B2B config being present; scope is limited to the new optional flow and follows existing B2B checkout patterns with tests.
> 
> **Overview**
> Adds **B2B post-order metadata** support to checkout-sdk so storefronts can finish the B2B invoice flow after an order is placed.
> 
> **`CheckoutService.persistB2BMetadata`** accepts `{ isInvoice, invoiceComment }`, dispatches on queue `b2bPostOrder`, and when `isInvoice` is true calls the B2B storefront payments API (`submitInvoice` with order id, comment, B2B token, and configured base URL). Non-invoice calls succeed without a network request. Prerequisites (order, B2B token, base URL) are validated before dispatch.
> 
> A new **`b2bPostOrder`** store slice tracks persist in-flight state, errors, and **`receiptId`** on success. Public selectors add **`getB2BReceiptId`**, **`isPersistingB2BMetadata`**, and **`getPersistB2BMetadataError`**. Wiring runs through service factory, store reducer, and payment module exports, with unit tests for the action creator, request sender, reducer, and service method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ee988d8b116e20e5719e7172e1ecbd69a10e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->