### PR TITLE
feat(checkout): CHECKOUT-9815 Add submitQuote

### DIFF
--- a/packages/core/src/config/capabilities.mock.ts
+++ b/packages/core/src/config/capabilities.mock.ts
@@ -1,0 +1,7 @@
+import { PartialDeep } from '../common/types';
+
+import { Capabilities } from './capabilities';
+
+export function getCapabilities(capabilities: PartialDeep<Capabilities> = {}): Capabilities {
+    return capabilities as Capabilities;
+}

--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -5,7 +5,10 @@ import { catchError, toArray } from 'rxjs/operators';
 import { CheckoutStore, createCheckoutStore } from '../checkout';
 import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { getCapabilities } from '../config/capabilities.mock';
 import { getConfig } from '../config/configs.mock';
+import { getConsignmentsState } from '../shipping/consignments.mock';
+import { getShippingOption } from '../shipping/shipping-options.mock';
 
 import B2BPostOrderActionCreator from './b2b-post-order-action-creator';
 import { B2BPostOrderActionType } from './b2b-post-order-actions';
@@ -24,6 +27,21 @@ describe('B2BPostOrderActionCreator', () => {
         baseUrl: 'https://api-b2b.bigcommerce.com',
     };
 
+    const mockStoreConfig = (quoteConfig?: { id: number } | null) => {
+        const storeConfig = getConfig().storeConfig;
+
+        jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+            ...storeConfig,
+            b2bApiSettings,
+            checkoutSettings: {
+                ...storeConfig.checkoutSettings,
+                ...(quoteConfig === undefined
+                    ? {}
+                    : { capabilities: getCapabilities({ userJourney: { quoteConfig } }) }),
+            },
+        });
+    };
+
     beforeEach(() => {
         store = createCheckoutStore({
             ...getCheckoutStoreStateWithOrder(),
@@ -36,12 +54,13 @@ describe('B2BPostOrderActionCreator', () => {
             getResponse({ data: { paymentId: 'pay_1', receiptId: 'rcpt_1' }, code: 200 }),
         );
 
-        jest.spyOn(requestSender, 'addOrderExtraFields').mockResolvedValue(getResponse(undefined));
+        jest.spyOn(requestSender, 'submitOrderExtraFields').mockResolvedValue(
+            getResponse(undefined),
+        );
 
-        jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
-            ...getConfig().storeConfig,
-            b2bApiSettings,
-        });
+        jest.spyOn(requestSender, 'submitQuote').mockResolvedValue(getResponse(undefined));
+
+        mockStoreConfig();
 
         actionCreator = new B2BPostOrderActionCreator(requestSender);
     });
@@ -71,13 +90,13 @@ describe('B2BPostOrderActionCreator', () => {
             );
         });
 
