### PR TITLE
fix(checkout): CHECKOUT-10222 Update InternalOrder Interface

### DIFF
--- a/packages/core/src/order/index.ts
+++ b/packages/core/src/order/index.ts
@@ -6,6 +6,7 @@ export { B2BContext } from './b2b-context';
 export {
     default as InternalOrder,
     InternalIncompleteOrder,
+    InternalOrderB2BMetadata,
     InternalOrderPayment,
 } from './internal-order';
 export { default as InternalOrderRequestBody } from './internal-order-request-body';

--- a/packages/core/src/order/internal-order-responses.ts
+++ b/packages/core/src/order/internal-order-responses.ts
@@ -1,7 +1,6 @@
 import { InternalResponseBody } from '../common/http-request';
 import { InternalCustomer } from '../customer';
 
-import { B2BContext } from './b2b-context';
 import InternalOrder from './internal-order';
 
 export type InternalOrderResponseBody = InternalResponseBody<
@@ -10,7 +9,6 @@ export type InternalOrderResponseBody = InternalResponseBody<
 >;
 
 export interface InternalOrderResponseData {
-    b2bContext?: B2BContext;
     customer: InternalCustomer;
     order: InternalOrder;
 }

--- a/packages/core/src/order/internal-order.ts
+++ b/packages/core/src/order/internal-order.ts
@@ -52,6 +52,12 @@ export default interface InternalOrder {
     isDownloadable: boolean;
     isComplete: boolean;
     callbackUrl?: string;
+    b2bMetadata?: InternalOrderB2BMetadata;
+}
+
+export interface InternalOrderB2BMetadata {
+    shippingAddressId: number | null;
+    billingAddressId: number | null;
 }
 
 export interface InternalIncompleteOrder {

--- a/packages/core/src/order/order-reducer.spec.ts
+++ b/packages/core/src/order/order-reducer.spec.ts
@@ -100,7 +100,7 @@ describe('orderReducer()', () => {
     it('stores B2B context in meta if it is submitted successfully', () => {
         const response = getSubmitOrderResponseBody();
         const headers = getSubmitOrderResponseHeaders();
-        const b2bContext = { billingAddressId: 1, shippingAddressId: 2 };
+        const b2bMetadata = { billingAddressId: 1, shippingAddressId: 2 };
         const action: SubmitOrderAction = {
             type: OrderActionType.SubmitOrderSucceeded,
             meta: {
@@ -109,13 +109,18 @@ describe('orderReducer()', () => {
             },
             payload: {
                 ...response.data,
-                b2bContext,
+                order: {
+                    ...response.data.order,
+                    b2bMetadata,
+                },
             },
         };
 
         expect(orderReducer(initialState, action)).toEqual(
             expect.objectContaining({
-                meta: expect.objectContaining({ b2bContext }),
+                meta: expect.objectContaining({
+                    b2bContext: { billingAddressId: 1, shippingAddressId: 2 },
+                }),
             }),
         );
     });

--- a/packages/core/src/order/order-reducer.ts
+++ b/packages/core/src/order/order-reducer.ts
@@ -4,6 +4,8 @@ import { omit } from 'lodash';
 import { clearErrorReducer } from '../common/error';
 import { objectMerge, objectSet } from '../common/utility';
 
+import { B2BContext } from './b2b-context';
+import InternalOrder from './internal-order';
 import { OrderAction, OrderActionType } from './order-actions';
 import OrderState, {
     DEFAULT_STATE,
@@ -59,12 +61,25 @@ function metaReducer(
                     payment: action.payload && action.payload.order && action.payload.order.payment,
                 }),
                 'b2bContext',
-                action.payload?.b2bContext,
+                mapToB2BContext(action.payload?.order),
             );
 
         default:
             return meta;
     }
+}
+
+function mapToB2BContext(order?: InternalOrder): B2BContext | undefined {
+    if (!order?.b2bMetadata) {
+        return undefined;
+    }
+
+    const { billingAddressId, shippingAddressId } = order.b2bMetadata;
+
+    return {
+        billingAddressId: billingAddressId ?? undefined,
+        shippingAddressId: shippingAddressId ?? undefined,
+    };
 }
 
 function errorsReducer(


### PR DESCRIPTION
## What/Why?

Update `InternalOrder` Interface to correctly save `shippingAddressId` and `billingAddressId`.

## Rollout/Rollback

Revert.

## Testing
### Manual Testing (CFF needs to be removed)
1. Getting ids from the order endpoint.
<img width="1363" height="898" alt="Screenshot 2026-07-16 at 14 13 02" src="https://github.com/user-attachments/assets/cb42cc1f-6e60-4e98-9062-13f855765e1b" />

2. Submit ids to the B2B API.
<img width="1363" height="898" alt="Screenshot 2026-07-16 at 14 13 23" src="https://github.com/user-attachments/assets/c0cacd4c-35d8-4b7f-a36b-11a3298e192a" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout order state and B2B address ID persistence; wrong mapping could break B2B billing/shipping selection after submit.
> 
> **Overview**
> B2B **billing** and **shipping** address IDs are now modeled on **`InternalOrder`** as optional **`b2bMetadata`** (`shippingAddressId` / `billingAddressId`, nullable) instead of a separate **`b2bContext`** field on the submit-order response payload.
> 
> On **submit/finalize success**, **`order-reducer`** derives **`meta.b2bContext`** from **`order.b2bMetadata`** via **`mapToB2BContext`** (nulls become omitted optional fields), so selectors and existing meta shape stay the same while the action payload matches the API. **`InternalOrderResponseData`** no longer declares **`b2bContext`**; tests put **`b2bMetadata`** on the nested **order**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b6199fde09508b8de9d41a05350ca69ec2bdab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->