### PR TITLE
fix(payments): STRIPE-1513 re-render place order on currency change

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -221,6 +221,21 @@ describe('StripeOCSPaymentStrategy', () => {
             expect(stripeIntegrationService.mountElement).toHaveBeenCalled();
         });
 
+        it('should call render when payment element ready event fires', async () => {
+            const renderMock = jest.fn();
+
+            await stripeCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeocs: {
+                    ...stripeOptions.stripeocs,
+                    containerId: 'containerId',
+                    render: renderMock,
+                },
+            });
+
+            expect(renderMock).toHaveBeenCalled();
+        });
+
         it('Throws error if no stripe actions loaded', async () => {
             const onErrorMock = jest.fn();
             const renderMock = jest.fn();
@@ -807,6 +822,71 @@ describe('StripeOCSPaymentStrategy', () => {
                 expect(
                     paymentIntegrationService.updatePaymentProviderCustomer,
                 ).not.toHaveBeenCalled();
+            });
+
+            it('should call render after currency change updates the payment provider customer', async () => {
+                const renderMock = jest.fn();
+                const currencyEvent = {
+                    complete: false,
+                    elementType: 'currencySelector',
+                    empty: false,
+                    value: { currency: 'EUR' },
+                };
+                let currencyChangeHandled: Promise<unknown> | undefined;
+
+                mockPaymentMethodWithAdaptivePricing(true);
+                mockStripeCheckoutWithCurrencySelector(
+                    jest.fn((_, callback) => {
+                        currencyChangeHandled = callback(currencyEvent);
+                    }),
+                );
+
+                await stripeCSPaymentStrategy.initialize({
+                    ...stripeOptions,
+                    stripeocs: {
+                        ...stripeOptions.stripeocs,
+                        render: renderMock,
+                    },
+                });
+                await currencyChangeHandled;
+
+                expect(
+                    paymentIntegrationService.updatePaymentProviderCustomer,
+                ).toHaveBeenCalledWith({
+                    isCustomerCurrencySelected: true,
+                    customerCurrency: 'eur',
+                });
+                // One render fires for payment element READY, the second one
+                // is the STRIPE-1513 fix that re-displays the place order button.
+                expect(renderMock).toHaveBeenCalledTimes(2);
+            });
+
+            it('should not call render for currency change when event has no currency value', async () => {
+                const renderMock = jest.fn();
+                let currencyChangeHandled: Promise<unknown> | undefined;
+
+                mockPaymentMethodWithAdaptivePricing(true);
+                mockStripeCheckoutWithCurrencySelector(
+                    jest.fn((_, callback) => {
+                        currencyChangeHandled = callback(StripeEventMock);
+                    }),
+                );
+
+                await stripeCSPaymentStrategy.initialize({
+                    ...stripeOptions,
+                    stripeocs: {
+                        ...stripeOptions.stripeocs,
+                        render: renderMock,
+                    },
+                });
+                await currencyChangeHandled;
+
+                expect(
+                    paymentIntegrationService.updatePaymentProviderCustomer,
+                ).not.toHaveBeenCalled();
+                // Only the payment element READY render fires; the currency
+                // change handler short-circuits before reaching render.
+                expect(renderMock).toHaveBeenCalledTimes(1);
             });
         });
     });

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -184,7 +184,6 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         const {
             containerId,
             layout,
-            render,
             paymentMethodSelect,
             handleClosePaymentMethod,
             togglePreloader,
@@ -217,7 +216,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         });
 
         stripeElement.on(StripeElementEvent.READY, () => {
-            render();
+            this._rerenderPlaceholderButton();
         });
 
         stripeElement.on(StripeElementEvent.CHANGE, (event: StripeEventType) => {
@@ -515,6 +514,8 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
                 isCustomerCurrencySelected: currencyCode !== stripeCurrencyCode,
                 customerCurrency: stripeCurrencyCode,
             });
+
+            this._rerenderPlaceholderButton();
         });
     }
 
@@ -523,5 +524,10 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
     ): Promise<void> {
         await this.deinitialize();
         await this.initialize(options);
+    }
+
+    private _rerenderPlaceholderButton(): void {
+        const { render } = this.stripeInitializationOptions || {};
+        render?.();
     }
 }


### PR DESCRIPTION
## What/Why?
When a shopper switches the currency in the Stripe OCS adaptive-pricing currency selector, the host re-receives `updatePaymentProviderCustomer` state but never gets a signal to re-render its placeholder/submit area. As a result, the **Place order** button stays hidden after switching back from store currency to the shopper's local currency, until the shopper re-selects a payment method.

This PR adds an explicit `render()` callback invocation after the adaptive pricing `CHANGE` handler finishes updating customer state, so the host can refresh the placeholder button.

## Rollout/Rollback
No feature flag. Rollback is a straight code revert — the change is fully contained in `stripe-cs-payment-strategy.ts` and its spec file. No DB migrations, no host (checkout-js) changes required.

## Testing
Before:

https://github.com/user-attachments/assets/b22022c4-be66-4711-b5bd-a9ecbef061d2

After:

https://github.com/user-attachments/assets/c85dde64-fa83-44d4-ac96-2cfd190309d1


<img width="729" height="83" alt="Screenshot 2026-06-08 at 18 57 30" src="https://github.com/user-attachments/assets/50f3197a-b56e-4123-9e7b-fd649a365aaa" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Stripe OCS UI callbacks with no auth or payment submission logic changes; behavior is covered by new unit tests.
> 
> **Overview**
> Fixes **STRIPE-1513** by ensuring the checkout host’s `render()` callback runs when Stripe OCS state changes, so the **Place order** placeholder can show again after adaptive-pricing currency switches.
> 
> `stripe-cs-payment-strategy` now routes both the payment element **READY** handler and the currency selector **CHANGE** path (after `updatePaymentProviderCustomer`) through a new `_rerenderPlaceholderButton()` helper that calls the stored `stripeocs.render` option. Specs cover READY render, a second render on valid currency change, and no extra render when the currency event has no value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 588d24f1a5f68b51822bc043174ada91529eee16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->