### PR TITLE
fix(checkout): CHECKOUT-10262 Consistently Send shouldSaveAddress Value

### DIFF
--- a/packages/core/src/address/address.ts
+++ b/packages/core/src/address/address.ts
@@ -4,10 +4,10 @@ export type AddressKey = keyof Address;
 
 export default interface Address extends AddressRequestBody {
     country: string;
-    shouldSaveAddress?: boolean;
 }
 
 export interface AddressRequestBody {
+    shouldSaveAddress?: boolean;
     firstName: string;
     lastName: string;
     company: string;

--- a/packages/core/src/address/map-to-address-request-body.spec.ts
+++ b/packages/core/src/address/map-to-address-request-body.spec.ts
@@ -17,8 +17,11 @@ describe('mapToAddressRequestBody()', () => {
         customFields: [],
     };
 
-    it('keeps all AddressRequestBody fields', () => {
-        expect(mapToAddressRequestBody(baseAddress)).toEqual(baseAddress);
+    it('keeps all AddressRequestBody fields and defaults shouldSaveAddress to false', () => {
+        expect(mapToAddressRequestBody(baseAddress)).toEqual({
+            ...baseAddress,
+            shouldSaveAddress: false,
+        });
     });
 
     it('keeps extraFields and label when present', () => {
@@ -28,7 +31,10 @@ describe('mapToAddressRequestBody()', () => {
             extraFields: [{ fieldId: '100', fieldValue: 'Acme' }],
         };
 
-        expect(mapToAddressRequestBody(address)).toEqual(address);
+        expect(mapToAddressRequestBody(address)).toEqual({
+            ...address,
+            shouldSaveAddress: false,
+        });
     });
 
     it('strips CustomerAddress b2b metadata and hoists extraFields', () => {
@@ -49,6 +55,7 @@ describe('mapToAddressRequestBody()', () => {
         expect(result).toEqual({
             ...baseAddress,
             extraFields: [{ fieldId: '100', fieldValue: 'Acme' }],
+            shouldSaveAddress: false,
         });
         expect(result).not.toHaveProperty('b2b');
         expect(result).not.toHaveProperty('label');

--- a/packages/core/src/address/map-to-address-request-body.ts
+++ b/packages/core/src/address/map-to-address-request-body.ts
@@ -25,12 +25,19 @@ export default function mapToAddressRequestBody(
 ): Partial<AddressRequestBody> {
     const { b2b, ...requestBody } = address;
 
+    // The API currently defaults shouldSaveAddress to true. We decided to handle this on the FE
+    // by consistently sending false as the default on 24 July 2026.
+    const requestBodyWithSaveFlag = {
+        ...requestBody,
+        shouldSaveAddress: requestBody.shouldSaveAddress ?? false,
+    };
+
     if (!b2b) {
-        return requestBody;
+        return requestBodyWithSaveFlag;
     }
 
     return {
-        ...requestBody,
-        extraFields: requestBody.extraFields ?? b2b.extraFields,
+        ...requestBodyWithSaveFlag,
+        extraFields: requestBodyWithSaveFlag.extraFields ?? b2b.extraFields,
     };
 }


### PR DESCRIPTION
## What/Why?

The checkout API currently defaults `shouldSaveAddress` to `true`.
We decided to handle this on the FE by consistently sending `false` as the default value.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout address save behavior for any caller that relied on omitting the field and inheriting API default true; explicit opt-in to save still works.
> 
> **Overview**
> Checkout address payloads sent through **`mapToAddressRequestBody`** now **always include `shouldSaveAddress`**, defaulting to **`false`** when the source address omits it—countering the API’s default of `true`.
> 
> **`shouldSaveAddress`** is moved from the **`Address`** type onto **`AddressRequestBody`** so it lives with the request shape. Explicit **`true`** (or any set value) is still passed through unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c1c356ea8a6103fa393ef68a2b4115ba39c7e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->