### PR TITLE
feat(checkout): CHECKOUT-10013 Add deleteCheckout

### DIFF
--- a/packages/core/src/cart/cart-reducer.spec.ts
+++ b/packages/core/src/cart/cart-reducer.spec.ts
@@ -183,4 +183,14 @@ describe('cartReducer()', () => {
             }),
         );
     });
+
+    it('removes cart data when checkout is deleted', () => {
+        expect(initialState.data).toBeDefined();
+
+        const action = {
+            type: CheckoutActionType.DeleteCheckoutSucceeded,
+        };
+
+        expect(cartReducer(initialState, action).data).toBeUndefined();
+    });
 });

--- a/packages/core/src/cart/cart-reducer.ts
+++ b/packages/core/src/cart/cart-reducer.ts
@@ -57,6 +57,9 @@ function dataReducer(
         case CheckoutHydrateActionType.HydrateInitialState:
             return objectMerge(data, action.payload?.checkout?.cart);
 
+        case CheckoutActionType.DeleteCheckoutSucceeded:
+            return undefined;
+
         default:
             return data;
     }

--- a/packages/core/src/checkout/checkout-action-creator.ts
+++ b/packages/core/src/checkout/checkout-action-creator.ts
@@ -9,7 +9,12 @@ import { ConfigActionCreator } from '../config';
 import { FormFieldsActionCreator } from '../form';
 
 import Checkout, { CheckoutRequestBody } from './checkout';
-import { CheckoutActionType, LoadCheckoutAction, UpdateCheckoutAction } from './checkout-actions';
+import {
+    CheckoutActionType,
+    DeleteCheckoutAction,
+    LoadCheckoutAction,
+    UpdateCheckoutAction,
+} from './checkout-actions';
 import { CheckoutHydrateActionType } from './checkout-hydrate-actions';
 import CheckoutInitialState from './checkout-initial-state';
 import CheckoutRequestSender from './checkout-request-sender';
