### PR TITLE
chore(order): BACK-714 Add bundled items to order interface

### DIFF
--- a/packages/core/src/order/order.ts
+++ b/packages/core/src/order/order.ts
@@ -10,6 +10,7 @@ import { OrderMetaState } from './order-state';
 export default interface Order {
     baseAmount: number;
     billingAddress: OrderBillingAddress;
+    bundledItems: Pick<LineItemMap, 'physicalItems' | 'digitalItems'>;
     cartId: string;
     coupons: Coupon[];
     consignments: OrderConsignment;

--- a/packages/core/src/order/orders.mock.ts
+++ b/packages/core/src/order/orders.mock.ts
@@ -18,6 +18,10 @@ export function getOrder(): Order {
     return {
         baseAmount: 200,
         billingAddress: getBillingAddress(),
+        bundledItems: {
+            physicalItems: [],
+            digitalItems: [],
+        },
         cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         consignments: getOrderConsignment(),
         comparisonShippingCost: 20,


### PR DESCRIPTION
## What/Why?
Add bundled items property to order interface

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and mock change with no runtime mapping logic in this PR; consumers must supply bundledItems once order data is wired up.
> 
> **Overview**
> Adds a required **`bundledItems`** field on the core **`Order`** type so bundled physical and digital line items can be modeled separately from **`lineItems`**.
> 
> The shape is **`Pick<LineItemMap, 'physicalItems' | 'digitalItems'>`** (no gift certificates or custom items). **`getOrder()`** in **`orders.mock.ts`** is updated with empty **`physicalItems`** / **`digitalItems`** arrays so tests and mocks satisfy the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4b2d0eff4bad32859c9624ecc14bd70267b727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->