### PR TITLE
fix(checkout): PAYPAL-6440 Fix T&C checkbox can be bypassed durring PSD2 flow but it is required

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-initialize-options.ts
@@ -2,6 +2,7 @@ import {
     BraintreeError,
     BraintreeFormOptions,
     BraintreeThreeDSecureOptions,
+    ButtonActions,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import { StandardError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
@@ -49,6 +50,22 @@ export interface BraintreePaypalPaymentInitializeOptions {
      * A callback for displaying error popup. This callback requires error object as parameter.
      */
     onError?(error: unknown): void;
+
+    /**
+     * A callback for the Smart Payment Button initialization.
+     * Used to register button actions (enable/disable) in the `checkout-sdk-js`
+     *
+     * @param actions - The Braintree PayPal Button actions
+     */
+    onInitButton(actions: ButtonActions): void;
+
+    /**
+     * Callback for the Checkout form validation.
+     *
+     * @param resolve - Callback for the successful form validation
+     * @param reject - Callback for the failed form validation
+     */
+    onValidate(resolve: () => void, reject: () => void): Promise<void>;
 }
 
 export interface WithBraintreePaypalPaymentInitializeOptions {

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-initialize-options.ts
@@ -2,7 +2,7 @@ import {
     BraintreeError,
     BraintreeFormOptions,
     BraintreeThreeDSecureOptions,
-    ButtonActions,
+    InitButtonActions,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import { StandardError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
@@ -57,7 +57,7 @@ export interface BraintreePaypalPaymentInitializeOptions {
      *
      * @param actions - The Braintree PayPal Button actions
      */
-    onInitButton?(actions: ButtonActions): void;
+    onInitButton?(actions: InitButtonActions): void;
 
     /**
      * Callback for the Checkout form validation.

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-initialize-options.ts
@@ -57,7 +57,7 @@ export interface BraintreePaypalPaymentInitializeOptions {
      *
      * @param actions - The Braintree PayPal Button actions
      */
-    onInitButton(actions: ButtonActions): void;
+    onInitButton?(actions: ButtonActions): void;
 
     /**
      * Callback for the Checkout form validation.
@@ -65,7 +65,7 @@ export interface BraintreePaypalPaymentInitializeOptions {
      * @param resolve - Callback for the successful form validation
      * @param reject - Callback for the failed form validation
      */
-    onValidate(resolve: () => void, reject: () => void): Promise<void>;
+    onValidate?(resolve: () => void, reject: () => void): Promise<void>;
 }
 
 export interface WithBraintreePaypalPaymentInitializeOptions {

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
@@ -194,7 +194,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
             eventEmitter.on('onClick', () => {
                 if (options.onClick) {
                     options.onClick(
-                        { fundingSource: paypalSdkMock.FUNDING.PAYPAL as string },
+                        { fundingSource: paypalSdkMock.FUNDING.PAYPAL! },
                         {
                             reject: jest.fn(),
                             resolve: jest.fn(),

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
@@ -48,6 +48,7 @@ import BraintreePaypalPaymentStrategy from './braintree-paypal-payment-strategy'
 
 describe('BraintreePaypalPaymentStrategy', () => {
     let eventEmitter: EventEmitter;
+    let loadingIndicator: LoadingIndicator;
     let strategy: BraintreePaypalPaymentStrategy;
     let paymentIntegrationService: PaymentIntegrationService;
     let braintreeScriptLoader: BraintreeScriptLoader;
@@ -96,6 +97,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
             braintreeSDKVersionManager,
         );
         braintreeMessages = new BraintreeMessages(paymentIntegrationService);
+        loadingIndicator = new LoadingIndicator();
         braintreeIntegrationService = new BraintreeIntegrationService(
             braintreeScriptLoader,
             window,
@@ -104,7 +106,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
             paymentIntegrationService,
             braintreeIntegrationService,
             braintreeMessages,
-            new LoadingIndicator(),
+            loadingIndicator,
         );
 
         const div = document.createElement('div');
@@ -174,6 +176,8 @@ describe('BraintreePaypalPaymentStrategy', () => {
 
         jest.spyOn(braintreeMessages, 'render');
 
+        jest.spyOn(loadingIndicator, 'show').mockReturnValue(undefined);
+
         jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation((options: PaypalButtonOptions) => {
             eventEmitter.on('approve', () => {
                 if (typeof options.onApprove === 'function') {
@@ -184,6 +188,18 @@ describe('BraintreePaypalPaymentStrategy', () => {
             eventEmitter.on('createOrder', () => {
                 if (typeof options.createOrder === 'function') {
                     options.createOrder();
+                }
+            });
+
+            eventEmitter.on('onClick', () => {
+                if (options.onClick) {
+                    options.onClick(
+                        { fundingSource: paypalSdkMock.FUNDING.PAYPAL as string },
+                        {
+                            reject: jest.fn(),
+                            resolve: jest.fn(),
+                        },
+                    );
                 }
             });
 
@@ -610,54 +626,101 @@ describe('BraintreePaypalPaymentStrategy', () => {
             expect(paymentIntegrationService.submitPayment).toHaveBeenLastCalledWith(expected);
         });
 
-        it('#createOrder button callback', async () => {
-            jest.spyOn(paymentIntegrationService, 'submitPayment').mockImplementation(() => {
-                throw providerError;
+        describe('#createOrder button callback', () => {
+            it('calls validation callback with provided params', async () => {
+                const onValidateMock = jest.fn().mockImplementation((resolve) => {
+                    resolve();
+                });
+
+                const braintreeOptions = {
+                    ...options,
+                    braintree: {
+                        onError: jest.fn(),
+                        containerId: '#checkout-button-container',
+                        bannerContainerId: 'banner-container-id',
+                        onValidate: onValidateMock,
+                    },
+                };
+
+                await strategy.initialize(braintreeOptions);
+
+                eventEmitter.emit('onClick');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(onValidateMock).toHaveBeenCalled();
             });
 
-            const braintreeOptions = {
-                ...options,
-                braintree: {
-                    onError: jest.fn(),
-                    containerId: '#checkout-button-container',
-                },
-            };
+            it('triggers the indicator through the validation callback call with provided params', async () => {
+                await strategy.initialize({
+                    ...options,
+                    braintree: {
+                        containerId: '#checkout-button-container',
+                        bannerContainerId: 'banner-container-id',
+                        onValidate: jest.fn().mockImplementation((onValidationPassed) => {
+                            onValidationPassed();
+                        }),
+                    },
+                });
 
-            await strategy.initialize(braintreeOptions);
+                eventEmitter.emit('onClick');
 
-            try {
-                await strategy.execute(orderRequestBody, options);
-            } catch (error) {
-                expect(braintreeOptions.braintree.onError).toHaveBeenCalledWith(
-                    new Error('INSTRUMENT_DECLINED'),
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(loadingIndicator.show).toHaveBeenCalled();
+            });
+
+            it('createPayment options check', async () => {
+                jest.spyOn(paymentIntegrationService, 'submitPayment').mockImplementation(() => {
+                    throw providerError;
+                });
+
+                const braintreeOptions = {
+                    ...options,
+                    braintree: {
+                        onError: jest.fn(),
+                        containerId: '#checkout-button-container',
+                    },
+                };
+
+                await strategy.initialize(braintreeOptions);
+
+                try {
+                    await strategy.execute(orderRequestBody, options);
+                } catch (error) {
+                    expect(braintreeOptions.braintree.onError).toHaveBeenCalledWith(
+                        new Error('INSTRUMENT_DECLINED'),
+                    );
+                }
+
+                jest.spyOn(paymentIntegrationService, 'submitPayment').mockImplementation(
+                    jest.fn(),
                 );
-            }
 
-            jest.spyOn(paymentIntegrationService, 'submitPayment').mockImplementation(jest.fn());
+                eventEmitter.emit('createOrder');
 
-            eventEmitter.emit('createOrder');
+                await new Promise((resolve) => process.nextTick(resolve));
 
-            await new Promise((resolve) => process.nextTick(resolve));
+                await strategy.execute(orderRequestBody, options);
 
-            await strategy.execute(orderRequestBody, options);
-
-            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith({
-                amount: 190,
-                currency: 'USD',
-                enableShippingAddress: true,
-                flow: 'checkout',
-                offerCredit: false,
-                shippingAddressEditable: false,
-                shippingAddressOverride: {
-                    city: 'Some City',
-                    countryCode: 'US',
-                    line1: '12345 Testing Way',
-                    line2: '',
-                    phone: '555-555-5555',
-                    postalCode: '95555',
-                    recipientName: 'Test Tester',
-                    state: 'CA',
-                },
+                expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith({
+                    amount: 190,
+                    currency: 'USD',
+                    enableShippingAddress: true,
+                    flow: 'checkout',
+                    offerCredit: false,
+                    shippingAddressEditable: false,
+                    shippingAddressOverride: {
+                        city: 'Some City',
+                        countryCode: 'US',
+                        line1: '12345 Testing Way',
+                        line2: '',
+                        phone: '555-555-5555',
+                        postalCode: '95555',
+                        recipientName: 'Test Tester',
+                        state: 'CA',
+                    },
+                });
             });
         });
 

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -349,9 +349,20 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                 env: testMode ? 'sandbox' : 'production',
                 commit: false,
                 fundingSource,
-                onClick: () => {
-                    this.toggleLoadingIndicator(true);
-                },
+                onInit: ((_, actions) => {
+                    options?.onInitButton(actions);
+                }),
+                onClick: ((_, actions) => {
+                    const { resolve, reject } = actions;
+
+                    const onValidationPassed = () => {
+                        this.toggleLoadingIndicator(true);
+
+                        return resolve();
+                    };
+
+                    return options?.onValidate?.(onValidationPassed, reject);
+                }),
                 createOrder: () => this.setupPayment(braintreePaypalCheckout, id, onPaymentError),
                 onApprove: async (authorizeData: PaypalAuthorizeData) => {
                     this.braintreeTokenizePayload = await this.tokenizePaymentOrThrow(

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -349,10 +349,10 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                 env: testMode ? 'sandbox' : 'production',
                 commit: false,
                 fundingSource,
-                onInit: ((_, actions) => {
+                onInit: (_, actions) => {
                     options?.onInitButton(actions);
-                }),
-                onClick: ((_, actions) => {
+                },
+                onClick: (_, actions) => {
                     const { resolve, reject } = actions;
 
                     const onValidationPassed = () => {
@@ -362,7 +362,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                     };
 
                     return options?.onValidate?.(onValidationPassed, reject);
-                }),
+                },
                 createOrder: () => this.setupPayment(braintreePaypalCheckout, id, onPaymentError),
                 onApprove: async (authorizeData: PaypalAuthorizeData) => {
                     this.braintreeTokenizePayload = await this.tokenizePaymentOrThrow(

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -361,7 +361,9 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                         return resolve();
                     };
 
-                    return options?.onValidate?.(onValidationPassed, reject);
+                    return typeof options?.onValidate !== 'undefined'
+                        ? options.onValidate(onValidationPassed, reject)
+                        : onValidationPassed();
                 },
                 createOrder: () => this.setupPayment(braintreePaypalCheckout, id, onPaymentError),
                 onApprove: async (authorizeData: PaypalAuthorizeData) => {

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -350,7 +350,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                 commit: false,
                 fundingSource,
                 onInit: (_, actions) => {
-                    options?.onInitButton(actions);
+                    options?.onInitButton?.(actions);
                 },
                 onClick: (_, actions) => {
                     const { resolve, reject } = actions;

--- a/packages/braintree-integration/src/index.ts
+++ b/packages/braintree-integration/src/index.ts
@@ -10,8 +10,9 @@ export { WithBraintreeAchPaymentInitializeOptions } from './braintree-ach/braint
 export { default as createBraintreePaypalButtonStrategy } from './braintree-paypal/create-braintree-paypal-button-strategy';
 export { default as createBraintreePaypalCustomerStrategy } from './braintree-paypal/create-braintree-paypal-customer-strategy';
 export { default as createBraintreePaypalPaymentStrategy } from './braintree-paypal/create-braintree-paypal-payment-strategy';
-export { WithBraintreePaypalCustomerInitializeOptions } from './braintree-paypal/braintree-paypal-customer-initialize-options';
 export { WithBraintreePaypalButtonInitializeOptions } from './braintree-paypal/braintree-paypal-button-initialize-options';
+export { WithBraintreePaypalCustomerInitializeOptions } from './braintree-paypal/braintree-paypal-customer-initialize-options';
+export { WithBraintreePaypalPaymentInitializeOptions } from './braintree-paypal/braintree-paypal-payment-initialize-options';
 
 /**
  * Braintree PayPal Credit strategies

--- a/packages/braintree-utils/src/paypal.ts
+++ b/packages/braintree-utils/src/paypal.ts
@@ -113,7 +113,8 @@ export interface PaypalButtonOptions {
     onAuthorize?(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<unknown>;
     createOrder?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<unknown>;
     onApprove?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<unknown>;
-    onClick?(): void;
+    onClick?(payload: ClickCallbackPayload, actions: ButtonActions): void;
+    onInit?(payload: InitCallbackPayload, actions: ButtonActions): void;
     onCancel?(): void;
     onError?(error: Error): void;
 }
@@ -171,4 +172,17 @@ export interface PaypalPaymentActions {
 
 export interface PaypalRequestActions {
     post(url: string, payload?: object, options?: object): Promise<{ id: string }>;
+}
+
+export interface InitCallbackPayload {
+    correlationID: string;
+}
+
+export interface ClickCallbackPayload {
+    fundingSource: string;
+}
+
+export interface ButtonActions {
+    reject(): void;
+    resolve(): void;
 }

--- a/packages/braintree-utils/src/paypal.ts
+++ b/packages/braintree-utils/src/paypal.ts
@@ -113,8 +113,8 @@ export interface PaypalButtonOptions {
     onAuthorize?(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<unknown>;
     createOrder?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<unknown>;
     onApprove?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<unknown>;
-    onClick?(payload: ClickCallbackPayload, actions: ButtonActions): void;
-    onInit?(payload: InitCallbackPayload, actions: ButtonActions): void;
+    onClick?(payload: ClickCallbackPayload, actions: ClickButtonActions): void;
+    onInit?(payload: InitCallbackPayload, actions: InitButtonActions): void;
     onCancel?(): void;
     onError?(error: Error): void;
 }
@@ -182,7 +182,12 @@ export interface ClickCallbackPayload {
     fundingSource: string;
 }
 
-export interface ButtonActions {
+export interface InitButtonActions {
+    enable(): void;
+    disable(): void;
+}
+
+export interface ClickButtonActions {
     reject(): void;
     resolve(): void;
 }


### PR DESCRIPTION
## What/Why?

We have a specific scenario related to PSD2 for Braintree where the total amount was changed on the Checkout page, but a different amount had previously been authorized on the Cart page using Braintree's Smart Payment button.

For this scenario T&C checkbox can be bypassed but it is required. We should fix this behavior.

**NOTE**: Relates to https://github.com/bigcommerce/checkout-js/pull/3088

## Rollout/Rollback

Revert

## Testing

Verified changes on the staging store

With vaulted feature:
https://github.com/user-attachments/assets/e82c2f57-43ad-47bf-8d96-4a7812c87fb5

Without vaulted feature:
https://github.com/user-attachments/assets/68ae4c69-fd74-4a96-80ed-50bc3bf90bb8


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the PayPal button click path in checkout payment flow; integrators must wire `onValidate` correctly or behavior falls back to immediate proceed, but wrong validation wiring could block or allow clicks incorrectly.
> 
> **Overview**
> Fixes a PSD2-related gap where shoppers could complete checkout via the Braintree **Smart Payment Button** without satisfying required checkout rules (e.g. **Terms & Conditions**), including when the checkout total differed from an amount authorized earlier on the cart.
> 
> The payment strategy no longer starts the PayPal flow on button click alone. It wires PayPal’s **`onClick` `resolve`/`reject`** so checkout can run validation first via a new optional **`onValidate(resolve, reject)`** initialize option; the loading indicator runs only after validation passes. **`onInitButton(actions)`** exposes PayPal’s enable/disable actions for integrators, and **`braintree-utils`** types now match the real `onClick`/`onInit` signatures. **`WithBraintreePaypalPaymentInitializeOptions`** is exported from the integration package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43429be06bcebceb0998bb92352e157f4c555ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->