### PR TITLE
feat(payment): PI-5047 [Barclaycard][Phase 4][FE] Remove the code

### DIFF
--- a/packages/core/src/common/registry/resolve-id-registry.spec.ts
+++ b/packages/core/src/common/registry/resolve-id-registry.spec.ts
@@ -106,7 +106,7 @@ describe('ResolveIdRegistry', () => {
         subject.register(registryKey1, () => new StrategyA());
         subject.register(registryKey2, () => new BarStrategy());
 
-        const query = { id: 'credit_card', gateway: 'barclaycard', type: 'PAYMENT_TYPE_HOSTED' };
+        const query = { id: 'credit_card', gateway: 'mollie', type: 'PAYMENT_TYPE_HOSTED' };
 
         expect(subject.get(query)).toBeInstanceOf(BarStrategy);
     });
@@ -127,14 +127,14 @@ describe('ResolveIdRegistry', () => {
     it('returns correct strategy for a entered registry when entry is with type', () => {
         const subject = new ResolveIdRegistry(true);
         const registryKey1 = { id: 'credit_card', gateway: 'bluesnap' };
-        const registryKey2 = { id: 'card', gateway: 'barclaycard' };
+        const registryKey2 = { id: 'card', gateway: 'mollie' };
         const registryKey3 = { type: 'PAYMENT_TYPE_HOSTED' };
 
         subject.register(registryKey1, () => new StrategyA());
         subject.register(registryKey2, () => new BarStrategy());
         subject.register(registryKey3, () => new FooStrategy());
 
-        const query = { id: 'credit_card', gateway: 'barclaycard', type: 'PAYMENT_TYPE_HOSTED' };
+        const query = { id: 'credit_card', gateway: 'mollie', type: 'PAYMENT_TYPE_HOSTED' };
 
         expect(subject.get(query)).toBeInstanceOf(FooStrategy);
     });
@@ -152,7 +152,7 @@ describe('ResolveIdRegistry', () => {
         subject.register(registryKey1, () => new StrategyA());
         subject.register(registryKey2, () => new BarStrategy());
 
-        const query = { id: 'credit_card', gateway: 'barclaycard', type: 'PAYMENT_TYPE_HOSTED' };
+        const query = { id: 'credit_card', gateway: 'mollie', type: 'PAYMENT_TYPE_HOSTED' };
 
         subject.get(query);
 

--- a/packages/core/src/payment/instrument/supported-payment-instruments.ts
+++ b/packages/core/src/payment/instrument/supported-payment-instruments.ts
@@ -129,10 +129,6 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'bolt',
         method: 'credit_card',
     },
-    'barclaycard.credit_card': {
-        provider: 'barclaycard',
-        method: 'credit_card',
-    },
     moneris: {
         provider: 'moneris',
         method: 'credit_card',

--- a/packages/offsite-integration/src/offsite-payment-strategy.ts
+++ b/packages/offsite-integration/src/offsite-payment-strategy.ts
@@ -80,6 +80,6 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
             return false;
         }
 
-        return payment.gatewayId === 'adyen' || payment.gatewayId === 'barclaycard';
+        return payment.gatewayId === 'adyen';
     }
 }


### PR DESCRIPTION
## What/Why?

Deprecation of Barclaycard

## Rollout/Rollback
Revert this PR

## Testing

Tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment instrument registration and offsite checkout payload rules; merchants still on Barclaycard could lose expected checkout behavior until fully migrated.
> 
> **Overview**
> Completes **Barclaycard deprecation** by dropping its credit-card instrument mapping and offsite checkout behavior.
> 
> The `barclaycard.credit_card` entry is removed from supported payment instruments, so Barclaycard is no longer recognized as a vaultable/supported card provider in core. **Offsite payment** no longer treats `gatewayId === 'barclaycard'` as requiring a full order payload (with return URL from the core app)—only Adyen keeps that path in `_shouldSubmitFullPayload`.
> 
> Registry resolution tests swap `barclaycard` gateway examples for `mollie` so behavior assertions stay the same without referencing the removed gateway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eebc7233339da756ff696daa76ecb1d41f98ef63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->