### PR TITLE
feat(payment): PAYPAL-4195 Add an ability to render Braintree PayPal PayLater button

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-wallet-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-wallet-strategy.spec.ts
@@ -244,13 +244,25 @@ describe('BraintreePaypalWalletStrategy', () => {
             );
         });
 
-        it('renders the Braintree PayPal button only', async () => {
+        it('renders the Braintree PayPal button', async () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYPAL,
                 style: { shape: 'rect', height: 45 },
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('renders the Braintree PayPal PayLater button with the gold color', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.PAYLATER,
+                style: { shape: 'rect', height: 45, color: 'gold' },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
             });

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-wallet-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-wallet-strategy.ts
@@ -6,6 +6,7 @@ import {
     BraintreePaypalWalletService,
     isBraintreeError,
     PaypalAuthorizeData,
+    PaypalButtonStyleColorOption,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     CheckoutButtonInitializeOptions,
@@ -104,11 +105,26 @@ export default class BraintreePaypalWalletStrategy implements CheckoutButtonStra
         const { style, onEligibilityFailure } = braintreepaypal;
         const { paypal } = this.braintreeHostWindow;
 
-        if (paypal) {
+        if (!paypal) {
+            this.braintreePaypalWalletService.removeElement(containerId);
+
+            return;
+        }
+
+        const fundingSources = [paypal.FUNDING.PAYPAL, paypal.FUNDING.PAYLATER];
+
+        let hasRenderedButton = false;
+
+        fundingSources.forEach((fundingSource) => {
+            const buttonStyle =
+                fundingSource === paypal.FUNDING.PAYLATER
+                    ? { ...getValidButtonStyle(style), color: PaypalButtonStyleColorOption.GOLD }
+                    : getValidButtonStyle(style);
+
             const paypalButtonRender = paypal.Buttons({
                 env: testMode ? 'sandbox' : 'production',
-                fundingSource: paypal.FUNDING.PAYPAL,
-                style: getValidButtonStyle(style),
+                fundingSource,
+                style: buttonStyle,
                 createOrder: () => this.setupPayment(braintreepaypal, intent),
                 onApprove: (authorizeData: PaypalAuthorizeData) =>
                     this.tokenizePayment(
@@ -121,11 +137,16 @@ export default class BraintreePaypalWalletStrategy implements CheckoutButtonStra
 
             if (paypalButtonRender.isEligible()) {
                 paypalButtonRender.render(`#${containerId}`);
-            } else if (onEligibilityFailure && typeof onEligibilityFailure === 'function') {
-                onEligibilityFailure();
+                hasRenderedButton = true;
             }
-        } else {
-            this.braintreePaypalWalletService.removeElement(containerId);
+        });
+
+        if (
+            !hasRenderedButton &&
+            onEligibilityFailure &&
+            typeof onEligibilityFailure === 'function'
+        ) {
+            onEligibilityFailure();
         }
     }
 


### PR DESCRIPTION
## What/Why?

Add an ability to render Braintree PayPal PayLater button

## Rollout/Rollback

Revert

## Testing

Manual

https://github.com/user-attachments/assets/e3ac654e-1d23-4251-8702-5a9df9c51ff0



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout wallet button rendering and eligibility callbacks; payment tokenization paths are reused but shoppers may see an extra Pay Later option and different failure timing when buttons are ineligible.
> 
> **Overview**
> **Braintree PayPal wallet** button rendering now tries **two funding sources**—`PAYPAL` and `PAYLATER`—instead of only the standard PayPal button. Each eligible option is rendered into the same container with the existing `createOrder` / `onApprove` flow unchanged.
> 
> **Pay Later** buttons get **gold** styling via `PaypalButtonStyleColorOption.GOLD` on top of the merchant’s validated button style; the standard PayPal button keeps the configured style only.
> 
> **Eligibility handling** is updated: `onEligibilityFailure` runs only when **no** button (PayPal or Pay Later) renders, rather than on the first ineligible attempt. If the PayPal SDK is missing on `window`, the container is still cleared via an early return.
> 
> Specs assert both `Buttons` configurations and rename the PayPal-only test accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6861f2307d45632e797e7bbb9e3cfa0287e0472f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->