### PR TITLE
fix(payment): PAYPAL-6718 BT google pay refresh 3ds state before verification

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-braintree-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-braintree-gateway.spec.ts
@@ -217,6 +217,160 @@ describe('GooglePayBraintreeGateway', () => {
             expect(nonce).toBe('verification_nonce');
         });
 
+        it('does not cancel before the first verification', async () => {
+            braintreeMock.initializationData.isThreeDSecureEnabled = true;
+            braintreeMock.initializationData.card_information = {
+                type: 'type',
+                number: '1234',
+                bin: 'bin',
+                isNetworkTokenized: false,
+            };
+
+            await googlePayBraintreeGateway.initialize(() => braintreeMock);
+
+            await googlePayBraintreeGateway.getNonce('googlepaybraintree');
+
+            expect(braintreeThreeDSecureMock.cancelVerifyCard).not.toHaveBeenCalled();
+            expect(braintreeThreeDSecureMock.verifyCard).toHaveBeenCalled();
+        });
+
+        it('cancels a stale authentication before a subsequent verification while one is in progress', async () => {
+            braintreeMock.initializationData.isThreeDSecureEnabled = true;
+            braintreeMock.initializationData.card_information = {
+                type: 'type',
+                number: '1234',
+                bin: 'bin',
+                isNetworkTokenized: false,
+            };
+
+            jest.spyOn(GooglePayGateway.prototype, 'getNonce').mockResolvedValue('token');
+
+            const verificationPayload = {
+                nonce: 'verification_nonce',
+                details: { cardType: '', lastFour: '', lastTwo: '' },
+                description: '',
+                liabilityShiftPossible: true,
+                liabilityShifted: true,
+            };
+
+            let resolveFirstVerify: (payload: unknown) => void = () => undefined;
+
+            jest.spyOn(braintreeThreeDSecureMock, 'verifyCard')
+                .mockReturnValueOnce(
+                    new Promise((resolve) => {
+                        resolveFirstVerify = resolve;
+                    }),
+                )
+                .mockResolvedValueOnce(verificationPayload);
+
+            await googlePayBraintreeGateway.initialize(() => braintreeMock);
+
+            const firstVerification = googlePayBraintreeGateway.getNonce('googlepaybraintree');
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+
+            const secondNonce = await googlePayBraintreeGateway.getNonce('googlepaybraintree');
+
+            expect(braintreeThreeDSecureMock.cancelVerifyCard).toHaveBeenCalled();
+            expect(secondNonce).toBe('verification_nonce');
+
+            resolveFirstVerify(verificationPayload);
+
+            await firstVerification;
+        });
+
+        it('keeps cancelling while any overlapping verification is still in progress', async () => {
+            braintreeMock.initializationData.isThreeDSecureEnabled = true;
+            braintreeMock.initializationData.card_information = {
+                type: 'type',
+                number: '1234',
+                bin: 'bin',
+                isNetworkTokenized: false,
+            };
+
+            jest.spyOn(GooglePayGateway.prototype, 'getNonce').mockResolvedValue('token');
+
+            const verificationPayload = {
+                nonce: 'verification_nonce',
+                details: { cardType: '', lastFour: '', lastTwo: '' },
+                description: '',
+                liabilityShiftPossible: true,
+                liabilityShifted: true,
+            };
+
+            let resolveFirstVerify: (payload: unknown) => void = () => undefined;
+            let resolveSecondVerify: (payload: unknown) => void = () => undefined;
+
+            jest.spyOn(braintreeThreeDSecureMock, 'verifyCard')
+                .mockReturnValueOnce(
+                    new Promise((resolve) => {
+                        resolveFirstVerify = resolve;
+                    }),
+                )
+                .mockReturnValueOnce(
+                    new Promise((resolve) => {
+                        resolveSecondVerify = resolve;
+                    }),
+                )
+                .mockResolvedValueOnce(verificationPayload);
+
+            await googlePayBraintreeGateway.initialize(() => braintreeMock);
+
+            // First and second verifications are started and left in progress.
+            const firstVerification = googlePayBraintreeGateway.getNonce('googlepaybraintree');
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+
+            const secondVerification = googlePayBraintreeGateway.getNonce('googlepaybraintree');
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+
+            resolveFirstVerify(verificationPayload);
+
+            await firstVerification;
+
+            (braintreeThreeDSecureMock.cancelVerifyCard as jest.Mock).mockClear();
+
+            const thirdNonce = await googlePayBraintreeGateway.getNonce('googlepaybraintree');
+
+            expect(braintreeThreeDSecureMock.cancelVerifyCard).toHaveBeenCalled();
+            expect(thirdNonce).toBe('verification_nonce');
+
+            resolveSecondVerify(verificationPayload);
+
+            await secondVerification;
+        });
+
+        it('re-throws when verifyCard rejects', async () => {
+            braintreeMock.initializationData.isThreeDSecureEnabled = true;
+            braintreeMock.initializationData.card_information = {
+                type: 'type',
+                number: '1234',
+                bin: 'bin',
+                isNetworkTokenized: false,
+            };
+
+            const verifyError = new Error(
+                'Cannot call verifyCard while existing authentication is in progress.',
+            );
+
+            jest.spyOn(braintreeThreeDSecureMock, 'verifyCard').mockRejectedValue(verifyError);
+
+            await googlePayBraintreeGateway.initialize(() => braintreeMock);
+
+            await expect(googlePayBraintreeGateway.getNonce('googlepaybraintree')).rejects.toThrow(
+                verifyError,
+            );
+
+            expect(braintreeThreeDSecureMock.cancelVerifyCard).not.toHaveBeenCalled();
+        });
+
         it('get nonce when 3DSecure is not enabled', async () => {
             braintreeMock.initializationData.card_information = {
                 type: 'type',

--- a/packages/google-pay-integration/src/gateways/google-pay-braintree-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-braintree-gateway.ts
@@ -1,7 +1,7 @@
 import {
     BraintreeGooglePayment,
-    BraintreeGooglePayThreeDSecure,
     BraintreeSdk,
+    BraintreeThreeDSecure,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     CancellablePromise,
@@ -27,6 +27,7 @@ export default class GooglePayBraintreeGateway extends GooglePayGateway {
     private _braintreeGooglePayment?: BraintreeGooglePayment;
     private _service: PaymentIntegrationService;
     private _methodId = GooglePayKey.BRAINTREE;
+    private _verificationsInProgress = 0;
 
     constructor(service: PaymentIntegrationService, private _braintreeSdk: BraintreeSdk) {
         super('braintree', service);
@@ -154,12 +155,18 @@ export default class GooglePayBraintreeGateway extends GooglePayGateway {
         return deviceData;
     }
 
-    private _braintreePresent3DSChallenge(
-        threeDSecure: BraintreeGooglePayThreeDSecure,
+    private async _braintreePresent3DSChallenge(
+        threeDSecure: BraintreeThreeDSecure,
         amount: number,
         nonce: string,
         bin: string,
     ) {
+        if (this._verificationsInProgress > 0) {
+            await this._cancelBraintree3DSVerification(threeDSecure);
+        }
+
+        this._verificationsInProgress += 1;
+
         const verification = new CancellablePromise(
             threeDSecure.verifyCard({
                 amount,
@@ -171,6 +178,20 @@ export default class GooglePayBraintreeGateway extends GooglePayGateway {
             }),
         );
 
-        return verification.promise;
+        try {
+            return await verification.promise;
+        } finally {
+            this._verificationsInProgress -= 1;
+        }
+    }
+
+    private async _cancelBraintree3DSVerification(
+        threeDSecure: BraintreeThreeDSecure,
+    ): Promise<void> {
+        try {
+            await threeDSecure.cancelVerifyCard();
+        } catch {
+            // No-op: cancelVerifyCard rejects when no authentication is in progress.
+        }
     }
 }

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -549,6 +549,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
     private _rerenderPlaceholderButton(): void {
         const { render } = this.stripeInitializationOptions || {};
+
         render?.();
     }
 }


### PR DESCRIPTION
## What
Fixes the Braintree Google Pay 3DS checkout error "Cannot call verifyCard while existing authentication is in progress." Before starting a new 3DS verification, the Braintree Google Pay gateway now calls `cancelVerifyCard` to release any authentication left in progress on the reused `threeDSecure` instance.
## Why
BraintreeSdk.getBraintreeThreeDS() caches and reuses a single `threeDSecure` instance. verifyCard sets an internal "authentication in progress" lock that is only released when its promise settles (after the full 3DS challenge). It can be left set on the shared instance when a challenge is interrupted. Calling `cancelVerifyCard()` before each verification clears the stale lock so every attempt starts clean.
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
#### Before

[3DSInProgressError.webm](https://github.com/user-attachments/assets/aa4294ef-42a2-4228-a2b7-f5b65f0bc27b)

#### After

[withChanges3ds.webm](https://github.com/user-attachments/assets/67562241-2e1f-41c3-8924-ebfc1faa33a7)

Diirect pay(PI-5111.google_pay_direct_pay_on_click=true)

[screen-capture.webm](https://github.com/user-attachments/assets/7cd6cb09-a65d-4702-92fb-045b182ffe28)

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment 3DS flow and concurrent nonce retrieval; behavior is scoped to Braintree Google Pay with tests, but incorrect cancel timing could affect liability shift or challenge UX.
> 
> **Overview**
> Fixes Braintree Google Pay checkout failures when **3DS** is enabled and a second `getNonce` runs while an earlier `verifyCard` is still in flight on the shared cached `threeDSecure` instance.
> 
> `GooglePayBraintreeGateway` now tracks overlapping verifications with `_verificationsInProgress`. Before starting another challenge it awaits **`cancelVerifyCard`** (errors swallowed when nothing is in progress), then wraps `verifyCard` in **try/finally** so the counter decrements when the promise settles. The 3DS helper type is aligned to **`BraintreeThreeDSecure`**.
> 
> New unit tests cover first verification without cancel, cancel on retry while one is pending, cancel when multiple overlap, and propagation when `verifyCard` rejects without calling cancel.
> 
> The Stripe CS strategy change is formatting only (blank line before `render?.()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 244fb7d013a972396009b0b9edceb16ab3250e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->