@@ -125,6 +130,34 @@ export default class CheckoutActionCreator {
                     .catch((response) => {
                         observer.error(
                             createErrorAction(CheckoutActionType.UpdateCheckoutFailed, response),
+                        );
+                    });
+            });
+    }
+
+    deleteCheckout(
+        options?: RequestOptions,
+    ): ThunkAction<DeleteCheckoutAction, InternalCheckoutSelectors> {
+        return (store) =>
+            new Observable((observer) => {
+                const state = store.getState();
+                const checkout = state.checkout.getCheckout();
+
+                if (!checkout) {
+                    throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+                }
+
+                observer.next(createAction(CheckoutActionType.DeleteCheckoutRequested));
+
+                this._checkoutRequestSender
+                    .deleteCheckout(checkout.id, options)
+                    .then(() => {
+                        observer.next(createAction(CheckoutActionType.DeleteCheckoutSucceeded));
+                        observer.complete();
+                    })
+                    .catch((response) => {
+                        observer.error(
+                            createErrorAction(CheckoutActionType.DeleteCheckoutFailed, response),
                         );
                     });
             });

--- a/packages/core/src/checkout/checkout-actions.ts
+++ b/packages/core/src/checkout/checkout-actions.ts
@@ -13,9 +13,13 @@ export enum CheckoutActionType {
     UpdateCheckoutRequested = 'UPDATE_CHECKOUT_REQUESTED',
     UpdateCheckoutSucceeded = 'UPDATE_CHECKOUT_SUCCEEDED',
     UpdateCheckoutFailed = 'UPDATE_CHECKOUT_FAILED',
+
+    DeleteCheckoutRequested = 'DELETE_CHECKOUT_REQUESTED',
+    DeleteCheckoutSucceeded = 'DELETE_CHECKOUT_SUCCEEDED',
+    DeleteCheckoutFailed = 'DELETE_CHECKOUT_FAILED',
 }
 
-export type CheckoutAction = LoadCheckoutAction | UpdateCheckoutAction;
+export type CheckoutAction = LoadCheckoutAction | UpdateCheckoutAction | DeleteCheckoutAction;
 
 export type LoadCheckoutAction =
     | LoadCheckoutRequestedAction
@@ -28,6 +32,11 @@ export type UpdateCheckoutAction =
     | UpdateCheckoutRequestedAction
     | UpdateCheckoutSucceededAction
     | UpdateCheckoutFailedAction;
+
+export type DeleteCheckoutAction =
+    | DeleteCheckoutRequestedAction
+    | DeleteCheckoutSucceededAction
+    | DeleteCheckoutFailedAction;
 
 export interface LoadCheckoutRequestedAction extends Action {
     type: CheckoutActionType.LoadCheckoutRequested;
@@ -51,4 +60,16 @@ export interface UpdateCheckoutSucceededAction extends Action<Checkout> {
 
 export interface UpdateCheckoutFailedAction extends Action<Error> {
     type: CheckoutActionType.UpdateCheckoutFailed;
+}
+
+export interface DeleteCheckoutRequestedAction extends Action {
+    type: CheckoutActionType.DeleteCheckoutRequested;
+}
+
+export interface DeleteCheckoutSucceededAction extends Action {
+    type: CheckoutActionType.DeleteCheckoutSucceeded;
+}
+
+export interface DeleteCheckoutFailedAction extends Action<Error> {
+    type: CheckoutActionType.DeleteCheckoutFailed;
 }

--- a/packages/core/src/checkout/checkout-reducer.spec.ts
+++ b/packages/core/src/checkout/checkout-reducer.spec.ts
@@ -2,7 +2,7 @@ import { createAction } from '@bigcommerce/data-store';
 import { omit } from 'lodash';
 
 import { CheckoutActionType } from '../checkout';
-import { getCheckout } from '../checkout/checkouts.mock';
+import { getCheckout, getCheckoutState } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 import { ConsignmentActionType } from '../shipping';
@@ -75,6 +75,17 @@ describe('checkoutReducer', () => {
             errors: { updateError: undefined },
             statuses: { isUpdating: false },
         });
+    });
+
+    it('removes checkout data when checkout is deleted', () => {
+        const stateWithData = getCheckoutState();
+
+        expect(stateWithData.data).toBeDefined();
+
+        const action = createAction(CheckoutActionType.DeleteCheckoutSucceeded);
+        const output = checkoutReducer(stateWithData, action);
+
+        expect(output.data).toBeUndefined();
     });
 
     it('returns new state when consignment gets created', () => {

--- a/packages/core/src/checkout/checkout-reducer.ts
+++ b/packages/core/src/checkout/checkout-reducer.ts
@@ -77,6 +77,9 @@ function dataReducer(
                 ]),
             ) as CheckoutDataState;
 
+        case CheckoutActionType.DeleteCheckoutSucceeded:
+            return undefined;
+
         case OrderActionType.SubmitOrderSucceeded:
             return objectSet(data, 'orderId', action.payload && action.payload.order.orderId);
 

--- a/packages/core/src/checkout/checkout-reducer.ts
+++ b/packages/core/src/checkout/checkout-reducer.ts
@@ -117,6 +117,13 @@ function errorsReducer(
         case CheckoutActionType.UpdateCheckoutFailed:
             return objectSet(errors, 'updateError', action.payload);
 
+        case CheckoutActionType.DeleteCheckoutRequested:
+        case CheckoutActionType.DeleteCheckoutSucceeded:
+            return objectSet(errors, 'deleteError', undefined);
+
+        case CheckoutActionType.DeleteCheckoutFailed:
+            return objectSet(errors, 'deleteError', action.payload);
+
         default:
             return errors;
     }
@@ -140,6 +147,13 @@ function statusesReducer(
         case CheckoutActionType.UpdateCheckoutFailed:
         case CheckoutActionType.UpdateCheckoutSucceeded:
             return objectSet(statuses, 'isUpdating', false);
+
+        case CheckoutActionType.DeleteCheckoutRequested:
+            return objectSet(statuses, 'isDeleting', true);
+
+        case CheckoutActionType.DeleteCheckoutFailed:
+        case CheckoutActionType.DeleteCheckoutSucceeded:
+            return objectSet(statuses, 'isDeleting', false);
 
         case SpamProtectionActionType.ExecuteRequested:
             return objectSet(statuses, 'isExecutingSpamCheck', true);

--- a/packages/core/src/checkout/checkout-request-sender.ts
+++ b/packages/core/src/checkout/checkout-request-sender.ts
@@ -71,4 +71,14 @@ export default class CheckoutRequestSender {
                 throw err;
             });
     }
