### PR TITLE
feat(checkout): CHECKOUT-9819 implement post order request for b2b user

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -669,6 +669,10 @@ describe('CheckoutService', () => {
             expect(b2bPostOrderActionCreator.persistB2BMetadata).toHaveBeenCalledWith({
                 isInvoice: true,
                 invoiceComment: 'Invoice comment',
+                poNumber: '',
+                referenceNumber: '',
+                extraFields: [],
+                extraInfo: {},
             });
 
             await result.catch(() => undefined);

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -736,10 +736,18 @@ export default class CheckoutService {
     persistB2BMetadata({
         isInvoice = false,
         invoiceComment = '',
+        poNumber = '',
+        referenceNumber = '',
+        extraFields = [],
+        extraInfo = {},
     }: PersistB2BMetadataOptions): Promise<CheckoutSelectors> {
         const action = this._b2bPostOrderActionCreator.persistB2BMetadata({
             isInvoice,
             invoiceComment,
+            poNumber,
+            referenceNumber,
+            extraFields,
+            extraInfo,
         });
 
         return this._dispatch(action, { queueId: 'b2bPostOrder' });

--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -36,6 +36,8 @@ describe('B2BPostOrderActionCreator', () => {
             getResponse({ data: { paymentId: 'pay_1', receiptId: 'rcpt_1' }, code: 200 }),
         );
 
+        jest.spyOn(requestSender, 'addOrderExtraFields').mockResolvedValue(getResponse(undefined));
+
         jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
             ...getConfig().storeConfig,
             b2bApiSettings,
@@ -69,12 +71,23 @@ describe('B2BPostOrderActionCreator', () => {
             );
         });
 
-        it('does not call closeInvoice when isInvoice is false', async () => {
+        it('calls addOrderExtraFields and dispatches succeeded with empty receiptId when isInvoice is false', async () => {
             const actions = await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store))
                 .pipe(toArray())
                 .toPromise();
 
             expect(requestSender.submitInvoice).not.toHaveBeenCalled();
+            expect(requestSender.addOrderExtraFields).toHaveBeenCalledWith(
+                {
+                    orderId: '295',
+                    poNumber: '',
+                    referenceNumber: '',
+                    extraFields: [],
+                    extraInfo: {},
+                },
+                'b2b-auth-token',
+                b2bApiSettings.baseUrl,
+            );
             expect(actions).toEqual([
                 { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
                 {
@@ -82,6 +95,39 @@ describe('B2BPostOrderActionCreator', () => {
                     payload: { receiptId: '' },
                 },
             ]);
+        });
+
+        it('forwards po number, reference number, extra fields and extra info to addOrderExtraFields', async () => {
+            const extraFields = [{ fieldName: 'department', fieldValue: 'engineering' }];
+            const extraInfo = { billingAddressId: 12 };
+
+            await from(
+                actionCreator.persistB2BMetadata({
+                    isInvoice: false,
+                    poNumber: 'PO-123',
+                    referenceNumber: 'REF-456',
+                    extraFields,
+                    extraInfo,
+                })(store),
+            ).toPromise();
+
+            expect(requestSender.addOrderExtraFields).toHaveBeenCalledWith(
+                {
+                    orderId: '295',
+                    poNumber: 'PO-123',
+                    referenceNumber: 'REF-456',
+                    extraFields,
+                    extraInfo,
+                },
+                'b2b-auth-token',
+                b2bApiSettings.baseUrl,
+            );
+        });
+
+        it('does not call addOrderExtraFields when isInvoice is true', async () => {
+            await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
+
+            expect(requestSender.addOrderExtraFields).not.toHaveBeenCalled();
         });
 
         it('throws when the order id is missing', () => {

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -21,6 +21,10 @@ export default class B2BPostOrderActionCreator {
     persistB2BMetadata({
         isInvoice,
         invoiceComment,
+        poNumber,
+        referenceNumber,
+        extraFields,
+        extraInfo,
     }: PersistB2BMetadataOptions): ThunkAction<
         PersistB2BMetadataAction,
         InternalCheckoutSelectors
@@ -50,6 +54,18 @@ export default class B2BPostOrderActionCreator {
                         );
 
                         payload = { receiptId: body.data.receiptId };
+                    } else {
+                        await this._requestSender.addOrderExtraFields(
+                            {
+                                orderId: `${orderId}`,
+                                poNumber: poNumber ?? '',
+                                referenceNumber: referenceNumber ?? '',
+                                extraFields: extraFields ?? [],
+                                extraInfo: extraInfo ?? {},
+                            },
+                            b2bToken,
+                            b2bBaseUrl,
+                        );
                     }
 
                     return createAction(

--- a/packages/core/src/payment/b2b-post-order-actions.ts
+++ b/packages/core/src/payment/b2b-post-order-actions.ts
@@ -1,10 +1,15 @@
 import { Action } from '@bigcommerce/data-store';
 
 import { B2BPostOrderData } from './b2b-post-order-state';
+import { AddOrderExtraFieldsPayload, ExtraField } from './b2b-post-order-request-sender';
 
 export interface PersistB2BMetadataOptions {
     isInvoice: boolean;
-    invoiceComment: string;
+    invoiceComment?: string;
+    poNumber?: string;
+    referenceNumber?: string;
+    extraFields?: ExtraField[];
+    extraInfo?: AddOrderExtraFieldsPayload['extraInfo'];
 }
 
 export enum B2BPostOrderActionType {

--- a/packages/core/src/payment/b2b-post-order-actions.ts
+++ b/packages/core/src/payment/b2b-post-order-actions.ts
@@ -1,14 +1,14 @@
 import { Action } from '@bigcommerce/data-store';
 
+import { AddOrderExtraFieldsPayload, B2BExtraField } from './b2b-post-order-request-sender';
 import { B2BPostOrderData } from './b2b-post-order-state';
-import { AddOrderExtraFieldsPayload, ExtraField } from './b2b-post-order-request-sender';
 
 export interface PersistB2BMetadataOptions {
     isInvoice: boolean;
     invoiceComment?: string;
     poNumber?: string;
     referenceNumber?: string;
-    extraFields?: ExtraField[];
+    extraFields?: B2BExtraField[];
     extraInfo?: AddOrderExtraFieldsPayload['extraInfo'];
 }
 

--- a/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
@@ -2,7 +2,10 @@ import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/
 
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
-import B2BPostOrderRequestSender, { CloseInvoicePayload } from './b2b-post-order-request-sender';
+import B2BPostOrderRequestSender, {
+    AddOrderExtraFieldsPayload,
+    CloseInvoicePayload,
+} from './b2b-post-order-request-sender';
 
 describe('B2BPostOrderRequestSender', () => {
     let requestSender: RequestSender;
@@ -68,6 +71,56 @@ describe('B2BPostOrderRequestSender', () => {
             await expect(
                 b2bPostOrderRequestSender.submitInvoice(
                     payload,
+                    'b2b-token-value',
+                    'https://api-b2b.bigcommerce.com',
+                ),
+            ).rejects.toEqual(getErrorResponse());
+        });
+    });
+
+    describe('#addOrderExtraFields()', () => {
+        const extraFieldsPayload: AddOrderExtraFieldsPayload = {
+            orderId: '295',
+            poNumber: 'PO-123',
+            referenceNumber: 'REF-456',
+            extraFields: [{ fieldName: 'department', fieldValue: 'engineering' }],
+            extraInfo: {
+                billingAddressId: 12,
+                shipppingAddressId: 34,
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'floor', fieldValue: 3 }],
+                    shippingAddressExtraFields: [{ fieldName: 'gate', fieldValue: 'B' }],
+                },
+            },
+        };
+
+        it('posts to the B2B orders endpoint with auth headers and payload', async () => {
+            await b2bPostOrderRequestSender.addOrderExtraFields(
+                extraFieldsPayload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/orders',
+                {
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                    body: extraFieldsPayload,
+                },
+            );
+        });
+
+        it('rejects when the request sender rejects', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
+
+            await expect(
+                b2bPostOrderRequestSender.addOrderExtraFields(
+                    extraFieldsPayload,
                     'b2b-token-value',
                     'https://api-b2b.bigcommerce.com',
                 ),

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -15,6 +15,26 @@ export interface CloseInvoiceResponseBody {
     code: number;
 }
 
+export interface ExtraField {
+    fieldName: string;
+    fieldValue: string | number | boolean | string[];
+}
+
+export interface AddOrderExtraFieldsPayload {
+    orderId: string;
+    poNumber: string;
+    referenceNumber: string;
+    extraFields: ExtraField[];
+    extraInfo: {
+        addressExtraFields?: {
+            billingAddressExtraFields: ExtraField[];
+            shippingAddressExtraFields: ExtraField[];
+        };
+        billingAddressId?: number;
+        shipppingAddressId?: number; // triple-p is intentional — wire contract
+    };
+}
+
 export default class B2BPostOrderRequestSender {
     constructor(private _requestSender: RequestSender) {}
 
@@ -37,5 +57,21 @@ export default class B2BPostOrderRequestSender {
                 body: payload,
             },
         );
+    }
+
+    async addOrderExtraFields(
+        payload: AddOrderExtraFieldsPayload,
+        b2bToken: string,
+        b2bBaseUrl: string,
+    ): Promise<Response<void>> {
+        return this._requestSender.post(`${b2bBaseUrl}/api/v2/orders`, {
+            credentials: false,
+            headers: {
+                'Content-Type': 'application/json',
+                authToken: b2bToken,
+                Authorization: `Bearer ${b2bToken}`,
+            },
+            body: payload,
+        });
     }
 }

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -15,7 +15,7 @@ export interface CloseInvoiceResponseBody {
     code: number;
 }
 
-export interface ExtraField {
+export interface B2BExtraField {
     fieldName: string;
     fieldValue: string | number | boolean | string[];
 }
@@ -24,11 +24,11 @@ export interface AddOrderExtraFieldsPayload {
     orderId: string;
     poNumber: string;
     referenceNumber: string;
-    extraFields: ExtraField[];
+    extraFields: B2BExtraField[];
     extraInfo: {
         addressExtraFields?: {
-            billingAddressExtraFields: ExtraField[];
-            shippingAddressExtraFields: ExtraField[];
+            billingAddressExtraFields: B2BExtraField[];
+            shippingAddressExtraFields: B2BExtraField[];
         };
         billingAddressId?: number;
         shipppingAddressId?: number; // triple-p is intentional — wire contract


### PR DESCRIPTION
## What/Why?

Extends the B2B post-order flow so that when an order is not an invoice, the SDK posts the order's extra metadata (PO number, reference number, and arbitrary extra fields) to the B2B Orders API. 

## Rollout/Rollback

Revert this PR

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a post-checkout external API call on the non-invoice B2B path; failures could leave orders without persisted B2B metadata though checkout already completed.
> 
> **Overview**
> Extends **`persistB2BMetadata`** so non-invoice B2B orders send PO number, reference number, custom **extra fields**, and **extraInfo** (e.g. address IDs and address extra fields) to the B2B Orders API via a new **`addOrderExtraFields`** POST to `/api/v2/orders`. Invoice orders still use **`submitInvoice`** only.
> 
> **`CheckoutService.persistB2BMetadata`** accepts the new options with empty defaults and forwards them through the action creator. Success for the non-invoice path still dispatches **`PersistB2BMetadataSucceeded`** with an empty **`receiptId`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55a974d8660c70dd1b6864cb1ade492e3859d408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->