### PR TITLE
refactor(checkout): CHECKOUT-10091 Update Capabilities Interface

### DIFF
--- a/packages/core/src/config/capabilities.ts
+++ b/packages/core/src/config/capabilities.ts
@@ -3,8 +3,8 @@
 // Please update both files if you want to make changes to the Capabilities interface
 
 export enum B2BPaymentMethodFilterType {
-    Standard = 'STANDARD',
-    Invoice = 'INVOICE',
+    Standard = 'standard',
+    Invoice = 'invoice',
 }
 
 export interface Capabilities {
@@ -17,6 +17,10 @@ export interface Capabilities {
         hasAddressExtraFields: boolean;
         hasOrderExtraFields: boolean;
         requiresB2BToken: boolean;
+        hasAddressLabel: boolean;
+        quoteConfig: {
+            id: number;
+        } | null;
     };
     customer: {
         superAdminCompanySelector: boolean;
@@ -34,10 +38,14 @@ export interface Capabilities {
         b2bPaymentMethodFilterType: B2BPaymentMethodFilterType | null;
         invoicePaymentComment: boolean;
         poConfig: {
-            label: string;
-            required: boolean;
-            creditLimit: number;
-            currency: string;
+            field: {
+                label: string;
+                required: boolean;
+            } | null;
+            creditLimitCheck: {
+                creditLimit: number;
+                currency: string;
+            } | null;
         } | null;
         additionalField: {
             label: string;
@@ -48,6 +56,6 @@ export interface Capabilities {
     orderConfirmation: {
         persistB2BMetadata: boolean;
         invoiceRedirect: boolean;
-        canCreatePersonalAccount: boolean;
+        cannotCreatePersonalAccount: boolean;
     };
 }

--- a/packages/payment-integration-api/src/config/capabilities.ts
+++ b/packages/payment-integration-api/src/config/capabilities.ts
@@ -3,8 +3,8 @@
 // Please update both files if you want to make changes to the Capabilities interface
 
 export enum B2BPaymentMethodFilterType {
-    Standard = 'STANDARD',
-    Invoice = 'INVOICE',
+    Standard = 'standard',
+    Invoice = 'invoice',
 }
 
 export interface Capabilities {
@@ -17,6 +17,10 @@ export interface Capabilities {
         hasAddressExtraFields: boolean;
         hasOrderExtraFields: boolean;
         requiresB2BToken: boolean;
+        hasAddressLabel: boolean;
+        quoteConfig: {
+            id: number;
+        } | null;
     };
     customer: {
         superAdminCompanySelector: boolean;
@@ -34,10 +38,14 @@ export interface Capabilities {
         b2bPaymentMethodFilterType: B2BPaymentMethodFilterType | null;
         invoicePaymentComment: boolean;
         poConfig: {
-            label: string;
-            required: boolean;
-            creditLimit: number;
-            currency: string;
+            field: {
+                label: string;
+                required: boolean;
+            } | null;
+            creditLimitCheck: {
+                creditLimit: number;
+                currency: string;
+            } | null;
         } | null;
         additionalField: {
             label: string;
@@ -48,6 +56,6 @@ export interface Capabilities {
     orderConfirmation: {
         persistB2BMetadata: boolean;
         invoiceRedirect: boolean;
-        canCreatePersonalAccount: boolean;
+        cannotCreatePersonalAccount: boolean;
     };
 }


### PR DESCRIPTION
## What/Why?

Update the capabilities to reflect recent API changes.

* poConfig restructured into two independently-nullable sub-configs
   * field: { label, required } | null
   * creditLimitCheck: { creditLimit, currency } | null
   * outer poConfig remains nullable
* userJourney gains two fields
   * hasAddressLabel: boolean
   * quoteConfig: { id: number } | null
* B2BPaymentMethodFilterType enum values lowercased
   * 'STANDARD' → 'standard'
   * 'INVOICE' → 'invoice'
* orderConfirmation field renamed
   * canCreatePersonalAccount → cannotCreatePersonalAccount

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Contract changes (poConfig shape, enum values, and inverted boolean on order confirmation) can break any consumer not updated in the same rollout.
> 
> **Overview**
> Aligns the shared **`Capabilities`** contract (kept in sync in `packages/core` and `packages/payment-integration-api`) with recent API changes.
> 
> **`userJourney`** adds **`hasAddressLabel`** and optional **`quoteConfig`** (`{ id }`). **`payment.poConfig`** is split into independently nullable **`field`** (label/required) and **`creditLimitCheck`** (credit limit/currency) instead of a flat shape. **`B2BPaymentMethodFilterType`** string values are lowercased (`standard` / `invoice`). **`orderConfirmation`** renames **`canCreatePersonalAccount`** to **`cannotCreatePersonalAccount`** (inverted meaning—call sites must flip logic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10953bbb27aa95fd25d832663d6148fb610a2a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->