### PR TITLE
feat(checkout): BACK-603 Update Checkout read backorder message string

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -176,5 +176,5 @@ export interface InventorySettings {
     showBackorderAvailabilityPrompt: boolean;
     backorderAvailabilityPrompt: string | null;
     defaultShippingExpectationPrompt: string | null;
-    shouldDisplayBackorderMessagesOnStorefront: boolean;
+    shouldDisplayBackorderMessages: boolean;
 }

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -149,7 +149,7 @@ export function getConfig(): Config {
                 defaultShippingExpectationPrompt: '',
                 showBackorderAvailabilityPrompt: false,
                 backorderAvailabilityPrompt: '',
-                shouldDisplayBackorderMessagesOnStorefront: false,
+                shouldDisplayBackorderMessages: false,
             },
         },
     };

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -181,5 +181,5 @@ export interface InventorySettings {
     showBackorderAvailabilityPrompt: boolean;
     backorderAvailabilityPrompt: string | null;
     defaultShippingExpectationPrompt: string | null;
-    shouldDisplayBackorderMessagesOnStorefront: boolean;
+    shouldDisplayBackorderMessages: boolean;
 }

--- a/packages/payment-integration-api/src/mocks/config.mock.ts
+++ b/packages/payment-integration-api/src/mocks/config.mock.ts
@@ -150,7 +150,7 @@ export default function getConfig(): Config {
                 showDefaultShippingExpectationPrompt: false,
                 backorderAvailabilityPrompt: '',
                 defaultShippingExpectationPrompt: '',
-                shouldDisplayBackorderMessagesOnStorefront: false,
+                shouldDisplayBackorderMessages: false,
             },
         },
     };

--- a/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
@@ -150,7 +150,7 @@ export default function getConfig(): Config {
                 showBackorderAvailabilityPrompt: false,
                 backorderAvailabilityPrompt: '',
                 defaultShippingExpectationPrompt: '',
-                shouldDisplayBackorderMessagesOnStorefront: false,
+                shouldDisplayBackorderMessages: false,
             },
         },
     };


### PR DESCRIPTION
## What/Why?

- Rename `shouldDisplayBackorderMessagesOnStorefront` to `shouldDisplayBackorderMessages`. There are no logic changes.

Context: Updating BCApp `shouldDisplayBackorderMessagesOnStorefront` and need to reflect that here. BCApp currently support both this new and old properties until checkout-js and checkout-sdk-js have will be fully updated.

## Rollout/Rollback

Revert

## Testing

N/A. No logic changes. Just a name change.

ping @animesh1987 @bc-shawnwang 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type and mock-only rename with no runtime logic changes; rollout risk is mainly if consumers still expect the old JSON key name.
> 
> **Overview**
> Renames the `InventorySettings` flag **`shouldDisplayBackorderMessagesOnStorefront`** to **`shouldDisplayBackorderMessages`** so checkout config matches the updated BCApp payload name. The change is limited to TypeScript types and mock config objects in **`packages/core`**, **`packages/payment-integration-api`**, and **`packages/payment-integrations-test-utils`**; behavior is unchanged.
> 
> This aligns checkout-js/checkout-sdk with BCApp’s new property while BCApp still accepts the legacy name until downstream clients are fully updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9bc159c050e3cc93cabc3683e2863510d55b472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->