### PR TITLE
feat(checkout): CHECKOUT-10080 Save Company Address

### DIFF
--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -322,6 +322,23 @@ describe('B2BPostOrderActionCreator', () => {
                 );
             });
 
+            it('deduplicates identical shipping addresses across consignments into a single save', async () => {
+                mockConsignments([
+                    createConsignment({ address1: '5 Same St', shouldSaveAddress: true }, 'c-1'),
+                    createConsignment({ address1: '5 Same St', shouldSaveAddress: true }, 'c-2'),
+                ]);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({ addressLine1: '5 Same St', isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
             it('merges billing and shipping into one entry when they are the same address', async () => {
                 mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
                 mockConsignments([createConsignment({ shouldSaveAddress: true })]);

--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -354,6 +354,83 @@ describe('B2BPostOrderActionCreator', () => {
                 );
             });
 
+            it('keeps billing and shipping separate when the address matches but extra fields differ', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([createConsignment({ shouldSaveAddress: true })]);
+
+                await from(
+                    actionCreator.persistB2BMetadata({
+                        isInvoice: false,
+                        extraInfo: {
+                            addressExtraFields: {
+                                billingAddressExtraFields: [
+                                    { fieldName: 'department', fieldValue: 'Finance' },
+                                ],
+                                shippingAddressExtraFields: [
+                                    { fieldName: 'dock', fieldValue: 'B7' },
+                                ],
+                            },
+                        },
+                    })(store),
+                ).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(2);
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    1,
+                    12345,
+                    expectedCompanyAddress({
+                        isBilling: 1,
+                        isShipping: 0,
+                        extraFields: [{ fieldName: 'department', fieldValue: 'Finance' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    2,
+                    12345,
+                    expectedCompanyAddress({
+                        isShipping: 1,
+                        extraFields: [{ fieldName: 'dock', fieldValue: 'B7' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('merges billing and shipping when both the address and extra fields match', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([createConsignment({ shouldSaveAddress: true })]);
+
+                await from(
+                    actionCreator.persistB2BMetadata({
+                        isInvoice: false,
+                        extraInfo: {
+                            addressExtraFields: {
+                                billingAddressExtraFields: [
+                                    { fieldName: 'department', fieldValue: 'Finance' },
+                                ],
+                                shippingAddressExtraFields: [
+                                    { fieldName: 'department', fieldValue: 'Finance' },
+                                ],
+                            },
+                        },
+                    })(store),
+                ).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({
+                        isBilling: 1,
+                        isShipping: 1,
+                        extraFields: [{ fieldName: 'department', fieldValue: 'Finance' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
             it('keeps billing and shipping separate when the addresses differ', async () => {
                 mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
                 mockConsignments([

--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -2,17 +2,25 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
+import { Address } from '../address';
+import { BillingAddress } from '../billing';
+import { getBillingAddress } from '../billing/billing-addresses.mock';
+import { getCart } from '../cart/carts.mock';
 import { CheckoutStore, createCheckoutStore } from '../checkout';
 import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 import { getCapabilities } from '../config/capabilities.mock';
 import { getConfig } from '../config/configs.mock';
-import { getConsignmentsState } from '../shipping/consignments.mock';
+import { Consignment } from '../shipping';
+import { getConsignment, getConsignmentsState } from '../shipping/consignments.mock';
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 import { getShippingOption } from '../shipping/shipping-options.mock';
 
 import B2BPostOrderActionCreator from './b2b-post-order-action-creator';
 import { B2BPostOrderActionType } from './b2b-post-order-actions';
-import B2BPostOrderRequestSender from './b2b-post-order-request-sender';
+import B2BPostOrderRequestSender, {
+    CreateCompanyAddressPayload,
+} from './b2b-post-order-request-sender';
 
 describe('B2BPostOrderActionCreator', () => {
     let store: CheckoutStore;
@@ -59,6 +67,10 @@ describe('B2BPostOrderActionCreator', () => {
         );
 
         jest.spyOn(requestSender, 'submitQuote').mockResolvedValue(getResponse(undefined));
+
+        jest.spyOn(requestSender, 'submitCompanyAddress').mockResolvedValue(
+            getResponse({ data: { addressId: '67890' }, code: 200 }),
+        );
 
         mockStoreConfig();
 
@@ -199,6 +211,264 @@ describe('B2BPostOrderActionCreator', () => {
                     error: true,
                 }),
             ]);
+        });
+
+        describe('company address flow', () => {
+            const createBillingAddress = (
+                overrides: Partial<BillingAddress> = {},
+            ): BillingAddress => ({
+                ...getBillingAddress(),
+                shouldSaveAddress: false,
+                ...overrides,
+            });
+
+            const createConsignment = (
+                shippingOverrides: Partial<Address> = {},
+                id = 'consignment-1',
+            ): Consignment => ({
+                ...getConsignment(),
+                id,
+                shippingAddress: {
+                    ...getShippingAddress(),
+                    shouldSaveAddress: false,
+                    ...shippingOverrides,
+                },
+            });
+
+            // Mirrors the shared billing/shipping address mocks (identical comparable fields, so they
+            // merge unless an override makes them differ).
+            const expectedCompanyAddress = (
+                overrides: Partial<CreateCompanyAddressPayload> = {},
+            ): CreateCompanyAddressPayload => ({
+                addressLine1: '12345 Testing Way',
+                addressLine2: '',
+                city: 'Some City',
+                label: '',
+                firstName: 'Test',
+                lastName: 'Tester',
+                phoneNumber: '555-555-5555',
+                zipCode: '95555',
+                country: { countryCode: 'US', countryName: 'United States' },
+                state: { stateCode: 'CA', stateName: 'California' },
+                isBilling: 0,
+                isCheckout: true,
+                isShipping: 0,
+                extraFields: [],
+                ...overrides,
+            });
+
+            const mockCompanyId = (companyId: number | null) => {
+                jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({
+                    ...getCart(),
+                    companyId,
+                });
+            };
+
+            const mockBillingAddress = (billingAddress: BillingAddress | undefined) => {
+                jest.spyOn(store.getState().billingAddress, 'getBillingAddress').mockReturnValue(
+                    billingAddress,
+                );
+            };
+
+            const mockConsignments = (consignments: Consignment[] | undefined) => {
+                jest.spyOn(store.getState().consignments, 'getConsignments').mockReturnValue(
+                    consignments,
+                );
+            };
+
+            beforeEach(() => {
+                mockCompanyId(12345);
+                mockBillingAddress(createBillingAddress());
+                mockConsignments([]);
+            });
+
+            it('maps the billing address from state when shouldSaveAddress is set', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({ isBilling: 1, isShipping: 0 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('maps a shipping address from every consignment that opts in', async () => {
+                mockConsignments([
+                    createConsignment({ address1: '1 First St', shouldSaveAddress: true }, 'c-1'),
+                    createConsignment({ address1: '2 Second St', shouldSaveAddress: false }, 'c-2'),
+                    createConsignment({ address1: '3 Third St', shouldSaveAddress: true }, 'c-3'),
+                ]);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(2);
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    1,
+                    12345,
+                    expectedCompanyAddress({ addressLine1: '1 First St', isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    2,
+                    12345,
+                    expectedCompanyAddress({ addressLine1: '3 Third St', isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('merges billing and shipping into one entry when they are the same address', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([createConsignment({ shouldSaveAddress: true })]);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({ isBilling: 1, isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('keeps billing and shipping separate when the addresses differ', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([
+                    createConsignment({ address1: '9 Other St', shouldSaveAddress: true }),
+                ]);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(2);
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    1,
+                    12345,
+                    expectedCompanyAddress({ isBilling: 1, isShipping: 0 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    2,
+                    12345,
+                    expectedCompanyAddress({ addressLine1: '9 Other St', isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('sources per-address extra fields from extraInfo.addressExtraFields', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([
+                    createConsignment({ address1: '9 Other St', shouldSaveAddress: true }),
+                ]);
+
+                await from(
+                    actionCreator.persistB2BMetadata({
+                        isInvoice: false,
+                        extraInfo: {
+                            addressExtraFields: {
+                                billingAddressExtraFields: [
+                                    { fieldName: 'department', fieldValue: 'Finance' },
+                                ],
+                                shippingAddressExtraFields: [
+                                    { fieldName: 'dock', fieldValue: 'B7' },
+                                ],
+                            },
+                        },
+                    })(store),
+                ).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    1,
+                    12345,
+                    expectedCompanyAddress({
+                        isBilling: 1,
+                        isShipping: 0,
+                        extraFields: [{ fieldName: 'department', fieldValue: 'Finance' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    2,
+                    12345,
+                    expectedCompanyAddress({
+                        addressLine1: '9 Other St',
+                        isShipping: 1,
+                        extraFields: [{ fieldName: 'dock', fieldValue: 'B7' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('submits company addresses before submitOrderExtraFields', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                const [companyAddressCallOrder] = (requestSender.submitCompanyAddress as jest.Mock)
+                    .mock.invocationCallOrder;
+                const [addOrderCallOrder] = (requestSender.submitOrderExtraFields as jest.Mock).mock
+                    .invocationCallOrder;
+
+                expect(companyAddressCallOrder).toBeLessThan(addOrderCallOrder);
+            });
+
+            it('does not submit a company address when nothing opts in', async () => {
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).not.toHaveBeenCalled();
+                expect(requestSender.submitOrderExtraFields).toHaveBeenCalled();
+            });
+
+            it('does not submit a company address when the cart has no company id', async () => {
+                mockCompanyId(null);
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).not.toHaveBeenCalled();
+                expect(requestSender.submitOrderExtraFields).toHaveBeenCalled();
+            });
+
+            it('does not submit a company address in the invoice flow', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).not.toHaveBeenCalled();
+            });
+
+            it('emits failed action without calling submitOrderExtraFields when submitCompanyAddress rejects', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                jest.spyOn(requestSender, 'submitCompanyAddress').mockRejectedValue(
+                    getErrorResponse(),
+                );
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    actionCreator.persistB2BMetadata(nonInvoiceOptions)(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(requestSender.submitOrderExtraFields).not.toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                    expect.objectContaining({
+                        type: B2BPostOrderActionType.PersistB2BMetadataFailed,
+                        error: true,
+                    }),
+                ]);
+            });
         });
 
         describe('quote-to-checkout flow', () => {

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -2,19 +2,26 @@ import { createAction, ThunkAction } from '@bigcommerce/data-store';
 import { concat, defer, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
-import { Address } from '../address';
+import { Address, isAddressEqual } from '../address';
 // TODO: CHECKOUT-9979 remove this import before delivery
 import { resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { BillingAddress } from '../billing';
 import { Checkout, InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { Consignment } from '../shipping';
 
 import {
     B2BPostOrderActionType,
     PersistB2BMetadataAction,
     PersistB2BMetadataOptions,
 } from './b2b-post-order-actions';
-import B2BPostOrderRequestSender, { QuoteOrderedPayload } from './b2b-post-order-request-sender';
+import B2BPostOrderRequestSender, {
+    AddOrderExtraFieldsPayload,
+    B2BExtraField,
+    CreateCompanyAddressPayload,
+    QuoteOrderedPayload,
+} from './b2b-post-order-request-sender';
 
 function mapToQuoteShippingAddress(
     address: Address,
@@ -50,6 +57,88 @@ function mapToQuoteOrderedPayload(
     };
 }
 
+type CompanyAddressExtraFields = NonNullable<
+    AddOrderExtraFieldsPayload['extraInfo']['addressExtraFields']
+>;
+
+function mapToCompanyAddress(
+    address: Address,
+    flags: Pick<CreateCompanyAddressPayload, 'isBilling' | 'isShipping'>,
+    extraFields: B2BExtraField[],
+): CreateCompanyAddressPayload {
+    return {
+        addressLine1: address.address1,
+        addressLine2: address.address2,
+        city: address.city,
+        label: address.label ?? '',
+        firstName: address.firstName,
+        lastName: address.lastName,
+        phoneNumber: address.phone,
+        zipCode: address.postalCode,
+        country: {
+            countryCode: address.countryCode,
+            countryName: address.country,
+        },
+        state: {
+            stateCode: address.stateOrProvinceCode,
+            stateName: address.stateOrProvince,
+        },
+        isBilling: flags.isBilling,
+        isCheckout: true,
+        isShipping: flags.isShipping,
+        extraFields,
+    };
+}
+
+function buildCompanyAddresses(
+    billingAddress: BillingAddress | undefined,
+    consignments: Consignment[] | undefined,
+    addressExtraFields: CompanyAddressExtraFields | undefined,
+): CreateCompanyAddressPayload[] {
+    const companyAddresses: CreateCompanyAddressPayload[] = [];
+    const shouldSaveBillingAddress = billingAddress?.shouldSaveAddress ? billingAddress : undefined;
+
+    let billingCompanyAddress: CreateCompanyAddressPayload | undefined;
+
+    if (shouldSaveBillingAddress) {
+        billingCompanyAddress = mapToCompanyAddress(
+            shouldSaveBillingAddress,
+            { isBilling: 1, isShipping: 0 },
+            addressExtraFields?.billingAddressExtraFields ?? [],
+        );
+
+        companyAddresses.push(billingCompanyAddress);
+    }
+
+    (consignments ?? []).forEach((consignment) => {
+        const { shippingAddress } = consignment;
+
+        if (!shippingAddress?.shouldSaveAddress) {
+            return;
+        }
+
+        if (
+            shouldSaveBillingAddress &&
+            billingCompanyAddress &&
+            isAddressEqual(shouldSaveBillingAddress, shippingAddress)
+        ) {
+            billingCompanyAddress.isShipping = 1;
+
+            return;
+        }
+
+        companyAddresses.push(
+            mapToCompanyAddress(
+                shippingAddress,
+                { isBilling: 0, isShipping: 1 },
+                addressExtraFields?.shippingAddressExtraFields ?? [],
+            ),
+        );
+    });
+
+    return companyAddresses;
+}
+
 export default class B2BPostOrderActionCreator {
     constructor(private _requestSender: B2BPostOrderRequestSender) {}
 
@@ -71,8 +160,14 @@ export default class B2BPostOrderActionCreator {
             const b2bBaseUrl = resolveB2bBaseUrl(
                 state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
             );
+            const companyId = state.cart.getCart()?.companyId;
             const storeConfig = state.config.getStoreConfig();
             const quoteId = storeConfig?.checkoutSettings.capabilities?.userJourney.quoteConfig?.id;
+            const companyAddresses = buildCompanyAddresses(
+                state.billingAddress.getBillingAddress(),
+                state.consignments.getConsignments(),
+                extraInfo?.addressExtraFields,
+            );
 
             if (!orderId || !b2bToken || !b2bBaseUrl) {
                 throw new MissingDataError(MissingDataErrorType.MissingOrder);
@@ -92,6 +187,19 @@ export default class B2BPostOrderActionCreator {
 
                         payload = { receiptId: body.data.receiptId };
                     } else {
+                        if (companyId && companyAddresses.length) {
+                            await Promise.all(
+                                companyAddresses.map((companyAddress) =>
+                                    this._requestSender.submitCompanyAddress(
+                                        companyId,
+                                        companyAddress,
+                                        b2bToken,
+                                        b2bBaseUrl,
+                                    ),
+                                ),
+                            );
+                        }
+
                         await this._requestSender.submitOrderExtraFields(
                             {
                                 orderId,

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -95,19 +95,20 @@ function buildCompanyAddresses(
     consignments: Consignment[] | undefined,
     addressExtraFields: CompanyAddressExtraFields | undefined,
 ): CreateCompanyAddressPayload[] {
-    const companyAddresses: CreateCompanyAddressPayload[] = [];
-    const shouldSaveBillingAddress = billingAddress?.shouldSaveAddress ? billingAddress : undefined;
+    const savedAddresses: Array<{
+        rawAddress: Address;
+        mappedAddress: CreateCompanyAddressPayload;
+    }> = [];
 
-    let billingCompanyAddress: CreateCompanyAddressPayload | undefined;
-
-    if (shouldSaveBillingAddress) {
-        billingCompanyAddress = mapToCompanyAddress(
-            shouldSaveBillingAddress,
-            { isBilling: 1, isShipping: 0 },
-            addressExtraFields?.billingAddressExtraFields ?? [],
-        );
-
-        companyAddresses.push(billingCompanyAddress);
+    if (billingAddress?.shouldSaveAddress) {
+        savedAddresses.push({
+            rawAddress: billingAddress,
+            mappedAddress: mapToCompanyAddress(
+                billingAddress,
+                { isBilling: 1, isShipping: 0 },
+                addressExtraFields?.billingAddressExtraFields ?? [],
+            ),
+        });
     }
 
     (consignments ?? []).forEach((consignment) => {
@@ -117,26 +118,27 @@ function buildCompanyAddresses(
             return;
         }
 
-        if (
-            shouldSaveBillingAddress &&
-            billingCompanyAddress &&
-            isAddressEqual(shouldSaveBillingAddress, shippingAddress)
-        ) {
-            billingCompanyAddress.isShipping = 1;
+        const savedAddress = savedAddresses.find(({ rawAddress }) =>
+            isAddressEqual(rawAddress, shippingAddress),
+        );
+
+        if (savedAddress) {
+            savedAddress.mappedAddress.isShipping = 1;
 
             return;
         }
 
-        companyAddresses.push(
-            mapToCompanyAddress(
+        savedAddresses.push({
+            rawAddress: shippingAddress,
+            mappedAddress: mapToCompanyAddress(
                 shippingAddress,
                 { isBilling: 0, isShipping: 1 },
                 addressExtraFields?.shippingAddressExtraFields ?? [],
             ),
-        );
+        });
     });
 
-    return companyAddresses;
+    return savedAddresses.map(({ mappedAddress }) => mappedAddress);
 }
 
 export default class B2BPostOrderActionCreator {

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -1,4 +1,5 @@
 import { createAction, ThunkAction } from '@bigcommerce/data-store';
+import { isEqual } from 'lodash';
 import { concat, defer, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -111,6 +112,8 @@ function buildCompanyAddresses(
         });
     }
 
+    const shippingExtraFields = addressExtraFields?.shippingAddressExtraFields ?? [];
+
     (consignments ?? []).forEach((consignment) => {
         const { shippingAddress } = consignment;
 
@@ -118,8 +121,10 @@ function buildCompanyAddresses(
             return;
         }
 
-        const savedAddress = savedAddresses.find(({ rawAddress }) =>
-            isAddressEqual(rawAddress, shippingAddress),
+        const savedAddress = savedAddresses.find(
+            ({ rawAddress, mappedAddress }) =>
+                isAddressEqual(rawAddress, shippingAddress) &&
+                isEqual(mappedAddress.extraFields ?? [], shippingExtraFields),
         );
 
         if (savedAddress) {
@@ -133,7 +138,7 @@ function buildCompanyAddresses(
             mappedAddress: mapToCompanyAddress(
                 shippingAddress,
                 { isBilling: 0, isShipping: 1 },
-                addressExtraFields?.shippingAddressExtraFields ?? [],
+                shippingExtraFields,
             ),
         });
     });

--- a/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
@@ -6,6 +6,7 @@ import { getShippingOption } from '../shipping/shipping-options.mock';
 import B2BPostOrderRequestSender, {
     AddOrderExtraFieldsPayload,
     CloseInvoicePayload,
+    CreateCompanyAddressPayload,
     QuoteOrderedPayload,
 } from './b2b-post-order-request-sender';
 
@@ -178,6 +179,60 @@ describe('B2BPostOrderRequestSender', () => {
                 b2bPostOrderRequestSender.submitQuote(
                     123,
                     submitQuotePayload,
+                    'b2b-token-value',
+                    'https://api-b2b.bigcommerce.com',
+                ),
+            ).rejects.toEqual(getErrorResponse());
+        });
+    });
+
+    describe('#submitCompanyAddress()', () => {
+        const companyAddressPayload: CreateCompanyAddressPayload = {
+            addressLine1: '123 Market Street',
+            addressLine2: 'Suite 400',
+            city: 'San Francisco',
+            label: 'HQ',
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            phoneNumber: '+1-415-555-0100',
+            zipCode: '94103',
+            country: { countryCode: 'US', countryName: 'United States' },
+            state: { stateCode: 'CA', stateName: 'California' },
+            isShipping: 1,
+            isBilling: 0,
+            extraFields: [{ fieldName: 'Department', fieldValue: 'Procurement' }],
+            isCheckout: true,
+        };
+
+        it('posts to the company addresses endpoint with auth headers and payload', async () => {
+            await b2bPostOrderRequestSender.submitCompanyAddress(
+                12345,
+                companyAddressPayload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/companies/12345/addresses',
+                {
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                    body: companyAddressPayload,
+                },
+            );
+        });
+
+        it('rejects when the request sender rejects', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
+
+            await expect(
+                b2bPostOrderRequestSender.submitCompanyAddress(
+                    12345,
+                    companyAddressPayload,
                     'b2b-token-value',
                     'https://api-b2b.bigcommerce.com',
                 ),

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -54,6 +54,36 @@ export interface QuoteOrderedPayload {
     } | null;
 }
 
+export interface CreateCompanyAddressPayload {
+    addressLine1: string;
+    addressLine2: string;
+    city: string;
+    label: string;
+    firstName: string;
+    lastName: string;
+    phoneNumber: string;
+    zipCode: string;
+    country: {
+        countryCode: string;
+        countryName: string;
+    };
+    state: {
+        stateCode: string;
+        stateName: string;
+    };
+    isBilling: 0 | 1;
+    isCheckout: boolean;
+    isShipping: 0 | 1;
+    extraFields?: B2BExtraField[];
+}
+
+interface CreateCompanyAddressResponseBody {
+    data: {
+        addressId: string;
+    };
+    code: number;
+}
+
 export default class B2BPostOrderRequestSender {
     constructor(private _requestSender: RequestSender) {}
 
@@ -101,6 +131,23 @@ export default class B2BPostOrderRequestSender {
         b2bBaseUrl: string,
     ): Promise<Response<void>> {
         return this._requestSender.post(`${b2bBaseUrl}/api/v2/orders`, {
+            credentials: false,
+            headers: {
+                'Content-Type': 'application/json',
+                authToken: b2bToken,
+                Authorization: `Bearer ${b2bToken}`,
+            },
+            body: payload,
+        });
+    }
+
+    async submitCompanyAddress(
+        companyId: number,
+        payload: CreateCompanyAddressPayload,
+        b2bToken: string,
+        b2bBaseUrl: string,
+    ): Promise<Response<CreateCompanyAddressResponseBody>> {
+        return this._requestSender.post(`${b2bBaseUrl}/api/v2/companies/${companyId}/addresses`, {
             credentials: false,
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
## What/Why?

Save company address as part of the persisting B2B metadata action.

- Each API call only saves one address.
- No `checkout-js` changes needed.


## Rollout/Rollback

Revert.

## Testing
### Save billing and shipping with two API calls.
<img width="1512" height="949" alt="Screenshot 2026-06-15 at 17 45 37" src="https://github.com/user-attachments/assets/18aff6e7-b258-47c6-b601-297957a14dfc" />
<img width="1512" height="949" alt="Screenshot 2026-06-15 at 17 45 44" src="https://github.com/user-attachments/assets/0de3fe5b-6a78-4b4e-961c-159f24d14bdb" />

### Save billing and shipping with one API call.
<img width="1512" height="949" alt="Screenshot 2026-06-15 at 17 55 00" src="https://github.com/user-attachments/assets/27cc43b8-4b88-451e-8267-78c9177bb1b3" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-order B2B orchestration and external address persistence; a failed save now fails the whole metadata action before order extra fields.
> 
> **Overview**
> Extends **non-invoice** `persistB2BMetadata` so checkout can persist billing/shipping addresses to the B2B company address book when the shopper opts in via `shouldSaveAddress`.
> 
> When the cart has a `companyId`, the action builds one or more `CreateCompanyAddressPayload` entries from billing and consignment shipping addresses (plus `extraInfo.addressExtraFields`), **deduplicates** matching shipping rows and **merges** billing/shipping into a single payload when the address and extra fields match. It then calls the new `POST .../companies/{id}/addresses` helper **before** `submitOrderExtraFields`; failures block the rest of the metadata flow. Invoice checkout skips this path; no `companyId` or no opt-in skips API calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cbfa93f6ece36fe8942d3e29c968fd0bcfa9459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->