### PR TITLE
fix(payments): STRIPE-1511 use Stripe session id for submitPayment

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -952,6 +952,83 @@ describe('StripeOCSPaymentStrategy', () => {
             });
         });
 
+        it('prefers live stripe checkout session id over clientToken on first submitPayment', async () => {
+            jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                Promise.resolve({
+                    ...getStripeCheckoutInstanceMock(),
+                    loadActions: () =>
+                        Promise.resolve({
+                            type: StripeLoadActionsResultType.SUCCESS,
+                            actions: {
+                                ...getStripeCheckoutSessionActionsMock(),
+                                getSession: jest.fn(() =>
+                                    Promise.resolve({
+                                        id: 'cs_live_session_id',
+                                    } as StripeCheckoutSession),
+                                ),
+                            },
+                        }),
+                }),
+            );
+
+            await stripeCSPaymentStrategy.initialize(stripeOptions);
+            await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paymentData: {
+                        formattedPayload: expect.objectContaining({
+                            credit_card_token: { token: 'cs_live_session_id' },
+                        }),
+                    },
+                }),
+            );
+        });
+
+        it('reads clientToken from fresh state after loadPaymentMethod runs', async () => {
+            const staleMethod = { ...getStripeOCSMock(), clientToken: 'stale_token' };
+            const freshMethod = { ...getStripeOCSMock(), clientToken: 'fresh_token' };
+
+            const getPaymentMethodSpy = jest
+                .spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow')
+                .mockReturnValue(staleMethod);
+
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockImplementation(() => {
+                getPaymentMethodSpy.mockReturnValue(freshMethod);
+
+                return Promise.resolve(paymentIntegrationService.getState());
+            });
+
+            jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                Promise.resolve({
+                    ...getStripeCheckoutInstanceMock(),
+                    loadActions: () =>
+                        Promise.resolve({
+                            type: StripeLoadActionsResultType.SUCCESS,
+                            actions: {
+                                ...getStripeCheckoutSessionActionsMock(),
+                                getSession: jest.fn(() =>
+                                    Promise.resolve({ id: '' } as StripeCheckoutSession),
+                                ),
+                            },
+                        }),
+                }),
+            );
+
+            await stripeCSPaymentStrategy.initialize(stripeOptions);
+            await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paymentData: {
+                        formattedPayload: expect.objectContaining({
+                            credit_card_token: { token: 'fresh_token' },
+                        }),
+                    },
+                }),
+            );
+        });
+
         it('execute with selected payment method id without ui handled', async () => {
             const eventMock = {
                 ...StripeEventMock,

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -83,7 +83,10 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
         try {
             await this._initStripeCheckoutSession(stripeocs, paymentMethod);
-            await this._updateStripeShopperData();
+
+            const stripeActions = await this._getStripeActionsOrThrow();
+
+            await this._updateStripeShopperData(stripeActions);
             this._initializePaymentElement(stripeocs, paymentMethod);
             this._initializeAdaptivePricingElement(stripeocs, paymentMethod);
         } catch (error) {
@@ -107,19 +110,23 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
             );
         }
 
-        const state = this.paymentIntegrationService.getState();
-        const { isStoreCreditApplied } = state.getCheckoutOrThrow();
+        const [, stripeActions] = await Promise.all([
+            this._applyStoreCreditIfNeeded(),
+            this._getStripeActionsOrThrow(),
+        ]);
 
-        if (isStoreCreditApplied) {
-            await this.paymentIntegrationService.applyStoreCredit(isStoreCreditApplied);
-        }
-
-        await this._updateCheckoutSessionData(gatewayId, methodId);
-
+        await this._updateCheckoutSessionData(gatewayId, methodId, stripeActions);
         await this.paymentIntegrationService.submitOrder(order, options);
 
-        const { clientToken } = state.getPaymentMethodOrThrow(methodId, gatewayId);
-        const paymentPayload = this._getPaymentPayload(methodId, clientToken || '');
+        const { id: stripeSessionId } = await stripeActions.getSession();
+
+        const { clientToken } = this.paymentIntegrationService
+            .getState()
+            .getPaymentMethodOrThrow(methodId, gatewayId);
+        const paymentPayload = this._getPaymentPayload(
+            methodId,
+            stripeSessionId || clientToken || '',
+        );
 
         try {
             await this.paymentIntegrationService.submitPayment(paymentPayload);
@@ -243,6 +250,16 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         );
     }
 
+    private async _applyStoreCreditIfNeeded(): Promise<void> {
+        const { isStoreCreditApplied } = this.paymentIntegrationService
+            .getState()
+            .getCheckoutOrThrow();
+
+        if (isStoreCreditApplied) {
+            await this.paymentIntegrationService.applyStoreCredit(isStoreCreditApplied);
+        }
+    }
+
     private async _getStripeActionsOrThrow(): Promise<StripeCheckoutSessionActions> {
         if (!this.stripeCheckout) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
@@ -284,8 +301,12 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         stripeElement?.collapse();
     }
 
-    private async _updateCheckoutSessionData(gatewayId: string, methodId: string): Promise<void> {
-        await this._updateStripeShopperData();
+    private async _updateCheckoutSessionData(
+        gatewayId: string,
+        methodId: string,
+        stripeActions: StripeCheckoutSessionActions,
+    ): Promise<void> {
+        await this._updateStripeShopperData(stripeActions);
 
         // INFO: to trigger checkout session data update on the BE side we need to make stripe config request
         await this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
@@ -403,9 +424,9 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         });
     }
 
