### PR TITLE
chore(checkout): CHECKOUT-10085 Update capability name for hideCheckMethod

### DIFF
--- a/packages/core/src/config/capabilities.ts
+++ b/packages/core/src/config/capabilities.ts
@@ -43,6 +43,7 @@ export interface Capabilities {
             label: string;
             required: boolean;
         } | null;
+        hideCheckPaymentMethod: boolean;
     };
     orderConfirmation: {
         persistB2BMetadata: boolean;

--- a/packages/payment-integration-api/src/config/capabilities.ts
+++ b/packages/payment-integration-api/src/config/capabilities.ts
@@ -43,6 +43,7 @@ export interface Capabilities {
             label: string;
             required: boolean;
         } | null;
+        hideCheckPaymentMethod: boolean;
     };
     orderConfirmation: {
         persistB2BMetadata: boolean;


### PR DESCRIPTION
## What/Why?
Update capability name for hideCheckMethod

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming or adding a capability field can break runtime config or UI that still expects the old key unless all mappings and defaults are updated elsewhere.
> 
> **Overview**
> Adds **`hideCheckPaymentMethod: boolean`** under **`Capabilities.payment`** in the mirrored capability definitions in **`packages/core`** and **`packages/payment-integration-api`**, keeping the two copies in sync per the file comments.
> 
> This aligns the checkout capability surface with the renamed “hide check payment method” flag (CHECKOUT-10085); consumers and capability config must use the new property name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b656b0e08a79e40e327bc65c2f886ebaa4bb28b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->