### PR TITLE
feat(checkout): CHECKOUT-10142 Add getB2BContext

### DIFF
--- a/packages/core/src/checkout/checkout-store-selector.spec.ts
+++ b/packages/core/src/checkout/checkout-store-selector.spec.ts
@@ -46,6 +46,49 @@ describe('CheckoutStoreSelector', () => {
         expect(selector.getSignInEmail()).toEqual(internalSelectors.signInEmail.getEmail());
     });
 
+    describe('#getB2BContext()', () => {
+        const b2bContext = { billingAddressId: 1, shippingAddressId: 2 };
+
+        it('returns undefined if neither B2B context nor receipt id is available', () => {
+            expect(selector.getB2BContext()).toBeUndefined();
+        });
+
+        it('returns B2B context merged with receipt id if both are available', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
+            jest.spyOn(internalSelectors.order, 'getB2BContext').mockReturnValue(b2bContext);
+            jest.spyOn(internalSelectors.b2bPostOrder, 'getReceiptId').mockReturnValue(
+                'receipt-id',
+            );
+
+            selector = createCheckoutStoreSelector(internalSelectors);
+
+            expect(selector.getB2BContext()).toEqual({ ...b2bContext, receiptId: 'receipt-id' });
+        });
+
+        it('returns B2B context of the order if receipt id is unavailable', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
+            jest.spyOn(internalSelectors.order, 'getB2BContext').mockReturnValue(b2bContext);
+
+            selector = createCheckoutStoreSelector(internalSelectors);
+
+            expect(selector.getB2BContext()).toEqual(b2bContext);
+        });
+
+        it('returns receipt id if B2B context of the order is unavailable', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
+            jest.spyOn(internalSelectors.b2bPostOrder, 'getReceiptId').mockReturnValue(
+                'receipt-id',
+            );
+
+            selector = createCheckoutStoreSelector(internalSelectors);
+
+            expect(selector.getB2BContext()).toEqual({ receiptId: 'receipt-id' });
+        });
+    });
+
     it('returns config', () => {
         expect(selector.getConfig()).toEqual(internalSelectors.config.getStoreConfig());
     });

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -12,7 +12,7 @@ import { Customer } from '../customer';
 import { Extension, ExtensionRegion } from '../extension';
 import { FormField } from '../form';
 import { Country } from '../geography';
-import { Order } from '../order';
+import { B2BContext, Order } from '../order';
 import { PaymentMethod } from '../payment';
 import { CardInstrument, PaymentInstrument } from '../payment/instrument';
 import { PaymentProviderCustomer } from '../payment-provider-customer';
