### PR TITLE
feat(payment): PAYMENTS-11661 Add payment method config to indicate s…

### DIFF
--- a/packages/amazon-pay-utils/src/mocks/amazon-pay-v2.mock.ts
+++ b/packages/amazon-pay-utils/src/mocks/amazon-pay-v2.mock.ts
@@ -101,6 +101,7 @@ export function getAmazonPayV2(region?: string): PaymentMethod<AmazonPayV2Initia
             isVaultingEnabled: false,
             merchantId: 'checkout_amazonpay',
             requireCustomerCode: false,
+            shouldVaultAllPayments: false,
             testMode: true,
         },
         id: 'amazonpay',

--- a/packages/apple-pay-integration/src/mocks/apple-pay-method.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-method.mock.ts
@@ -14,6 +14,7 @@ export function getApplePay(): PaymentMethod {
             isVaultingEnabled: false,
             hasDefaultStoredInstrument: false,
             isHostedFormEnabled: false,
+            shouldVaultAllPayments: false,
         },
         type: 'PAYMENT_TYPE_WALLET',
         initializationStrategy: {

--- a/packages/braintree-integration/src/braintree-ach/braintree-ach-payment-method.mock.ts
+++ b/packages/braintree-integration/src/braintree-ach/braintree-ach-payment-method.mock.ts
@@ -10,6 +10,7 @@ export function getBraintreeAchPaymentMethod(): PaymentMethod {
         config: {
             displayName: 'Braintree ACH',
             isVaultingEnabled: true,
+            shouldVaultAllPayments: false,
         },
         initializationData: {
             isAcceleratedCheckoutEnabled: false,

--- a/packages/core/src/payment/payment-method-config.ts
+++ b/packages/core/src/payment/payment-method-config.ts
@@ -14,6 +14,7 @@ export default interface PaymentMethodConfig {
     redirectUrl?: string;
     requireCustomerCode?: boolean;
     returnUrl?: string;
+    shouldVaultAllPayments?: boolean;
     showCardHolderName?: boolean;
     testMode?: boolean;
 }

--- a/packages/core/src/payment/payment-methods.mock.ts
+++ b/packages/core/src/payment/payment-methods.mock.ts
@@ -670,6 +670,7 @@ export function getMollie(): PaymentMethod {
             isVaultingCvvEnabled: false,
             isVaultingEnabled: false,
             isVisaCheckoutEnabled: false,
+            shouldVaultAllPayments: false,
             merchantId: 'test_T0k3n',
             requireCustomerCode: false,
             testMode: true,
@@ -775,6 +776,7 @@ export function getApplePay() {
             isVaultingEnabled: false,
             hasDefaultStoredInstrument: false,
             isHostedFormEnabled: false,
+            shouldVaultAllPayments: false,
         },
         type: 'PAYMENT_TYPE_WALLET',
         initializationStrategy: {

--- a/packages/mollie-integration/src/mollie.mock.ts
+++ b/packages/mollie-integration/src/mollie.mock.ts
@@ -158,6 +158,7 @@ export function getMollie(): PaymentMethod {
             isVisaCheckoutEnabled: false,
             merchantId: 'test_T0k3n',
             requireCustomerCode: false,
+            shouldVaultAllPayments: false,
             testMode: true,
         },
         initializationData: {

--- a/packages/payment-integration-api/src/payment/payment-method-config.ts
+++ b/packages/payment-integration-api/src/payment/payment-method-config.ts
@@ -14,5 +14,6 @@ export default interface PaymentMethodConfig {
     redirectUrl?: string;
     requireCustomerCode?: boolean;
     returnUrl?: string;
+    shouldVaultAllPayments?: boolean;
     testMode?: boolean;
 }


### PR DESCRIPTION
…upport for vaulting all payments

## What/Why?
Introduce the concept of vaulting all payments as a configuration for a payment method.
Updates existing payment method mocks to include this config.

This configuration will require a notice to be displayed to shoppers for applicable payment methods.


## Rollout/Rollback

- standard rollout/ revert changes if required.

## Testing
- specs added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional config and mock-only updates with no payment or vaulting logic changes in this PR.
> 
> **Overview**
> Adds optional **`shouldVaultAllPayments`** to **`PaymentMethodConfig`** in both **`packages/core`** and **`packages/payment-integration-api`**, so payment methods can signal that all payments are vaulted (distinct from optional **`isVaultingEnabled`** shopper choice).
> 
> Several payment-method mocks (Amazon Pay v2, Apple Pay, Braintree ACH, Mollie, and core **`getMollie`** / **`getApplePay`**) now set **`shouldVaultAllPayments: false`** so tests reflect the new field. This PR does not add checkout UI or runtime behavior; the PR notes that a shopper notice will follow when the flag is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8823822503b486c386400d758e3246222e83a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->