### PR TITLE
fix(checkout): CHECKOUT-10249 Enable B2C Quote Flow

### DIFF
--- a/packages/core/src/payment/b2b-payments-refresh-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-action-creator.spec.ts
@@ -6,6 +6,7 @@ import { CheckoutStore, createCheckoutStore } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 import { getConfig } from '../config/configs.mock';
+import { getGuestCustomer } from '../customer/customers.mock';
 
 import B2BPaymentsRefreshActionCreator from './b2b-payments-refresh-action-creator';
 import { B2BPaymentsRefreshActionType } from './b2b-payments-refresh-actions';
@@ -151,6 +152,38 @@ describe('B2BPaymentsRefreshActionCreator', () => {
             });
 
             expect(() => actionCreator.refreshB2BPaymentMethods()(store)).toThrow();
+        });
+
+        it('refreshes without a token when the customer is a guest', async () => {
+            store = createCheckoutStore({
+                ...getCheckoutStoreState(),
+                customer: { data: getGuestCustomer(), errors: {}, statuses: {} },
+                paymentMethods: {
+                    data: paymentMethods,
+                    errors: {},
+                    statuses: {},
+                },
+            });
+
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
+
+            const actions = await from(actionCreator.refreshB2BPaymentMethods()(store))
+                .pipe(toArray())
+                .toPromise();
+
+            expect(requestSender.refresh).toHaveBeenCalledWith(
+                expect.any(Array),
+                undefined,
+                b2bApiSettings.baseUrl,
+                undefined,
+            );
+            expect(actions).toEqual([
+                { type: B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsRequested },
+                { type: B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsSucceeded },
+            ]);
         });
 
         it('throws when the b2b base url is missing', () => {

--- a/packages/core/src/payment/b2b-payments-refresh-action-creator.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-action-creator.ts
@@ -25,11 +25,12 @@ export default class B2BPaymentsRefreshActionCreator {
             const state = store.getState();
             const paymentMethods = state.paymentMethods.getPaymentMethods() ?? [];
             const b2bToken = state.b2bToken.getToken();
+            const isGuest = state.customer.getCustomer()?.isGuest ?? false;
             const b2bBaseUrl = resolveB2bBaseUrl(
                 state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
             );
 
-            if (!b2bToken || !b2bBaseUrl) {
+            if (!b2bBaseUrl || (!b2bToken && !isGuest)) {
                 throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
             }
 

--- a/packages/core/src/payment/b2b-payments-refresh-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-request-sender.spec.ts
@@ -44,6 +44,26 @@ describe('B2BPaymentsRefreshRequestSender', () => {
             );
         });
 
+        it('posts without auth headers when no token is provided', async () => {
+            await b2bPaymentsRefreshRequestSender.refresh(
+                payments,
+                undefined,
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/payments/refresh',
+                {
+                    timeout: undefined,
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: { payments },
+                },
+            );
+        });
+
         it('forwards the request timeout', async () => {
             const timeout = createTimeout();
 

--- a/packages/core/src/payment/b2b-payments-refresh-request-sender.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-request-sender.ts
@@ -12,7 +12,7 @@ export default class B2BPaymentsRefreshRequestSender {
 
     async refresh(
         payments: B2BPaymentsRefreshPayment[],
-        b2bToken: string,
+        b2bToken: string | undefined,
         b2bBaseUrl: string,
         options?: RequestOptions,
     ): Promise<Response<unknown>> {
@@ -21,8 +21,7 @@ export default class B2BPaymentsRefreshRequestSender {
             credentials: false,
             headers: {
                 'Content-Type': 'application/json',
-                authToken: b2bToken,
-                Authorization: `Bearer ${b2bToken}`,
+                ...(b2bToken ? { authToken: b2bToken, Authorization: `Bearer ${b2bToken}` } : {}),
             },
             body: { payments },
         });

--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -7,6 +7,7 @@ import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../checko
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 import { getCapabilities } from '../config/capabilities.mock';
 import { getConfig } from '../config/configs.mock';
+import { getGuestCustomer } from '../customer/customers.mock';
 import { getConsignmentsState } from '../shipping/consignments.mock';
 import { getShippingOption } from '../shipping/shipping-options.mock';
 
@@ -328,6 +329,40 @@ describe('B2BPostOrderActionCreator', () => {
                 await from(actionCreator.persistB2BMetadata(invoiceOptions)(store)).toPromise();
 
                 expect(requestSender.submitQuote).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('guest quote-to-checkout flow', () => {
+            beforeEach(() => {
+                store = createCheckoutStore({
+                    ...getCheckoutStoreStateWithOrder(),
+                    customer: { data: getGuestCustomer(), errors: {}, statuses: {} },
+                });
+
+                mockStoreConfig({ id: 941 });
+            });
+
+            it('submits the quote without a token and skips submitOrderExtraFields', async () => {
+                const actions = await from(
+                    actionCreator.persistB2BMetadata(nonInvoiceOptions)(store),
+                )
+                    .pipe(toArray())
+                    .toPromise();
+
+                expect(requestSender.submitOrderExtraFields).not.toHaveBeenCalled();
+                expect(requestSender.submitQuote).toHaveBeenCalledWith(
+                    941,
+                    expect.objectContaining({ orderId: 295 }),
+                    undefined,
+                    b2bApiSettings.baseUrl,
+                );
+                expect(actions).toEqual([
+                    { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                    {
+                        type: B2BPostOrderActionType.PersistB2BMetadataSucceeded,
+                        payload: { receiptId: '' },
+                    },
+                ]);
             });
         });
     });

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -68,13 +68,14 @@ export default class B2BPostOrderActionCreator {
             const state = store.getState();
             const orderId = state.order.getOrderOrThrow().orderId;
             const b2bToken = state.b2bToken.getToken();
+            const isGuest = state.customer.getCustomer()?.isGuest ?? false;
             const b2bBaseUrl = resolveB2bBaseUrl(
                 state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
             );
             const storeConfig = state.config.getStoreConfig();
             const quoteId = storeConfig?.checkoutSettings.capabilities?.userJourney.quoteConfig?.id;
 
-            if (!orderId || !b2bToken || !b2bBaseUrl) {
+            if (!orderId || !b2bBaseUrl || (!b2bToken && !isGuest)) {
                 throw new MissingDataError(MissingDataErrorType.MissingOrder);
             }
 
@@ -84,6 +85,10 @@ export default class B2BPostOrderActionCreator {
                     let payload = { receiptId: '' };
 
                     if (isInvoice) {
+                        if (!b2bToken) {
+                            throw new MissingDataError(MissingDataErrorType.MissingOrder);
+                        }
+
                         const { body } = await this._requestSender.submitInvoice(
                             { orderId: `${orderId}`, comment: invoiceComment ?? '' },
                             b2bToken,
@@ -92,17 +97,19 @@ export default class B2BPostOrderActionCreator {
 
                         payload = { receiptId: body.data.receiptId };
                     } else {
-                        await this._requestSender.submitOrderExtraFields(
-                            {
-                                orderId,
-                                poNumber: poNumber ?? '',
-                                referenceNumber: referenceNumber ?? '',
-                                extraFields: extraFields ?? [],
-                                extraInfo: extraInfo ?? {},
-                            },
-                            b2bToken,
-                            b2bBaseUrl,
-                        );
+                        if (b2bToken) {
+                            await this._requestSender.submitOrderExtraFields(
+                                {
+                                    orderId,
+                                    poNumber: poNumber ?? '',
+                                    referenceNumber: referenceNumber ?? '',
+                                    extraFields: extraFields ?? [],
+                                    extraInfo: extraInfo ?? {},
+                                },
+                                b2bToken,
+                                b2bBaseUrl,
+                            );
+                        }
 
                         if (typeof quoteId === 'number') {
                             const checkout = state.checkout.getCheckoutOrThrow();

--- a/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
@@ -171,6 +171,26 @@ describe('B2BPostOrderRequestSender', () => {
             );
         });
 
+        it('posts without auth headers when no token is provided', async () => {
+            await b2bPostOrderRequestSender.submitQuote(
+                123,
+                submitQuotePayload,
+                undefined,
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/rfq/123/ordered',
+                {
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: submitQuotePayload,
+                },
+            );
+        });
+
         it('rejects when the request sender rejects', async () => {
             jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
 

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -81,15 +81,14 @@ export default class B2BPostOrderRequestSender {
     async submitQuote(
         quoteId: number,
         payload: QuoteOrderedPayload,
-        b2bToken: string,
+        b2bToken: string | undefined,
         b2bBaseUrl: string,
     ): Promise<Response<void>> {
         return this._requestSender.post(`${b2bBaseUrl}/api/v2/rfq/${quoteId}/ordered`, {
             credentials: false,
             headers: {
                 'Content-Type': 'application/json',
-                authToken: b2bToken,
-                Authorization: `Bearer ${b2bToken}`,
+                ...(b2bToken ? { authToken: b2bToken, Authorization: `Bearer ${b2bToken}` } : {}),
             },
             body: payload,
         });


### PR DESCRIPTION
Jira: [CHECKOUT-10249](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10249)

## What/Why?

This PR mirrors the b2b-checkout-app to enable b2c quote flow, which:
- refreshes payment methods without a token when the customer is a guest.
- submits the quote without a token and skips submitOrderExtraFields.
- submits post-order sync without auth headers when no token is provided.

Changes on `checkout-js` side will be created when bumping this SDK version.

## Rollout/Rollback

No feature flag; the new behaviour only activates for guest sessions (`customer.isGuest`), which previously always failed. Rollback is a straight revert.

## Testing
### Manual testing

#### Open quote
<img width="1158" height="121" alt="Screenshot 2026-07-21 at 11 37 46" src="https://github.com/user-attachments/assets/977aa599-d377-4549-b08f-d40325fe3522" />


#### Ordered quote
<img width="1158" height="121" alt="Screenshot 2026-07-21 at 11 39 24" src="https://github.com/user-attachments/assets/aefb9f54-64b9-477a-ae59-b392e05f6706" />


#### Finishing payment

https://github.com/user-attachments/assets/b41eec10-19e2-4b25-b1be-833cb00b7471


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-checkout B2B API calls and auth gating; invoice paths still require a token, but tokenless guest quote/payment refresh depends on backend accepting unauthenticated requests.
> 
> **Overview**
> Enables **guest (B2C) quote checkout** to use the same B2B API paths as logged-in B2B users, but **without requiring a B2B auth token** when `customer.isGuest` is true.
> 
> **Payment refresh:** `refreshB2BPaymentMethods` no longer throws on a missing token for guests; it still requires a B2B base URL. `B2BPaymentsRefreshRequestSender.refresh` accepts an optional token and only sends `authToken` / `Authorization` when a token is present.
> 
> **Post-order / quote ordered:** `persistB2BMetadata` allows missing tokens for guests (still requires order id and base URL). **Invoice** flow still **requires** a token. For non-invoice flows, `submitOrderExtraFields` runs only when a token exists; **quote “ordered”** (`submitQuote`) can run for guests with `undefined` token. `submitQuote` on the request sender mirrors optional auth headers.
> 
> Specs cover guest refresh, tokenless POSTs, and guest quote-to-checkout (skips extra fields, submits quote without token).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc84831caa4189d7978eb7b9f3ce786b84a3c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[CHECKOUT-10249]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