### PR TITLE
refactor(checkout): CHECKOUT-10019 Update Order Request Interface

### DIFF
--- a/packages/core/src/order/internal-order-request-body.ts
+++ b/packages/core/src/order/internal-order-request-body.ts
@@ -18,10 +18,8 @@ export interface InternalOrderPaymentRequestBody {
 }
 
 export interface InternalOrderB2BMetadata {
-    // For invoice flow
     invoiceComment?: string;
-    // For all B2B flows
+    orderExtraFields?: B2BExtraField[];
     poNumber?: string;
     referenceNumber?: string;
-    orderExtraFields?: B2BExtraField[];
 }

--- a/packages/core/src/order/internal-order-request-body.ts
+++ b/packages/core/src/order/internal-order-request-body.ts
@@ -1,4 +1,5 @@
 import { PaymentInstrument } from '../payment';
+import { B2BExtraField } from '../payment/b2b-post-order-request-sender';
 
 export default interface InternalOrderRequestBody {
     cartId: string;
@@ -7,10 +8,20 @@ export default interface InternalOrderRequestBody {
     customerMessage?: string;
     externalSource?: string;
     shouldSaveInstrument?: boolean;
+    b2bMetadata?: InternalOrderB2BMetadata;
 }
 
 export interface InternalOrderPaymentRequestBody {
     name: string;
     gateway?: string;
     paymentData?: PaymentInstrument;
+}
+
+export interface InternalOrderB2BMetadata {
+    // For invoice flow
+    invoiceComment?: string;
+    // For all B2B flows
+    poNumber?: string;
+    referenceNumber?: string;
+    orderExtraFields?: B2BExtraField[];
 }

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -87,6 +87,9 @@ interface CreateCompanyAddressResponseBody {
 export default class B2BPostOrderRequestSender {
     constructor(private _requestSender: RequestSender) {}
 
+    // To be deleted
+    // invoiceComment will be sent to the Order API
+    // Server side needs to pass order id to B2B when it is an invoice-to-checkout
     async submitInvoice(
         payload: CloseInvoicePayload,
         b2bToken: string,
@@ -108,6 +111,9 @@ export default class B2BPostOrderRequestSender {
         );
     }
 
+    // To be deleted
+    // no additional info wil be sent to Order API
+    // server side can pass the rest of the info to B2B by reading the checkout object and order object
     async submitQuote(
         quoteId: number,
         payload: QuoteOrderedPayload,
@@ -125,6 +131,9 @@ export default class B2BPostOrderRequestSender {
         });
     }
 
+    // To be deleted
+    // poNumber, referenceNumber, orderExtraFields will be sent to Order API.
+    // server side can pass the rest of the info to B2B by reading the checkout object and order object
     async submitOrderExtraFields(
         payload: AddOrderExtraFieldsPayload,
         b2bToken: string,
@@ -141,6 +150,8 @@ export default class B2BPostOrderRequestSender {
         });
     }
 
+    // To be deleted
+    // server side can pass company address info to B2B by reading the checkout object
     async submitCompanyAddress(
         companyId: number,
         payload: CreateCompanyAddressPayload,

--- a/packages/payment-integration-api/src/address/address.ts
+++ b/packages/payment-integration-api/src/address/address.ts
@@ -1,3 +1,5 @@
+import { AddressExtraFieldValue } from '../form';
+
 export type AddressKey = keyof Address;
 
 export default interface Address extends AddressRequestBody {
@@ -21,4 +23,6 @@ export interface AddressRequestBody {
         fieldId: string;
         fieldValue: string | number | string[];
     }>;
+    extraFields?: AddressExtraFieldValue[];
+    label?: string;
 }

--- a/packages/payment-integration-api/src/form/extra-field.ts
+++ b/packages/payment-integration-api/src/form/extra-field.ts
@@ -1,0 +1,4 @@
+export interface AddressExtraFieldValue {
+    fieldId: string;
+    fieldValue: string | number;
+}

--- a/packages/payment-integration-api/src/form/index.ts
+++ b/packages/payment-integration-api/src/form/index.ts
@@ -1,1 +1,2 @@
+export { AddressExtraFieldValue } from './extra-field';
 export { default as FormField, FormFields } from './form-fields';


### PR DESCRIPTION
## What/Why?

Remove five B2B API calls via internal order API contract changes.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the order-placement contract and B2B integration boundary; behavior depends on coordinated server-side handling before the marked B2B client methods are removed.
> 
> **Overview**
> Extends the **internal order request** so B2B checkout data can ride on the Order API instead of separate storefront B2B calls. `InternalOrderRequestBody` gains optional `b2bMetadata` (`invoiceComment`, `poNumber`, `referenceNumber`, `orderExtraFields`).
> 
> `B2BPostOrderRequestSender` methods (`submitInvoice`, `submitQuote`, `submitOrderExtraFields`, `submitCompanyAddress`) are annotated **to be deleted**, with notes on what moves to Order API vs what the server should forward from checkout/order.
> 
> Address types in **payment-integration-api** add optional `extraFields` and `label`, plus a new exported `AddressExtraFieldValue` type for B2B address extras on the wire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511efb279b0d44e4dbad23b560b6a1a60bb9d926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->