### PR TITLE
refactor(checkout): CHECKOUT-10080 Reorder Company Address Save Call

### DIFF
--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -532,12 +532,18 @@ describe('B2BPostOrderActionCreator', () => {
                 expect(requestSender.submitOrderExtraFields).toHaveBeenCalled();
             });
 
-            it('does not submit a company address in the invoice flow', async () => {
+            it('submits a company address in the invoice flow', async () => {
                 mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
 
                 await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
 
-                expect(requestSender.submitCompanyAddress).not.toHaveBeenCalled();
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({ isBilling: 1, isShipping: 0 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
             });
 
             it('emits failed action without calling submitOrderExtraFields when submitCompanyAddress rejects', async () => {

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -185,6 +185,19 @@ export default class B2BPostOrderActionCreator {
                 defer(async () => {
                     let payload = { receiptId: '' };
 
+                    if (companyId && companyAddresses.length) {
+                        await Promise.all(
+                            companyAddresses.map((companyAddress) =>
+                                this._requestSender.submitCompanyAddress(
+                                    companyId,
+                                    companyAddress,
+                                    b2bToken,
+                                    b2bBaseUrl,
+                                ),
+                            ),
+                        );
+                    }
+
                     if (isInvoice) {
                         const { body } = await this._requestSender.submitInvoice(
                             { orderId: `${orderId}`, comment: invoiceComment ?? '' },
@@ -194,19 +207,6 @@ export default class B2BPostOrderActionCreator {
 
                         payload = { receiptId: body.data.receiptId };
                     } else {
-                        if (companyId && companyAddresses.length) {
-                            await Promise.all(
-                                companyAddresses.map((companyAddress) =>
-                                    this._requestSender.submitCompanyAddress(
-                                        companyId,
-                                        companyAddress,
-                                        b2bToken,
-                                        b2bBaseUrl,
-                                    ),
-                                ),
-                            );
-                        }
-
                         await this._requestSender.submitOrderExtraFields(
                             {
                                 orderId,


### PR DESCRIPTION
## What/Why?
Saving company address should apply to the invoice flow. Currently, it's not.

<img width="1916" height="1248" alt="image" src="https://github.com/user-attachments/assets/6a674060-2bbb-454c-9b75-ec7627cbb248" />

## Rollout/Rollback

Revert.

## Testing
CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-order B2B API sequencing for invoice orders; failure on address save now blocks invoice submission, which is intended but affects a production checkout path.
> 
> **Overview**
> **Company address persistence now runs for invoice checkout**, not only the standard post-order path.
> 
> In `persistB2BMetadata`, the `submitCompanyAddress` batch is **moved above** the `isInvoice` branch so opted-in billing/shipping addresses are saved whenever `companyId` and mapped addresses exist—**before** `submitInvoice` or `submitOrderExtraFields`. Non-invoice behavior (save first, then extra fields / quote) is unchanged aside from sharing that earlier step.
> 
> The spec now expects **one** `submitCompanyAddress` call in the invoice flow when `shouldSaveAddress` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb677b64644a286006be35476cb594619407610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->