### PR TITLE
feat(payment): PAYPAL-4191 PPCP credit wallet strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -86,3 +86,6 @@ export { WithPayPalCommerceFastlanePaymentInitializeOptions } from './paypal-com
  */
 export { default as createPayPalCommerceWalletStrategy } from './paypal-commerce/create-paypal-commerce-wallet-strategy';
 export { WithPayPalCommerceWalletInitializeOptions } from './paypal-commerce/paypal-commerce-wallet-initialize-options';
+
+export { default as createPayPalCommerceCreditWalletStrategy } from './paypal-commerce-credit/create-paypal-commerce-credit-wallet-strategy';
+export { WithPayPalCommerceCreditWalletInitializeOptions } from './paypal-commerce-credit/paypal-commerce-credit-wallet-initialize-options';

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-wallet-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-wallet-strategy.spec.ts
@@ -1,0 +1,21 @@
+import {
+    createWalletButtonIntegrationService,
+    WalletButtonIntegrationService,
+} from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import createPayPalCommerceCreditWalletStrategy from './create-paypal-commerce-credit-wallet-strategy';
+import PayPalCommerceCreditWalletStrategy from './paypal-commerce-credit-wallet-strategy';
+
+describe('createPayPalCommerceCreditWalletStrategy', () => {
+    let walletButtonIntegrationService: WalletButtonIntegrationService;
+
+    beforeEach(() => {
+        walletButtonIntegrationService = createWalletButtonIntegrationService('/graphql');
+    });
+
+    it('creates an instance of PayPalCommerceCreditWalletStrategy', () => {
+        const strategy = createPayPalCommerceCreditWalletStrategy(walletButtonIntegrationService);
+
+        expect(strategy).toBeInstanceOf(PayPalCommerceCreditWalletStrategy);
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-wallet-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-wallet-strategy.ts
@@ -1,0 +1,23 @@
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import { toResolvableModule } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { WalletPaymentButtonStrategyFactory } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import PaypalCommerceWalletService from '../paypal-commerce-wallet-service';
+
+import PayPalCommerceCreditWalletStrategy from './paypal-commerce-credit-wallet-strategy';
+
+const createPayPalCommerceCreditWalletStrategy: WalletPaymentButtonStrategyFactory<
+    PayPalCommerceCreditWalletStrategy
+> = (walletButtonIntegrationService) =>
+    new PayPalCommerceCreditWalletStrategy(
+        new PaypalCommerceWalletService(
+            walletButtonIntegrationService,
+            new PayPalCommerceScriptLoader(getScriptLoader()),
+        ),
+    );
+
+export default toResolvableModule(createPayPalCommerceCreditWalletStrategy, [
+    { id: 'paypalcommercepaypalcredit' },
+]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-wallet-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-wallet-initialize-options.ts
@@ -1,0 +1,12 @@
+export default interface PayPalCommerceCreditWalletInitializeOptions {
+    cartId: string;
+    currency: {
+        code: string;
+    };
+    initializationData: string;
+    clientToken: string;
+}
+
+export interface WithPayPalCommerceCreditWalletInitializeOptions {
+    paypalcommercepaypalcredit?: PayPalCommerceCreditWalletInitializeOptions;
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-wallet-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-wallet-strategy.spec.ts
@@ -1,0 +1,304 @@
+import {
+    CheckoutButtonInitializeOptions,
+    InvalidArgumentError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import getPayPalSDKMock from '../mocks/get-paypal-sdk.mock';
+import PaypalCommerceWalletService from '../paypal-commerce-wallet-service';
+
+import { WithPayPalCommerceCreditWalletInitializeOptions } from './paypal-commerce-credit-wallet-initialize-options';
+import PayPalCommerceCreditWalletStrategy from './paypal-commerce-credit-wallet-strategy';
+
+describe('PayPalCommerceCreditWalletStrategy', () => {
+    let strategy: PayPalCommerceCreditWalletStrategy;
+    let paypalCommerceWalletService: jest.Mocked<PaypalCommerceWalletService>;
+
+    const defaultContainerId = 'paypal-commerce-credit-wallet-button';
+    const defaultMethodId = 'paypalcommercepaypalcredit';
+    const defaultCartId = 'abc123';
+    const defaultOrderId = 'ORDER_ID';
+    const defaultButtonStyle = { color: 'gold', label: 'checkout' };
+
+    const initializationOptions: CheckoutButtonInitializeOptions &
+        WithPayPalCommerceCreditWalletInitializeOptions = {
+        methodId: defaultMethodId,
+        containerId: defaultContainerId,
+        paypalcommercepaypalcredit: {
+            cartId: defaultCartId,
+            currency: {
+                code: 'USD',
+            },
+            initializationData: btoa(
+                JSON.stringify({
+                    initializationData: {
+                        clientId: 'test-client-id',
+                        paymentButtonStyles: {
+                            cartButtonStyles: defaultButtonStyle,
+                        },
+                    },
+                }),
+            ),
+            clientToken: 'test-client-token',
+        },
+    };
+
+    beforeEach(() => {
+        const paypalSdk = getPayPalSDKMock();
+
+        paypalCommerceWalletService = {
+            addBillingAddress: jest.fn(),
+            createPaymentOrderIntent: jest.fn().mockResolvedValue(defaultOrderId),
+            getPayPalSdkOrThrow: jest.fn().mockReturnValue(paypalSdk),
+            getValidButtonStyle: jest.fn().mockReturnValue({ height: 45 }),
+            loadPayPalSdk: jest.fn(),
+            proxyTokenizationPayment: jest.fn(),
+            removeElement: jest.fn(),
+        } as unknown as jest.Mocked<PaypalCommerceWalletService>;
+
+        strategy = new PayPalCommerceCreditWalletStrategy(paypalCommerceWalletService);
+    });
+
+    it('throws when methodId is not provided', async () => {
+        const optionsWithoutMethodId = {
+            ...initializationOptions,
+            methodId: undefined,
+        } as unknown as CheckoutButtonInitializeOptions &
+            WithPayPalCommerceCreditWalletInitializeOptions;
+
+        await expect(strategy.initialize(optionsWithoutMethodId)).rejects.toEqual(
+            new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            ),
+        );
+    });
+
+    it('throws when containerId is not provided', async () => {
+        const optionsWithoutContainerId = {
+            ...initializationOptions,
+            containerId: undefined,
+        } as unknown as CheckoutButtonInitializeOptions &
+            WithPayPalCommerceCreditWalletInitializeOptions;
+
+        await expect(strategy.initialize(optionsWithoutContainerId)).rejects.toEqual(
+            new InvalidArgumentError(
+                'Unable to initialize payment because "options.containerId" argument is not provided.',
+            ),
+        );
+    });
+
+    it('throws when paypalcommercepaypalcredit is not provided', async () => {
+        const optionsWithoutPaymentOptions = {
+            ...initializationOptions,
+            paypalcommercepaypalcredit: undefined,
+        } as unknown as CheckoutButtonInitializeOptions &
+            WithPayPalCommerceCreditWalletInitializeOptions;
+
+        await expect(strategy.initialize(optionsWithoutPaymentOptions)).rejects.toEqual(
+            new InvalidArgumentError(
+                'Unable to initialize payment because "options.paypalcommercepaypalcredit" argument is not provided.',
+            ),
+        );
+    });
+
+    it('renders credit button with PAYLATER as first eligible funding source', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = paypalCommerceWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        const buttonOptions = buttonsSpy.mock.calls[0][0];
+
+        expect(buttonOptions.fundingSource).toEqual(paypalSdk.FUNDING.PAYLATER);
+        expect(paypalButtons.render).toHaveBeenCalledWith(`#${defaultContainerId}`);
+    });
+
+    it('renders credit button with CREDIT funding source when PAYLATER is not eligible', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = paypalCommerceWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockImplementation((options: any) => {
+            if (options.fundingSource === paypalSdk.FUNDING.PAYLATER) {
+                return {
+                    ...paypalButtons,
+                    isEligible: jest.fn().mockReturnValue(false),
+                };
+            }
+
+            return paypalButtons;
+        });
+
+        await strategy.initialize(initializationOptions);
+
+        const creditButtonOptions = buttonsSpy.mock.calls[1][0];
+
+        expect(creditButtonOptions.fundingSource).toEqual(paypalSdk.FUNDING.CREDIT);
+        expect(paypalButtons.render).toHaveBeenCalledWith(`#${defaultContainerId}`);
+    });
+
+    it('applies cart button styles from initialization data', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = paypalCommerceWalletService.getPayPalSdkOrThrow();
+
+        jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        expect(paypalCommerceWalletService.getValidButtonStyle).toHaveBeenCalledWith(
+            defaultButtonStyle,
+        );
+    });
+
+    it('creates payment order intent with correct method ID', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = paypalCommerceWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        const buttonOptions = buttonsSpy.mock.calls[0][0];
+
+        await buttonOptions.createOrder();
+
+        expect(paypalCommerceWalletService.createPaymentOrderIntent).toHaveBeenCalledWith(
+            'paypalcommerce.paypalcredit',
+            defaultCartId,
+        );
+    });
+
+    it('adds billing address and proxies tokenization on approve', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = paypalCommerceWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        const buttonOptions = buttonsSpy.mock.calls[0][0];
+
+        await buttonOptions.onApprove?.(
+            { orderID: defaultOrderId },
+            {
+                order: {
+                    get: jest.fn().mockResolvedValue({
+                        payer: {
+                            name: {
+                                given_name: 'Jane',
+                                surname: 'Smith',
+                            },
+                            email_address: 'jane@smith.com',
+                            address: {
+                                address_line_1: '456 Oak Ave',
+                                address_line_2: 'Apt 200',
+                                admin_area_2: 'Denver',
+                                admin_area_1: 'CO',
+                                postal_code: '80202',
+                                country_code: 'US',
+                            },
+                            phone: {
+                                phone_number: {
+                                    national_number: '3035555555',
+                                },
+                            },
+                        },
+                    }),
+                },
+            },
+        );
+
+        expect(paypalCommerceWalletService.addBillingAddress).toHaveBeenCalledWith(defaultCartId, {
+            firstName: 'Jane',
+            lastName: 'Smith',
+            company: '',
+            address1: '456 Oak Ave',
+            address2: 'Apt 200',
+            city: 'Denver',
+            email: 'jane@smith.com',
+            stateOrProvince: 'CO',
+            stateOrProvinceCode: 'CO',
+            countryCode: 'US',
+            postalCode: '80202',
+            phone: '3035555555',
+            shouldSaveAddress: false,
+        });
+        expect(paypalCommerceWalletService.proxyTokenizationPayment).toHaveBeenCalledWith(
+            defaultCartId,
+            defaultOrderId,
+        );
+    });
+
+    it('removes element when no funding source is eligible', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(false),
+            render: jest.fn(),
+        };
+        const paypalSdk = paypalCommerceWalletService.getPayPalSdkOrThrow();
+
+        jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        expect(paypalCommerceWalletService.removeElement).toHaveBeenCalledWith(defaultContainerId);
+    });
+
+    it('returns resolved promise on deinitialize', async () => {
+        const result = strategy.deinitialize();
+
+        expect(result).toBeInstanceOf(Promise);
+        await expect(result).resolves.toBeUndefined();
+    });
+
+    it('uses fallback style when cartButtonStyles is not provided', async () => {
+        const optionsWithoutButtonStyle: CheckoutButtonInitializeOptions &
+            WithPayPalCommerceCreditWalletInitializeOptions = {
+            methodId: defaultMethodId,
+            containerId: defaultContainerId,
+            paypalcommercepaypalcredit: {
+                cartId: defaultCartId,
+                currency: {
+                    code: 'USD',
+                },
+                initializationData: btoa(
+                    JSON.stringify({
+                        initializationData: {
+                            clientId: 'test-client-id',
+                        },
+                    }),
+                ),
+                clientToken: 'test-client-token',
+            },
+        };
+
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = paypalCommerceWalletService.getPayPalSdkOrThrow();
+
+        jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(optionsWithoutButtonStyle);
+
+        expect(paypalCommerceWalletService.getValidButtonStyle).toHaveBeenCalledWith(undefined);
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-wallet-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-wallet-strategy.ts
@@ -1,0 +1,157 @@
+import {
+    CheckoutButtonInitializeOptions,
+    CheckoutButtonStrategy,
+    InvalidArgumentError,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PayPalCommerceInitializationData } from '@bigcommerce/checkout-sdk/paypal-commerce-utils';
+import { AddressRequestBody } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import {
+    ApproveCallbackActions,
+    ApproveCallbackPayload,
+    PayPalButtonStyleOptions,
+    PayPalCommerceButtonsOptions,
+    PayPalOrderDetails,
+} from '../paypal-commerce-types';
+import PaypalCommerceWalletService from '../paypal-commerce-wallet-service';
+
+import { WithPayPalCommerceCreditWalletInitializeOptions } from './paypal-commerce-credit-wallet-initialize-options';
+
+export default class PayPalCommerceCreditWalletStrategy implements CheckoutButtonStrategy {
+    constructor(private paypalCommerceHeadlessWalletButtonService: PaypalCommerceWalletService) {}
+
+    async initialize(
+        options: CheckoutButtonInitializeOptions & WithPayPalCommerceCreditWalletInitializeOptions,
+    ): Promise<void> {
+        const { paypalcommercepaypalcredit, containerId, methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.containerId" argument is not provided.',
+            );
+        }
+
+        if (!paypalcommercepaypalcredit) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.paypalcommercepaypalcredit" argument is not provided.',
+            );
+        }
+
+        let parsedInitializationData: PaymentMethod<PayPalCommerceInitializationData>;
+
+        try {
+            parsedInitializationData = JSON.parse(
+                atob(paypalcommercepaypalcredit.initializationData),
+            );
+        } catch {
+            throw new InvalidArgumentError("Failed to parse payment method 'initializationData'.");
+        }
+
+        await this.paypalCommerceHeadlessWalletButtonService.loadPayPalSdk(
+            parsedInitializationData,
+            paypalcommercepaypalcredit.currency.code,
+            false,
+        );
+
+        const buttonStyle =
+            parsedInitializationData.initializationData?.paymentButtonStyles?.cartButtonStyles;
+
+        this.renderButton(
+            containerId,
+            'paypalcommerce.paypalcredit',
+            paypalcommercepaypalcredit.cartId,
+            buttonStyle,
+        );
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    private renderButton(
+        containerId: string,
+        methodId: string,
+        cartId: string,
+        buttonStyle?: PayPalButtonStyleOptions,
+    ): void {
+        const paypalSdk = this.paypalCommerceHeadlessWalletButtonService.getPayPalSdkOrThrow();
+        const fundingSources = [paypalSdk.FUNDING.PAYLATER, paypalSdk.FUNDING.CREDIT];
+
+        const defaultCallbacks = {
+            createOrder: () =>
+                this.paypalCommerceHeadlessWalletButtonService.createPaymentOrderIntent(
+                    methodId,
+                    cartId,
+                ),
+            onApprove: async (
+                { orderID }: ApproveCallbackPayload,
+                actions: ApproveCallbackActions,
+            ) => {
+                const orderDetails = await actions.order.get();
+                const billingAddress = this.mapOrderDetailsToBillingAddress(orderDetails);
+
+                await this.paypalCommerceHeadlessWalletButtonService.addBillingAddress(
+                    cartId,
+                    billingAddress,
+                );
+
+                await this.paypalCommerceHeadlessWalletButtonService.proxyTokenizationPayment(
+                    cartId,
+                    orderID,
+                );
+            },
+        };
+
+        let hasRenderedSmartButton = false;
+
+        fundingSources.forEach((fundingSource) => {
+            if (!hasRenderedSmartButton) {
+                const buttonRenderOptions: PayPalCommerceButtonsOptions = {
+                    fundingSource,
+                    style: this.paypalCommerceHeadlessWalletButtonService.getValidButtonStyle(
+                        buttonStyle,
+                    ),
+                    ...defaultCallbacks,
+                };
+
+                const paypalButton = paypalSdk.Buttons(buttonRenderOptions);
+
+                if (paypalButton.isEligible()) {
+                    paypalButton.render(`#${containerId}`);
+                    hasRenderedSmartButton = true;
+                }
+            }
+        });
+
+        if (!hasRenderedSmartButton) {
+            this.paypalCommerceHeadlessWalletButtonService.removeElement(containerId);
+        }
+    }
+
+    private mapOrderDetailsToBillingAddress(orderDetails: PayPalOrderDetails): AddressRequestBody {
+        const { payer } = orderDetails;
+
+        return {
+            firstName: payer.name.given_name,
+            lastName: payer.name.surname,
+            company: '',
+            address1: payer.address.address_line_1,
+            address2: payer.address.address_line_2,
+            city: payer.address.admin_area_2,
+            email: payer.email_address,
+            stateOrProvince: payer.address.admin_area_1 ?? '',
+            stateOrProvinceCode: payer.address.admin_area_1 ?? '',
+            countryCode: payer.address.country_code,
+            postalCode: payer.address.postal_code,
+            phone: payer.phone?.phone_number.national_number ?? '',
+            shouldSaveAddress: false,
+        };
+    }
+}


### PR DESCRIPTION
## What/Why?
Add an ability to render PayPalCommerce PayLater button with Wallet buttons tool
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
Manual

[screen-capture (4).webm](https://github.com/user-attachments/assets/a810ba0b-c359-4998-aeac-d838a8349db1)

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout payment button rendering and post-approval billing/tokenization for a new method ID, but reuses the existing wallet service and is covered by focused unit tests.
> 
> **Overview**
> Adds a **headless wallet button** integration for PayPal Commerce **Pay Later / PayPal Credit** (`paypalcommercepaypalcredit`), exported alongside the existing PayPal wallet strategy.
> 
> The new `PayPalCommerceCreditWalletStrategy` loads the PayPal SDK from base64 `initializationData`, then renders a single smart button by trying **`PAYLATER` first** and falling back to **`CREDIT`** when the first source is ineligible. It applies **cart button styles** from init data, creates orders via `paypalcommerce.paypalcredit`, and on approve **maps payer billing** and **proxies tokenization** through the shared `PaypalCommerceWalletService`. If neither funding source is eligible, the **container element is removed**.
> 
> Wiring includes a factory registered for `paypalcommercepaypalcredit`, initialize options under `options.paypalcommercepaypalcredit`, and unit tests for validation, funding-source selection, order/approve flow, and ineligibility handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa62ac29c5e3625e440e1f6517a97900ead6d0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->