### PR TITLE
Revert "refactor(checkout): CHECKOUT-10143 Remove post-order B2B Action"

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -65,6 +65,8 @@ import {
     B2BCompanyPaymentMethodRequestSender,
     B2BPaymentsRefreshActionCreator,
     B2BPaymentsRefreshRequestSender,
+    B2BPostOrderActionCreator,
+    B2BPostOrderRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistryV2,
     PaymentMethodActionCreator,
@@ -130,6 +132,8 @@ import createCheckoutStore from './create-checkout-store';
 describe('CheckoutService', () => {
     let b2bPaymentsRefreshActionCreator: B2BPaymentsRefreshActionCreator;
     let b2bPaymentsRefreshRequestSender: B2BPaymentsRefreshRequestSender;
+    let b2bPostOrderActionCreator: B2BPostOrderActionCreator;
+    let b2bPostOrderRequestSender: B2BPostOrderRequestSender;
     let billingAddressActionCreator: BillingAddressActionCreator;
     let billingAddressRequestSender: BillingAddressRequestSender;
     let checkoutActionCreator: CheckoutActionCreator;
@@ -411,6 +415,14 @@ describe('CheckoutService', () => {
             b2bPaymentsRefreshRequestSender,
         );
 
+        b2bPostOrderRequestSender = new B2BPostOrderRequestSender(requestSender);
+
+        jest.spyOn(b2bPostOrderRequestSender, 'submitInvoice').mockResolvedValue(
+            getResponse({ data: { paymentId: 'pay_1', receiptId: 'rcpt_1' }, code: 200 }),
+        );
+
+        b2bPostOrderActionCreator = new B2BPostOrderActionCreator(b2bPostOrderRequestSender);
+
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             paymentStrategyRegistry,
             paymentStrategyRegistryV2,
@@ -468,6 +480,7 @@ describe('CheckoutService', () => {
             extensionActionCreator,
             workerExtensionMessenger,
             b2bPaymentsRefreshActionCreator,
+            b2bPostOrderActionCreator,
         );
     });
 
@@ -634,6 +647,33 @@ describe('CheckoutService', () => {
             expect(b2bPaymentsRefreshActionCreator.refreshB2BPaymentMethods).toHaveBeenCalledWith(
                 undefined,
             );
+
+            await result.catch(() => undefined);
+        });
+    });
+
+    describe('#persistB2BMetadata()', () => {
+        it('exposes the method on the service', () => {
+            expect(typeof checkoutService.persistB2BMetadata).toBe('function');
+        });
+
+        it('dispatches the action creator and returns a promise', async () => {
+            jest.spyOn(b2bPostOrderActionCreator, 'persistB2BMetadata');
+
+            const result = checkoutService.persistB2BMetadata({
+                isInvoice: true,
+                invoiceComment: 'Invoice comment',
+            });
+
+            expect(result).toBeInstanceOf(Promise);
+            expect(b2bPostOrderActionCreator.persistB2BMetadata).toHaveBeenCalledWith({
+                isInvoice: true,
+                invoiceComment: 'Invoice comment',
+                poNumber: '',
+                referenceNumber: '',
+                extraFields: [],
+                extraInfo: {},
+            });
 
             await result.catch(() => undefined);
         });

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -37,12 +37,14 @@ import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
 import {
     B2BPaymentsRefreshActionCreator,
+    B2BPostOrderActionCreator,
     OrderFinalizeOptions,
     PaymentInitializeOptions,
     PaymentMethodActionCreator,
     PaymentRequestOptions,
     PaymentStrategyActionCreator,
 } from '../payment';
+import { PersistB2BMetadataOptions } from '../payment/b2b-post-order-actions';
 import { InstrumentActionCreator } from '../payment/instrument';
 import {
     ConsignmentActionCreator,
@@ -114,6 +116,7 @@ export default class CheckoutService {
         private _extensionActionCreator: ExtensionActionCreator,
         private _workerExtensionMessenger: WorkerExtensionMessenger,
         private _b2bPaymentsRefreshActionCreator: B2BPaymentsRefreshActionCreator,
+        private _b2bPostOrderActionCreator: B2BPostOrderActionCreator,
     ) {
         this._errorTransformer = createCheckoutServiceErrorTransformer();
     }
@@ -734,6 +737,36 @@ export default class CheckoutService {
         const action = this._b2bPaymentsRefreshActionCreator.refreshB2BPaymentMethods(options);
 
         return this._dispatch(action, { queueId: 'b2bPaymentsRefresh' });
+    }
+
+    /**
+     * Persists B2B order metadata (e.g. invoice comment) after an order is placed
+     *
+     * ```js
+     * const state = await service.persistB2BMetadata(comment);
+     * ```
+     *
+     * @param PersistB2BMetadataOptions - Passing an object to prepare the payload for the request.
+     * @returns A promise that resolves to the current state.
+     */
+    persistB2BMetadata({
+        isInvoice = false,
+        invoiceComment = '',
+        poNumber = '',
+        referenceNumber = '',
+        extraFields = [],
+        extraInfo = {},
+    }: PersistB2BMetadataOptions): Promise<CheckoutSelectors> {
+        const action = this._b2bPostOrderActionCreator.persistB2BMetadata({
+            isInvoice,
+            invoiceComment,
+            poNumber,
+            referenceNumber,
+            extraFields,
+            extraInfo,
+        });
+
+        return this._dispatch(action, { queueId: 'b2bPostOrder' });
     }
 
     /**

--- a/packages/core/src/checkout/checkout-store-error-selector.ts
+++ b/packages/core/src/checkout/checkout-store-error-selector.ts
@@ -303,6 +303,13 @@ export default interface CheckoutStoreErrorSelector {
     getLoadB2BTokenError(): Error | undefined;
 
     /**
+     * Returns an error if unable to persist B2B order metadata.
+     *
+     * @returns The error object if unable to persist B2B metadata, otherwise undefined.
+     */
+    getPersistB2BMetadataError(): Error | undefined;
+
+    /**
      * Returns an error if unable to create customer account.
      *
      * @returns The error object if unable to create account, otherwise undefined.
@@ -398,6 +405,7 @@ export function createCheckoutStoreErrorSelectorFactory(): CheckoutStoreErrorSel
             getLoadConfigError: state.config.getLoadError,
             getSignInEmailError: state.signInEmail.getSendError,
             getLoadB2BTokenError: state.b2bToken.getLoadError,
+            getPersistB2BMetadataError: state.b2bPostOrder.getPersistError,
             getCreateCustomerAccountError: state.customer.getCreateAccountError,
             getCreateCustomerAddressError: state.customer.getCreateAddressError,
             getPickupOptionsError: state.pickupOptions.getLoadError,

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -67,11 +67,11 @@ export default interface CheckoutStoreSelector {
     getB2BToken(): string | undefined;
 
     /**
-     * Gets the B2B invoice payment receipt id returned after an order is submitted.
+     * Gets the B2B receipt id produced after persisting order metadata.
      *
-     * @returns The B2B receipt id if it is available, otherwise undefined.
+     * @returns The B2B receipt id string if it has been persisted, otherwise undefined.
      */
-    getB2BReceiptId(): number | undefined;
+    getB2BReceiptId(): string | undefined;
 
     /**
      * Gets the shipping address of the current checkout.
@@ -522,8 +522,8 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
     );
 
     const getB2BReceiptId = createSelector(
-        ({ order }: InternalCheckoutSelectors) => order.getB2BReceiptId,
-        (getB2BReceiptId) => clone(getB2BReceiptId),
+        ({ b2bPostOrder }: InternalCheckoutSelectors) => b2bPostOrder.getReceiptId,
+        (getReceiptId) => clone(getReceiptId),
     );
 
     const isPaymentDataRequired = createSelector(

--- a/packages/core/src/checkout/checkout-store-state.ts
+++ b/packages/core/src/checkout/checkout-store-state.ts
@@ -10,7 +10,12 @@ import { FormFieldsState } from '../form';
 import { CountryState } from '../geography';
 import { OrderState } from '../order';
 import { OrderBillingAddressState } from '../order-billing-address';
-import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payment';
+import {
+    B2BPostOrderState,
+    PaymentMethodState,
+    PaymentState,
+    PaymentStrategyState,
+} from '../payment';
 import { InstrumentState } from '../payment/instrument';
 import { PaymentProviderCustomerState } from '../payment-provider-customer';
 import { RemoteCheckoutState } from '../remote-checkout';
@@ -27,6 +32,7 @@ import { SubscriptionsState } from '../subscription';
 import CheckoutState from './checkout-state';
 
 export default interface CheckoutStoreState {
+    b2bPostOrder: B2BPostOrderState;
     b2bToken: B2BTokenState;
     billingAddress: BillingAddressState;
     cart: CartState;

--- a/packages/core/src/checkout/checkout-store-status-selector.ts
+++ b/packages/core/src/checkout/checkout-store-status-selector.ts
@@ -296,6 +296,13 @@ export default interface CheckoutStoreStatusSelector {
     isLoadingB2BToken(): boolean;
 
     /**
+     * Checks whether B2B order metadata is being persisted.
+     *
+     * @returns True if B2B order metadata is being persisted, otherwise false.
+     */
+    isPersistingB2BMetadata(): boolean;
+
+    /**
      * Checks whether the current customer is applying a gift certificate.
      *
      * @returns True if applying a gift certificate, otherwise false.
@@ -523,6 +530,7 @@ export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusS
             isLoadingConfig: state.config.isLoading,
             isSendingSignInEmail: state.signInEmail.isSending,
             isLoadingB2BToken: state.b2bToken.isLoading,
+            isPersistingB2BMetadata: state.b2bPostOrder.isPersisting,
             isCustomerStepPending: isCustomerStepPending(state),
             isShippingStepPending: isShippingStepPending(state),
             isPaymentStepPending: isPaymentStepPending(state),

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -119,6 +119,7 @@ export function getCheckoutState(): CheckoutState {
 
 export function getCheckoutStoreState(): CheckoutStoreState {
     return {
+        b2bPostOrder: { errors: {}, statuses: {} },
         b2bToken: { errors: {}, statuses: {} },
         billingAddress: getBillingAddressState(),
         cart: getCartState(),

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -38,6 +38,8 @@ import {
     B2BCompanyPaymentMethodRequestSender,
     B2BPaymentsRefreshActionCreator,
     B2BPaymentsRefreshRequestSender,
+    B2BPostOrderActionCreator,
+    B2BPostOrderRequestSender,
     createPaymentClient,
     createPaymentStrategyRegistry,
     createPaymentStrategyRegistryV2,
@@ -233,6 +235,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         extensionActionCreator,
         workerExtensionMessenger,
         new B2BPaymentsRefreshActionCreator(new B2BPaymentsRefreshRequestSender(requestSender)),
+        new B2BPostOrderActionCreator(new B2BPostOrderRequestSender(requestSender)),
     );
 }
 

--- a/packages/core/src/checkout/create-checkout-store-reducer.ts
+++ b/packages/core/src/checkout/create-checkout-store-reducer.ts
@@ -12,7 +12,12 @@ import { formFieldsReducer } from '../form';
 import { countryReducer } from '../geography';
 import { orderReducer } from '../order';
 import { orderBillingAddressReducer } from '../order-billing-address';
-import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '../payment';
+import {
+    b2bPostOrderReducer,
+    paymentMethodReducer,
+    paymentReducer,
+    paymentStrategyReducer,
+} from '../payment';
 import { instrumentReducer } from '../payment/instrument';
 import { paymentProviderCustomerReducer } from '../payment-provider-customer';
 import { remoteCheckoutReducer } from '../remote-checkout';
@@ -31,6 +36,7 @@ import CheckoutStoreState from './checkout-store-state';
 
 export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState, Action> {
     return combineReducers({
+        b2bPostOrder: b2bPostOrderReducer,
         b2bToken: b2bTokenReducer,
         billingAddress: billingAddressReducer,
         cart: cartReducer,

--- a/packages/core/src/checkout/create-internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/create-internal-checkout-selectors.ts
@@ -12,6 +12,7 @@ import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
 import { createOrderBillingAddressSelectorFactory } from '../order-billing-address';
 import {
+    createB2BPostOrderSelectorFactory,
     createPaymentMethodSelectorFactory,
     createPaymentSelectorFactory,
     createPaymentStrategySelectorFactory,
@@ -41,6 +42,7 @@ export type InternalCheckoutSelectorsFactory = (
 ) => InternalCheckoutSelectors;
 
 export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
+    const createB2BPostOrderSelector = createB2BPostOrderSelectorFactory();
     const createB2BTokenSelector = createB2BTokenSelectorFactory();
     const createBillingAddressSelector = createBillingAddressSelectorFactory();
     const createCartSelector = createCartSelectorFactory();
@@ -72,6 +74,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createExtensionSelector = createExtensionSelectorFactory();
 
     return (state, options = {}) => {
+        const b2bPostOrder = createB2BPostOrderSelector(state.b2bPostOrder);
         const b2bToken = createB2BTokenSelector(state.b2bToken);
         const billingAddress = createBillingAddressSelector(state.billingAddress);
         const cart = createCartSelector(state.cart);
@@ -115,6 +118,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const config = createConfigSelector(state.config, state.formFields);
 
         const selectors = {
+            b2bPostOrder,
             b2bToken,
             billingAddress,
             cart,

--- a/packages/core/src/checkout/internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/internal-checkout-selectors.ts
@@ -10,7 +10,12 @@ import { FormSelector } from '../form';
 import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import OrderBillingAddressSelector from '../order-billing-address/order-billing-address-selector';
-import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
+import {
+    B2BPostOrderSelector,
+    PaymentMethodSelector,
+    PaymentSelector,
+    PaymentStrategySelector,
+} from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { PaymentProviderCustomerSelector } from '../payment-provider-customer';
 import { RemoteCheckoutSelector } from '../remote-checkout';
@@ -28,6 +33,7 @@ import { SubscriptionsSelector } from '../subscription';
 import CheckoutSelector from './checkout-selector';
 
 export default interface InternalCheckoutSelectors {
+    b2bPostOrder: B2BPostOrderSelector;
     b2bToken: B2BTokenSelector;
     billingAddress: BillingAddressSelector;
     cart: CartSelector;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,8 +15,7 @@ export {
 export { getCheckoutStoreStateWithOrder } from './checkout/checkouts.mock';
 export { StoreConfig } from './config';
 export { Customer } from './customer';
-export { AddressExtraFieldValue } from './form';
-export { Order, OrderActionCreator, OrderB2BMetadata, OrderRequestBody } from './order';
+export { Order, OrderActionCreator, OrderRequestBody } from './order';
 export { getOrder } from './order/orders.mock';
 export {
     Payment,

--- a/packages/core/src/order/index.ts
+++ b/packages/core/src/order/index.ts
@@ -8,7 +8,6 @@ export {
     InternalOrderPayment,
 } from './internal-order';
 export { default as InternalOrderRequestBody } from './internal-order-request-body';
-export { OrderB2BMetadata } from './order-b2b-metadata';
 
 export { default as OrderActionCreator } from './order-action-creator';
 export { default as orderReducer } from './order-reducer';

--- a/packages/core/src/order/internal-b2b-context.ts
+++ b/packages/core/src/order/internal-b2b-context.ts
@@ -1,3 +1,0 @@
-export default interface InternalB2BContext {
-    receiptId?: number;
-}

--- a/packages/core/src/order/internal-order-request-body.ts
+++ b/packages/core/src/order/internal-order-request-body.ts
@@ -1,5 +1,5 @@
-import { AddressExtraFieldValue } from '../form';
 import { PaymentInstrument } from '../payment';
+import { B2BExtraField } from '../payment/b2b-post-order-request-sender';
 
 export default interface InternalOrderRequestBody {
     cartId: string;
@@ -19,7 +19,7 @@ export interface InternalOrderPaymentRequestBody {
 
 export interface InternalOrderB2BMetadata {
     invoiceComment?: string;
-    orderExtraFields?: AddressExtraFieldValue[];
+    orderExtraFields?: B2BExtraField[];
     poNumber?: string;
     referenceNumber?: string;
 }

--- a/packages/core/src/order/internal-order-responses.ts
+++ b/packages/core/src/order/internal-order-responses.ts
@@ -1,7 +1,6 @@
 import { InternalResponseBody } from '../common/http-request';
 import { InternalCustomer } from '../customer';
 
-import InternalB2BContext from './internal-b2b-context';
 import InternalOrder from './internal-order';
 
 export type InternalOrderResponseBody = InternalResponseBody<
@@ -10,7 +9,6 @@ export type InternalOrderResponseBody = InternalResponseBody<
 >;
 
 export interface InternalOrderResponseData {
-    b2bContext?: InternalB2BContext;
     customer: InternalCustomer;
     order: InternalOrder;
 }

--- a/packages/core/src/order/order-b2b-metadata.ts
+++ b/packages/core/src/order/order-b2b-metadata.ts
@@ -1,8 +1,0 @@
-import { AddressExtraFieldValue } from '../form';
-
-export interface OrderB2BMetadata {
-    invoiceComment?: string;
-    orderExtraFields?: AddressExtraFieldValue[];
-    poNumber?: string;
-    referenceNumber?: string;
-}

--- a/packages/core/src/order/order-reducer.ts
+++ b/packages/core/src/order/order-reducer.ts
@@ -56,7 +56,6 @@ function metaReducer(
                 callbackUrl: action.payload && action.payload.order.callbackUrl,
                 orderToken: action.payload && action.payload.order.token,
                 payment: action.payload && action.payload.order && action.payload.order.payment,
-                b2bReceiptId: action.payload?.b2bContext?.receiptId,
             });
 
         default:

--- a/packages/core/src/order/order-request-body.ts
+++ b/packages/core/src/order/order-request-body.ts
@@ -20,8 +20,6 @@ import {
     WithMollieIssuerInstrument,
 } from '../payment';
 
-import { OrderB2BMetadata } from './order-b2b-metadata';
-
 /**
  * An object that contains the information required for submitting an order.
  */
@@ -40,12 +38,6 @@ export default interface OrderRequestBody {
      * works if the customer has previously signed in.
      */
     useStoreCredit?: boolean;
-
-    /**
-     * B2B order metadata to persist through the Order API, such as the invoice
-     * comment, purchase order number, reference number and order extra fields.
-     */
-    b2bMetadata?: OrderB2BMetadata;
 }
 
 export type OrderPaymentInstrument =

--- a/packages/core/src/order/order-selector.ts
+++ b/packages/core/src/order/order-selector.ts
@@ -13,7 +13,6 @@ export default interface OrderSelector {
     getOrder(): Order | undefined;
     getOrderOrThrow(): Order;
     getOrderMeta(): OrderMetaState | undefined;
-    getB2BReceiptId(): number | undefined;
     getLoadError(): Error | undefined;
     getPaymentId(methodId: string): string | undefined;
     isLoading(): boolean;
@@ -59,11 +58,6 @@ export function createOrderSelectorFactory(): OrderSelectorFactory {
         (meta) => () => meta,
     );
 
-    const getB2BReceiptId = createSelector(
-        (state: OrderState) => state.meta?.b2bReceiptId,
-        (b2bReceiptId) => () => b2bReceiptId,
-    );
-
     const getLoadError = createSelector(
         (state: OrderState) => state.errors.loadError,
         (error) => () => error,
@@ -94,7 +88,6 @@ export function createOrderSelectorFactory(): OrderSelectorFactory {
                 getOrder: getOrder(state, { billingAddress, coupons }),
                 getOrderOrThrow: getOrderOrThrow(state, { billingAddress, coupons }),
                 getOrderMeta: getOrderMeta(state),
-                getB2BReceiptId: getB2BReceiptId(state),
                 getLoadError: getLoadError(state),
                 getPaymentId: getPaymentId(state),
                 isLoading: isLoading(state),

--- a/packages/core/src/order/order-state.ts
+++ b/packages/core/src/order/order-state.ts
@@ -17,7 +17,6 @@ export interface OrderMetaState extends InternalOrderMeta {
     orderToken?: string;
     callbackUrl?: string;
     payment?: InternalOrderPayment;
-    b2bReceiptId?: number;
 }
 
 export interface OrderErrorsState {

--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -1,0 +1,704 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { Address } from '../address';
+import { BillingAddress } from '../billing';
+import { getBillingAddress } from '../billing/billing-addresses.mock';
+import { getCart } from '../cart/carts.mock';
+import { CheckoutStore, createCheckoutStore } from '../checkout';
+import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { getCapabilities } from '../config/capabilities.mock';
+import { getConfig } from '../config/configs.mock';
+import { Consignment } from '../shipping';
+import { getConsignment, getConsignmentsState } from '../shipping/consignments.mock';
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
+import { getShippingOption } from '../shipping/shipping-options.mock';
+
+import B2BPostOrderActionCreator from './b2b-post-order-action-creator';
+import { B2BPostOrderActionType } from './b2b-post-order-actions';
+import B2BPostOrderRequestSender, {
+    CreateCompanyAddressPayload,
+} from './b2b-post-order-request-sender';
+
+describe('B2BPostOrderActionCreator', () => {
+    let store: CheckoutStore;
+    let requestSender: B2BPostOrderRequestSender;
+    let actionCreator: B2BPostOrderActionCreator;
+
+    const comment = 'Invoice comment';
+    const invoiceOptions = { isInvoice: true, invoiceComment: comment };
+    const nonInvoiceOptions = { isInvoice: false, invoiceComment: '' };
+    const b2bApiSettings = {
+        clientId: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
+        baseUrl: 'https://api-b2b.bigcommerce.com',
+    };
+
+    const mockStoreConfig = (quoteConfig?: { id: number } | null) => {
+        const storeConfig = getConfig().storeConfig;
+
+        jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+            ...storeConfig,
+            b2bApiSettings,
+            checkoutSettings: {
+                ...storeConfig.checkoutSettings,
+                ...(quoteConfig === undefined
+                    ? {}
+                    : { capabilities: getCapabilities({ userJourney: { quoteConfig } }) }),
+            },
+        });
+    };
+
+    beforeEach(() => {
+        store = createCheckoutStore({
+            ...getCheckoutStoreStateWithOrder(),
+            b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+        });
+
+        requestSender = new B2BPostOrderRequestSender(createRequestSender());
+
+        jest.spyOn(requestSender, 'submitInvoice').mockResolvedValue(
+            getResponse({ data: { paymentId: 'pay_1', receiptId: 'rcpt_1' }, code: 200 }),
+        );
+
+        jest.spyOn(requestSender, 'submitOrderExtraFields').mockResolvedValue(
+            getResponse(undefined),
+        );
+
+        jest.spyOn(requestSender, 'submitQuote').mockResolvedValue(getResponse(undefined));
+
+        jest.spyOn(requestSender, 'submitCompanyAddress').mockResolvedValue(
+            getResponse({ data: { addressId: '67890' }, code: 200 }),
+        );
+
+        mockStoreConfig();
+
+        actionCreator = new B2BPostOrderActionCreator(requestSender);
+    });
+
+    describe('#persistB2BMetadata()', () => {
+        it('emits requested and succeeded actions on success', async () => {
+            const actions = await from(actionCreator.persistB2BMetadata(invoiceOptions)(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                {
+                    type: B2BPostOrderActionType.PersistB2BMetadataSucceeded,
+                    payload: { receiptId: 'rcpt_1' },
+                },
+            ]);
+        });
+
+        it('calls closeInvoice with the order id, comment, token and base url', async () => {
+            await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
+
+            expect(requestSender.submitInvoice).toHaveBeenCalledWith(
+                { orderId: '295', comment },
+                'b2b-auth-token',
+                b2bApiSettings.baseUrl,
+            );
+        });
+
+        it('calls submitOrderExtraFields and dispatches succeeded with empty receiptId when isInvoice is false', async () => {
+            const actions = await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(requestSender.submitInvoice).not.toHaveBeenCalled();
+            expect(requestSender.submitOrderExtraFields).toHaveBeenCalledWith(
+                {
+                    orderId: 295,
+                    poNumber: '',
+                    referenceNumber: '',
+                    extraFields: [],
+                    extraInfo: {},
+                },
+                'b2b-auth-token',
+                b2bApiSettings.baseUrl,
+            );
+            expect(actions).toEqual([
+                { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                {
+                    type: B2BPostOrderActionType.PersistB2BMetadataSucceeded,
+                    payload: { receiptId: '' },
+                },
+            ]);
+        });
+
+        it('forwards po number, reference number, extra fields and extra info to submitOrderExtraFields', async () => {
+            const extraFields = [{ fieldName: 'department', fieldValue: 'engineering' }];
+            const extraInfo = { billingAddressId: 12 };
+
+            await from(
+                actionCreator.persistB2BMetadata({
+                    isInvoice: false,
+                    poNumber: 'PO-123',
+                    referenceNumber: 'REF-456',
+                    extraFields,
+                    extraInfo,
+                })(store),
+            ).toPromise();
+
+            expect(requestSender.submitOrderExtraFields).toHaveBeenCalledWith(
+                {
+                    orderId: 295,
+                    poNumber: 'PO-123',
+                    referenceNumber: 'REF-456',
+                    extraFields,
+                    extraInfo,
+                },
+                'b2b-auth-token',
+                b2bApiSettings.baseUrl,
+            );
+        });
+
+        it('does not call submitOrderExtraFields when isInvoice is true', async () => {
+            await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
+
+            expect(requestSender.submitOrderExtraFields).not.toHaveBeenCalled();
+        });
+
+        it('throws when the order id is missing', () => {
+            store = createCheckoutStore({
+                ...getCheckoutStoreState(),
+                b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+            });
+
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
+
+            expect(() => actionCreator.persistB2BMetadata(invoiceOptions)(store)).toThrow();
+        });
+
+        it('throws when the b2b token is missing', () => {
+            store = createCheckoutStore(getCheckoutStoreStateWithOrder());
+
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
+
+            expect(() => actionCreator.persistB2BMetadata(invoiceOptions)(store)).toThrow();
+        });
+
+        it('throws when the b2b base url is missing', () => {
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings: { ...b2bApiSettings, baseUrl: '' },
+            });
+
+            expect(() => actionCreator.persistB2BMetadata(invoiceOptions)(store)).toThrow();
+        });
+
+        it('emits failed action when the request rejects', async () => {
+            jest.spyOn(requestSender, 'submitInvoice').mockRejectedValue(getErrorResponse());
+
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(actionCreator.persistB2BMetadata(invoiceOptions)(store))
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                expect.objectContaining({
+                    type: B2BPostOrderActionType.PersistB2BMetadataFailed,
+                    error: true,
+                }),
+            ]);
+        });
+
+        describe('company address flow', () => {
+            const createBillingAddress = (
+                overrides: Partial<BillingAddress> = {},
+            ): BillingAddress => ({
+                ...getBillingAddress(),
+                shouldSaveAddress: false,
+                ...overrides,
+            });
+
+            const createConsignment = (
+                shippingOverrides: Partial<Address> = {},
+                id = 'consignment-1',
+            ): Consignment => ({
+                ...getConsignment(),
+                id,
+                shippingAddress: {
+                    ...getShippingAddress(),
+                    shouldSaveAddress: false,
+                    ...shippingOverrides,
+                },
+            });
+
+            // Mirrors the shared billing/shipping address mocks (identical comparable fields, so they
+            // merge unless an override makes them differ).
+            const expectedCompanyAddress = (
+                overrides: Partial<CreateCompanyAddressPayload> = {},
+            ): CreateCompanyAddressPayload => ({
+                addressLine1: '12345 Testing Way',
+                addressLine2: '',
+                city: 'Some City',
+                label: '',
+                firstName: 'Test',
+                lastName: 'Tester',
+                phoneNumber: '555-555-5555',
+                zipCode: '95555',
+                country: { countryCode: 'US', countryName: 'United States' },
+                state: { stateCode: 'CA', stateName: 'California' },
+                isBilling: 0,
+                isCheckout: true,
+                isShipping: 0,
+                extraFields: [],
+                ...overrides,
+            });
+
+            const mockCompanyId = (companyId: number | null) => {
+                jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({
+                    ...getCart(),
+                    companyId,
+                });
+            };
+
+            const mockBillingAddress = (billingAddress: BillingAddress | undefined) => {
+                jest.spyOn(store.getState().billingAddress, 'getBillingAddress').mockReturnValue(
+                    billingAddress,
+                );
+            };
+
+            const mockConsignments = (consignments: Consignment[] | undefined) => {
+                jest.spyOn(store.getState().consignments, 'getConsignments').mockReturnValue(
+                    consignments,
+                );
+            };
+
+            beforeEach(() => {
+                mockCompanyId(12345);
+                mockBillingAddress(createBillingAddress());
+                mockConsignments([]);
+            });
+
+            it('maps the billing address from state when shouldSaveAddress is set', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({ isBilling: 1, isShipping: 0 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('maps a shipping address from every consignment that opts in', async () => {
+                mockConsignments([
+                    createConsignment({ address1: '1 First St', shouldSaveAddress: true }, 'c-1'),
+                    createConsignment({ address1: '2 Second St', shouldSaveAddress: false }, 'c-2'),
+                    createConsignment({ address1: '3 Third St', shouldSaveAddress: true }, 'c-3'),
+                ]);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(2);
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    1,
+                    12345,
+                    expectedCompanyAddress({ addressLine1: '1 First St', isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    2,
+                    12345,
+                    expectedCompanyAddress({ addressLine1: '3 Third St', isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('deduplicates identical shipping addresses across consignments into a single save', async () => {
+                mockConsignments([
+                    createConsignment({ address1: '5 Same St', shouldSaveAddress: true }, 'c-1'),
+                    createConsignment({ address1: '5 Same St', shouldSaveAddress: true }, 'c-2'),
+                ]);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({ addressLine1: '5 Same St', isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('merges billing and shipping into one entry when they are the same address', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([createConsignment({ shouldSaveAddress: true })]);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({ isBilling: 1, isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('keeps billing and shipping separate when the address matches but extra fields differ', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([createConsignment({ shouldSaveAddress: true })]);
+
+                await from(
+                    actionCreator.persistB2BMetadata({
+                        isInvoice: false,
+                        extraInfo: {
+                            addressExtraFields: {
+                                billingAddressExtraFields: [
+                                    { fieldName: 'department', fieldValue: 'Finance' },
+                                ],
+                                shippingAddressExtraFields: [
+                                    { fieldName: 'dock', fieldValue: 'B7' },
+                                ],
+                            },
+                        },
+                    })(store),
+                ).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(2);
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    1,
+                    12345,
+                    expectedCompanyAddress({
+                        isBilling: 1,
+                        isShipping: 0,
+                        extraFields: [{ fieldName: 'department', fieldValue: 'Finance' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    2,
+                    12345,
+                    expectedCompanyAddress({
+                        isShipping: 1,
+                        extraFields: [{ fieldName: 'dock', fieldValue: 'B7' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('merges billing and shipping when both the address and extra fields match', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([createConsignment({ shouldSaveAddress: true })]);
+
+                await from(
+                    actionCreator.persistB2BMetadata({
+                        isInvoice: false,
+                        extraInfo: {
+                            addressExtraFields: {
+                                billingAddressExtraFields: [
+                                    { fieldName: 'department', fieldValue: 'Finance' },
+                                ],
+                                shippingAddressExtraFields: [
+                                    { fieldName: 'department', fieldValue: 'Finance' },
+                                ],
+                            },
+                        },
+                    })(store),
+                ).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({
+                        isBilling: 1,
+                        isShipping: 1,
+                        extraFields: [{ fieldName: 'department', fieldValue: 'Finance' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('keeps billing and shipping separate when the addresses differ', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([
+                    createConsignment({ address1: '9 Other St', shouldSaveAddress: true }),
+                ]);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(2);
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    1,
+                    12345,
+                    expectedCompanyAddress({ isBilling: 1, isShipping: 0 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    2,
+                    12345,
+                    expectedCompanyAddress({ addressLine1: '9 Other St', isShipping: 1 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('sources per-address extra fields from extraInfo.addressExtraFields', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+                mockConsignments([
+                    createConsignment({ address1: '9 Other St', shouldSaveAddress: true }),
+                ]);
+
+                await from(
+                    actionCreator.persistB2BMetadata({
+                        isInvoice: false,
+                        extraInfo: {
+                            addressExtraFields: {
+                                billingAddressExtraFields: [
+                                    { fieldName: 'department', fieldValue: 'Finance' },
+                                ],
+                                shippingAddressExtraFields: [
+                                    { fieldName: 'dock', fieldValue: 'B7' },
+                                ],
+                            },
+                        },
+                    })(store),
+                ).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    1,
+                    12345,
+                    expectedCompanyAddress({
+                        isBilling: 1,
+                        isShipping: 0,
+                        extraFields: [{ fieldName: 'department', fieldValue: 'Finance' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+                expect(requestSender.submitCompanyAddress).toHaveBeenNthCalledWith(
+                    2,
+                    12345,
+                    expectedCompanyAddress({
+                        addressLine1: '9 Other St',
+                        isShipping: 1,
+                        extraFields: [{ fieldName: 'dock', fieldValue: 'B7' }],
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('submits company addresses before submitOrderExtraFields', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                const [companyAddressCallOrder] = (requestSender.submitCompanyAddress as jest.Mock)
+                    .mock.invocationCallOrder;
+                const [addOrderCallOrder] = (requestSender.submitOrderExtraFields as jest.Mock).mock
+                    .invocationCallOrder;
+
+                expect(companyAddressCallOrder).toBeLessThan(addOrderCallOrder);
+            });
+
+            it('does not submit a company address when nothing opts in', async () => {
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).not.toHaveBeenCalled();
+                expect(requestSender.submitOrderExtraFields).toHaveBeenCalled();
+            });
+
+            it('does not submit a company address when the cart has no company id', async () => {
+                mockCompanyId(null);
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).not.toHaveBeenCalled();
+                expect(requestSender.submitOrderExtraFields).toHaveBeenCalled();
+            });
+
+            it('submits a company address in the invoice flow', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledTimes(1);
+                expect(requestSender.submitCompanyAddress).toHaveBeenCalledWith(
+                    12345,
+                    expectedCompanyAddress({ isBilling: 1, isShipping: 0 }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('emits failed action without calling submitOrderExtraFields when submitCompanyAddress rejects', async () => {
+                mockBillingAddress(createBillingAddress({ shouldSaveAddress: true }));
+
+                jest.spyOn(requestSender, 'submitCompanyAddress').mockRejectedValue(
+                    getErrorResponse(),
+                );
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    actionCreator.persistB2BMetadata(nonInvoiceOptions)(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(requestSender.submitOrderExtraFields).not.toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                    expect.objectContaining({
+                        type: B2BPostOrderActionType.PersistB2BMetadataFailed,
+                        error: true,
+                    }),
+                ]);
+            });
+        });
+
+        describe('quote-to-checkout flow', () => {
+            it('calls submitQuote after submitOrderExtraFields with the payload mapped from checkout state', async () => {
+                mockStoreConfig({ id: 941 });
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).toHaveBeenCalledWith(
+                    941,
+                    {
+                        orderId: 295,
+                        storeHash: 'k1drp8k8',
+                        shippingTotal: 15,
+                        taxTotal: 3,
+                        shippingMethod: getShippingOption(),
+                        shippingAddress: {
+                            country: 'United States',
+                            state: 'California',
+                            city: 'Some City',
+                            zipCode: '95555',
+                            address: '12345 Testing Way',
+                            apartment: '',
+                            firstName: 'Test',
+                            lastName: 'Tester',
+                        },
+                    },
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+
+                const [addOrderCallOrder] = (requestSender.submitOrderExtraFields as jest.Mock).mock
+                    .invocationCallOrder;
+                const [submitQuoteCallOrder] = (requestSender.submitQuote as jest.Mock).mock
+                    .invocationCallOrder;
+
+                expect(submitQuoteCallOrder).toBeGreaterThan(addOrderCallOrder);
+            });
+
+            it('does not call submitQuote when quoteConfig is null', async () => {
+                mockStoreConfig(null);
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).not.toHaveBeenCalled();
+            });
+
+            it('does not call submitQuote when capabilities are undefined', async () => {
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).not.toHaveBeenCalled();
+            });
+
+            it('sends null shipping fields when the checkout has no consignments', async () => {
+                store = createCheckoutStore({
+                    ...getCheckoutStoreStateWithOrder(),
+                    b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+                    consignments: { ...getConsignmentsState(), data: [] },
+                });
+                mockStoreConfig({ id: 941 });
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).toHaveBeenCalledWith(
+                    941,
+                    expect.objectContaining({
+                        shippingTotal: null,
+                        shippingMethod: null,
+                        shippingAddress: null,
+                    }),
+                    'b2b-auth-token',
+                    b2bApiSettings.baseUrl,
+                );
+            });
+
+            it('emits failed action without calling submitQuote when the checkout state is missing', async () => {
+                store = createCheckoutStore({
+                    ...getCheckoutStoreStateWithOrder(),
+                    b2bToken: { data: { token: 'b2b-auth-token' }, errors: {}, statuses: {} },
+                    checkout: { errors: {}, statuses: {} },
+                });
+                mockStoreConfig({ id: 941 });
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    actionCreator.persistB2BMetadata(nonInvoiceOptions)(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(requestSender.submitOrderExtraFields).toHaveBeenCalled();
+                expect(requestSender.submitQuote).not.toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                    expect.objectContaining({
+                        type: B2BPostOrderActionType.PersistB2BMetadataFailed,
+                        error: true,
+                    }),
+                ]);
+            });
+
+            it('emits failed action when submitQuote rejects', async () => {
+                mockStoreConfig({ id: 941 });
+
+                jest.spyOn(requestSender, 'submitQuote').mockRejectedValue(getErrorResponse());
+
+                const errorHandler = jest.fn((action) => of(action));
+                const actions = await from(
+                    actionCreator.persistB2BMetadata(nonInvoiceOptions)(store),
+                )
+                    .pipe(catchError(errorHandler), toArray())
+                    .toPromise();
+
+                expect(requestSender.submitOrderExtraFields).toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                    expect.objectContaining({
+                        type: B2BPostOrderActionType.PersistB2BMetadataFailed,
+                        error: true,
+                    }),
+                ]);
+            });
+
+            it('does not call submitQuote in the invoice flow even when a quote id is present', async () => {
+                mockStoreConfig({ id: 941 });
+
+                await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitQuote).not.toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -1,0 +1,250 @@
+import { createAction, ThunkAction } from '@bigcommerce/data-store';
+import { isEqual } from 'lodash';
+import { concat, defer, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { Address, isAddressEqual } from '../address';
+// TODO: CHECKOUT-9979 remove this import before delivery
+import { resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { BillingAddress } from '../billing';
+import { Checkout, InternalCheckoutSelectors } from '../checkout';
+import { throwErrorAction } from '../common/error';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { Consignment } from '../shipping';
+
+import {
+    B2BPostOrderActionType,
+    PersistB2BMetadataAction,
+    PersistB2BMetadataOptions,
+} from './b2b-post-order-actions';
+import B2BPostOrderRequestSender, {
+    AddOrderExtraFieldsPayload,
+    B2BExtraField,
+    CreateCompanyAddressPayload,
+    QuoteOrderedPayload,
+} from './b2b-post-order-request-sender';
+
+function mapToQuoteShippingAddress(
+    address: Address,
+): NonNullable<QuoteOrderedPayload['shippingAddress']> {
+    return {
+        country: address.country,
+        state: address.stateOrProvince,
+        city: address.city,
+        zipCode: address.postalCode,
+        address: address.address1,
+        apartment: address.address2,
+        firstName: address.firstName,
+        lastName: address.lastName,
+    };
+}
+
+function mapToQuoteOrderedPayload(
+    checkout: Checkout,
+    orderId: number,
+    storeHash: string,
+): QuoteOrderedPayload {
+    const consignment = checkout.consignments[0];
+
+    return {
+        orderId,
+        storeHash,
+        shippingTotal: consignment ? checkout.shippingCostTotal : null,
+        taxTotal: checkout.taxTotal,
+        shippingMethod: consignment?.selectedShippingOption ?? null,
+        shippingAddress: consignment
+            ? mapToQuoteShippingAddress(consignment.shippingAddress)
+            : null,
+    };
+}
+
+type CompanyAddressExtraFields = NonNullable<
+    AddOrderExtraFieldsPayload['extraInfo']['addressExtraFields']
+>;
+
+function mapToCompanyAddress(
+    address: Address,
+    flags: Pick<CreateCompanyAddressPayload, 'isBilling' | 'isShipping'>,
+    extraFields: B2BExtraField[],
+): CreateCompanyAddressPayload {
+    return {
+        addressLine1: address.address1,
+        addressLine2: address.address2,
+        city: address.city,
+        label: address.label ?? '',
+        firstName: address.firstName,
+        lastName: address.lastName,
+        phoneNumber: address.phone,
+        zipCode: address.postalCode,
+        country: {
+            countryCode: address.countryCode,
+            countryName: address.country,
+        },
+        state: {
+            stateCode: address.stateOrProvinceCode,
+            stateName: address.stateOrProvince,
+        },
+        isBilling: flags.isBilling,
+        isCheckout: true,
+        isShipping: flags.isShipping,
+        extraFields,
+    };
+}
+
+function buildCompanyAddresses(
+    billingAddress: BillingAddress | undefined,
+    consignments: Consignment[] | undefined,
+    addressExtraFields: CompanyAddressExtraFields | undefined,
+): CreateCompanyAddressPayload[] {
+    const savedAddresses: Array<{
+        rawAddress: Address;
+        mappedAddress: CreateCompanyAddressPayload;
+    }> = [];
+
+    if (billingAddress?.shouldSaveAddress) {
+        savedAddresses.push({
+            rawAddress: billingAddress,
+            mappedAddress: mapToCompanyAddress(
+                billingAddress,
+                { isBilling: 1, isShipping: 0 },
+                addressExtraFields?.billingAddressExtraFields ?? [],
+            ),
+        });
+    }
+
+    const shippingExtraFields = addressExtraFields?.shippingAddressExtraFields ?? [];
+
+    (consignments ?? []).forEach((consignment) => {
+        const { shippingAddress } = consignment;
+
+        if (!shippingAddress?.shouldSaveAddress) {
+            return;
+        }
+
+        const savedAddress = savedAddresses.find(
+            ({ rawAddress, mappedAddress }) =>
+                isAddressEqual(rawAddress, shippingAddress) &&
+                isEqual(mappedAddress.extraFields ?? [], shippingExtraFields),
+        );
+
+        if (savedAddress) {
+            savedAddress.mappedAddress.isShipping = 1;
+
+            return;
+        }
+
+        savedAddresses.push({
+            rawAddress: shippingAddress,
+            mappedAddress: mapToCompanyAddress(
+                shippingAddress,
+                { isBilling: 0, isShipping: 1 },
+                shippingExtraFields,
+            ),
+        });
+    });
+
+    return savedAddresses.map(({ mappedAddress }) => mappedAddress);
+}
+
+export default class B2BPostOrderActionCreator {
+    constructor(private _requestSender: B2BPostOrderRequestSender) {}
+
+    persistB2BMetadata({
+        isInvoice,
+        invoiceComment,
+        poNumber,
+        referenceNumber,
+        extraFields,
+        extraInfo,
+    }: PersistB2BMetadataOptions): ThunkAction<
+        PersistB2BMetadataAction,
+        InternalCheckoutSelectors
+    > {
+        return (store) => {
+            const state = store.getState();
+            const orderId = state.order.getOrderOrThrow().orderId;
+            const b2bToken = state.b2bToken.getToken();
+            const b2bBaseUrl = resolveB2bBaseUrl(
+                state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
+            );
+            const companyId = state.cart.getCart()?.companyId;
+            const storeConfig = state.config.getStoreConfig();
+            const quoteId = storeConfig?.checkoutSettings.capabilities?.userJourney.quoteConfig?.id;
+            const companyAddresses = buildCompanyAddresses(
+                state.billingAddress.getBillingAddress(),
+                state.consignments.getConsignments(),
+                extraInfo?.addressExtraFields,
+            );
+
+            if (!orderId || !b2bToken || !b2bBaseUrl) {
+                throw new MissingDataError(MissingDataErrorType.MissingOrder);
+            }
+
+            return concat(
+                of(createAction(B2BPostOrderActionType.PersistB2BMetadataRequested)),
+                defer(async () => {
+                    let payload = { receiptId: '' };
+
+                    if (companyId && companyAddresses.length) {
+                        await Promise.all(
+                            companyAddresses.map((companyAddress) =>
+                                this._requestSender.submitCompanyAddress(
+                                    companyId,
+                                    companyAddress,
+                                    b2bToken,
+                                    b2bBaseUrl,
+                                ),
+                            ),
+                        );
+                    }
+
+                    if (isInvoice) {
+                        const { body } = await this._requestSender.submitInvoice(
+                            { orderId: `${orderId}`, comment: invoiceComment ?? '' },
+                            b2bToken,
+                            b2bBaseUrl,
+                        );
+
+                        payload = { receiptId: body.data.receiptId };
+                    } else {
+                        await this._requestSender.submitOrderExtraFields(
+                            {
+                                orderId,
+                                poNumber: poNumber ?? '',
+                                referenceNumber: referenceNumber ?? '',
+                                extraFields: extraFields ?? [],
+                                extraInfo: extraInfo ?? {},
+                            },
+                            b2bToken,
+                            b2bBaseUrl,
+                        );
+
+                        if (typeof quoteId === 'number') {
+                            const checkout = state.checkout.getCheckoutOrThrow();
+
+                            await this._requestSender.submitQuote(
+                                quoteId,
+                                mapToQuoteOrderedPayload(
+                                    checkout,
+                                    orderId,
+                                    storeConfig?.storeProfile.storeHash ?? '',
+                                ),
+                                b2bToken,
+                                b2bBaseUrl,
+                            );
+                        }
+                    }
+
+                    return createAction(
+                        B2BPostOrderActionType.PersistB2BMetadataSucceeded,
+                        payload,
+                    );
+                }),
+            ).pipe(
+                catchError((error) =>
+                    throwErrorAction(B2BPostOrderActionType.PersistB2BMetadataFailed, error),
+                ),
+            );
+        };
+    }
+}

--- a/packages/core/src/payment/b2b-post-order-actions.ts
+++ b/packages/core/src/payment/b2b-post-order-actions.ts
@@ -1,0 +1,36 @@
+import { Action } from '@bigcommerce/data-store';
+
+import { AddOrderExtraFieldsPayload, B2BExtraField } from './b2b-post-order-request-sender';
+import { B2BPostOrderData } from './b2b-post-order-state';
+
+export interface PersistB2BMetadataOptions {
+    isInvoice: boolean;
+    invoiceComment?: string;
+    poNumber?: string;
+    referenceNumber?: string;
+    extraFields?: B2BExtraField[];
+    extraInfo?: AddOrderExtraFieldsPayload['extraInfo'];
+}
+
+export enum B2BPostOrderActionType {
+    PersistB2BMetadataRequested = 'PERSIST_B2B_METADATA_REQUESTED',
+    PersistB2BMetadataSucceeded = 'PERSIST_B2B_METADATA_SUCCEEDED',
+    PersistB2BMetadataFailed = 'PERSIST_B2B_METADATA_FAILED',
+}
+
+export type PersistB2BMetadataAction =
+    | PersistB2BMetadataRequestedAction
+    | PersistB2BMetadataSucceededAction
+    | PersistB2BMetadataFailedAction;
+
+export interface PersistB2BMetadataRequestedAction extends Action {
+    type: B2BPostOrderActionType.PersistB2BMetadataRequested;
+}
+
+export interface PersistB2BMetadataSucceededAction extends Action<B2BPostOrderData> {
+    type: B2BPostOrderActionType.PersistB2BMetadataSucceeded;
+}
+
+export interface PersistB2BMetadataFailedAction extends Action<Error> {
+    type: B2BPostOrderActionType.PersistB2BMetadataFailed;
+}

--- a/packages/core/src/payment/b2b-post-order-reducer.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-reducer.spec.ts
@@ -1,0 +1,48 @@
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+
+import { B2BPostOrderActionType } from './b2b-post-order-actions';
+import b2bPostOrderReducer from './b2b-post-order-reducer';
+import B2BPostOrderState, { DEFAULT_STATE } from './b2b-post-order-state';
+
+describe('b2bPostOrderReducer()', () => {
+    let initialState: B2BPostOrderState;
+
+    beforeEach(() => {
+        initialState = DEFAULT_STATE;
+    });
+
+    it('returns persisting state on requested', () => {
+        const action = createAction(B2BPostOrderActionType.PersistB2BMetadataRequested);
+        const state = b2bPostOrderReducer(initialState, action);
+
+        expect(state.statuses.isPersisting).toBe(true);
+        expect(state.errors.persistB2bMetadataError).toBeUndefined();
+    });
+
+    it('stores receipt id and clears persisting state on success', () => {
+        const data = { receiptId: 'rcpt_1' };
+        const action = createAction(B2BPostOrderActionType.PersistB2BMetadataSucceeded, data);
+        const state = b2bPostOrderReducer(initialState, action);
+
+        expect(state.data).toEqual(data);
+        expect(state.statuses.isPersisting).toBe(false);
+        expect(state.errors.persistB2bMetadataError).toBeUndefined();
+    });
+
+    it('stores error and clears persisting state on failure', () => {
+        const error = new Error('Failed to persist B2B metadata');
+        const action = createErrorAction(B2BPostOrderActionType.PersistB2BMetadataFailed, error);
+        const state = b2bPostOrderReducer(initialState, action);
+
+        expect(state.errors.persistB2bMetadataError).toBe(error);
+        expect(state.statuses.isPersisting).toBe(false);
+        expect(state.data).toBeUndefined();
+    });
+
+    it('returns previous state for unknown actions', () => {
+        const action = { type: 'UNKNOWN_ACTION' } as any;
+        const state = b2bPostOrderReducer(initialState, action);
+
+        expect(state).toEqual(initialState);
+    });
+});

--- a/packages/core/src/payment/b2b-post-order-reducer.ts
+++ b/packages/core/src/payment/b2b-post-order-reducer.ts
@@ -1,0 +1,72 @@
+import { Action, combineReducers, composeReducers } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
+import { objectSet } from '../common/utility';
+
+import { B2BPostOrderActionType, PersistB2BMetadataAction } from './b2b-post-order-actions';
+import B2BPostOrderState, {
+    B2BPostOrderData,
+    B2BPostOrderErrorsState,
+    B2BPostOrderStatusesState,
+    DEFAULT_STATE,
+} from './b2b-post-order-state';
+
+export default function b2bPostOrderReducer(
+    state: B2BPostOrderState = DEFAULT_STATE,
+    action: Action,
+): B2BPostOrderState {
+    const reducer = combineReducers<B2BPostOrderState>({
+        data: dataReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
+        statuses: statusesReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: B2BPostOrderData | undefined,
+    action: PersistB2BMetadataAction,
+): B2BPostOrderData | undefined {
+    switch (action.type) {
+        case B2BPostOrderActionType.PersistB2BMetadataSucceeded:
+            return action.payload;
+
+        default:
+            return data;
+    }
+}
+
+function errorsReducer(
+    errors: B2BPostOrderErrorsState = DEFAULT_STATE.errors,
+    action: PersistB2BMetadataAction,
+): B2BPostOrderErrorsState {
+    switch (action.type) {
+        case B2BPostOrderActionType.PersistB2BMetadataRequested:
+        case B2BPostOrderActionType.PersistB2BMetadataSucceeded:
+            return objectSet(errors, 'persistB2bMetadataError', undefined);
+
+        case B2BPostOrderActionType.PersistB2BMetadataFailed:
+            return objectSet(errors, 'persistB2bMetadataError', action.payload);
+
+        default:
+            return errors;
+    }
+}
+
+function statusesReducer(
+    statuses: B2BPostOrderStatusesState = DEFAULT_STATE.statuses,
+    action: PersistB2BMetadataAction,
+): B2BPostOrderStatusesState {
+    switch (action.type) {
+        case B2BPostOrderActionType.PersistB2BMetadataRequested:
+            return objectSet(statuses, 'isPersisting', true);
+
+        case B2BPostOrderActionType.PersistB2BMetadataFailed:
+        case B2BPostOrderActionType.PersistB2BMetadataSucceeded:
+            return objectSet(statuses, 'isPersisting', false);
+
+        default:
+            return statuses;
+    }
+}

--- a/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
@@ -1,0 +1,242 @@
+import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
+
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { getShippingOption } from '../shipping/shipping-options.mock';
+
+import B2BPostOrderRequestSender, {
+    AddOrderExtraFieldsPayload,
+    CloseInvoicePayload,
+    CreateCompanyAddressPayload,
+    QuoteOrderedPayload,
+} from './b2b-post-order-request-sender';
+
+describe('B2BPostOrderRequestSender', () => {
+    let requestSender: RequestSender;
+    let b2bPostOrderRequestSender: B2BPostOrderRequestSender;
+
+    const payload: CloseInvoicePayload = {
+        orderId: '295',
+        comment: 'Invoice comment',
+    };
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        jest.spyOn(requestSender, 'post').mockResolvedValue(
+            getResponse({ paymentId: 'pay_1', receiptId: 'rcpt_1' }),
+        );
+
+        b2bPostOrderRequestSender = new B2BPostOrderRequestSender(requestSender);
+    });
+
+    describe('#persistMetadata()', () => {
+        it('posts to the IP orders endpoint with auth headers and payload', async () => {
+            await b2bPostOrderRequestSender.submitInvoice(
+                payload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v1/ip/storefront/payments/bigcommerce/orders',
+                {
+                    timeout: undefined,
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                    body: payload,
+                },
+            );
+        });
+
+        it('forwards the request timeout', async () => {
+            const timeout = createTimeout();
+
+            await b2bPostOrderRequestSender.submitInvoice(
+                payload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+                { timeout },
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v1/ip/storefront/payments/bigcommerce/orders',
+                expect.objectContaining({ timeout }),
+            );
+        });
+
+        it('rejects when the request sender rejects', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
+
+            await expect(
+                b2bPostOrderRequestSender.submitInvoice(
+                    payload,
+                    'b2b-token-value',
+                    'https://api-b2b.bigcommerce.com',
+                ),
+            ).rejects.toEqual(getErrorResponse());
+        });
+    });
+
+    describe('#submitOrderExtraFields()', () => {
+        const extraFieldsPayload: AddOrderExtraFieldsPayload = {
+            orderId: 295,
+            poNumber: 'PO-123',
+            referenceNumber: 'REF-456',
+            extraFields: [{ fieldName: 'department', fieldValue: 'engineering' }],
+            extraInfo: {
+                billingAddressId: 12,
+                shipppingAddressId: 34,
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'floor', fieldValue: 3 }],
+                    shippingAddressExtraFields: [{ fieldName: 'gate', fieldValue: 'B' }],
+                },
+            },
+        };
+
+        it('posts to the B2B orders endpoint with auth headers and payload', async () => {
+            await b2bPostOrderRequestSender.submitOrderExtraFields(
+                extraFieldsPayload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/orders',
+                {
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                    body: extraFieldsPayload,
+                },
+            );
+        });
+
+        it('rejects when the request sender rejects', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
+
+            await expect(
+                b2bPostOrderRequestSender.submitOrderExtraFields(
+                    extraFieldsPayload,
+                    'b2b-token-value',
+                    'https://api-b2b.bigcommerce.com',
+                ),
+            ).rejects.toEqual(getErrorResponse());
+        });
+    });
+
+    describe('#submitQuote()', () => {
+        const submitQuotePayload: QuoteOrderedPayload = {
+            orderId: 295,
+            storeHash: 'k1drp8k8',
+            shippingTotal: 15,
+            taxTotal: 3,
+            shippingMethod: getShippingOption(),
+            shippingAddress: {
+                country: 'United States',
+                state: 'California',
+                city: 'Some City',
+                zipCode: '95555',
+                address: '12345 Testing Way',
+                apartment: '',
+                firstName: 'Test',
+                lastName: 'Tester',
+            },
+        };
+
+        it('posts to the RFQ ordered endpoint with auth headers and payload', async () => {
+            await b2bPostOrderRequestSender.submitQuote(
+                123,
+                submitQuotePayload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/rfq/123/ordered',
+                {
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                    body: submitQuotePayload,
+                },
+            );
+        });
+
+        it('rejects when the request sender rejects', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
+
+            await expect(
+                b2bPostOrderRequestSender.submitQuote(
+                    123,
+                    submitQuotePayload,
+                    'b2b-token-value',
+                    'https://api-b2b.bigcommerce.com',
+                ),
+            ).rejects.toEqual(getErrorResponse());
+        });
+    });
+
+    describe('#submitCompanyAddress()', () => {
+        const companyAddressPayload: CreateCompanyAddressPayload = {
+            addressLine1: '123 Market Street',
+            addressLine2: 'Suite 400',
+            city: 'San Francisco',
+            label: 'HQ',
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            phoneNumber: '+1-415-555-0100',
+            zipCode: '94103',
+            country: { countryCode: 'US', countryName: 'United States' },
+            state: { stateCode: 'CA', stateName: 'California' },
+            isShipping: 1,
+            isBilling: 0,
+            extraFields: [{ fieldName: 'Department', fieldValue: 'Procurement' }],
+            isCheckout: true,
+        };
+
+        it('posts to the company addresses endpoint with auth headers and payload', async () => {
+            await b2bPostOrderRequestSender.submitCompanyAddress(
+                12345,
+                companyAddressPayload,
+                'b2b-token-value',
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/companies/12345/addresses',
+                {
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'b2b-token-value',
+                        Authorization: 'Bearer b2b-token-value',
+                    },
+                    body: companyAddressPayload,
+                },
+            );
+        });
+
+        it('rejects when the request sender rejects', async () => {
+            jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
+
+            await expect(
+                b2bPostOrderRequestSender.submitCompanyAddress(
+                    12345,
+                    companyAddressPayload,
+                    'b2b-token-value',
+                    'https://api-b2b.bigcommerce.com',
+                ),
+            ).rejects.toEqual(getErrorResponse());
+        });
+    });
+});

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -1,0 +1,171 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { RequestOptions } from '../common/http-request';
+import { ShippingOption } from '../shipping';
+
+export interface CloseInvoicePayload {
+    orderId: string;
+    comment: string;
+}
+
+export interface CloseInvoiceResponseBody {
+    data: {
+        paymentId: string;
+        receiptId: string;
+    };
+    code: number;
+}
+
+export interface B2BExtraField {
+    fieldName: string;
+    fieldValue: string | number | boolean | string[];
+}
+
+export interface AddOrderExtraFieldsPayload {
+    orderId: number;
+    poNumber: string;
+    referenceNumber: string;
+    extraFields: B2BExtraField[];
+    extraInfo: {
+        addressExtraFields?: {
+            billingAddressExtraFields: B2BExtraField[];
+            shippingAddressExtraFields: B2BExtraField[];
+        };
+        billingAddressId?: number;
+        shipppingAddressId?: number; // triple-p is intentional — wire contract
+    };
+}
+
+export interface QuoteOrderedPayload {
+    orderId: number;
+    storeHash: string;
+    shippingTotal: number | null;
+    taxTotal: number;
+    shippingMethod: ShippingOption | null;
+    shippingAddress: {
+        country: string;
+        state: string;
+        city: string;
+        zipCode: string;
+        address: string;
+        apartment: string;
+        firstName: string;
+        lastName: string;
+    } | null;
+}
+
+export interface CreateCompanyAddressPayload {
+    addressLine1: string;
+    addressLine2: string;
+    city: string;
+    label: string;
+    firstName: string;
+    lastName: string;
+    phoneNumber: string;
+    zipCode: string;
+    country: {
+        countryCode: string;
+        countryName: string;
+    };
+    state: {
+        stateCode: string;
+        stateName: string;
+    };
+    isBilling: 0 | 1;
+    isCheckout: boolean;
+    isShipping: 0 | 1;
+    extraFields?: B2BExtraField[];
+}
+
+interface CreateCompanyAddressResponseBody {
+    data: {
+        addressId: string;
+    };
+    code: number;
+}
+
+export default class B2BPostOrderRequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    // To be deleted
+    // invoiceComment will be sent to the Order API
+    // Server side needs to pass order id to B2B when it is an invoice-to-checkout
+    async submitInvoice(
+        payload: CloseInvoicePayload,
+        b2bToken: string,
+        b2bBaseUrl: string,
+        options?: RequestOptions,
+    ): Promise<Response<CloseInvoiceResponseBody>> {
+        return this._requestSender.post(
+            `${b2bBaseUrl}/api/v1/ip/storefront/payments/bigcommerce/orders`,
+            {
+                timeout: options?.timeout,
+                credentials: false,
+                headers: {
+                    'Content-Type': 'application/json',
+                    authToken: b2bToken,
+                    Authorization: `Bearer ${b2bToken}`,
+                },
+                body: payload,
+            },
+        );
+    }
+
+    // To be deleted
+    // no additional info wil be sent to Order API
+    // server side can pass the rest of the info to B2B by reading the checkout object and order object
+    async submitQuote(
+        quoteId: number,
+        payload: QuoteOrderedPayload,
+        b2bToken: string,
+        b2bBaseUrl: string,
+    ): Promise<Response<void>> {
+        return this._requestSender.post(`${b2bBaseUrl}/api/v2/rfq/${quoteId}/ordered`, {
+            credentials: false,
+            headers: {
+                'Content-Type': 'application/json',
+                authToken: b2bToken,
+                Authorization: `Bearer ${b2bToken}`,
+            },
+            body: payload,
+        });
+    }
+
+    // To be deleted
+    // poNumber, referenceNumber, orderExtraFields will be sent to Order API.
+    // server side can pass the rest of the info to B2B by reading the checkout object and order object
+    async submitOrderExtraFields(
+        payload: AddOrderExtraFieldsPayload,
+        b2bToken: string,
+        b2bBaseUrl: string,
+    ): Promise<Response<void>> {
+        return this._requestSender.post(`${b2bBaseUrl}/api/v2/orders`, {
+            credentials: false,
+            headers: {
+                'Content-Type': 'application/json',
+                authToken: b2bToken,
+                Authorization: `Bearer ${b2bToken}`,
+            },
+            body: payload,
+        });
+    }
+
+    // To be deleted
+    // server side can pass company address info to B2B by reading the checkout object
+    async submitCompanyAddress(
+        companyId: number,
+        payload: CreateCompanyAddressPayload,
+        b2bToken: string,
+        b2bBaseUrl: string,
+    ): Promise<Response<CreateCompanyAddressResponseBody>> {
+        return this._requestSender.post(`${b2bBaseUrl}/api/v2/companies/${companyId}/addresses`, {
+            credentials: false,
+            headers: {
+                'Content-Type': 'application/json',
+                authToken: b2bToken,
+                Authorization: `Bearer ${b2bToken}`,
+            },
+            body: payload,
+        });
+    }
+}

--- a/packages/core/src/payment/b2b-post-order-selector.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-selector.spec.ts
@@ -1,0 +1,55 @@
+import { createB2BPostOrderSelectorFactory } from './b2b-post-order-selector';
+import B2BPostOrderState, { DEFAULT_STATE } from './b2b-post-order-state';
+
+describe('createB2BPostOrderSelectorFactory()', () => {
+    const createSelector = createB2BPostOrderSelectorFactory();
+
+    it('returns undefined receipt id when no data is loaded', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getReceiptId()).toBeUndefined();
+    });
+
+    it('returns the receipt id string when data is loaded', () => {
+        const state: B2BPostOrderState = {
+            ...DEFAULT_STATE,
+            data: { receiptId: 'rcpt_1' },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getReceiptId()).toBe('rcpt_1');
+    });
+
+    it('returns false for isPersisting when not persisting', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.isPersisting()).toBe(false);
+    });
+
+    it('returns true for isPersisting when persisting', () => {
+        const state: B2BPostOrderState = {
+            ...DEFAULT_STATE,
+            statuses: { isPersisting: true },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.isPersisting()).toBe(true);
+    });
+
+    it('returns undefined for getPersistError when no error', () => {
+        const selector = createSelector(DEFAULT_STATE);
+
+        expect(selector.getPersistError()).toBeUndefined();
+    });
+
+    it('returns error for getPersistError when there is an error', () => {
+        const error = new Error('B2B metadata persist failed');
+        const state: B2BPostOrderState = {
+            ...DEFAULT_STATE,
+            errors: { persistB2bMetadataError: error },
+        };
+        const selector = createSelector(state);
+
+        expect(selector.getPersistError()).toBe(error);
+    });
+});

--- a/packages/core/src/payment/b2b-post-order-selector.ts
+++ b/packages/core/src/payment/b2b-post-order-selector.ts
@@ -1,0 +1,38 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { createSelector } from '../common/selector';
+
+import B2BPostOrderState, { DEFAULT_STATE } from './b2b-post-order-state';
+
+export default interface B2BPostOrderSelector {
+    getReceiptId(): string | undefined;
+    getPersistError(): Error | undefined;
+    isPersisting(): boolean;
+}
+
+export type B2BPostOrderSelectorFactory = (state: B2BPostOrderState) => B2BPostOrderSelector;
+
+export function createB2BPostOrderSelectorFactory(): B2BPostOrderSelectorFactory {
+    const getReceiptId = createSelector(
+        (state: B2BPostOrderState) => state.data?.receiptId,
+        (receiptId) => () => receiptId,
+    );
+
+    const getPersistError = createSelector(
+        (state: B2BPostOrderState) => state.errors.persistB2bMetadataError,
+        (error) => () => error,
+    );
+
+    const isPersisting = createSelector(
+        (state: B2BPostOrderState) => !!state.statuses.isPersisting,
+        (status) => () => status,
+    );
+
+    return memoizeOne((state: B2BPostOrderState = DEFAULT_STATE): B2BPostOrderSelector => {
+        return {
+            getReceiptId: getReceiptId(state),
+            getPersistError: getPersistError(state),
+            isPersisting: isPersisting(state),
+        };
+    });
+}

--- a/packages/core/src/payment/b2b-post-order-state.ts
+++ b/packages/core/src/payment/b2b-post-order-state.ts
@@ -1,0 +1,22 @@
+export interface B2BPostOrderData {
+    receiptId: string;
+}
+
+export default interface B2BPostOrderState {
+    data?: B2BPostOrderData;
+    errors: B2BPostOrderErrorsState;
+    statuses: B2BPostOrderStatusesState;
+}
+
+export interface B2BPostOrderErrorsState {
+    persistB2bMetadataError?: Error;
+}
+
+export interface B2BPostOrderStatusesState {
+    isPersisting?: boolean;
+}
+
+export const DEFAULT_STATE: B2BPostOrderState = {
+    errors: {},
+    statuses: {},
+};

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -47,6 +47,14 @@ export {
     default as B2BPaymentsRefreshRequestSender,
     B2BPaymentsRefreshPayment,
 } from './b2b-payments-refresh-request-sender';
+export { default as B2BPostOrderActionCreator } from './b2b-post-order-action-creator';
+export { default as B2BPostOrderRequestSender } from './b2b-post-order-request-sender';
+export { default as b2bPostOrderReducer } from './b2b-post-order-reducer';
+export {
+    default as B2BPostOrderSelector,
+    createB2BPostOrderSelectorFactory,
+} from './b2b-post-order-selector';
+export { default as B2BPostOrderState } from './b2b-post-order-state';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';
 export { default as PaymentMethodConfig } from './payment-method-config';


### PR DESCRIPTION
Reverts bigcommerce/checkout-sdk-js#3300

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes B2B checkout integration contract (when and how metadata is sent) and adds multiple post-order external API calls using the B2B token; receipt id type and source changed for consumers of `getB2BReceiptId`.
> 
> **Overview**
> Restores the **post-order B2B** path that was removed in CHECKOUT-10143: callers use **`checkoutService.persistB2BMetadata()`** after place order instead of sending B2B fields on **`submitOrder`**.
> 
> The new **`b2bPostOrder`** store slice drives loading/error selectors (`isPersistingB2BMetadata`, `getPersistB2BMetadataError`) and **`getB2BReceiptId`** (now a **string** from persist success, not a **number** on order submit). **`OrderRequestBody.b2bMetadata`** and public **`OrderB2BMetadata`** exports are dropped; receipt id is no longer read from order API **`b2bContext`**.
> 
> **`B2BPostOrderActionCreator`** orchestrates authenticated B2B API calls: invoice close, order extra fields (PO/reference/custom fields), optional **company address** saves when `shouldSaveAddress` is set, and **quote ordered** when quote capabilities are configured—in that order, with invoice vs non-invoice branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f00db59fd27ec13417e08299ed99ff8f5956fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->