### PR TITLE
feat(payment): PAYPAL-6640 removed the unnecessary request since it fires before strategy initialization

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -99,8 +99,6 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
             await this._paymentIntegrationService.loadDefaultCheckout();
         }
 
-        await this._paymentIntegrationService.loadPaymentMethod(methodId);
-
         const state = this._paymentIntegrationService.getState();
 
         this._paymentMethod = state.getPaymentMethodOrThrow(methodId);


### PR DESCRIPTION
## What/Why?

Removed the unnecessary request since it fires before strategy initialization

## Rollout/Rollback

Revert

## Testing

Verified changes on integration store

- [x] PDP
- [x] Cart Page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> If the method is not already in integration state when the button initializes, `getPaymentMethodOrThrow` could fail where the explicit load previously masked that gap.
> 
> **Overview**
> Removes the **`loadPaymentMethod(methodId)`** call from **`ApplePayButtonStrategy.initialize`**, so button setup no longer triggers an extra payment-method fetch before the strategy finishes initializing.
> 
> Initialization still loads the default checkout when not in buy-now mode, then reads the Apple Pay method from integration state via **`getPaymentMethodOrThrow`**, relying on the payment method already being present from the broader checkout/button initialization flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795de6a5c2e348796fefe3aa170af9278f0d8f3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->