### PR TITLE
feat(checkout): CHECKOUT-9819 update order id to be number

### DIFF
--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -79,7 +79,7 @@ describe('B2BPostOrderActionCreator', () => {
             expect(requestSender.submitInvoice).not.toHaveBeenCalled();
             expect(requestSender.addOrderExtraFields).toHaveBeenCalledWith(
                 {
-                    orderId: '295',
+                    orderId: 295,
                     poNumber: '',
                     referenceNumber: '',
                     extraFields: [],
@@ -113,7 +113,7 @@ describe('B2BPostOrderActionCreator', () => {
 
             expect(requestSender.addOrderExtraFields).toHaveBeenCalledWith(
                 {
-                    orderId: '295',
+                    orderId: 295,
                     poNumber: 'PO-123',
                     referenceNumber: 'REF-456',
                     extraFields,

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -57,7 +57,7 @@ export default class B2BPostOrderActionCreator {
                     } else {
                         await this._requestSender.addOrderExtraFields(
                             {
-                                orderId: `${orderId}`,
+                                orderId,
                                 poNumber: poNumber ?? '',
                                 referenceNumber: referenceNumber ?? '',
                                 extraFields: extraFields ?? [],

--- a/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
@@ -80,7 +80,7 @@ describe('B2BPostOrderRequestSender', () => {
 
     describe('#addOrderExtraFields()', () => {
         const extraFieldsPayload: AddOrderExtraFieldsPayload = {
-            orderId: '295',
+            orderId: 295,
             poNumber: 'PO-123',
             referenceNumber: 'REF-456',
             extraFields: [{ fieldName: 'department', fieldValue: 'engineering' }],

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -21,7 +21,7 @@ export interface B2BExtraField {
 }
 
 export interface AddOrderExtraFieldsPayload {
-    orderId: string;
+    orderId: number;
     poNumber: string;
     referenceNumber: string;
     extraFields: B2BExtraField[];


### PR DESCRIPTION
## What/Why?

Update order_id passed to post order API to be number instead of string.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small type and serialization change on one B2B endpoint; invoice flow is unchanged.
> 
> **Overview**
> Aligns the B2B **`addOrderExtraFields`** post-order payload with the API by typing **`orderId` as a number** and sending it without string coercion.
> 
> **`AddOrderExtraFieldsPayload`** now declares `orderId: number`. **`persistB2BMetadata`** passes the checkout order id through as a number to `addOrderExtraFields` instead of `` `${orderId}` ``. Invoice **`submitInvoice`** still sends `orderId` as a string. Specs were updated to expect numeric `orderId` in those calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 574744a8bd08f8810c6d390134f580565f267e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->