+
+    deleteCheckout(id: string, { timeout }: RequestOptions = {}): Promise<Response<void>> {
+        const url = `/api/storefront/carts/${id}`;
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
+
+        return this._requestSender.delete<void>(url, { headers, timeout });
+    }
 }

--- a/packages/core/src/checkout/checkout-selector.ts
+++ b/packages/core/src/checkout/checkout-selector.ts
@@ -18,9 +18,11 @@ export default interface CheckoutSelector {
     getOutstandingBalance(useStoreCredit?: boolean): number | undefined;
     getLoadError(): Error | undefined;
     getUpdateError(): Error | undefined;
+    getDeleteError(): Error | undefined;
     isExecutingSpamCheck(): boolean;
     isLoading(): boolean;
     isUpdating(): boolean;
+    isDeleting(): boolean;
 }
 
 export type CheckoutSelectorFactory = (
@@ -122,6 +124,11 @@ export function createCheckoutSelectorFactory(): CheckoutSelectorFactory {
         (error) => () => error,
     );
 
+    const getDeleteError = createSelector(
+        (state: CheckoutState) => state.errors.deleteError,
+        (error) => () => error,
+    );
+
     const isExecutingSpamCheck = createSelector(
         (state: CheckoutState) => state.statuses.isExecutingSpamCheck,
         (isExecutingSpamCheck) => () => isExecutingSpamCheck === true,
@@ -135,6 +142,11 @@ export function createCheckoutSelectorFactory(): CheckoutSelectorFactory {
     const isUpdating = createSelector(
         (state: CheckoutState) => state.statuses.isUpdating,
         (isUpdating) => () => isUpdating === true,
+    );
+
+    const isDeleting = createSelector(
+        (state: CheckoutState) => state.statuses.isDeleting,
+        (isDeleting) => () => isDeleting === true,
     );
 
     return memoizeOne(
@@ -174,9 +186,11 @@ export function createCheckoutSelectorFactory(): CheckoutSelectorFactory {
                 }),
                 getLoadError: getLoadError(state),
                 getUpdateError: getUpdateError(state),
+                getDeleteError: getDeleteError(state),
                 isExecutingSpamCheck: isExecutingSpamCheck(state),
                 isLoading: isLoading(state),
                 isUpdating: isUpdating(state),
+                isDeleting: isDeleting(state),
             };
         },
     );

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -265,6 +265,22 @@ export default class CheckoutService {
     }
 
     /**
+     * Deletes the current checkout.
+     *
+     * ```js
+     * await service.deleteCheckout();
+     * ```
+     *
+     * @param options - Options for deleting the current checkout.
+     * @returns A promise that resolves to the current state.
+     */
+    deleteCheckout(options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._checkoutActionCreator.deleteCheckout(options);
+
+        return this._dispatch(action);
+    }
+
+    /**
      * Loads an order by an id.
      *
      * The method can only retrieve an order if the order belongs to the current

--- a/packages/core/src/checkout/checkout-state.ts
+++ b/packages/core/src/checkout/checkout-state.ts
@@ -16,12 +16,14 @@ export type CheckoutDataState = Omit<
 export interface CheckoutErrorsState {
     loadError?: Error;
     updateError?: Error;
+    deleteError?: Error;
 }
 
 export interface CheckoutStatusesState {
     isExecutingSpamCheck?: boolean;
     isLoading?: boolean;
     isUpdating?: boolean;
+    isDeleting?: boolean;
 }
 
 export const DEFAULT_STATE: CheckoutState = {

--- a/packages/core/src/checkout/checkout-store-error-selector.ts
+++ b/packages/core/src/checkout/checkout-store-error-selector.ts
@@ -37,6 +37,13 @@ export default interface CheckoutStoreErrorSelector {
     getUpdateCheckoutError(): Error | undefined;
 
     /**
+     * Returns an error if unable to delete the current checkout.
+     *
+     * @returns The error object if unable to delete, otherwise undefined.
+     */
+    getDeleteCheckoutError(): Error | undefined;
+
+    /**
      * Returns an error if unable to submit the current order.
      *
      * @returns The error object if unable to submit, otherwise undefined.
@@ -365,6 +372,7 @@ export function createCheckoutStoreErrorSelectorFactory(): CheckoutStoreErrorSel
         const selector = {
             getLoadCheckoutError: state.checkout.getLoadError,
             getUpdateCheckoutError: state.checkout.getUpdateError,
+            getDeleteCheckoutError: state.checkout.getDeleteError,
             getSubmitOrderError: state.paymentStrategies.getExecuteError,
             getFinalizeOrderError: state.paymentStrategies.getFinalizeError,
             getLoadOrderError: state.order.getLoadError,

--- a/packages/core/src/checkout/checkout-store-status-selector.ts
+++ b/packages/core/src/checkout/checkout-store-status-selector.ts
@@ -36,6 +36,13 @@ export default interface CheckoutStoreStatusSelector {
     isUpdatingCheckout(): boolean;
 
     /**
+     * Checks whether the current checkout is being deleted.
+     *
+     * @returns True if the current checkout is being deleted, otherwise false.
+     */
+    isDeletingCheckout(): boolean;
+
+    /**
      * Checks whether spam check is executing.
      *
      * @returns True if the current checkout is being updated, otherwise false.
@@ -484,6 +491,7 @@ export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusS
         const selector = {
             isLoadingCheckout: state.checkout.isLoading,
             isUpdatingCheckout: state.checkout.isUpdating,
+            isDeletingCheckout: state.checkout.isDeleting,
             isExecutingSpamCheck: state.checkout.isExecutingSpamCheck,
             isSubmittingOrder: isSubmittingOrder(state),
             isFinalizingOrder: state.paymentStrategies.isFinalizing,


### PR DESCRIPTION
## What/Why?

Add `deleteCheckout` to `CheckoutService` in preparation for deleting the checkout when leaving a quote-to-checkout flow.

This function uses the https://docs.bigcommerce.com/developer/api-reference/rest/storefront/carts/delete-cart endpoint.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes the live cart via API and clears core checkout/cart state; callers must handle missing checkout and any related slice data that is not reset on delete.
> 
> **Overview**
> Adds **`deleteCheckout`** on `CheckoutService`, wired through the existing checkout action/reducer flow so callers can remove the active checkout (e.g. when exiting quote-to-checkout).
> 
> The action creator issues a **Storefront DELETE** to `/api/storefront/carts/{checkoutId}` via new `CheckoutRequestSender.deleteCheckout`, with requested/succeeded/failed actions, **`isDeleting`** / **`deleteError`** state, and public selectors **`isDeletingCheckout`** and **`getDeleteCheckoutError`**.
> 
> On **`DeleteCheckoutSucceeded`**, checkout and cart **data slices are cleared** (`undefined`), so `getCheckout()` / cart data reflect an empty session after a successful delete. Reducer specs cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dd8499b69950652fe6080772cd3788369bbfb83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->