### PR TITLE
feat(checkout): SHIPPING-4147 fallback to full country list if shippa…

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -474,7 +474,11 @@ describe('CheckoutService', () => {
             paymentMethodActionCreator,
             paymentStrategyActionCreator,
             new PickupOptionActionCreator(new PickupOptionRequestSender(requestSender)),
-            new ShippingCountryActionCreator(shippingCountryRequestSender, store),
+            new ShippingCountryActionCreator(
+                shippingCountryRequestSender,
+                store,
+                countryRequestSender,
+            ),
             shippingStrategyActionCreator,
             signInEmailActionCreator,
             spamProtectionActionCreator,

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -223,6 +223,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new ShippingCountryActionCreator(
             new ShippingCountryRequestSender(experimentRequestSender, { locale }),
             store,
+            new CountryRequestSender(experimentRequestSender, { locale }),
         ),
         new ShippingStrategyActionCreator(
             createShippingStrategyRegistry(store, experimentRequestSender),

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -16,6 +16,7 @@ import CouponActionCreator from '../coupon/coupon-action-creator';
 import CouponRequestSender from '../coupon/coupon-request-sender';
 import { CustomerActionCreator, CustomerRequestSender } from '../customer';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
+import { CountryRequestSender } from '../geography';
 import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import {
@@ -137,6 +138,7 @@ export default function createPaymentIntegrationService(
     const shippingCountryActionCreator = new ShippingCountryActionCreator(
         new ShippingCountryRequestSender(requestSender, { locale: getLocale() }),
         store,
+        new CountryRequestSender(requestSender, { locale: getLocale() }),
     );
 
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(

--- a/packages/core/src/shipping/shipping-country-action-creator.spec.ts
+++ b/packages/core/src/shipping/shipping-country-action-creator.spec.ts
@@ -8,7 +8,8 @@ import { CheckoutStore } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import createCheckoutStore from '../checkout/create-checkout-store';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
-import { getCountries } from '../geography/countries.mock';
+import { CountryRequestSender } from '../geography';
+import { getAustralia, getCountries } from '../geography/countries.mock';
 
 import ShippingCountryActionCreator from './shipping-country-action-creator';
 import { ShippingCountryActionType } from './shipping-country-actions';
@@ -16,21 +17,32 @@ import ShippingCountryRequestSender from './shipping-country-request-sender';
 
 describe('ShippingCountryActionCreator', () => {
     let requestSender: ShippingCountryRequestSender;
+    let countryRequestSender: CountryRequestSender;
     let shippingCountryActionCreator: ShippingCountryActionCreator;
     let errorResponse: Response<ErrorResponseBody>;
     let response: Response<any>;
+    let fallbackResponse: Response<any>;
     let store: CheckoutStore;
 
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreState());
         response = getResponse({ data: getCountries() });
+        fallbackResponse = getResponse({ data: [getAustralia()] });
         errorResponse = getErrorResponse();
 
         requestSender = new ShippingCountryRequestSender(createRequestSender(), {});
+        countryRequestSender = new CountryRequestSender(createRequestSender(), {});
 
         jest.spyOn(requestSender, 'loadCountries').mockReturnValue(Promise.resolve(response));
+        jest.spyOn(countryRequestSender, 'loadCountries').mockReturnValue(
+            Promise.resolve(fallbackResponse),
+        );
 
-        shippingCountryActionCreator = new ShippingCountryActionCreator(requestSender, store);
+        shippingCountryActionCreator = new ShippingCountryActionCreator(
+            requestSender,
+            store,
+            countryRequestSender,
+        );
     });
 
     describe('#loadCountries()', () => {
@@ -49,7 +61,7 @@ describe('ShippingCountryActionCreator', () => {
                 });
         });
 
-        it('emits error actions if unable to load countries', () => {
+        it('emits error actions if unable to load countries with a non-5xx error', () => {
             jest.spyOn(requestSender, 'loadCountries').mockReturnValue(
                 Promise.reject(errorResponse),
             );
@@ -61,6 +73,7 @@ describe('ShippingCountryActionCreator', () => {
                 .pipe(catchError(errorHandler), toArray())
                 .subscribe((actions) => {
                     expect(errorHandler).toHaveBeenCalled();
+                    expect(countryRequestSender.loadCountries).not.toHaveBeenCalled();
                     expect(actions).toEqual([
                         { type: ShippingCountryActionType.LoadShippingCountriesRequested },
                         {
@@ -72,12 +85,96 @@ describe('ShippingCountryActionCreator', () => {
                 });
         });
 
+        it('does not fall back to /store/countries on a timeout response', () => {
+            const timeoutResponse = getErrorResponse(undefined, undefined, 0, '');
+
+            jest.spyOn(requestSender, 'loadCountries').mockReturnValue(
+                Promise.reject(timeoutResponse),
+            );
+
+            const errorHandler = jest.fn((action) => of(action));
+
+            shippingCountryActionCreator
+                .loadCountries()
+                .pipe(catchError(errorHandler), toArray())
+                .subscribe(() => {
+                    expect(countryRequestSender.loadCountries).not.toHaveBeenCalled();
+                });
+        });
+
+        describe('when the shipping countries request fails with a 5xx error', () => {
+            let serverErrorResponse: Response<ErrorResponseBody>;
+
+            beforeEach(() => {
+                serverErrorResponse = getErrorResponse(
+                    undefined,
+                    undefined,
+                    500,
+                    'Internal Server Error',
+                );
+
+                jest.spyOn(requestSender, 'loadCountries').mockReturnValue(
+                    Promise.reject(serverErrorResponse),
+                );
+            });
+
+            it('falls back to /store/countries and emits success with its data', () => {
+                shippingCountryActionCreator
+                    .loadCountries()
+                    .pipe(toArray())
+                    .subscribe((actions) => {
+                        expect(actions).toEqual([
+                            { type: ShippingCountryActionType.LoadShippingCountriesRequested },
+                            {
+                                type: ShippingCountryActionType.LoadShippingCountriesSucceeded,
+                                payload: fallbackResponse.body.data,
+                            },
+                        ]);
+                    });
+            });
+
+            it('calls the fallback without a channelId, passing through the given options', () => {
+                const options = { timeout: undefined };
+
+                shippingCountryActionCreator
+                    .loadCountries(options)
+                    .pipe(toArray())
+                    .subscribe(() => {
+                        expect(countryRequestSender.loadCountries).toHaveBeenCalledWith(options);
+                    });
+            });
+
+            it('emits the original error if the fallback also fails', () => {
+                jest.spyOn(countryRequestSender, 'loadCountries').mockReturnValue(
+                    Promise.reject(getErrorResponse()),
+                );
+
+                const errorHandler = jest.fn((action) => of(action));
+
+                shippingCountryActionCreator
+                    .loadCountries()
+                    .pipe(catchError(errorHandler), toArray())
+                    .subscribe((actions) => {
+                        expect(errorHandler).toHaveBeenCalled();
+                        expect(actions).toEqual([
+                            { type: ShippingCountryActionType.LoadShippingCountriesRequested },
+                            {
+                                type: ShippingCountryActionType.LoadShippingCountriesFailed,
+                                payload: serverErrorResponse,
+                                error: true,
+                            },
+                        ]);
+                    });
+            });
+        });
+
         describe('when checkout is undefined', () => {
             beforeEach(() => {
                 store = createCheckoutStore({ checkout: undefined });
                 shippingCountryActionCreator = new ShippingCountryActionCreator(
                     requestSender,
                     store,
+                    countryRequestSender,
                 );
             });
 

--- a/packages/core/src/shipping/shipping-country-action-creator.spec.ts
+++ b/packages/core/src/shipping/shipping-country-action-creator.spec.ts
@@ -46,46 +46,46 @@ describe('ShippingCountryActionCreator', () => {
     });
 
     describe('#loadCountries()', () => {
-        it('emits actions if able to load countries', () => {
-            shippingCountryActionCreator
+        it('emits actions if able to load countries', async () => {
+            const actions = await shippingCountryActionCreator
                 .loadCountries()
                 .pipe(toArray())
-                .subscribe((actions) => {
-                    expect(actions).toEqual([
-                        { type: ShippingCountryActionType.LoadShippingCountriesRequested },
-                        {
-                            type: ShippingCountryActionType.LoadShippingCountriesSucceeded,
-                            payload: response.body.data,
-                        },
-                    ]);
-                });
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: ShippingCountryActionType.LoadShippingCountriesRequested },
+                {
+                    type: ShippingCountryActionType.LoadShippingCountriesSucceeded,
+                    payload: response.body.data,
+                },
+            ]);
         });
 
-        it('emits error actions if unable to load countries with a non-5xx error', () => {
+        it('emits error actions if unable to load countries with a non-5xx error', async () => {
             jest.spyOn(requestSender, 'loadCountries').mockReturnValue(
                 Promise.reject(errorResponse),
             );
 
             const errorHandler = jest.fn((action) => of(action));
 
-            shippingCountryActionCreator
+            const actions = await shippingCountryActionCreator
                 .loadCountries()
                 .pipe(catchError(errorHandler), toArray())
-                .subscribe((actions) => {
-                    expect(errorHandler).toHaveBeenCalled();
-                    expect(countryRequestSender.loadCountries).not.toHaveBeenCalled();
-                    expect(actions).toEqual([
-                        { type: ShippingCountryActionType.LoadShippingCountriesRequested },
-                        {
-                            type: ShippingCountryActionType.LoadShippingCountriesFailed,
-                            payload: errorResponse,
-                            error: true,
-                        },
-                    ]);
-                });
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(countryRequestSender.loadCountries).not.toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: ShippingCountryActionType.LoadShippingCountriesRequested },
+                {
+                    type: ShippingCountryActionType.LoadShippingCountriesFailed,
+                    payload: errorResponse,
+                    error: true,
+                },
+            ]);
         });
 
-        it('does not fall back to /store/countries on a timeout response', () => {
+        it('does not fall back to /store/countries on a timeout response', async () => {
             const timeoutResponse = getErrorResponse(undefined, undefined, 0, '');
 
             jest.spyOn(requestSender, 'loadCountries').mockReturnValue(
@@ -94,12 +94,12 @@ describe('ShippingCountryActionCreator', () => {
 
             const errorHandler = jest.fn((action) => of(action));
 
-            shippingCountryActionCreator
+            await shippingCountryActionCreator
                 .loadCountries()
                 .pipe(catchError(errorHandler), toArray())
-                .subscribe(() => {
-                    expect(countryRequestSender.loadCountries).not.toHaveBeenCalled();
-                });
+                .toPromise();
+
+            expect(countryRequestSender.loadCountries).not.toHaveBeenCalled();
         });
 
         describe('when the shipping countries request fails with a 5xx error', () => {
@@ -118,53 +118,53 @@ describe('ShippingCountryActionCreator', () => {
                 );
             });
 
-            it('falls back to /store/countries and emits success with its data', () => {
-                shippingCountryActionCreator
+            it('falls back to /store/countries and emits success with its data', async () => {
+                const actions = await shippingCountryActionCreator
                     .loadCountries()
                     .pipe(toArray())
-                    .subscribe((actions) => {
-                        expect(actions).toEqual([
-                            { type: ShippingCountryActionType.LoadShippingCountriesRequested },
-                            {
-                                type: ShippingCountryActionType.LoadShippingCountriesSucceeded,
-                                payload: fallbackResponse.body.data,
-                            },
-                        ]);
-                    });
+                    .toPromise();
+
+                expect(actions).toEqual([
+                    { type: ShippingCountryActionType.LoadShippingCountriesRequested },
+                    {
+                        type: ShippingCountryActionType.LoadShippingCountriesSucceeded,
+                        payload: fallbackResponse.body.data,
+                    },
+                ]);
             });
 
-            it('calls the fallback without a channelId, passing through the given options', () => {
+            it('calls the fallback without a channelId, passing through the given options', async () => {
                 const options = { timeout: undefined };
 
-                shippingCountryActionCreator
+                await shippingCountryActionCreator
                     .loadCountries(options)
                     .pipe(toArray())
-                    .subscribe(() => {
-                        expect(countryRequestSender.loadCountries).toHaveBeenCalledWith(options);
-                    });
+                    .toPromise();
+
+                expect(countryRequestSender.loadCountries).toHaveBeenCalledWith(options);
             });
 
-            it('emits the original error if the fallback also fails', () => {
+            it('emits the original error if the fallback also fails', async () => {
                 jest.spyOn(countryRequestSender, 'loadCountries').mockReturnValue(
                     Promise.reject(getErrorResponse()),
                 );
 
                 const errorHandler = jest.fn((action) => of(action));
 
-                shippingCountryActionCreator
+                const actions = await shippingCountryActionCreator
                     .loadCountries()
                     .pipe(catchError(errorHandler), toArray())
-                    .subscribe((actions) => {
-                        expect(errorHandler).toHaveBeenCalled();
-                        expect(actions).toEqual([
-                            { type: ShippingCountryActionType.LoadShippingCountriesRequested },
-                            {
-                                type: ShippingCountryActionType.LoadShippingCountriesFailed,
-                                payload: serverErrorResponse,
-                                error: true,
-                            },
-                        ]);
-                    });
+                    .toPromise();
+
+                expect(errorHandler).toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: ShippingCountryActionType.LoadShippingCountriesRequested },
+                    {
+                        type: ShippingCountryActionType.LoadShippingCountriesFailed,
+                        payload: serverErrorResponse,
+                        error: true,
+                    },
+                ]);
             });
         });
 
@@ -178,10 +178,10 @@ describe('ShippingCountryActionCreator', () => {
                 );
             });
 
-            it('passes null as channelId when checkout is undefined', () => {
+            it('passes null as channelId when checkout is undefined', async () => {
                 const loadCountriesSpy = jest.spyOn(requestSender, 'loadCountries');
 
-                shippingCountryActionCreator.loadCountries().subscribe();
+                await shippingCountryActionCreator.loadCountries().toPromise();
 
                 expect(loadCountriesSpy).toHaveBeenCalledWith(null, undefined);
             });

--- a/packages/core/src/shipping/shipping-country-action-creator.ts
+++ b/packages/core/src/shipping/shipping-country-action-creator.ts
@@ -3,6 +3,7 @@ import { Observable, Observer } from 'rxjs';
 
 import CheckoutStore from '../checkout/checkout-store';
 import { RequestOptions } from '../common/http-request';
+import { CountryRequestSender } from '../geography';
 
 import { LoadShippingCountriesAction, ShippingCountryActionType } from './shipping-country-actions';
 import ShippingCountryRequestSender from './shipping-country-request-sender';
@@ -11,6 +12,7 @@ export default class ShippingCountryActionCreator {
     constructor(
         private _shippingCountryRequestSender: ShippingCountryRequestSender,
         private _store: CheckoutStore,
+        private _countryRequestSender: CountryRequestSender,
     ) {}
 
     loadCountries(options?: RequestOptions): Observable<LoadShippingCountriesAction> {
@@ -34,6 +36,28 @@ export default class ShippingCountryActionCreator {
                     observer.complete();
                 })
                 .catch((response) => {
+                    if (response && response.status >= 500) {
+                        return this._countryRequestSender
+                            .loadCountries(options)
+                            .then((fallbackResponse) => {
+                                observer.next(
+                                    createAction(
+                                        ShippingCountryActionType.LoadShippingCountriesSucceeded,
+                                        fallbackResponse.body.data,
+                                    ),
+                                );
+                                observer.complete();
+                            })
+                            .catch(() => {
+                                observer.error(
+                                    createErrorAction(
+                                        ShippingCountryActionType.LoadShippingCountriesFailed,
+                                        response,
+                                    ),
+                                );
+                            });
+                    }
+
                     observer.error(
                         createErrorAction(
                             ShippingCountryActionType.LoadShippingCountriesFailed,


### PR DESCRIPTION
…ble country endpoint fails with 500

## What/Why?

2 weeks ago there was an incident where `/internalapi/v1/shipping/countries` started to return 500 due to geo data issue, which resulted in storefront checkout being completed blocked for the impacted stores, given no countries are returned and can be selected during shipping step.

During incident retro, team proposed an idea that it's probably better to have a degraded experience than entirely blocking checkout, if we fallback to the default full country list when shippable countries endpoint fail. 

As an example: if a store configured "AU and NZ" as 2 shippable countries with shipping provider configured for them, and when `/internalapi/v1/shipping/countries` fails and we fallback to return all country list 
- for shoppers in AU and NZ, they can still select AU and NZ and continue with checkout (just a longer list to choose from -- degraded experience)
- for shoppers in other countries, they can select their country but end up with a "no shipping available for that region" message, so not worse than not seeing their country in the first place.

So this PR is to introduce that fallback call to `/stores/countries` when `/internalapi/v1/shipping/countries` fails. 

NOTE: this is just POC at this stage to gather feedback. 

## Rollout/Rollback
- rollback checkout-sdk version
- revert PR

## Testing
Manual testing

Step 1: setup custom checkout with checkout-sdk and checkout.js running locally and point my vm store to it
<img width="2032" height="1281" alt="Screenshot 2026-07-24 at 3 56 57 pm" src="https://github.com/user-attachments/assets/5b7e9026-5ae8-4d09-b2ce-71bf829653bc" />


Step 2: check page when `/shipping/countries` still returns normal 200
<img width="1461" height="865" alt="Screenshot 2026-07-24 at 3 57 41 pm" src="https://github.com/user-attachments/assets/c2a97021-3795-49ed-9c1c-492ea8e0c1ed" />

Step 3: throw 500 for the endpoint locally and see checkout falls back to full countries list 

```
➜  bigcommerce git:(master) ✗ git diff
diff --git a/lib/Store/InternalApi/V1/Shipping/Geography/CountriesController.php b/lib/Store/InternalApi/V1/Shipping/Geography/CountriesController.php
index e4ae18f1809..d942f293fc6 100644
--- a/lib/Store/InternalApi/V1/Shipping/Geography/CountriesController.php
+++ b/lib/Store/InternalApi/V1/Shipping/Geography/CountriesController.php
@@ -45,6 +45,7 @@ class CountriesController extends ResourceController
      */
     public function indexAction(): array
     {
+        throw InternalApiException::create500("something goes wrong");
``` 
<img width="1688" height="984" alt="Screenshot 2026-07-24 at 4 02 25 pm" src="https://github.com/user-attachments/assets/d233d59a-fe47-4b3e-a246-835acc962fd9" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout shipping country loading on server errors and may show countries that are not actually shippable until shipping options fail later; scope is limited to the shipping countries load path with tests.
> 
> **Overview**
> When loading **shipping countries** fails with a **5xx** from the shippable-countries endpoint, checkout now **falls back** to the full **store countries** list (`CountryRequestSender`) instead of failing with no countries—so shoppers can still pick a country during shipping (degraded UX vs. a blocked checkout).
> 
> `ShippingCountryActionCreator` takes a new `CountryRequestSender` dependency; **non-5xx** errors and **timeouts** still fail without calling the fallback. If the fallback also fails, the **original** shipping-countries error is surfaced. Service wiring in `create-checkout-service`, payment integration, and tests cover success, 5xx fallback, no fallback on 4xx/timeout, and fallback failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3ef9424e469b05a30c0f82bc29271eea1ccb6e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->