### PR TITLE
fix(payment): fix GooglePay strategy spec crashing under Jest 29 / Node 22

### DIFF
--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -113,7 +113,7 @@ describe('GooglePayPaymentStrategy', () => {
         };
     });
 
-    beforeAll(() => {
+    beforeEach(() => {
         button = document.createElement('div');
 
         button.id = BUTTON_ID;
@@ -125,8 +125,7 @@ describe('GooglePayPaymentStrategy', () => {
     });
 
     afterEach(() => {
-        (button.addEventListener as jest.Mock).mockClear();
-        (button.removeEventListener as jest.Mock).mockClear();
+        button.remove();
     });
 
     describe('#initialize', () => {
@@ -449,9 +448,11 @@ describe('GooglePayPaymentStrategy', () => {
 
             await strategy.initialize(options);
 
-            button.click();
+            const [, clickHandler] = (button.addEventListener as jest.Mock).mock.calls.find(
+                ([eventName]) => eventName === 'click',
+            );
 
-            await new Promise((resolve) => process.nextTick(resolve));
+            await expect(clickHandler(new MouseEvent('click'))).rejects.toThrow(internalError);
 
             expect(LoadingHide).toHaveBeenCalled();
             expect(rejectedInitializeWidgetMock).toHaveBeenCalledTimes(1);
@@ -741,9 +742,13 @@ describe('GooglePayPaymentStrategy', () => {
 
                     await strategy.initialize(options);
 
-                    button.click();
+                    const [, clickHandler] = (button.addEventListener as jest.Mock).mock.calls.find(
+                        ([eventName]) => eventName === 'click',
+                    );
 
-                    await new Promise((resolve) => process.nextTick(resolve));
+                    await expect(clickHandler(new MouseEvent('click'))).rejects.toThrow(
+                        MissingDataError,
+                    );
 
                     expect(processor.handleCoupons).not.toHaveBeenCalled();
                 });
@@ -867,6 +872,8 @@ describe('GooglePayPaymentStrategy', () => {
             });
 
             it('should hide loading indicator after completing checkout', async () => {
+                completeCheckoutFlowSpy.mockRestore();
+
                 button.click();
 
                 await new Promise((resolve) => process.nextTick(resolve));


### PR DESCRIPTION
## What/Why?

The `google-pay-integration` test suite was failing on `master` with `Jest worker encountered N child process exceptions, exceeding retry limit` — unrelated to any feature work.

Root cause: the CHECKOUT-10061 toolchain upgrade (TypeScript 4.7→5.8, **Jest 29 + Node 22**, bigcommerce/checkout-sdk-js#3273) made the worker crash on unhandled promise rejections; Jest 26 previously tolerated them. `google-pay-payment-strategy.spec.ts` had two distinct problems, the first masking the second:

1. **Leaked unhandled rejections from fire-and-forget click handlers.** Several tests trigger an async click handler via `button.click()` and never await it. When the handler reports an error via `onError` and re-throws, the rejection is never handled → it crashes the worker. This was amplified by the `button` being created once in `beforeAll` and shared across all tests with no `deinitialize` in between, so click listeners accumulated and a later `button.click()` fired an *earlier* test's throwing handler. (The newer container-mode tests added in bigcommerce/checkout-sdk-js#3247 already avoid this by capturing and awaiting the handler.)
2. **A pre-existing assertion failure masked by the crash.** PI-5216 (bigcommerce/checkout-sdk-js#3267) mocked `_completeCheckoutFlow` to a no-op in the direct-pay describe, but that method is the only place `LoadingHide` is called on the success path — so `should hide loading indicator after completing checkout` could never pass.

This PR fixes the suite with **test-only changes — no production code is touched**:
- Create a fresh `button` per test (`beforeAll` → `beforeEach`, removed in `afterEach`) so click listeners can't accumulate across tests.
- For the two tests whose flow rejects (`onError`, `getNonce`), capture the registered click handler and `await expect(...).rejects.toThrow(...)` instead of fire-and-forget `button.click()` — matching the existing #3247 container-test pattern.
- For `should hide loading indicator after completing checkout`, restore the real `_completeCheckoutFlow` (jsdom only logs the unimplemented `window.location.replace`, it doesn't throw) so the test asserts genuine production behaviour rather than a stub.

## Rollout/Rollback

No production impact — changes are limited to `packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts`. No experiments, feature flags, or database migrations. Rollback is a straight revert of this commit.

## Testing

- `npx nx run google-pay-integration:test` → **71 suites / 414 tests pass**, run repeatedly with no flaky worker crashes (the failure was timing-sensitive).
- `npx eslint packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts` → clean.
- Verified each change is independently necessary: with the fresh button alone, reverting `onError` to `button.click()` still crashes; the `_completeCheckoutFlow` test now exercises the real method (confirmed it calls `LoadingHide` via production code, not a stub).

Before:
<img width="754" height="393" alt="Screenshot 2026-06-25 at 14 23 20" src="https://github.com/user-attachments/assets/88ebb150-d4ed-4c8a-bd61-352c6a3f6271" />

After:
<img width="750" height="175" alt="Screenshot 2026-06-25 at 14 24 42" src="https://github.com/user-attachments/assets/a843319d-e011-437d-bc06-64e60180ec3b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to one spec file with no production code, payment runtime, or deployment impact.
> 
> **Overview**
> **Test-only** updates to `google-pay-payment-strategy.spec.ts` so the suite stops crashing Jest workers after the Jest 29 / Node 22 upgrade (unhandled promise rejections are no longer tolerated).
> 
> Wallet button setup now uses **`beforeEach`** to create and append a fresh DOM node and **`afterEach`** to remove it, instead of a shared **`beforeAll`** button that let click listeners stack across tests.
> 
> For flows that **reject** (`onError` on widget failure, coupons path when `getNonce` fails), tests no longer fire **`button.click()`** without awaiting; they pull the registered **`click`** handler from **`addEventListener`** mocks and **`await expect(...).rejects.toThrow(...)`**, matching the existing container-button pattern.
> 
> In the direct-pay-on-click block, **`should hide loading indicator after completing checkout`** restores the real **`_completeCheckoutFlow`** (drops the no-op spy) so **`LoadingHide`** is asserted on the actual success path instead of a stub that never hid loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a86996546d67b8c8530506ba3e28d42c01c4b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->