@@ -67,11 +67,11 @@ export default interface CheckoutStoreSelector {
     getB2BToken(): string | undefined;
 
     /**
-     * Gets the B2B receipt id produced after persisting order metadata.
+     * Gets the B2B context of the current order.
      *
-     * @returns The B2B receipt id string if it has been persisted, otherwise undefined.
+     * @returns The B2B context if it is available, otherwise undefined.
      */
-    getB2BReceiptId(): string | undefined;
+    getB2BContext(): B2BContext | undefined;
 
     /**
      * Gets the shipping address of the current checkout.
@@ -521,9 +521,20 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         (getToken) => clone(getToken),
     );
 
-    const getB2BReceiptId = createSelector(
+    const getB2BContext = createSelector(
+        ({ order }: InternalCheckoutSelectors) => order.getB2BContext,
         ({ b2bPostOrder }: InternalCheckoutSelectors) => b2bPostOrder.getReceiptId,
-        (getReceiptId) => clone(getReceiptId),
+        (getB2BContext, getReceiptId) =>
+            clone(() => {
+                const b2bContext = getB2BContext();
+                const receiptId = getReceiptId();
+
+                if (!b2bContext && receiptId === undefined) {
+                    return;
+                }
+
+                return { ...b2bContext, receiptId };
+            }),
     );
 
     const isPaymentDataRequired = createSelector(
@@ -661,7 +672,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             isPaymentDataSubmitted: isPaymentDataSubmitted(state),
             getSignInEmail: getSignInEmail(state),
             getB2BToken: getB2BToken(state),
-            getB2BReceiptId: getB2BReceiptId(state),
+            getB2BContext: getB2BContext(state),
             getInstruments: getInstruments(state),
             getCustomerAccountFields: getCustomerAccountFields(state),
             getBillingAddressFields: getBillingAddressFields(state),

--- a/packages/core/src/order/b2b-context.ts
+++ b/packages/core/src/order/b2b-context.ts
@@ -1,0 +1,5 @@
+export default interface B2BContext {
+    billingAddressId?: number;
+    shippingAddressId?: number;
+    receiptId?: string;
+}

--- a/packages/core/src/order/b2b-context.ts
+++ b/packages/core/src/order/b2b-context.ts
@@ -1,4 +1,4 @@
-export default interface B2BContext {
+export interface B2BContext {
     billingAddressId?: number;
     shippingAddressId?: number;
     receiptId?: string;

--- a/packages/core/src/order/index.ts
+++ b/packages/core/src/order/index.ts
@@ -2,7 +2,7 @@ export * from './internal-order-responses';
 export * from './order-actions';
 
 export { default as Order, GatewayOrderPayment, OrderMeta } from './order';
-export { default as B2BContext } from './b2b-context';
+export { B2BContext } from './b2b-context';
 export {
     default as InternalOrder,
     InternalIncompleteOrder,

--- a/packages/core/src/order/index.ts
+++ b/packages/core/src/order/index.ts
@@ -2,6 +2,7 @@ export * from './internal-order-responses';
 export * from './order-actions';
 
 export { default as Order, GatewayOrderPayment, OrderMeta } from './order';
+export { default as B2BContext } from './b2b-context';
 export {
     default as InternalOrder,
     InternalIncompleteOrder,

--- a/packages/core/src/order/internal-order-responses.ts
+++ b/packages/core/src/order/internal-order-responses.ts
@@ -1,6 +1,7 @@
 import { InternalResponseBody } from '../common/http-request';
 import { InternalCustomer } from '../customer';
 
+import B2BContext from './b2b-context';
 import InternalOrder from './internal-order';
 
 export type InternalOrderResponseBody = InternalResponseBody<
@@ -9,6 +10,7 @@ export type InternalOrderResponseBody = InternalResponseBody<
 >;
 
 export interface InternalOrderResponseData {
+    b2bContext?: B2BContext;
     customer: InternalCustomer;
     order: InternalOrder;
 }

--- a/packages/core/src/order/internal-order-responses.ts
+++ b/packages/core/src/order/internal-order-responses.ts
@@ -1,7 +1,7 @@
 import { InternalResponseBody } from '../common/http-request';
 import { InternalCustomer } from '../customer';
 
-import B2BContext from './b2b-context';
+import { B2BContext } from './b2b-context';
 import InternalOrder from './internal-order';
 
 export type InternalOrderResponseBody = InternalResponseBody<

--- a/packages/core/src/order/order-reducer.spec.ts
+++ b/packages/core/src/order/order-reducer.spec.ts
@@ -97,6 +97,50 @@ describe('orderReducer()', () => {
         );
     });
 
+    it('stores B2B context in meta if it is submitted successfully', () => {
+        const response = getSubmitOrderResponseBody();
+        const headers = getSubmitOrderResponseHeaders();
+        const b2bContext = { billingAddressId: 1, shippingAddressId: 2 };
+        const action: SubmitOrderAction = {
+            type: OrderActionType.SubmitOrderSucceeded,
+            meta: {
+                ...response.meta,
+                token: headers.token,
+            },
+            payload: {
+                ...response.data,
+                b2bContext,
+            },
+        };
+
+        expect(orderReducer(initialState, action)).toEqual(
+            expect.objectContaining({
+                meta: expect.objectContaining({ b2bContext }),
+            }),
+        );
+    });
+
+    it('clears stale B2B context in meta if the new order does not have one', () => {
+        const response = getSubmitOrderResponseBody();
+        const headers = getSubmitOrderResponseHeaders();
+        const action: SubmitOrderAction = {
+            type: OrderActionType.SubmitOrderSucceeded,
+            meta: {
+                ...response.meta,
+                token: headers.token,
+            },
+            payload: response.data,
+        };
+        const staleState: OrderState = {
+            ...initialState,
+            meta: { b2bContext: { billingAddressId: 1, shippingAddressId: 2 } },
+        };
+
+        const state = orderReducer(staleState, action);
+
+        expect(state.meta && state.meta.b2bContext).toBeUndefined();
+    });
+
     it('returns new data if it is finalized successfully', () => {
         const response = getCompleteOrderResponseBody();
         const action: FinalizeOrderAction = {

--- a/packages/core/src/order/order-reducer.ts
+++ b/packages/core/src/order/order-reducer.ts
@@ -51,12 +51,16 @@ function metaReducer(
     switch (action.type) {
         case OrderActionType.FinalizeOrderSucceeded:
         case OrderActionType.SubmitOrderSucceeded:
-            return objectMerge(meta, {
-                ...action.meta,
-                callbackUrl: action.payload && action.payload.order.callbackUrl,
-                orderToken: action.payload && action.payload.order.token,
-                payment: action.payload && action.payload.order && action.payload.order.payment,
-            });
+            return objectSet(
+                objectMerge(meta, {
+                    ...action.meta,
+                    callbackUrl: action.payload && action.payload.order.callbackUrl,
+                    orderToken: action.payload && action.payload.order.token,
+                    payment: action.payload && action.payload.order && action.payload.order.payment,
+                }),
+                'b2bContext',
+                action.payload?.b2bContext,
+            );
 
         default:
             return meta;

--- a/packages/core/src/order/order-selector.spec.ts
+++ b/packages/core/src/order/order-selector.spec.ts
@@ -54,6 +54,31 @@ describe('OrderSelector', () => {
         });
     });
 
+    describe('#getB2BContext()', () => {
+        it('returns B2B context', () => {
+            const b2bContext = { billingAddressId: 1, shippingAddressId: 2 };
+            const orderState = set(getOrderState(), 'meta.b2bContext', b2bContext);
+
+            orderSelector = createOrderSelector(
+                orderState,
+                selectors.orderBillingAddress,
+                selectors.coupons,
+            );
+
+            expect(orderSelector.getB2BContext()).toEqual(b2bContext);
+        });
+
+        it('returns undefined if B2B context is unavailable', () => {
+            orderSelector = createOrderSelector(
+                state.order,
+                selectors.orderBillingAddress,
+                selectors.coupons,
+            );
+
+            expect(orderSelector.getB2BContext()).toBeUndefined();
+        });
+    });
+
     describe('#getLoadError()', () => {
         it('returns error if unable to load', () => {
             const loadError = new RequestError(getErrorResponse());

--- a/packages/core/src/order/order-selector.ts
+++ b/packages/core/src/order/order-selector.ts
@@ -6,7 +6,7 @@ import { guard } from '../common/utility';
 import { CouponSelector } from '../coupon';
 import OrderBillingAddressSelector from '../order-billing-address/order-billing-address-selector';
 
-import B2BContext from './b2b-context';
+import { B2BContext } from './b2b-context';
 import Order from './order';
 import OrderState, { DEFAULT_STATE, OrderMetaState } from './order-state';
 

--- a/packages/core/src/order/order-selector.ts
+++ b/packages/core/src/order/order-selector.ts
@@ -6,6 +6,7 @@ import { guard } from '../common/utility';
 import { CouponSelector } from '../coupon';
 import OrderBillingAddressSelector from '../order-billing-address/order-billing-address-selector';
 
+import B2BContext from './b2b-context';
 import Order from './order';
 import OrderState, { DEFAULT_STATE, OrderMetaState } from './order-state';
 
@@ -13,6 +14,7 @@ export default interface OrderSelector {
     getOrder(): Order | undefined;
     getOrderOrThrow(): Order;
     getOrderMeta(): OrderMetaState | undefined;
+    getB2BContext(): B2BContext | undefined;
     getLoadError(): Error | undefined;
     getPaymentId(methodId: string): string | undefined;
     isLoading(): boolean;
@@ -58,6 +60,11 @@ export function createOrderSelectorFactory(): OrderSelectorFactory {
         (meta) => () => meta,
     );
 
+    const getB2BContext = createSelector(
+        (state: OrderState) => state.meta?.b2bContext,
+        (b2bContext) => () => b2bContext,
+    );
+
     const getLoadError = createSelector(
         (state: OrderState) => state.errors.loadError,
         (error) => () => error,
@@ -88,6 +95,7 @@ export function createOrderSelectorFactory(): OrderSelectorFactory {
                 getOrder: getOrder(state, { billingAddress, coupons }),
                 getOrderOrThrow: getOrderOrThrow(state, { billingAddress, coupons }),
                 getOrderMeta: getOrderMeta(state),
+                getB2BContext: getB2BContext(state),
                 getLoadError: getLoadError(state),
                 getPaymentId: getPaymentId(state),
                 isLoading: isLoading(state),

--- a/packages/core/src/order/order-state.ts
+++ b/packages/core/src/order/order-state.ts
@@ -1,6 +1,6 @@
 import { Omit } from '../common/types';
 
-import B2BContext from './b2b-context';
+import { B2BContext } from './b2b-context';
 import { InternalOrderMeta, InternalOrderPayment } from './internal-order';
 import Order from './order';
 

--- a/packages/core/src/order/order-state.ts
+++ b/packages/core/src/order/order-state.ts
@@ -1,5 +1,6 @@
 import { Omit } from '../common/types';
 
+import B2BContext from './b2b-context';
 import { InternalOrderMeta, InternalOrderPayment } from './internal-order';
 import Order from './order';
 
@@ -17,6 +18,7 @@ export interface OrderMetaState extends InternalOrderMeta {
     orderToken?: string;
     callbackUrl?: string;
     payment?: InternalOrderPayment;
+    b2bContext?: B2BContext;
 }
 
 export interface OrderErrorsState {


### PR DESCRIPTION
## What/Why?

Reflect API changes:
- The internal order endpoint returns  `billingAddressId?: number;` and `shippingAddressId?: number;` when an order is placed with existing company addresses.

Add `getB2BContext` internal selector to return all B2B post order metadata, including:
- billingAddressId?: number;
- shippingAddressId?: number;
- receiptId?: string;
  
## Rollout/Rollback

CI.

## Testing

### Manual testing
#### Invoice flow

https://github.com/user-attachments/assets/4818895f-d00b-4703-8d38-cf3c44e1f593

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes `getB2BReceiptId` in favor of `getB2BContext`, which is a breaking change for SDK consumers; behavior affects B2B checkout/order flows.
> 
> **Overview**
> Introduces a unified **`B2BContext`** (`billingAddressId`, `shippingAddressId`, `receiptId`) for B2B post-order metadata, aligned with the internal order API when company addresses are used at checkout.
> 
> **Order state** now persists `b2bContext` from submit/finalize order responses (and clears stale context when a later order omits it). **`OrderSelector#getB2BContext`** reads it from order meta.
> 
> On the public checkout API, **`getB2BReceiptId` is replaced by `getB2BContext`**, which merges order B2B fields with the existing B2B post-order receipt id when either is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01009dd54872dbd00832df3a5929694032e5bfa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->