### PR TITLE
feat(payment): PAYPAL-4190 PPCP wallet strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-wallet-service.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-wallet-service.spec.ts
@@ -1,0 +1,248 @@
+import {
+    MissingDataError,
+    PaymentMethodClientUnavailableError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    AddressRequestBody,
+    createWalletButtonIntegrationService,
+    WalletButtonIntegrationService,
+} from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import { getPayPalCommercePaymentMethod, getPayPalSDKMock } from './mocks';
+import PayPalCommerceScriptLoader from './paypal-commerce-script-loader';
+import {
+    PayPalButtonStyleOptions,
+    PayPalSDK,
+    StyleButtonColor,
+    StyleButtonLabel,
+    StyleButtonShape,
+} from './paypal-commerce-types';
+import PaypalCommerceWalletService from './paypal-commerce-wallet-service';
+
+describe('PaypalCommerceWalletService', () => {
+    let paymentMethod: ReturnType<typeof getPayPalCommercePaymentMethod>;
+    let paypalCommerceScriptLoader: PayPalCommerceScriptLoader;
+    let paypalSdk: PayPalSDK;
+    let service: PaypalCommerceWalletService;
+    let walletButtonIntegrationService: WalletButtonIntegrationService;
+
+    const cartId = 'cart-123';
+    const orderId = 'order-123';
+    const externalCheckoutUrl = 'https://store.example/checkout.php?action=set_external_checkout';
+
+    beforeEach(() => {
+        paymentMethod = getPayPalCommercePaymentMethod();
+        paypalSdk = getPayPalSDKMock();
+        walletButtonIntegrationService = createWalletButtonIntegrationService('/graphql');
+        paypalCommerceScriptLoader = new PayPalCommerceScriptLoader({} as never);
+
+        service = new PaypalCommerceWalletService(
+            walletButtonIntegrationService,
+            paypalCommerceScriptLoader,
+        );
+
+        jest.spyOn(paypalCommerceScriptLoader, 'getPayPalSDK').mockResolvedValue(paypalSdk);
+        jest.spyOn(walletButtonIntegrationService, 'getRedirectToCheckoutUrl').mockResolvedValue({
+            body: { redirectUrls: { externalCheckoutUrl } },
+        } as Awaited<ReturnType<WalletButtonIntegrationService['getRedirectToCheckoutUrl']>>);
+        jest.spyOn(walletButtonIntegrationService, 'createPaymentOrderIntent').mockResolvedValue({
+            body: { orderId },
+        } as Awaited<ReturnType<WalletButtonIntegrationService['createPaymentOrderIntent']>>);
+        jest.spyOn(walletButtonIntegrationService, 'addBillingAddress').mockResolvedValue({
+            body: {},
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+        } as Awaited<ReturnType<WalletButtonIntegrationService['addBillingAddress']>>);
+
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { assign: jest.fn() },
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('creates an instance of PaypalCommerceWalletService', () => {
+        expect(service).toBeInstanceOf(PaypalCommerceWalletService);
+    });
+
+    describe('#loadPayPalSdk', () => {
+        it('loads and returns paypal sdk', async () => {
+            const output = await service.loadPayPalSdk(paymentMethod, 'USD', true, true);
+
+            expect(paypalCommerceScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethod,
+                'USD',
+                undefined,
+                true,
+                true,
+            );
+            expect(output).toBe(paypalSdk);
+        });
+    });
+
+    describe('#getPayPalSdkOrThrow', () => {
+        it('returns paypal sdk if it was loaded earlier', async () => {
+            await service.loadPayPalSdk(paymentMethod, 'USD');
+
+            const output = service.getPayPalSdkOrThrow();
+
+            expect(output).toBe(paypalSdk);
+        });
+
+        it('throws an error if paypal sdk is not defined', () => {
+            expect(() => service.getPayPalSdkOrThrow()).toThrow(
+                PaymentMethodClientUnavailableError,
+            );
+        });
+    });
+
+    describe('#proxyTokenizationPayment', () => {
+        it('throws if order id is missing', async () => {
+            await expect(service.proxyTokenizationPayment(cartId)).rejects.toThrow(
+                MissingDataError,
+            );
+        });
+
+        it('requests external checkout url and redirects customer', async () => {
+            await service.proxyTokenizationPayment(cartId, orderId);
+
+            expect(walletButtonIntegrationService.getRedirectToCheckoutUrl).toHaveBeenCalledWith({
+                paymentWalletData: {
+                    providerId: 'paypalcommerce',
+                    providerOrderId: orderId,
+                },
+                cartEntityId: cartId,
+                queryParams: [
+                    { key: 'payment_type', value: 'paypal' },
+                    { key: 'action', value: 'set_external_checkout' },
+                    { key: 'provider', value: 'paypalcommerce' },
+                ],
+            });
+            expect(window.location.assign).toHaveBeenCalledWith(externalCheckoutUrl);
+        });
+
+        it('throws if checkout response does not contain redirect url', async () => {
+            jest.spyOn(
+                walletButtonIntegrationService,
+                'getRedirectToCheckoutUrl',
+            ).mockResolvedValue({
+                body: { redirectUrls: null },
+                headers: {},
+                status: 200,
+                statusText: 'OK',
+            } as Awaited<ReturnType<WalletButtonIntegrationService['getRedirectToCheckoutUrl']>>);
+
+            await expect(service.proxyTokenizationPayment(cartId, orderId)).rejects.toThrow(
+                'Failed to redirection to checkout page',
+            );
+        });
+    });
+
+    describe('#createPaymentOrderIntent', () => {
+        it('creates payment order intent and returns order id', async () => {
+            const output = await service.createPaymentOrderIntent('paypalcommerce', cartId, {
+                headers: { 'x-test': 'value' },
+            });
+
+            expect(walletButtonIntegrationService.createPaymentOrderIntent).toHaveBeenCalledWith(
+                {
+                    cartEntityId: cartId,
+                    paymentWalletEntityId: 'paypalcommerce',
+                },
+                { headers: { 'x-test': 'value' } },
+            );
+            expect(output).toBe(orderId);
+        });
+    });
+
+    describe('#addBillingAddress', () => {
+        it('passes billing address payload to wallet button service', async () => {
+            const address = { city: 'Austin' } as AddressRequestBody;
+
+            await service.addBillingAddress(cartId, address, {
+                headers: { 'x-test': 'value' },
+            });
+
+            expect(walletButtonIntegrationService.addBillingAddress).toHaveBeenCalledWith(
+                cartId,
+                address,
+                { headers: { 'x-test': 'value' } },
+            );
+        });
+    });
+
+    describe('#getValidButtonStyle', () => {
+        it('returns only valid style fields', () => {
+            const style = {
+                color: StyleButtonColor.gold,
+                height: 60,
+                label: StyleButtonLabel.pay,
+                shape: StyleButtonShape.pill,
+            } as PayPalButtonStyleOptions;
+
+            const output = service.getValidButtonStyle(style);
+
+            expect(output).toEqual({
+                color: StyleButtonColor.gold,
+                height: 55,
+                label: StyleButtonLabel.pay,
+                shape: StyleButtonShape.pill,
+            });
+        });
+
+        it('omits invalid fields and uses default height', () => {
+            const style = {
+                color: 'invalid',
+                height: undefined,
+                label: 'invalid',
+                shape: 'invalid',
+            } as unknown as PayPalButtonStyleOptions;
+
+            const output = service.getValidButtonStyle(style);
+
+            expect(output).toEqual({
+                height: 40,
+            });
+        });
+    });
+
+    describe('#getValidHeight', () => {
+        it('returns default height when height is not provided', () => {
+            expect(service.getValidHeight()).toBe(40);
+        });
+
+        it('returns min height when value is too small', () => {
+            expect(service.getValidHeight(1)).toBe(25);
+        });
+
+        it('returns max height when value is too large', () => {
+            expect(service.getValidHeight(100)).toBe(55);
+        });
+
+        it('returns provided value when it is in range', () => {
+            expect(service.getValidHeight(35)).toBe(35);
+        });
+    });
+
+    describe('#removeElement', () => {
+        it('hides the element when it exists', () => {
+            document.body.innerHTML = '<div id="wallet-container"></div>';
+
+            service.removeElement('wallet-container');
+
+            expect(document.getElementById('wallet-container')?.style.display).toBe('none');
+        });
+
+        it('does not throw when element id is not provided', () => {
+            expect(() => service.removeElement()).not.toThrow();
+        });
+
+        it('does not throw when element is not found', () => {
+            expect(() => service.removeElement('missing-id')).not.toThrow();
+        });
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-wallet-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-wallet-service.ts
@@ -1,0 +1,175 @@
+import { Response } from '@bigcommerce/request-sender';
+import { isNil, omitBy } from 'lodash';
+
+import {
+    MissingDataError,
+    MissingDataErrorType,
+    PaymentMethod,
+    PaymentMethodClientUnavailableError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    AddressRequestBody,
+    BillingAddressResponse,
+    GraphQLRequestOptions,
+    WalletButtonIntegrationService,
+} from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import PayPalCommerceScriptLoader from './paypal-commerce-script-loader';
+import {
+    PayPalButtonStyleOptions,
+    PayPalCommerceInitializationData,
+    PayPalSDK,
+    StyleButtonColor,
+    StyleButtonLabel,
+    StyleButtonShape,
+} from './paypal-commerce-types';
+
+export default class PaypalCommerceWalletService {
+    private paypalSdk?: PayPalSDK;
+
+    constructor(
+        private walletButtonIntegrationService: WalletButtonIntegrationService,
+        private paypalCommerceScriptLoader: PayPalCommerceScriptLoader,
+    ) {}
+
+    /**
+     *
+     * PayPalSDK methods
+     *
+     */
+    async loadPayPalSdk(
+        paymentMethod: PaymentMethod<PayPalCommerceInitializationData>,
+        providedCurrencyCode: string,
+        initializesOnCheckoutPage?: boolean,
+        forceLoad?: boolean,
+    ): Promise<PayPalSDK | undefined> {
+        this.paypalSdk = await this.paypalCommerceScriptLoader.getPayPalSDK(
+            paymentMethod,
+            providedCurrencyCode,
+            undefined,
+            initializesOnCheckoutPage,
+            forceLoad,
+        );
+
+        return this.paypalSdk;
+    }
+
+    getPayPalSdkOrThrow(): PayPalSDK {
+        if (!this.paypalSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this.paypalSdk;
+    }
+
+    /**
+     *
+     * Payment submitting and tokenizing methods
+     *
+     */
+    async proxyTokenizationPayment(cartId: string, orderId?: string): Promise<void> {
+        if (!orderId) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        const inputData = {
+            paymentWalletData: {
+                providerId: 'paypalcommerce',
+                providerOrderId: orderId,
+            },
+            cartEntityId: cartId,
+            queryParams: [
+                { key: 'payment_type', value: 'paypal' },
+                { key: 'action', value: 'set_external_checkout' },
+                { key: 'provider', value: 'paypalcommerce' },
+            ],
+        };
+
+        const response = await this.walletButtonIntegrationService.getRedirectToCheckoutUrl(
+            inputData,
+        );
+
+        if (!response.body.redirectUrls?.externalCheckoutUrl) {
+            throw new Error('Failed to redirection to checkout page');
+        }
+
+        window.location.assign(response.body.redirectUrls.externalCheckoutUrl);
+    }
+
+    async createPaymentOrderIntent(
+        providerId: string,
+        cartId: string,
+        options?: GraphQLRequestOptions,
+    ): Promise<string> {
+        const inputData = {
+            cartEntityId: cartId,
+            paymentWalletEntityId: providerId,
+        };
+        const response = await this.walletButtonIntegrationService.createPaymentOrderIntent(
+            inputData,
+            options,
+        );
+
+        return response.body.orderId;
+    }
+
+    async addBillingAddress(
+        cartId: string,
+        address: AddressRequestBody,
+        options?: GraphQLRequestOptions,
+    ): Promise<Response<BillingAddressResponse>> {
+        return this.walletButtonIntegrationService.addBillingAddress(cartId, address, options);
+    }
+
+    /**
+     *
+     * Buttons style methods
+     *
+     */
+    getValidButtonStyle(style?: PayPalButtonStyleOptions): PayPalButtonStyleOptions {
+        const { color, height, label, shape } = style || {};
+
+        const validStyles = {
+            color: color && StyleButtonColor[color] ? color : undefined,
+            height: this.getValidHeight(height),
+            label: label && StyleButtonLabel[label] ? label : undefined,
+            shape: shape && StyleButtonShape[shape] ? shape : undefined,
+        };
+
+        return omitBy(validStyles, isNil);
+    }
+
+    getValidHeight(height?: number): number {
+        const defaultHeight = 40;
+        const minHeight = 25;
+        const maxHeight = 55;
+
+        if (!height || typeof height !== 'number') {
+            return defaultHeight;
+        }
+
+        if (height > maxHeight) {
+            return maxHeight;
+        }
+
+        if (height < minHeight) {
+            return minHeight;
+        }
+
+        return height;
+    }
+
+    /**
+     *
+     * Utils methods
+     *
+     */
+    removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            // For now this is a temporary solution, further removeElement method will be removed
+            element.style.display = 'none';
+        }
+    }
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-wallet-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-wallet-strategy.ts
@@ -1,17 +1,23 @@
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
 import { toResolvableModule } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import {
-    WalletButtonIntegrationService,
-    WalletPaymentButtonStrategyFactory,
-} from '@bigcommerce/checkout-sdk/wallet-button-integration';
+import { WalletPaymentButtonStrategyFactory } from '@bigcommerce/checkout-sdk/wallet-button-integration';
 
-import PayPalCommerceWalletStrategy from './paypal-commerce-wallet-strategy';
+import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import PaypalCommerceWalletService from '../paypal-commerce-wallet-service';
 
-const createPayPalCommerceWalletStrategy: WalletPaymentButtonStrategyFactory<
-    PayPalCommerceWalletStrategy
-> = (walletButtonIntegrationService: WalletButtonIntegrationService) => {
-    return new PayPalCommerceWalletStrategy(walletButtonIntegrationService);
-};
+import PaypalCommerceWalletStrategy from './paypal-commerce-wallet-strategy';
 
-export default toResolvableModule(createPayPalCommerceWalletStrategy, [
+const createPaypalCommerceWalletStrategy: WalletPaymentButtonStrategyFactory<
+    PaypalCommerceWalletStrategy
+> = (walletButtonIntegrationService) =>
+    new PaypalCommerceWalletStrategy(
+        new PaypalCommerceWalletService(
+            walletButtonIntegrationService,
+            new PayPalCommerceScriptLoader(getScriptLoader()),
+        ),
+    );
+
+export default toResolvableModule(createPaypalCommerceWalletStrategy, [
     { id: 'paypalcommercepaypal' },
 ]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-initialize-options.ts
@@ -1,5 +1,10 @@
 export default interface PayPalCommerceWalletInitializeOptions {
+    cartId: string;
+    currency: {
+        code: string;
+    };
     initializationData: string;
+    clientToken: string;
 }
 
 export interface WithPayPalCommerceWalletInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-strategy.spec.ts
@@ -1,0 +1,171 @@
+import {
+    CheckoutButtonInitializeOptions,
+    InvalidArgumentError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import getPayPalSDKMock from '../mocks/get-paypal-sdk.mock';
+import PaypalCommerceWalletService from '../paypal-commerce-wallet-service';
+
+import { WithPayPalCommerceWalletInitializeOptions } from './paypal-commerce-wallet-initialize-options';
+import PaypalCommerceWalletStrategy from './paypal-commerce-wallet-strategy';
+
+describe('PaypalCommerceWalletStrategy', () => {
+    let strategy: PaypalCommerceWalletStrategy;
+    let paypalCommerceWalletService: jest.Mocked<PaypalCommerceWalletService>;
+
+    const defaultContainerId = 'paypal-commerce-wallet-button';
+    const defaultMethodId = 'paypalcommerce';
+    const defaultCartId = 'abc123';
+    const defaultOrderId = 'ORDER_ID';
+
+    const initializationOptions: CheckoutButtonInitializeOptions &
+        WithPayPalCommerceWalletInitializeOptions = {
+        methodId: defaultMethodId,
+        containerId: defaultContainerId,
+        paypalcommercepaypal: {
+            cartId: defaultCartId,
+            currency: {
+                code: 'USD',
+            },
+            initializationData: btoa(
+                JSON.stringify({
+                    initializationData: {
+                        clientId: 'test-client-id',
+                    },
+                }),
+            ),
+            clientToken: 'test-client-token',
+        },
+    };
+
+    beforeEach(() => {
+        const paypalSdk = getPayPalSDKMock();
+
+        paypalCommerceWalletService = {
+            addBillingAddress: jest.fn(),
+            createPaymentOrderIntent: jest.fn().mockResolvedValue(defaultOrderId),
+            getPayPalSdkOrThrow: jest.fn().mockReturnValue(paypalSdk),
+            getValidButtonStyle: jest.fn().mockReturnValue({ height: 45 }),
+            loadPayPalSdk: jest.fn(),
+            proxyTokenizationPayment: jest.fn(),
+            removeElement: jest.fn(),
+        } as unknown as jest.Mocked<PaypalCommerceWalletService>;
+
+        strategy = new PaypalCommerceWalletStrategy(paypalCommerceWalletService);
+    });
+
+    it('throws when methodId is not provided', async () => {
+        const optionsWithoutMethodId = {
+            ...initializationOptions,
+            methodId: undefined,
+        } as unknown as CheckoutButtonInitializeOptions & WithPayPalCommerceWalletInitializeOptions;
+
+        await expect(strategy.initialize(optionsWithoutMethodId)).rejects.toEqual(
+            new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            ),
+        );
+    });
+
+    it('throws when payment method initializationData cannot be parsed', async () => {
+        const invalidInitializationOptions = {
+            ...initializationOptions,
+            paypalcommercepaypal: {
+                ...initializationOptions.paypalcommercepaypal!,
+                initializationData: '%%%invalid-base64%%%',
+            },
+        };
+
+        await expect(strategy.initialize(invalidInitializationOptions)).rejects.toEqual(
+            new InvalidArgumentError("Failed to parse payment method 'initializationData'."),
+        );
+    });
+
+    it('creates wallet intent', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = paypalCommerceWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        const buttonOptions = buttonsSpy.mock.calls[0][0];
+
+        await buttonOptions.createOrder();
+
+        expect(paypalCommerceWalletService.createPaymentOrderIntent).toHaveBeenCalledWith(
+            'paypalcommerce.paypal',
+            defaultCartId,
+        );
+        expect(paypalButtons.render).toHaveBeenCalledWith(`#${defaultContainerId}`);
+        expect(buttonOptions.onShippingAddressChange).toBeUndefined();
+        expect(buttonOptions.onShippingOptionsChange).toBeUndefined();
+    });
+
+    it('adds billing address and proxies tokenization on approve', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = paypalCommerceWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        const buttonOptions = buttonsSpy.mock.calls[0][0];
+
+        await buttonOptions.onApprove?.(
+            { orderID: defaultOrderId },
+            {
+                order: {
+                    get: jest.fn().mockResolvedValue({
+                        payer: {
+                            name: {
+                                given_name: 'John',
+                                surname: 'Doe',
+                            },
+                            email_address: 'john@doe.com',
+                            address: {
+                                address_line_1: '123 Main St',
+                                address_line_2: 'Suite 100',
+                                admin_area_2: 'Austin',
+                                admin_area_1: 'TX',
+                                postal_code: '73301',
+                                country_code: 'US',
+                            },
+                            phone: {
+                                phone_number: {
+                                    national_number: '5555555555',
+                                },
+                            },
+                        },
+                    }),
+                },
+            },
+        );
+
+        expect(paypalCommerceWalletService.addBillingAddress).toHaveBeenCalledWith(defaultCartId, {
+            firstName: 'John',
+            lastName: 'Doe',
+            company: '',
+            address1: '123 Main St',
+            address2: 'Suite 100',
+            city: 'Austin',
+            email: 'john@doe.com',
+            stateOrProvince: 'TX',
+            stateOrProvinceCode: 'TX',
+            countryCode: 'US',
+            postalCode: '73301',
+            phone: '5555555555',
+            shouldSaveAddress: false,
+        });
+        expect(paypalCommerceWalletService.proxyTokenizationPayment).toHaveBeenCalledWith(
+            defaultCartId,
+            defaultOrderId,
+        );
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-wallet-strategy.ts
@@ -1,31 +1,128 @@
 import {
     CheckoutButtonInitializeOptions,
     CheckoutButtonStrategy,
+    InvalidArgumentError,
+    PaymentMethod,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { WalletButtonIntegrationService } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+import { PayPalCommerceInitializationData } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
+import { AddressRequestBody } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import {
+    ApproveCallbackActions,
+    ApproveCallbackPayload,
+    PayPalCommerceButtonsOptions,
+    PayPalOrderDetails,
+} from '../paypal-commerce-types';
+import PaypalCommerceWalletService from '../paypal-commerce-wallet-service';
 
 import { WithPayPalCommerceWalletInitializeOptions } from './paypal-commerce-wallet-initialize-options';
 
-/**
- * PayPal Commerce Wallet Button Strategy stub for headless wallet button integration.
- *
- * This is an empty stub class at this stage. Concrete implementation will be
- * added in follow-up tickets.
- */
-export default class PayPalCommerceWalletStrategy implements CheckoutButtonStrategy {
-    constructor(private walletButtonIntegrationService: WalletButtonIntegrationService) {}
-
-    getWalletButtonIntegrationService(): WalletButtonIntegrationService {
-        return this.walletButtonIntegrationService;
-    }
+export default class PaypalCommerceWalletStrategy implements CheckoutButtonStrategy {
+    constructor(private paypalCommerceHeadlessWalletButtonService: PaypalCommerceWalletService) {}
 
     async initialize(
-        _options: CheckoutButtonInitializeOptions & WithPayPalCommerceWalletInitializeOptions,
+        options: CheckoutButtonInitializeOptions & WithPayPalCommerceWalletInitializeOptions,
     ): Promise<void> {
-        return Promise.resolve();
+        const { paypalcommercepaypal, containerId, methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.containerId" argument is not provided.`,
+            );
+        }
+
+        if (!paypalcommercepaypal) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.paypalcommercepaypal" argument is not provided.`,
+            );
+        }
+
+        let parsedInitializationData: PaymentMethod<PayPalCommerceInitializationData>;
+
+        try {
+            parsedInitializationData = JSON.parse(atob(paypalcommercepaypal.initializationData));
+        } catch {
+            throw new InvalidArgumentError("Failed to parse payment method 'initializationData'.");
+        }
+
+        await this.paypalCommerceHeadlessWalletButtonService.loadPayPalSdk(
+            parsedInitializationData,
+            paypalcommercepaypal.currency.code,
+            false,
+        );
+
+        this.renderButton(containerId, 'paypalcommerce.paypal', paypalcommercepaypal.cartId);
     }
 
     deinitialize(): Promise<void> {
         return Promise.resolve();
+    }
+
+    private renderButton(containerId: string, methodId: string, cartId: string): void {
+        const paypalSdk = this.paypalCommerceHeadlessWalletButtonService.getPayPalSdkOrThrow();
+
+        const defaultCallbacks = {
+            createOrder: () =>
+                this.paypalCommerceHeadlessWalletButtonService.createPaymentOrderIntent(
+                    methodId,
+                    cartId,
+                ),
+            onApprove: async (
+                { orderID }: ApproveCallbackPayload,
+                actions: ApproveCallbackActions,
+            ) => {
+                const orderDetails = await actions.order.get();
+                const billingAddress = this.mapOrderDetailsToBillingAddress(orderDetails);
+
+                await this.paypalCommerceHeadlessWalletButtonService.addBillingAddress(
+                    cartId,
+                    billingAddress,
+                );
+                await this.paypalCommerceHeadlessWalletButtonService.proxyTokenizationPayment(
+                    cartId,
+                    orderID,
+                );
+            },
+        };
+
+        const buttonRenderOptions: PayPalCommerceButtonsOptions = {
+            fundingSource: paypalSdk.FUNDING.PAYPAL,
+            style: this.paypalCommerceHeadlessWalletButtonService.getValidButtonStyle(),
+            ...defaultCallbacks,
+        };
+
+        const paypalButton = paypalSdk.Buttons(buttonRenderOptions);
+
+        if (paypalButton.isEligible()) {
+            paypalButton.render(`#${containerId}`);
+        } else {
+            this.paypalCommerceHeadlessWalletButtonService.removeElement(containerId);
+        }
+    }
+
+    private mapOrderDetailsToBillingAddress(orderDetails: PayPalOrderDetails): AddressRequestBody {
+        const { payer } = orderDetails;
+
+        return {
+            firstName: payer.name.given_name,
+            lastName: payer.name.surname,
+            company: '',
+            address1: payer.address.address_line_1,
+            address2: payer.address.address_line_2,
+            city: payer.address.admin_area_2,
+            email: payer.email_address,
+            stateOrProvince: payer.address.admin_area_1 ?? '',
+            stateOrProvinceCode: payer.address.admin_area_1 ?? '',
+            countryCode: payer.address.country_code,
+            postalCode: payer.address.postal_code,
+            phone: payer.phone?.phone_number.national_number ?? '',
+            shouldSaveAddress: false,
+        };
     }
 }

--- a/packages/wallet-button-integration/src/index.ts
+++ b/packages/wallet-button-integration/src/index.ts
@@ -1,4 +1,9 @@
 export { default as createWalletButtonIntegrationService } from './create-wallet-button-integration-service';
 export { default as WalletButtonIntegrationService } from './wallet-button-integration-service';
 export { default as WalletPaymentButtonStrategyFactory } from './wallet-button-factory';
+export {
+    AddressRequestBody,
+    BillingAddressResponse,
+    BillingAddressUpdateRequestBody,
+} from './billing/billing-address';
 export { GraphQLRequestOptions } from './graphql-request-options';


### PR DESCRIPTION
## What/Why?
Add PayPalCommerce button for Wallet buttons tool
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
Unit
Manual

[screen-capture (2).webm](https://github.com/user-attachments/assets/a3087acd-ff99-4873-94e8-c03066ab1a9c)

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout payment flow, billing data from PayPal, and full-page redirect to external checkout; scoped to wallet buttons with unit test coverage.
> 
> **Overview**
> Replaces the **stub** `PaypalCommerceWalletStrategy` with a working PayPal Commerce wallet button for the Wallet Buttons tool (`paypalcommercepaypal`).
> 
> **`PaypalCommerceWalletService`** centralizes PayPal SDK loading, GraphQL **payment order intent**, **billing address** updates, **external checkout redirect** after approval, and button **style** validation. The strategy factory now composes this service with `PayPalCommerceScriptLoader` instead of injecting `WalletButtonIntegrationService` directly.
> 
> On **initialize**, the strategy validates options, decodes `initializationData`, loads the SDK, and renders PayPal **Buttons** with `createOrder` → intent and **onApprove** → map payer details to billing, then proxy tokenization via redirect. Wallet init options gain **`cartId`**, **`currency`**, and **`clientToken`**. **`wallet-button-integration`** re-exports billing address types for consumers.
> 
> Unit specs cover the service and strategy flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bd9370651770d01f9d4fe4b1565601c8e836145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->