### PR TITLE
feat(checkout): CHECKOUT-10067 update cart interface

### DIFF
--- a/packages/core/src/cart/cart.ts
+++ b/packages/core/src/cart/cart.ts
@@ -10,6 +10,7 @@ export default interface Cart {
     id: string;
     customerId: number;
     companyId: number | null;
+    companyName: string | null;
     currency: Currency;
     email: string;
     isTaxIncluded: boolean;

--- a/packages/core/src/cart/carts.mock.ts
+++ b/packages/core/src/cart/carts.mock.ts
@@ -11,6 +11,7 @@ export function getCart(): Cart {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         customerId: 4,
         companyId: null,
+        companyName: null,
         currency: getCurrency(),
         email: 'foo@bar.com',
         isTaxIncluded: false,

--- a/packages/payment-integration-api/src/cart/cart.ts
+++ b/packages/payment-integration-api/src/cart/cart.ts
@@ -9,6 +9,7 @@ export default interface Cart {
     id: string;
     customerId: number;
     companyId: number | null;
+    companyName: string | null;
     currency: Currency;
     email: string;
     isTaxIncluded: boolean;

--- a/packages/payment-integration-api/src/mocks/carts.mock.ts
+++ b/packages/payment-integration-api/src/mocks/carts.mock.ts
@@ -15,6 +15,7 @@ export default function getCart(): Cart {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         customerId: 4,
         companyId: null,
+        companyName: null,
         currency: getCurrency(),
         email: 'foo@bar.com',
         isTaxIncluded: false,

--- a/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
@@ -15,6 +15,7 @@ export default function getCart(): Cart {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         customerId: 4,
         companyId: null,
+        companyName: null,
         currency: getCurrency(),
         email: 'foo@bar.com',
         isTaxIncluded: false,


### PR DESCRIPTION
## What/Why?

Update cart interface to include companyName

## Rollout/Rollback

Revert this PR.

## Testing

CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and mock updates with no runtime logic; consumers must supply companyName where they build Cart objects, but nullable default limits breakage.
> 
> **Overview**
> Adds **`companyName: string | null`** to the shared **`Cart`** type so checkout can carry B2B company display name alongside existing **`companyId`**.
> 
> The field is added on **`Cart`** in **`packages/core`** and **`packages/payment-integration-api`**, with **`getCart()`** mocks in core, payment-integration-api, and payment-integrations-test-utils defaulting **`companyName`** to **`null`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f6432f9aa5bd6e28f719665c6a01e9fd99bc985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->