-    private async _updateStripeShopperData(): Promise<void> {
-        const stripeActions = await this._getStripeActionsOrThrow();
-
+    private async _updateStripeShopperData(
+        stripeActions: StripeCheckoutSessionActions,
+    ): Promise<void> {
         await this._updateStripeEmail(stripeActions);
         await this._updateStripeShippingAddress(stripeActions);
         await this._updateStripeBillingAddress(stripeActions);


### PR DESCRIPTION
## What/Why?
When the Stripe Checkout Session was created on the BE, the strategy was passing the BE-issued clientToken to submitPayment. The live Stripe Checkout Session has its own canonical ID — and that's what the BE actually needs to look up the session and confirm payment.

This change makes the strategy prefer the live session ID from stripeActions.getSession() when calling submitPayment, falling back to clientToken only when no live session ID is available. The result: payment confirmation now matches the session shoppers actually saw, eliminating the class of mismatches that occur when the BE-side session diverges from the client-side one (re-initialization, expiry recovery, etc.).

Alongside that, a few small cleanups inside execute():
  - Store-credit application and Stripe-actions loading now run in parallel — one fewer round-trip in the critical path.
  - clientToken is now read from fresh state (after loadPaymentMethod runs), so any token refresh during the flow is respected.

## Rollout/Rollback
Rollback this PR

## Testing


https://github.com/user-attachments/assets/57e35bde-d2d2-487a-84cd-f54477593569

<img width="719" height="77" alt="Screenshot 2026-06-05 at 12 47 16" src="https://github.com/user-attachments/assets/31c4d4c3-efa2-4853-94a4-630e504bad87" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which token the backend receives on payment submit—affects checkout payment confirmation for Stripe OCS; scope is limited to one strategy with new unit tests.
> 
> **Overview**
> **Stripe Checkout Session (CS) payment** now sends the **live Stripe session id** from `stripeActions.getSession()` as the `credit_card_token` on the first `submitPayment`, using the backend `clientToken` only when that id is missing. That aligns confirmation with the session the shopper actually used and avoids mismatches after re-init or expiry recovery.
> 
> In **`execute()`**, store-credit application and loading Stripe actions run **in parallel** via `Promise.all`, and **`clientToken` is read from state after** `loadPaymentMethod` (inside `_updateCheckoutSessionData`) so refreshed tokens are used. **`_updateStripeShopperData`** and **`_updateCheckoutSessionData`** now take a shared **`StripeCheckoutSessionActions`** instance instead of calling `_getStripeActionsOrThrow()` again inside each helper; **`initialize()`** loads actions once before updating shopper data on the element.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7acff3c142ab4a5c3c91ecc17e4bdc2ada73b980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->