### PR TITLE
feat(payment): remove experiment for new Stripe JS version for Stripe OCS

### DIFF
--- a/packages/google-pay-integration/src/google-pay-stripe/google-pay-stripe-gateway.ts
+++ b/packages/google-pay-integration/src/google-pay-stripe/google-pay-stripe-gateway.ts
@@ -142,7 +142,7 @@ export default class GooglePayStripeGateway extends GooglePayGateway {
 
         const locale = this.paymentIntegrationService.getState().getCartLocale();
 
-        if (methodId === 'googlepaystripeocs' && !!initializationData.useNewStripeJsVersion) {
+        if (methodId === 'googlepaystripeocs') {
             return this.scriptLoader.getStripeClient(
                 initializationData,
                 locale,

--- a/packages/google-pay-integration/src/types.ts
+++ b/packages/google-pay-integration/src/types.ts
@@ -397,7 +397,6 @@ export interface GooglePayStripeInitializationData extends GooglePayBaseInitiali
     stripePublishableKey: string;
     stripeVersion: string;
     shopperLanguage: string;
-    useNewStripeJsVersion?: boolean;
 }
 
 export interface GooglePayCheckoutComInitializationData extends GooglePayBaseInitializationData {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
@@ -211,7 +211,7 @@ describe('StripeLinkV2ButtonStrategy', () => {
                     captureMethod: 'automatic',
                 },
                 'en',
-                StripeJsVersion.V3,
+                StripeJsVersion.CLOVER,
             );
             expect(elements.create).toHaveBeenCalledWith(
                 'expressCheckout',
@@ -236,7 +236,7 @@ describe('StripeLinkV2ButtonStrategy', () => {
                     captureMethod: 'manual',
                 },
                 'en',
-                StripeJsVersion.V3,
+                StripeJsVersion.CLOVER,
             );
             expect(elements.create).toHaveBeenCalledWith(
                 'expressCheckout',
@@ -249,20 +249,6 @@ describe('StripeLinkV2ButtonStrategy', () => {
                 mode: 'payment',
             });
             expect(element.mount).toHaveBeenCalledWith('#checkout-button');
-        });
-
-        it('loads Stripe client with new Stripe JS version', async () => {
-            jest.spyOn(stripeIntegrationService, 'getStripeJsVersion').mockReturnValue(
-                StripeJsVersion.CLOVER,
-            );
-
-            await strategy.initialize(initialiseOptions);
-
-            expect(scriptLoader.getStripeClient).toHaveBeenCalledWith(
-                stripePaymentMethod.initializationData,
-                'en',
-                StripeJsVersion.CLOVER,
-            );
         });
     });
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.ts
@@ -28,6 +28,7 @@ import {
     StripeEventType,
     StripeInitializationData,
     StripeIntegrationService,
+    StripeJsVersion,
     StripeLinkV2Event,
     StripeLinkV2Options,
     StripeLinkV2ShippingRate,
@@ -93,14 +94,12 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
 
         const { initializationData } = paymentMethod;
         const { captureMethod } = initializationData;
-        const stripeJsVersion =
-            this.stripeIntegrationService.getStripeJsVersion(initializationData);
 
         this._captureMethod = captureMethod;
         this._stripeClient = await this.scriptLoader.getStripeClient(
             initializationData,
             state.getCartLocale(),
-            stripeJsVersion,
+            StripeJsVersion.CLOVER,
         );
 
         await this.paymentIntegrationService.loadDefaultCheckout();

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
@@ -220,7 +220,7 @@ describe('StripeLinkV2CustomerStrategy', () => {
                     captureMethod: 'automatic',
                 },
                 'en',
-                StripeJsVersion.V3,
+                StripeJsVersion.CLOVER,
             );
             expect(elements.create).toHaveBeenCalledWith(
                 'expressCheckout',
@@ -245,7 +245,7 @@ describe('StripeLinkV2CustomerStrategy', () => {
                     captureMethod: 'manual',
                 },
                 'en',
-                StripeJsVersion.V3,
+                StripeJsVersion.CLOVER,
             );
             expect(elements.create).toHaveBeenCalledWith(
                 'expressCheckout',
@@ -258,20 +258,6 @@ describe('StripeLinkV2CustomerStrategy', () => {
                 mode: 'payment',
             });
             expect(element.mount).toHaveBeenCalledWith('#checkout-button');
-        });
-
-        it('loads Stripe client with new Stripe JS version', async () => {
-            jest.spyOn(stripeIntegrationService, 'getStripeJsVersion').mockReturnValue(
-                StripeJsVersion.CLOVER,
-            );
-
-            await strategy.initialize(initialiseOptions);
-
-            expect(scriptLoader.getStripeClient).toHaveBeenCalledWith(
-                stripePaymentMethod.initializationData,
-                'en',
-                StripeJsVersion.CLOVER,
-            );
         });
     });
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
@@ -29,6 +29,7 @@ import {
     StripeEventType,
     StripeInitializationData,
     StripeIntegrationService,
+    StripeJsVersion,
     StripeLinkV2Event,
     StripeLinkV2Options,
     StripeLinkV2ShippingRate,
@@ -96,14 +97,12 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
 
         const { initializationData } = paymentMethod;
         const { captureMethod } = initializationData;
-        const stripeJsVersion =
-            this.stripeIntegrationService.getStripeJsVersion(initializationData);
 
         this._captureMethod = captureMethod;
         this._stripeClient = await this.scriptLoader.getStripeClient(
             initializationData,
             state.getCartLocale(),
-            stripeJsVersion,
+            StripeJsVersion.CLOVER,
         );
 
         await this._mountExpressCheckoutElement(container, this._stripeClient, buttonHeight);

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -391,21 +391,6 @@ describe('StripeOCSPaymentStrategy', () => {
             expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledWith(
                 getStripeOCSMock().initializationData,
                 'en',
-                StripeJsVersion.V3,
-            );
-        });
-
-        it('loads stripe js with new Stripe JS version', async () => {
-            jest.spyOn(stripeIntegrationService, 'getStripeJsVersion').mockReturnValue(
-                StripeJsVersion.CLOVER,
-            );
-
-            await stripeOCSPaymentStrategy.initialize(stripeOptions);
-
-            expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
-            expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledWith(
-                getStripeOCSMock().initializationData,
-                'en',
                 StripeJsVersion.CLOVER,
             );
         });

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -30,6 +30,7 @@ import {
     StripeInitializationData,
     StripeInstrumentSetupFutureUsage,
     StripeIntegrationService,
+    StripeJsVersion,
     StripePIPaymentMethodOptions,
     StripePIPaymentMethodSavingOptions,
     StripeResult,
@@ -246,13 +247,11 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         }
 
         const state = this.paymentIntegrationService.getState();
-        const stripeJsVersion =
-            this.stripeIntegrationService.getStripeJsVersion(initializationData);
 
         return this.scriptLoader.getStripeClient(
             initializationData,
             state.getCartLocale(),
-            stripeJsVersion,
+            StripeJsVersion.CLOVER,
         );
     }
 

--- a/packages/stripe-utils/src/stripe-integration-service.mock.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.mock.ts
@@ -3,7 +3,7 @@ import {
     PaymentMethodFailedError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { StripeJsVersion, StripeStringConstants } from './stripe';
+import { StripeStringConstants } from './stripe';
 import StripeIntegrationService from './stripe-integration-service';
 import { getStripeJsMock } from './stripe.mock';
 
@@ -44,7 +44,6 @@ export const getStripeIntegrationServiceMock = () =>
         throwStripeError: jest.fn(() => {
             throw new Error('throw stripe error');
         }),
-        getStripeJsVersion: jest.fn(() => StripeJsVersion.V3),
         mapStripeAddress: jest.fn((address) => ({
             city: address?.city,
             country: address?.countryCode,

--- a/packages/stripe-utils/src/stripe-integration-service.spec.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.spec.ts
@@ -20,8 +20,6 @@ import {
     StripeElement,
     StripeElements,
     StripeError,
-    StripeInitializationData,
-    StripeJsVersion,
     StripePaymentMethodType,
 } from './stripe';
 import StripePaymentInitializeOptions from './stripe-initialize-options';
@@ -797,28 +795,6 @@ describe('StripeIntegrationService', () => {
 
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalled();
             expect(stripeScriptLoader.updateStripeElements).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('#getStripeJsVersion', () => {
-        it('should return Clover if experiment is true', () => {
-            const initializationData = {
-                useNewStripeJsVersion: true,
-            } as StripeInitializationData;
-
-            expect(stripeIntegrationService.getStripeJsVersion(initializationData)).toBe(
-                StripeJsVersion.CLOVER,
-            );
-        });
-
-        it('should return V3 if experiment is false', () => {
-            const initializationData = {
-                useNewStripeJsVersion: false,
-            } as StripeInitializationData;
-
-            expect(stripeIntegrationService.getStripeJsVersion(initializationData)).toBe(
-                StripeJsVersion.V3,
-            );
         });
     });
 

--- a/packages/stripe-utils/src/stripe-integration-service.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.ts
@@ -21,8 +21,6 @@ import {
     StripeElements,
     StripeElementType,
     StripeError,
-    StripeInitializationData,
-    StripeJsVersion,
     StripePaymentIntentStatus,
     StripeStringConstants,
 } from './stripe';
@@ -238,12 +236,6 @@ export default class StripeIntegrationService {
         }
 
         this.scriptLoader.updateStripeElements({ clientSecret: clientToken });
-    }
-
-    getStripeJsVersion(initializationData: StripeInitializationData): StripeJsVersion {
-        return initializationData.useNewStripeJsVersion
-            ? StripeJsVersion.CLOVER
-            : StripeJsVersion.V3;
     }
 
     mapStripeAddress(address?: Address): AddressOptions {

--- a/packages/stripe-utils/src/stripe.ts
+++ b/packages/stripe-utils/src/stripe.ts
@@ -800,7 +800,6 @@ export interface StripeInitializationData {
     enableLink?: boolean;
     allowRedisplayForStoredInstruments?: boolean;
     captureMethod?: 'automatic' | 'manual';
-    useNewStripeJsVersion?: boolean;
     checkoutSessionEnabled?: boolean;
     sendSecondPaymentRequestOnStripeError?: boolean;
     adaptivePricingEnabled?: boolean;


### PR DESCRIPTION
## What/Why?

The experiment that switched Stripe OCS to the new Stripe JS version has been fully rolled out and works correctly, so the flag can be removed and the rolled-out behavior kept.

- Removed `useNewStripeJsVersion` from `StripeInitializationData` (stripe-utils) and `GooglePayStripeInitializationData` (google-pay-integration).
- Removed `StripeIntegrationService.getStripeJsVersion()` — it only mapped the flag to a Stripe JS version.
- `stripe-ocs-payment-strategy`, `stripe-link-v2-button-strategy` and `stripe-link-v2-customer-strategy` now always load Stripe JS `CLOVER` (same as `stripe-cs-payment-strategy` already does).
- `google-pay-stripe-gateway` always loads `CLOVER` for `googlepaystripeocs` (the `googlepaystripeupe` path keeps V3 + betas).
- Updated specs/mocks accordingly and removed the now-redundant "new Stripe JS version" tests.

There is no behavior change compared to current production, where the flag serves `true`.

## Rollout/Rollback

Regular release. This should be released **before** the server side stops sending `useNewStripeJsVersion` in `initializationData`, so no SDK version in the wild relies on the removed field.

Rollback: revert this PR.

## Testing

<img width="1011" height="1293" alt="Screenshot 2026-07-07 at 18 08 57" src="https://github.com/user-attachments/assets/aedab380-0ee1-4ada-91cb-5e18f5508a0c" />
<img width="1005" height="1317" alt="Screenshot 2026-07-07 at 18 09 15" src="https://github.com/user-attachments/assets/4b6d71bc-6732-4900-8e32-51a748480d15" />
<img width="994" height="358" alt="Screenshot 2026-07-07 at 18 09 25" src="https://github.com/user-attachments/assets/58836f8f-9c02-47b5-8325-b9b724f8ae89" />
<img width="997" height="1236" alt="Screenshot 2026-07-07 at 18 20 35" src="https://github.com/user-attachments/assets/9262adc5-8164-4b0e-977c-ac6dcf8ee1be" />
<img width="993" height="530" alt="Screenshot 2026-07-07 at 18 20 54" src="https://github.com/user-attachments/assets/e99ac535-47e8-4cba-907c-62f2179438e5" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout payment script loading across Stripe OCS and Google Pay; behavior should match the rolled-out experiment, but mis-timed deploy vs. server could affect stores still on legacy V3 if the flag were ever false.
> 
> **Overview**
> Removes the **`useNewStripeJsVersion`** rollout flag and hard-codes the **CLOVER** Stripe JS loader everywhere that flag previously opted in.
> 
> **`StripeIntegrationService.getStripeJsVersion()`** is deleted; **Stripe OCS** payment, **Link V2** button/customer strategies, and **`googlepaystripeocs`** now always call **`getStripeClient`** with **`StripeJsVersion.CLOVER`**. The optional field is dropped from **`StripeInitializationData`** and **`GooglePayStripeInitializationData`**. **`googlepaystripeupe`** still loads **V3** with UPE betas.
> 
> Specs and mocks are updated to expect **CLOVER** only; redundant “new Stripe JS version” tests are removed. Intended to match production with the experiment on; release before the server stops sending the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166d7f505ff154fd8106074d07eaaa9985ca9a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->