### PR TITLE
fix(checkout): CHECKOUT-10249 Add Fallback B2B Token

### DIFF
--- a/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.spec.ts
@@ -18,6 +18,10 @@ describe('B2BTokenActionCreator', () => {
     let actionCreator: B2BTokenActionCreator;
 
     const b2bResponse = getResponse({ code: 200, data: { token: 'b2b-auth-token' } });
+    const b2bApiSettings = {
+        clientId: '123456',
+        baseUrl: 'https://api-b2b.bigcommerce.com',
+    };
 
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreState());
@@ -25,9 +29,10 @@ describe('B2BTokenActionCreator', () => {
 
         jest.spyOn(requestSender, 'getB2BToken').mockResolvedValue(b2bResponse);
 
-        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
-            getConfig().storeConfig,
-        );
+        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue({
+            ...getConfig().storeConfig,
+            b2bApiSettings,
+        });
         jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue(getCustomer());
         jest.spyOn(store.getState().checkout, 'getCheckoutOrThrow').mockReturnValue(getCheckout());
 
@@ -52,15 +57,6 @@ describe('B2BTokenActionCreator', () => {
         it('calls getB2BToken with b2bApiSettings from initial state', async () => {
             const customer = getCustomer();
             const checkout = getCheckout();
-            const b2bApiSettings = {
-                clientId: 'dl7c39mdpul6hyc489yk0vzxl6jesyx',
-                baseUrl: 'https://api-b2b.bigcommerce.com',
-            };
-
-            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue({
-                ...getConfig().storeConfig,
-                b2bApiSettings,
-            });
 
             await from(actionCreator.loadB2BToken()(store)).toPromise();
 
@@ -72,6 +68,14 @@ describe('B2BTokenActionCreator', () => {
                 b2bApiSettings.baseUrl,
                 undefined,
             );
+        });
+
+        it('throws when the b2b api settings are missing', () => {
+            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
+                getConfig().storeConfig,
+            );
+
+            expect(() => actionCreator.loadB2BToken()(store)).toThrow();
         });
 
         it('emits error actions if getB2BToken fails', async () => {

--- a/packages/core/src/b2b-token/b2b-token-action-creator.ts
+++ b/packages/core/src/b2b-token/b2b-token-action-creator.ts
@@ -6,6 +6,7 @@ import { catchError } from 'rxjs/operators';
 import { resolveB2bAppClientId, resolveB2bBaseUrl } from '../b2b-dev-tools';
 import { InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 
 import { B2BTokenActionType, LoadB2BTokenAction } from './b2b-token-actions';
@@ -25,6 +26,11 @@ export default class B2BTokenActionCreator {
             const { baseUrl = '', clientId = '' } = storeConfig.b2bApiSettings ?? {};
             const b2bClientId = resolveB2bAppClientId(clientId);
             const b2bBaseUrl = resolveB2bBaseUrl(baseUrl);
+
+            if (!b2bBaseUrl || !b2bClientId) {
+                throw new MissingDataError(MissingDataErrorType.MissingB2BConfig);
+            }
+
             const { id: customerId } = state.customer.getCustomerOrThrow();
             const { channelId } = state.checkout.getCheckoutOrThrow();
 

--- a/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.spec.ts
@@ -23,6 +23,20 @@ describe('B2BTokenRequestSender', () => {
         b2bTokenRequestSender = new B2BTokenRequestSender(requestSender);
     });
 
+    describe('#getCurrentCustomerJWT()', () => {
+        it('fetches the current customer JWT with the app client id and returns the token', async () => {
+            const token = await b2bTokenRequestSender.getCurrentCustomerJWT('my-client-id');
+
+            expect(requestSender.get).toHaveBeenCalledWith('/customer/current.jwt', {
+                params: { app_client_id: 'my-client-id' },
+                headers: SDK_VERSION_HEADERS,
+                timeout: undefined,
+            });
+
+            expect(token).toBe(jwtToken);
+        });
+    });
+
     describe('#getB2BToken()', () => {
         it('fetches BC JWT then exchanges it for a B2B token', async () => {
             await b2bTokenRequestSender.getB2BToken(

--- a/packages/core/src/b2b-token/b2b-token-request-sender.ts
+++ b/packages/core/src/b2b-token/b2b-token-request-sender.ts
@@ -12,6 +12,16 @@ export interface B2BTokenResponseBody {
 export default class B2BTokenRequestSender {
     constructor(private _requestSender: RequestSender) {}
 
+    async getCurrentCustomerJWT(appClientId: string, options?: RequestOptions): Promise<string> {
+        const { body } = await this._requestSender.get<{ token: string }>('/customer/current.jwt', {
+            timeout: options?.timeout,
+            params: { app_client_id: appClientId },
+            headers: SDK_VERSION_HEADERS,
+        });
+
+        return body.token;
+    }
+
     async getB2BToken(
         appClientId: string,
         customerId: number,
@@ -20,21 +30,14 @@ export default class B2BTokenRequestSender {
         b2bBaseUrl: string,
         options?: RequestOptions,
     ): Promise<Response<B2BTokenResponseBody>> {
-        const { body: jwtBody } = await this._requestSender.get<{ token: string }>(
-            '/customer/current.jwt',
-            {
-                timeout: options?.timeout,
-                params: { app_client_id: appClientId },
-                headers: SDK_VERSION_HEADERS,
-            },
-        );
+        const bcToken = await this.getCurrentCustomerJWT(appClientId, options);
 
         return this._requestSender.post(`${b2bBaseUrl}/api/v2/login`, {
             timeout: options?.timeout,
             credentials: false,
             headers: { 'Content-Type': 'application/json' },
             body: {
-                bcToken: jwtBody.token,
+                bcToken,
                 customerId,
                 storeHash,
                 channelId,

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -413,6 +413,7 @@ describe('CheckoutService', () => {
 
         b2bPaymentsRefreshActionCreator = new B2BPaymentsRefreshActionCreator(
             b2bPaymentsRefreshRequestSender,
+            new B2BTokenRequestSender(requestSender),
         );
 
         b2bPostOrderRequestSender = new B2BPostOrderRequestSender(requestSender);
@@ -421,7 +422,10 @@ describe('CheckoutService', () => {
             getResponse({ data: { paymentId: 'pay_1', receiptId: 'rcpt_1' }, code: 200 }),
         );
 
-        b2bPostOrderActionCreator = new B2BPostOrderActionCreator(b2bPostOrderRequestSender);
+        b2bPostOrderActionCreator = new B2BPostOrderActionCreator(
+            b2bPostOrderRequestSender,
+            new B2BTokenRequestSender(requestSender),
+        );
 
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             paymentStrategyRegistry,

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -234,8 +234,14 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         formFieldsActionCreator,
         extensionActionCreator,
         workerExtensionMessenger,
-        new B2BPaymentsRefreshActionCreator(new B2BPaymentsRefreshRequestSender(requestSender)),
-        new B2BPostOrderActionCreator(new B2BPostOrderRequestSender(requestSender)),
+        new B2BPaymentsRefreshActionCreator(
+            new B2BPaymentsRefreshRequestSender(requestSender),
+            new B2BTokenRequestSender(requestSender),
+        ),
+        new B2BPostOrderActionCreator(
+            new B2BPostOrderRequestSender(requestSender),
+            new B2BTokenRequestSender(requestSender),
+        ),
     );
 }
 

--- a/packages/core/src/common/error/errors/missing-data-error.ts
+++ b/packages/core/src/common/error/errors/missing-data-error.ts
@@ -1,6 +1,7 @@
 import StandardError from './standard-error';
 
 export enum MissingDataErrorType {
+    MissingB2BConfig,
     MissingBillingAddress,
     MissingCart,
     MissingCheckout,
@@ -37,6 +38,9 @@ export default class MissingDataError extends StandardError {
 
 function getErrorMessage(type: MissingDataErrorType): string {
     switch (type) {
+        case MissingDataErrorType.MissingB2BConfig:
+            return 'Unable to proceed because B2B configuration is unavailable.';
+
         case MissingDataErrorType.MissingBillingAddress:
             return 'Unable to proceed because billing address data is unavailable.';
 

--- a/packages/core/src/payment/b2b-auth-headers.ts
+++ b/packages/core/src/payment/b2b-auth-headers.ts
@@ -1,0 +1,19 @@
+export interface B2BAuthTokens {
+    b2bToken?: string;
+    bcToken?: string;
+}
+
+export function getB2BAuthHeaders({ b2bToken, bcToken }: B2BAuthTokens): {
+    authToken?: string;
+    Authorization?: string;
+} {
+    if (b2bToken) {
+        return { authToken: b2bToken, Authorization: `Bearer ${b2bToken}` };
+    }
+
+    if (bcToken) {
+        return { authToken: bcToken };
+    }
+
+    return {};
+}

--- a/packages/core/src/payment/b2b-payments-refresh-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-action-creator.spec.ts
@@ -2,6 +2,7 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
+import { B2BTokenRequestSender } from '../b2b-token';
 import { CheckoutStore, createCheckoutStore } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
@@ -16,6 +17,7 @@ import PaymentMethod from './payment-method';
 describe('B2BPaymentsRefreshActionCreator', () => {
     let store: CheckoutStore;
     let requestSender: B2BPaymentsRefreshRequestSender;
+    let b2bTokenRequestSender: B2BTokenRequestSender;
     let actionCreator: B2BPaymentsRefreshActionCreator;
 
     const b2bApiSettings = {
@@ -66,12 +68,18 @@ describe('B2BPaymentsRefreshActionCreator', () => {
 
         jest.spyOn(requestSender, 'refresh').mockResolvedValue(getResponse({}));
 
+        b2bTokenRequestSender = new B2BTokenRequestSender(createRequestSender());
+
+        jest.spyOn(b2bTokenRequestSender, 'getCurrentCustomerJWT').mockResolvedValue(
+            'bc-jwt-token',
+        );
+
         jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
             ...getConfig().storeConfig,
             b2bApiSettings,
         });
 
-        actionCreator = new B2BPaymentsRefreshActionCreator(requestSender);
+        actionCreator = new B2BPaymentsRefreshActionCreator(requestSender, b2bTokenRequestSender);
     });
 
     describe('#refreshB2BPaymentMethods()', () => {
@@ -95,7 +103,7 @@ describe('B2BPaymentsRefreshActionCreator', () => {
                     { code: 'stripe-card', name: 'stripev3' },
                     { code: 'no-display-no-gateway', name: '' },
                 ],
-                'b2b-auth-token',
+                { b2bToken: 'b2b-auth-token', bcToken: undefined },
                 b2bApiSettings.baseUrl,
                 undefined,
             );
@@ -117,7 +125,7 @@ describe('B2BPaymentsRefreshActionCreator', () => {
 
             expect(requestSender.refresh).toHaveBeenCalledWith(
                 [],
-                'b2b-auth-token',
+                { b2bToken: 'b2b-auth-token', bcToken: undefined },
                 b2bApiSettings.baseUrl,
                 undefined,
             );
@@ -130,28 +138,10 @@ describe('B2BPaymentsRefreshActionCreator', () => {
 
             expect(requestSender.refresh).toHaveBeenCalledWith(
                 expect.any(Array),
-                'b2b-auth-token',
+                { b2bToken: 'b2b-auth-token', bcToken: undefined },
                 b2bApiSettings.baseUrl,
                 options,
             );
-        });
-
-        it('throws when the b2b token is missing', () => {
-            store = createCheckoutStore({
-                ...getCheckoutStoreState(),
-                paymentMethods: {
-                    data: paymentMethods,
-                    errors: {},
-                    statuses: {},
-                },
-            });
-
-            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
-                ...getConfig().storeConfig,
-                b2bApiSettings,
-            });
-
-            expect(() => actionCreator.refreshB2BPaymentMethods()(store)).toThrow();
         });
 
         it('refreshes without a token when the customer is a guest', async () => {
@@ -174,9 +164,10 @@ describe('B2BPaymentsRefreshActionCreator', () => {
                 .pipe(toArray())
                 .toPromise();
 
+            expect(b2bTokenRequestSender.getCurrentCustomerJWT).not.toHaveBeenCalled();
             expect(requestSender.refresh).toHaveBeenCalledWith(
                 expect.any(Array),
-                undefined,
+                { b2bToken: undefined, bcToken: undefined },
                 b2bApiSettings.baseUrl,
                 undefined,
             );
@@ -186,13 +177,32 @@ describe('B2BPaymentsRefreshActionCreator', () => {
             ]);
         });
 
-        it('throws when the b2b base url is missing', () => {
-            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
-                ...getConfig().storeConfig,
-                b2bApiSettings: { ...b2bApiSettings, baseUrl: '' },
+        it('refreshes with a bc token when a signed-in customer has no b2b token', async () => {
+            store = createCheckoutStore({
+                ...getCheckoutStoreState(),
+                paymentMethods: {
+                    data: paymentMethods,
+                    errors: {},
+                    statuses: {},
+                },
             });
 
-            expect(() => actionCreator.refreshB2BPaymentMethods()(store)).toThrow();
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings,
+            });
+
+            await from(actionCreator.refreshB2BPaymentMethods()(store)).toPromise();
+
+            expect(b2bTokenRequestSender.getCurrentCustomerJWT).toHaveBeenCalledWith(
+                b2bApiSettings.clientId,
+            );
+            expect(requestSender.refresh).toHaveBeenCalledWith(
+                expect.any(Array),
+                { b2bToken: undefined, bcToken: 'bc-jwt-token' },
+                b2bApiSettings.baseUrl,
+                undefined,
+            );
         });
 
         it('emits failed action when the request rejects', async () => {

--- a/packages/core/src/payment/b2b-payments-refresh-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-action-creator.spec.ts
@@ -205,6 +205,15 @@ describe('B2BPaymentsRefreshActionCreator', () => {
             );
         });
 
+        it('throws when the b2b base url is missing', () => {
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                b2bApiSettings: { ...b2bApiSettings, baseUrl: '' },
+            });
+
+            expect(() => actionCreator.refreshB2BPaymentMethods()(store)).toThrow();
+        });
+
         it('emits failed action when the request rejects', async () => {
             jest.spyOn(requestSender, 'refresh').mockRejectedValue(getErrorResponse());
 

--- a/packages/core/src/payment/b2b-payments-refresh-action-creator.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-action-creator.ts
@@ -7,6 +7,7 @@ import { resolveB2bAppClientId, resolveB2bBaseUrl } from '../b2b-dev-tools';
 import { B2BTokenRequestSender } from '../b2b-token';
 import { InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 
 import {
@@ -30,6 +31,10 @@ export default class B2BPaymentsRefreshActionCreator {
             const b2bToken = state.b2bToken.getToken();
             const storeConfig = state.config.getStoreConfig();
             const b2bBaseUrl = resolveB2bBaseUrl(storeConfig?.b2bApiSettings?.baseUrl ?? '');
+
+            if (!b2bBaseUrl) {
+                throw new MissingDataError(MissingDataErrorType.MissingB2BConfig);
+            }
 
             const payments = paymentMethods.map((method) => ({
                 code: method.id,

--- a/packages/core/src/payment/b2b-payments-refresh-action-creator.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-action-creator.ts
@@ -3,10 +3,10 @@ import { concat, defer, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 // TODO: CHECKOUT-9979 remove this import before delivery
-import { resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { resolveB2bAppClientId, resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { B2BTokenRequestSender } from '../b2b-token';
 import { InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
-import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 
 import {
@@ -16,7 +16,10 @@ import {
 import B2BPaymentsRefreshRequestSender from './b2b-payments-refresh-request-sender';
 
 export default class B2BPaymentsRefreshActionCreator {
-    constructor(private _requestSender: B2BPaymentsRefreshRequestSender) {}
+    constructor(
+        private _requestSender: B2BPaymentsRefreshRequestSender,
+        private _b2bTokenRequestSender: B2BTokenRequestSender,
+    ) {}
 
     refreshB2BPaymentMethods(
         options?: RequestOptions,
@@ -25,14 +28,8 @@ export default class B2BPaymentsRefreshActionCreator {
             const state = store.getState();
             const paymentMethods = state.paymentMethods.getPaymentMethods() ?? [];
             const b2bToken = state.b2bToken.getToken();
-            const isGuest = state.customer.getCustomer()?.isGuest ?? false;
-            const b2bBaseUrl = resolveB2bBaseUrl(
-                state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
-            );
-
-            if (!b2bBaseUrl || (!b2bToken && !isGuest)) {
-                throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
-            }
+            const storeConfig = state.config.getStoreConfig();
+            const b2bBaseUrl = resolveB2bBaseUrl(storeConfig?.b2bApiSettings?.baseUrl ?? '');
 
             const payments = paymentMethods.map((method) => ({
                 code: method.id,
@@ -42,7 +39,26 @@ export default class B2BPaymentsRefreshActionCreator {
             return concat(
                 of(createAction(B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsRequested)),
                 defer(async () => {
-                    await this._requestSender.refresh(payments, b2bToken, b2bBaseUrl, options);
+                    const isGuest = state.customer.getCustomer()?.isGuest ?? false;
+
+                    let bcToken: string | undefined;
+
+                    if (!b2bToken && !isGuest) {
+                        const b2bClientId = resolveB2bAppClientId(
+                            storeConfig?.b2bApiSettings?.clientId ?? '',
+                        );
+
+                        bcToken = await this._b2bTokenRequestSender.getCurrentCustomerJWT(
+                            b2bClientId,
+                        );
+                    }
+
+                    await this._requestSender.refresh(
+                        payments,
+                        { b2bToken, bcToken },
+                        b2bBaseUrl,
+                        options,
+                    );
 
                     return createAction(
                         B2BPaymentsRefreshActionType.RefreshB2BPaymentMethodsSucceeded,

--- a/packages/core/src/payment/b2b-payments-refresh-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-request-sender.spec.ts
@@ -25,7 +25,7 @@ describe('B2BPaymentsRefreshRequestSender', () => {
         it('posts to the payments refresh endpoint with auth headers and payload', async () => {
             await b2bPaymentsRefreshRequestSender.refresh(
                 payments,
-                'b2b-token-value',
+                { b2bToken: 'b2b-token-value' },
                 'https://api-b2b.bigcommerce.com',
             );
 
@@ -47,7 +47,7 @@ describe('B2BPaymentsRefreshRequestSender', () => {
         it('posts without auth headers when no token is provided', async () => {
             await b2bPaymentsRefreshRequestSender.refresh(
                 payments,
-                undefined,
+                {},
                 'https://api-b2b.bigcommerce.com',
             );
 
@@ -64,12 +64,33 @@ describe('B2BPaymentsRefreshRequestSender', () => {
             );
         });
 
+        it('posts with only the authToken header when a bc token is provided', async () => {
+            await b2bPaymentsRefreshRequestSender.refresh(
+                payments,
+                { bcToken: 'bc-jwt-token' },
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/payments/refresh',
+                {
+                    timeout: undefined,
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'bc-jwt-token',
+                    },
+                    body: { payments },
+                },
+            );
+        });
+
         it('forwards the request timeout', async () => {
             const timeout = createTimeout();
 
             await b2bPaymentsRefreshRequestSender.refresh(
                 payments,
-                'b2b-token-value',
+                { b2bToken: 'b2b-token-value' },
                 'https://api-b2b.bigcommerce.com',
                 { timeout },
             );
@@ -83,7 +104,7 @@ describe('B2BPaymentsRefreshRequestSender', () => {
         it('uses the provided b2bBaseUrl for the endpoint', async () => {
             await b2bPaymentsRefreshRequestSender.refresh(
                 payments,
-                'b2b-token-value',
+                { b2bToken: 'b2b-token-value' },
                 'https://api-b2b.staging.zone',
             );
 
@@ -96,7 +117,7 @@ describe('B2BPaymentsRefreshRequestSender', () => {
         it('sends an empty payments array when given one', async () => {
             await b2bPaymentsRefreshRequestSender.refresh(
                 [],
-                'b2b-token-value',
+                { b2bToken: 'b2b-token-value' },
                 'https://api-b2b.bigcommerce.com',
             );
 
@@ -112,7 +133,7 @@ describe('B2BPaymentsRefreshRequestSender', () => {
             await expect(
                 b2bPaymentsRefreshRequestSender.refresh(
                     payments,
-                    'b2b-token-value',
+                    { b2bToken: 'b2b-token-value' },
                     'https://api-b2b.bigcommerce.com',
                 ),
             ).rejects.toEqual(getErrorResponse());

--- a/packages/core/src/payment/b2b-payments-refresh-request-sender.ts
+++ b/packages/core/src/payment/b2b-payments-refresh-request-sender.ts
@@ -2,6 +2,8 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions } from '../common/http-request';
 
+import { B2BAuthTokens, getB2BAuthHeaders } from './b2b-auth-headers';
+
 export interface B2BPaymentsRefreshPayment {
     code: string;
     name: string;
@@ -12,7 +14,7 @@ export default class B2BPaymentsRefreshRequestSender {
 
     async refresh(
         payments: B2BPaymentsRefreshPayment[],
-        b2bToken: string | undefined,
+        auth: B2BAuthTokens,
         b2bBaseUrl: string,
         options?: RequestOptions,
     ): Promise<Response<unknown>> {
@@ -21,7 +23,7 @@ export default class B2BPaymentsRefreshRequestSender {
             credentials: false,
             headers: {
                 'Content-Type': 'application/json',
-                ...(b2bToken ? { authToken: b2bToken, Authorization: `Bearer ${b2bToken}` } : {}),
+                ...getB2BAuthHeaders(auth),
             },
             body: { payments },
         });

--- a/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.spec.ts
@@ -2,6 +2,7 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
+import { B2BTokenRequestSender } from '../b2b-token';
 import { CheckoutStore, createCheckoutStore } from '../checkout';
 import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
@@ -18,6 +19,7 @@ import B2BPostOrderRequestSender from './b2b-post-order-request-sender';
 describe('B2BPostOrderActionCreator', () => {
     let store: CheckoutStore;
     let requestSender: B2BPostOrderRequestSender;
+    let b2bTokenRequestSender: B2BTokenRequestSender;
     let actionCreator: B2BPostOrderActionCreator;
 
     const comment = 'Invoice comment';
@@ -61,9 +63,15 @@ describe('B2BPostOrderActionCreator', () => {
 
         jest.spyOn(requestSender, 'submitQuote').mockResolvedValue(getResponse(undefined));
 
+        b2bTokenRequestSender = new B2BTokenRequestSender(createRequestSender());
+
+        jest.spyOn(b2bTokenRequestSender, 'getCurrentCustomerJWT').mockResolvedValue(
+            'bc-jwt-token',
+        );
+
         mockStoreConfig();
 
-        actionCreator = new B2BPostOrderActionCreator(requestSender);
+        actionCreator = new B2BPostOrderActionCreator(requestSender, b2bTokenRequestSender);
     });
 
     describe('#persistB2BMetadata()', () => {
@@ -164,7 +172,7 @@ describe('B2BPostOrderActionCreator', () => {
             expect(() => actionCreator.persistB2BMetadata(invoiceOptions)(store)).toThrow();
         });
 
-        it('throws when the b2b token is missing', () => {
+        it('emits failed action when the b2b token is missing in the invoice flow', async () => {
             store = createCheckoutStore(getCheckoutStoreStateWithOrder());
 
             jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
@@ -172,7 +180,19 @@ describe('B2BPostOrderActionCreator', () => {
                 b2bApiSettings,
             });
 
-            expect(() => actionCreator.persistB2BMetadata(invoiceOptions)(store)).toThrow();
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(actionCreator.persistB2BMetadata(invoiceOptions)(store))
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(requestSender.submitInvoice).not.toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: B2BPostOrderActionType.PersistB2BMetadataRequested },
+                expect.objectContaining({
+                    type: B2BPostOrderActionType.PersistB2BMetadataFailed,
+                    error: true,
+                }),
+            ]);
         });
 
         it('throws when the b2b base url is missing', () => {
@@ -227,7 +247,7 @@ describe('B2BPostOrderActionCreator', () => {
                             lastName: 'Tester',
                         },
                     },
-                    'b2b-auth-token',
+                    { b2bToken: 'b2b-auth-token', bcToken: undefined },
                     b2bApiSettings.baseUrl,
                 );
 
@@ -237,6 +257,24 @@ describe('B2BPostOrderActionCreator', () => {
                     .invocationCallOrder;
 
                 expect(submitQuoteCallOrder).toBeGreaterThan(addOrderCallOrder);
+            });
+
+            it('submits the quote with a bc token when a signed-in customer has no b2b token', async () => {
+                store = createCheckoutStore(getCheckoutStoreStateWithOrder());
+                mockStoreConfig({ id: 941 });
+
+                await from(actionCreator.persistB2BMetadata(nonInvoiceOptions)(store)).toPromise();
+
+                expect(requestSender.submitOrderExtraFields).not.toHaveBeenCalled();
+                expect(b2bTokenRequestSender.getCurrentCustomerJWT).toHaveBeenCalledWith(
+                    b2bApiSettings.clientId,
+                );
+                expect(requestSender.submitQuote).toHaveBeenCalledWith(
+                    941,
+                    expect.objectContaining({ orderId: 295 }),
+                    { b2bToken: undefined, bcToken: 'bc-jwt-token' },
+                    b2bApiSettings.baseUrl,
+                );
             });
 
             it('does not call submitQuote when quoteConfig is null', async () => {
@@ -270,7 +308,7 @@ describe('B2BPostOrderActionCreator', () => {
                         shippingMethod: null,
                         shippingAddress: null,
                     }),
-                    'b2b-auth-token',
+                    { b2bToken: 'b2b-auth-token', bcToken: undefined },
                     b2bApiSettings.baseUrl,
                 );
             });
@@ -350,10 +388,11 @@ describe('B2BPostOrderActionCreator', () => {
                     .toPromise();
 
                 expect(requestSender.submitOrderExtraFields).not.toHaveBeenCalled();
+                expect(b2bTokenRequestSender.getCurrentCustomerJWT).not.toHaveBeenCalled();
                 expect(requestSender.submitQuote).toHaveBeenCalledWith(
                     941,
                     expect.objectContaining({ orderId: 295 }),
-                    undefined,
+                    { b2bToken: undefined, bcToken: undefined },
                     b2bApiSettings.baseUrl,
                 );
                 expect(actions).toEqual([

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -4,7 +4,8 @@ import { catchError } from 'rxjs/operators';
 
 import { Address } from '../address';
 // TODO: CHECKOUT-9979 remove this import before delivery
-import { resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { resolveB2bAppClientId, resolveB2bBaseUrl } from '../b2b-dev-tools';
+import { B2BTokenRequestSender } from '../b2b-token';
 import { Checkout, InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
@@ -51,7 +52,10 @@ function mapToQuoteOrderedPayload(
 }
 
 export default class B2BPostOrderActionCreator {
-    constructor(private _requestSender: B2BPostOrderRequestSender) {}
+    constructor(
+        private _requestSender: B2BPostOrderRequestSender,
+        private _b2bTokenRequestSender: B2BTokenRequestSender,
+    ) {}
 
     persistB2BMetadata({
         isInvoice,
@@ -68,15 +72,18 @@ export default class B2BPostOrderActionCreator {
             const state = store.getState();
             const orderId = state.order.getOrderOrThrow().orderId;
             const b2bToken = state.b2bToken.getToken();
-            const isGuest = state.customer.getCustomer()?.isGuest ?? false;
             const b2bBaseUrl = resolveB2bBaseUrl(
                 state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
             );
             const storeConfig = state.config.getStoreConfig();
             const quoteId = storeConfig?.checkoutSettings.capabilities?.userJourney.quoteConfig?.id;
 
-            if (!orderId || !b2bBaseUrl || (!b2bToken && !isGuest)) {
+            if (!orderId) {
                 throw new MissingDataError(MissingDataErrorType.MissingOrder);
+            }
+
+            if (!b2bBaseUrl) {
+                throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
             }
 
             return concat(
@@ -86,7 +93,7 @@ export default class B2BPostOrderActionCreator {
 
                     if (isInvoice) {
                         if (!b2bToken) {
-                            throw new MissingDataError(MissingDataErrorType.MissingOrder);
+                            throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
                         }
 
                         const { body } = await this._requestSender.submitInvoice(
@@ -113,6 +120,19 @@ export default class B2BPostOrderActionCreator {
 
                         if (typeof quoteId === 'number') {
                             const checkout = state.checkout.getCheckoutOrThrow();
+                            const isGuest = state.customer.getCustomer()?.isGuest ?? false;
+
+                            let bcToken: string | undefined;
+
+                            if (!b2bToken && !isGuest) {
+                                const b2bClientId = resolveB2bAppClientId(
+                                    storeConfig?.b2bApiSettings?.clientId ?? '',
+                                );
+
+                                bcToken = await this._b2bTokenRequestSender.getCurrentCustomerJWT(
+                                    b2bClientId,
+                                );
+                            }
 
                             await this._requestSender.submitQuote(
                                 quoteId,
@@ -121,7 +141,7 @@ export default class B2BPostOrderActionCreator {
                                     orderId,
                                     storeConfig?.storeProfile.storeHash ?? '',
                                 ),
-                                b2bToken,
+                                { b2bToken, bcToken },
                                 b2bBaseUrl,
                             );
                         }

--- a/packages/core/src/payment/b2b-post-order-action-creator.ts
+++ b/packages/core/src/payment/b2b-post-order-action-creator.ts
@@ -83,7 +83,7 @@ export default class B2BPostOrderActionCreator {
             }
 
             if (!b2bBaseUrl) {
-                throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+                throw new MissingDataError(MissingDataErrorType.MissingB2BConfig);
             }
 
             return concat(
@@ -93,7 +93,7 @@ export default class B2BPostOrderActionCreator {
 
                     if (isInvoice) {
                         if (!b2bToken) {
-                            throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+                            throw new MissingDataError(MissingDataErrorType.MissingB2BConfig);
                         }
 
                         const { body } = await this._requestSender.submitInvoice(

--- a/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.spec.ts
@@ -153,7 +153,7 @@ describe('B2BPostOrderRequestSender', () => {
             await b2bPostOrderRequestSender.submitQuote(
                 123,
                 submitQuotePayload,
-                'b2b-token-value',
+                { b2bToken: 'b2b-token-value' },
                 'https://api-b2b.bigcommerce.com',
             );
 
@@ -175,7 +175,7 @@ describe('B2BPostOrderRequestSender', () => {
             await b2bPostOrderRequestSender.submitQuote(
                 123,
                 submitQuotePayload,
-                undefined,
+                {},
                 'https://api-b2b.bigcommerce.com',
             );
 
@@ -191,6 +191,27 @@ describe('B2BPostOrderRequestSender', () => {
             );
         });
 
+        it('posts with only the authToken header when a bc token is provided', async () => {
+            await b2bPostOrderRequestSender.submitQuote(
+                123,
+                submitQuotePayload,
+                { bcToken: 'bc-jwt-token' },
+                'https://api-b2b.bigcommerce.com',
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                'https://api-b2b.bigcommerce.com/api/v2/rfq/123/ordered',
+                {
+                    credentials: false,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        authToken: 'bc-jwt-token',
+                    },
+                    body: submitQuotePayload,
+                },
+            );
+        });
+
         it('rejects when the request sender rejects', async () => {
             jest.spyOn(requestSender, 'post').mockRejectedValue(getErrorResponse());
 
@@ -198,7 +219,7 @@ describe('B2BPostOrderRequestSender', () => {
                 b2bPostOrderRequestSender.submitQuote(
                     123,
                     submitQuotePayload,
-                    'b2b-token-value',
+                    { b2bToken: 'b2b-token-value' },
                     'https://api-b2b.bigcommerce.com',
                 ),
             ).rejects.toEqual(getErrorResponse());

--- a/packages/core/src/payment/b2b-post-order-request-sender.ts
+++ b/packages/core/src/payment/b2b-post-order-request-sender.ts
@@ -3,6 +3,8 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 import { RequestOptions } from '../common/http-request';
 import { ShippingOption } from '../shipping';
 
+import { B2BAuthTokens, getB2BAuthHeaders } from './b2b-auth-headers';
+
 export interface CloseInvoicePayload {
     orderId: string;
     comment: string;
@@ -70,8 +72,7 @@ export default class B2BPostOrderRequestSender {
                 credentials: false,
                 headers: {
                     'Content-Type': 'application/json',
-                    authToken: b2bToken,
-                    Authorization: `Bearer ${b2bToken}`,
+                    ...getB2BAuthHeaders({ b2bToken }),
                 },
                 body: payload,
             },
@@ -81,14 +82,14 @@ export default class B2BPostOrderRequestSender {
     async submitQuote(
         quoteId: number,
         payload: QuoteOrderedPayload,
-        b2bToken: string | undefined,
+        auth: B2BAuthTokens,
         b2bBaseUrl: string,
     ): Promise<Response<void>> {
         return this._requestSender.post(`${b2bBaseUrl}/api/v2/rfq/${quoteId}/ordered`, {
             credentials: false,
             headers: {
                 'Content-Type': 'application/json',
-                ...(b2bToken ? { authToken: b2bToken, Authorization: `Bearer ${b2bToken}` } : {}),
+                ...getB2BAuthHeaders(auth),
             },
             body: payload,
         });
@@ -103,8 +104,7 @@ export default class B2BPostOrderRequestSender {
             credentials: false,
             headers: {
                 'Content-Type': 'application/json',
-                authToken: b2bToken,
-                Authorization: `Bearer ${b2bToken}`,
+                ...getB2BAuthHeaders({ b2bToken }),
             },
             body: payload,
         });

--- a/packages/core/src/payment/payment-method-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-method-action-creator.spec.ts
@@ -481,15 +481,18 @@ describe('PaymentMethodActionCreator', () => {
                 ).rejects.toThrow(MissingDataError);
             });
 
-            it('throws MissingDataError when the B2B token is missing', async () => {
+            it('returns methods unfiltered when the B2B token is missing', async () => {
                 jest.spyOn(store.getState().b2bToken, 'getToken').mockReturnValue(undefined);
 
+                const methods = [getPaymentMethod()];
+
                 await expect(
-                    (paymentMethodActionCreator as any)._applyB2bFilter(
-                        [getPaymentMethod()],
-                        store.getState(),
-                    ),
-                ).rejects.toThrow(MissingDataError);
+                    (paymentMethodActionCreator as any)._applyB2bFilter(methods, store.getState()),
+                ).resolves.toEqual(methods);
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
             });
 
             it('throws MissingDataError when companyId is missing', async () => {

--- a/packages/core/src/payment/payment-method-action-creator.ts
+++ b/packages/core/src/payment/payment-method-action-creator.ts
@@ -184,8 +184,12 @@ export default class PaymentMethodActionCreator {
             state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
         );
 
-        if (customer.isGuest || !b2bToken || !baseUrl || !cart.companyId) {
+        if (customer.isGuest || !baseUrl || !cart.companyId) {
             throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+        }
+
+        if (!b2bToken) {
+            return methods;
         }
 
         const b2bPaymentFilterType =


### PR DESCRIPTION
## What/Why?

Mirroring b2b-checkout to:
- fetch the current customer JWT with the app client id and returns the token
- refresh payment methods without a token when the customer is a guest
- refresh payment methods with a bc token when a signed-in customer has no b2b token
- submit a quote with a bc token when a signed-in customer has no b2b token
- submit post-order sync with only the authToken header when a bc token is provided
- returns methods unfiltered when the B2B token is missing

## Rollout/Rollback

Revert.

## Testing
Manual tested 3 quote flows:
- B2C signed-in customer quote.
- B2B quote.
- B2C guest qutoe.
- 
<img width="1151" height="217" alt="image" src="https://github.com/user-attachments/assets/81f4146b-b344-414f-a4cb-b7e77922cee5" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication for B2B payment refresh, quote submission, and payment-method filtering—incorrect fallback behavior could break checkout for signed-in B2B users without a loaded B2B token.
> 
> **Overview**
> Adds a **BC customer JWT fallback** when a signed-in shopper has no B2B token, aligning checkout SDK behavior with b2b-checkout.
> 
> **Token & config:** `B2BTokenRequestSender` exposes `getCurrentCustomerJWT()` (used by full B2B login). `loadB2BToken` now fails fast with `MissingB2BConfig` if B2B base URL or client id is missing.
> 
> **Auth on B2B API calls:** New `getB2BAuthHeaders` maps either a B2B token (`authToken` + `Authorization: Bearer`) or a BC JWT (`authToken` only). Payment refresh and quote submission take `{ b2bToken, bcToken }` instead of a single optional string.
> 
> **Relaxed requirements:** Payment method refresh no longer errors when the B2B token is absent—guests call refresh with no auth; signed-in users without a B2B token fetch a BC JWT first. Quote-to-checkout `submitQuote` uses the same fallback. **Invoices** still require a B2B token (missing token surfaces `MissingB2BConfig` via the failed action). B2B company payment filtering **skips** the company API and returns methods unchanged when there is no B2B token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6cc5de3ef682d7e14818d03ebf05bca185cc55a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->