-        it('calls addOrderExtraFields and dispatches succeeded with empty receiptId when isInvoice is false', async () => {
+        it('calls submitOrderExtraFields and dispatches succeeded with empty receiptId when isInvoice is false', async () => {
             const actions = await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store))
                 .pipe(toArray())
                 .toPromise();
 
             expect(requestSender.submitInvoice).not.toHaveBeenCalled();
-            expect(requestSender.addOrderExtraFields).toHaveBeenCalledWith(
+            expect(requestSender.submitOrderExtraFields).toHaveBeenCalledWith(
                 {
                     orderId: 295,
                     poNumber: '',
@@ -97,7 +116,7 @@ describe('B2BPostOrderActionCreator', () => {
             ]);
         });
 
-        it('forwards po number, reference number, extra fields and extra info to addOrderExtraFields', async () => {
+        it('forwards po number, reference number, extra fields and extra info to submitOrderExtraFields', async () => {
             const extraFields = [{ fieldName: 'department', fieldValue: 'engineering' }];
             const extraInfo = { billingAddressId: 12 };
 
@@ -111,7 +130,7 @@ describe('B2BPostOrderActionCreator', () => {
                 })(store),
             ).toPromise();
 
-            expect(requestSender.addOrderExtraFields).toHaveBeenCalledWith(
+            expect(requestSender.submitOrderExtraFields).toHaveBeenCalledWith(
                 {
                     orderId: 295,
                     poNumber: 'PO-123',
@@ -124,10 +143,10 @@ describe('B2BPostOrderActionCreator', () => {
             );
         });
 
-        it('does not call addOrderExtraFields when isInvoice is true', async () => {
+        it('does not call submitOrderExtraFields when isInvoice is true', async () => {
             await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
 
-            expect(requestSender.addOrderExtraFields).not.toHaveBeenCalled();
+            expect(requestSender.submitOrderExtraFields).not.toHaveBeenCalled();
         });
 
         it('throws when the order id is missing', () => {
@@ -180,6 +199,136 @@ describe('B2BPostOrderActionCreator', () => {
                     error: true,
                 }),
             ]);
+        });
+
+        describe('quote-to-checkout flow', () => {
+            it('calls submitQuote after submitOrderExtraFields with the payload mapped from checkout state', async () => {
+                mockStoreConfig({ id: 941 });
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).toHaveBeenCalledWith(
+                    941,
+                    {
+                        orderId: 295,
+                        storeHash: 'k1drp8k8',
+                        shippingTotal: 15,
+                        taxTotal: 3,
+                        shippingMethod: getShippingOption(),
+                        shippingAddress: {
+                            country: 'United States',
+                            state: 'California',
+                            city: 'Some City',
+                            zipCode: '95555',
+                            address: '12345 Testing Way',
+                            apartment: '',
+                            firstName: 'Test',
+                            lastName: 'Tester',
+                        },
+                    },
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+
+                const [addOrderCallOrder] = (requestSender.submitOrderExtraFields as jest.Mock).mock
+                    .invocationCallOrder;
+                const [submitQuoteCallOrder] = (requestSender.submitQuote as jest.Mock).mock
+                    .invocationCallOrder;
+
+                expect(submitQuoteCallOrder).toBeGreaterThan(addOrderCallOrder);
+            });
+
+            it('does not call submitQuote when quoteConfig is null', async () => {
+                mockStoreConfig(null);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).not.toHaveBeenCalled();
+            });
+
+            it('does not call submitQuote when capabilities are undefined', async () => {
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).not.toHaveBeenCalled();
+            });
+
+            it('sends null shipping fields when the checkout has no consignments', async () => {
+                store = createCheckoutStore({
+                    ...getCheckoutStoreStateWithOrder(),
+                    b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+                    consignments: { ...getConsignmentsState(), data: [] },
+                });
+                mockStoreConfig({ id: 941 });
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).toHaveBeenCalledWith(
+                    941,
+                    expect.objectContaining({
+                        shippingTotal: null,
+                        shippingMethod: null,
+                        shippingAddress: null,
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('emits failed action without calling submitQuote when the checkout state is missing', async () => {
+                store = createCheckoutStore({
+                    ...getCheckoutStoreStateWithOrder(),
+                    b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+                    checkout: { errors: {}, statuses: {} },
+                });
+                mockStoreConfig({ id: 941 });
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    actionCreator.persistB2BMetadata(nonInvoiceOptions)(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(requestSender.submitOrderExtraFields).toHaveBeenCalled();
+                expect(requestSender.submitQuote).not.toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                    expect.objectContaining({
+                        type: B2BPostOrderActionType.PersistB2BMetadataFailed,
+                        error: true,
+                    }),
+                ]);
+            });
+
+            it('emits failed action when submitQuote rejects', async () => {
+                mockStoreConfig({ id: 941 });
+
+                jest.spyOn(requestSender, 'submitQuote').mockRejectedValue(getErrorResponse());
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    actionCreator.persistB2BMetadata(nonInvoiceOptions)(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(requestSender.submitOrderExtraFields).toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                    expect.objectContaining({
+                        type: B2BPostOrderActionType.PersistB2BMetadataFailed,
+                        error: true,
+                    }),
+                ]);
+            });
+
+            it('does not call submitQuote in the invoice flow even when a quote id is present', async () => {
+                mockStoreConfig({ id: 941 });
+
+                await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).not.toHaveBeenCalled();
+            });
         });
     });
 });

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -36,6 +36,8 @@ export default class B2BPostOrderActionCreator {
             const b2bBaseUrl = resolveB2bBaseUrl(
                 state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
             );
+            const storeConfig = state.config.getStoreConfig();
+            const quoteId = storeConfig?.checkoutSettings.capabilities?.userJourney.quoteConfig?.id;
 
             if (!orderId || !b2bToken || !b2bBaseUrl) {
                 throw new MissingDataError(MissingDataErrorType.MissingOrder);
@@ -55,7 +57,7 @@ export default class B2BPostOrderActionCreator {
 
                         payload = { receiptId: body.data.receiptId };
                     } else {
-                        await this._requestSender.addOrderExtraFields(
+                        await this._requestSender.submitOrderExtraFields(
                             {
                                 orderId,
                                 poNumber: poNumber ?? '',
@@ -66,6 +68,36 @@ export default class B2BPostOrderActionCreator {
                             b2bToken,
                             b2bBaseUrl,
                         );
+
+                        if (typeof quoteId === 'number') {
+                            const checkout = state.checkout.getCheckoutOrThrow();
+                            const consignment = checkout.consignments[0];
+
+                            await this._requestSender.submitQuote(
+                                quoteId,
+                                {
+                                    orderId,
+                                    storeHash: storeConfig?.storeProfile.storeHash ?? '',
+                                    shippingTotal: consignment ? checkout.shippingCostTotal : null,
+                                    taxTotal: checkout.taxTotal,
+                                    shippingMethod: consignment?.selectedShippingOption ?? null,
+                                    shippingAddress: consignment
+                                        ? {
+                                              country: consignment.shippingAddress.country,
+                                              state: consignment.shippingAddress.stateOrProvince,
+                                              city: consignment.shippingAddress.city,
+                                              zipCode: consignment.shippingAddress.postalCode,
+                                              address: consignment.shippingAddress.address1,
+                                              apartment: consignment.shippingAddress.address2,
+                                              firstName: consignment.shippingAddress.firstName,
+                                              lastName: consignment.shippingAddress.lastName,
+                                          }
+                                        : null,
+                                },
+                                b2bToken,
+                                b2bBaseUrl,
+                            );
+                        }
                     }
 
                     return createAction(

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -2,9 +2,10 @@ import { createAction, ThunkAction } from '@bigcommerce/data-store';
 import { concat, defer, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
+import { Address } from '../address';
 // TODO: CHECKOUT-9979 remove this import before delivery
 import { resolveB2bBaseUrl } from '../b2b-dev-tools';
-import { InternalCheckoutSelectors } from '../checkout';
+import { Checkout, InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 
@@ -13,7 +14,41 @@ import {
     PersistB2BMetadataAction,
     PersistB2BMetadataOptions,
 } from './b2b-post-order-actions';
-import B2BPostOrderRequestSender from './b2b-post-order-request-sender';
+import B2BPostOrderRequestSender, { QuoteOrderedPayload } from './b2b-post-order-request-sender';
+
+function mapToQuoteShippingAddress(
+    address: Address,
+): NonNullable<QuoteOrderedPayload['shippingAddress']> {
+    return {
+        country: address.country,
+        state: address.stateOrProvince,
+        city: address.city,
+        zipCode: address.postalCode,
+        address: address.address1,
+        apartment: address.address2,
+        firstName: address.firstName,
+        lastName: address.lastName,
+    };
+}
+
+function mapToQuoteOrderedPayload(
+    checkout: Checkout,
+    orderId: number,
+    storeHash: string,
+): QuoteOrderedPayload {
+    const consignment = checkout.consignments[0];
+
+    return {
+        orderId,
+        storeHash,
+        shippingTotal: consignment ? checkout.shippingCostTotal : null,
+        taxTotal: checkout.taxTotal,
+        shippingMethod: consignment?.selectedShippingOption ?? null,
+        shippingAddress: consignment
+            ? mapToQuoteShippingAddress(consignment.shippingAddress)
+            : null,
+    };
+}
 
 export default class B2BPostOrderActionCreator {
     constructor(private _requestSender: B2BPostOrderRequestSender) {}
@@ -71,29 +106,14 @@ export default class B2BPostOrderActionCreator {
 
                         if (typeof quoteId === 'number') {
                             const checkout = state.checkout.getCheckoutOrThrow();
-                            const consignment = checkout.consignments[0];
 
                             await this._requestSender.submitQuote(
                                 quoteId,
-                                {
+                                mapToQuoteOrderedPayload(
+                                    checkout,
                                     orderId,
-                                    storeHash: storeConfig?.storeProfile.storeHash ?? '',
-                                    shippingTotal: consignment ? checkout.shippingCostTotal : null,
-                                    taxTotal: checkout.taxTotal,
-                                    shippingMethod: consignment?.selectedShippingOption ?? null,
-                                    shippingAddress: consignment
-                                        ? {
-                                              country: consignment.shippingAddress.country,
-                                              state: consignment.shippingAddress.stateOrProvince,
-                                              city: consignment.shippingAddress.city,
-                                              zipCode: consignment.shippingAddress.postalCode,
-                                              address: consignment.shippingAddress.address1,
-                                              apartment: consignment.shippingAddress.address2,
-                                              firstName: consignment.shippingAddress.firstName,
-                                              lastName: consignment.shippingAddress.lastName,
-                                          }
-                                        : null,
-                                },
+                                    storeConfig?.storeProfile.storeHash ?? '',
+                                ),
                                 b2bToken,
                                 b2bBaseUrl,
                             );

--- a/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
@@ -1,10 +1,12 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { getShippingOption } from '../shipping/shipping-options.mock';
 
 import B2BPostOrderRequestSender, {
     AddOrderExtraFieldsPayload,
     CloseInvoicePayload,
+    QuoteOrderedPayload,
 } from './b2b-post-order-request-sender';
 
 describe('B2BPostOrderRequestSender', () => {
@@ -78,7 +80,7 @@ describe('B2BPostOrderRequestSender', () => {
         });
     });
 
-    describe('#addOrderExtraFields()', () => {
+    describe('#submitOrderExtraFields()', () => {
         const extraFieldsPayload: AddOrderExtraFieldsPayload = {
             orderId: 295,
             poNumber: 'PO-123',
@@ -95,7 +97,7 @@ describe('B2BPostOrderRequestSender', () => {
         };
 
         it('posts to the B2B orders endpoint with auth headers and payload', async () => {
-            await b2bPostOrderRequestSender.addOrderExtraFields(
+            await b2bPostOrderRequestSender.submitOrderExtraFields(
                 extraFieldsPayload,
                 'b2b-token-value',
                 'https://api-b2b.bigcommerce.com',
@@ -119,8 +121,63 @@ describe('B2BPostOrderRequestSender', () => {
             jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
 
             await expect(
-                b2bPostOrderRequestSender.addOrderExtraFields(
+                b2bPostOrderRequestSender.submitOrderExtraFields(
                     extraFieldsPayload,
+                    'b2b-token-value',
+                    'https://api-b2b.bigcommerce.com',
+                ),
+            ).rejects.toEqual(getErrorResponse());
+        });
+    });
+
+    describe('#submitQuote()', () => {
+        const submitQuotePayload: QuoteOrderedPayload = {
+            orderId: 295,
+            storeHash: 'k1drp8k8',
+            shippingTotal: 15,
+            taxTotal: 3,
+            shippingMethod: getShippingOption(),
+            shippingAddress: {
+                country: 'United States',
+                state: 'California',
+                city: 'Some City',
+                zipCode: '95555',
+                address: '12345 Testing Way',
+                apartment: '',
+                firstName: 'Test',
+                lastName: 'Tester',
+            },
+        };
+
+        it('posts to the RFQ ordered endpoint with auth headers and payload', async () => {
+            await b2bPostOrderRequestSender.submitQuote(
+                123,
+                submitQuotePayload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/rfq/123/ordered',
+                {
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                    body: submitQuotePayload,
+                },
+            );
+        });
+
+        it('rejects when the request sender rejects', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
+
+            await expect(
+                b2bPostOrderRequestSender.submitQuote(
+                    123,
+                    submitQuotePayload,
                     'b2b-token-value',
                     'https://api-b2b.bigcommerce.com',
                 ),

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -1,6 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions } from '../common/http-request';
+import { ShippingOption } from '../shipping';
 
 export interface CloseInvoicePayload {
     orderId: string;
@@ -35,6 +36,24 @@ export interface AddOrderExtraFieldsPayload {
     };
 }
 
+export interface QuoteOrderedPayload {
+    orderId: number;
+    storeHash: string;
+    shippingTotal: number | null;
+    taxTotal: number;
+    shippingMethod: ShippingOption | null;
+    shippingAddress: {
+        country: string;
+        state: string;
+        city: string;
+        zipCode: string;
+        address: string;
+        apartment: string;
+        firstName: string;
+        lastName: string;
+    } | null;
+}
+
 export default class B2BPostOrderRequestSender {
     constructor(private _requestSender: RequestSender) {}
 
@@ -59,7 +78,24 @@ export default class B2BPostOrderRequestSender {
         );
     }
 
-    async addOrderExtraFields(
+    async submitQuote(
+        quoteId: number,
+        payload: QuoteOrderedPayload,
+        b2bToken: string,
+        b2bBaseUrl: string,
+    ): Promise<Response<void>> {
+        return this._requestSender.post(`${b2bBaseUrl}/api/v2/rfq/${quoteId}/ordered`, {
+            credentials: false,
+            headers: {
+                'Content-Type': 'application/json',
+                authToken: b2bToken,
+                Authorization: `Bearer ${b2bToken}`,
+            },
+            body: payload,
+        });
+    }
+
+    async submitOrderExtraFields(
         payload: AddOrderExtraFieldsPayload,
         b2bToken: string,
         b2bBaseUrl: string,


### PR DESCRIPTION
## What/Why?

At the end of a quote-to-checkout flow, save the quote ID to the order.

No change needed on the `checkout-js` side.

## Rollout/Rollback

Revert.

## Testing

### Manual testing
<img width="1178" height="1002" alt="Screenshot 2026-06-12 at 15 03 22" src="https://github.com/user-attachments/assets/37f40cc0-b0c8-4f50-8a00-1ec2eb7ca9db" />


<img width="1035" height="810" alt="Screenshot 2026-06-12 at 15 05 13" src="https://github.com/user-attachments/assets/c8f4174e-0c12-4f74-bc89-a239ac80b66c" />

<img width="1245" height="701" alt="Screenshot 2026-06-12 at 15 06 34" src="https://github.com/user-attachments/assets/1fac93d0-f522-462a-8c06-665955f54c11" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a second post-order B2B call on the order-placement path when a quote id is present; failures fail the whole persist action after extra fields may already have been sent.
> 
> **Overview**
> Completes **quote-to-checkout** post-order handling by notifying the B2B API when a placed order should be linked to an RFQ quote.
> 
> After **`submitOrderExtraFields`** in the non-invoice **`persistB2BMetadata`** path, the action creator reads **`quoteConfig.id`** from checkout capabilities; when that id is a number, it maps checkout state (order id, store hash, tax, and first-consignment shipping totals/method/address, with **null** shipping fields when there are no consignments) and calls the new **`submitQuote`** request, which **POST**s to **`/api/v2/rfq/{quoteId}/ordered`**. Invoice checkout still only calls **`submitInvoice`** and never **`submitQuote`**.
> 
> The B2B orders helper is renamed from **`addOrderExtraFields`** to **`submitOrderExtraFields`** (behavior unchanged). A small **`getCapabilities`** test mock supports quote-config scenarios in specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0829bf3e768c7bc253f4c8baf70d9d9452c17c42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->