### PR TITLE
feat(payment): add shipping options filtering callback for Stripe Link V2

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
@@ -6,6 +6,7 @@ import {
     PaymentIntegrationService,
     PaymentMethodCancelledError,
     RequestError,
+    ShippingOption,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getCart,
@@ -321,6 +322,47 @@ describe('StripeLinkV2ButtonStrategy', () => {
             });
         });
 
+        it('resolves onShippingAddressChange with unfiltered shipping rates if filterAvailableShippingOptions fails', async () => {
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+            await strategy.initialize({
+                ...initialiseOptions,
+                stripeocs: {
+                    ...initialiseOptions.stripeocs,
+                    filterAvailableShippingOptions: jest
+                        .fn()
+                        .mockRejectedValue(new Error('filter failed')),
+                },
+            });
+
+            stripeEventEmitter.emit(StripeElementEvent.SHIPPING_ADDRESS_CHANGE, {
+                address: {
+                    city: 'London',
+                    country: 'UK',
+                    postal_code: '091-22',
+                    state: 'CA',
+                },
+                resolve: stripeEvent,
+            });
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(stripeEvent).toHaveBeenCalledWith({
+                shippingRates: [
+                    {
+                        amount: 0,
+                        displayName: 'Flat Rate',
+                        id: '0:61d4bb52f746477e1d4fb411221318c3',
+                    },
+                ],
+            });
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'Failed to filter available shipping options:',
+                expect.any(Error),
+            );
+
+            consoleErrorSpy.mockRestore();
+        });
+
         it('calls onShippingAddressChange callback with empty address', async () => {
             await strategy.initialize(initialiseOptions);
 
@@ -444,6 +486,137 @@ describe('StripeLinkV2ButtonStrategy', () => {
             });
             await new Promise((resolve) => process.nextTick(resolve));
 
+            expect(stripeEvent).toHaveBeenCalledWith({
+                shippingRates: [
+                    {
+                        amount: 200000,
+                        displayName: 'description2',
+                        id: 2,
+                    },
+                    {
+                        amount: 100000,
+                        displayName: 'description',
+                        id: 1,
+                    },
+                ],
+            });
+        });
+
+        it('re-selects the first available option if filterAvailableShippingOptions removes the selected one', async () => {
+            jest.spyOn(paymentIntegrationService, 'getState').mockReturnValue({
+                ...paymentIntegrationService.getState(),
+                getConsignments: jest.fn().mockReturnValue([
+                    {
+                        availableShippingOptions: [
+                            {
+                                id: 1,
+                                description: 'description',
+                                cost: 1000,
+                            },
+                            {
+                                id: 2,
+                                description: 'description2',
+                                cost: 2000,
+                            },
+                        ],
+                        selectedShippingOption: {
+                            id: 2,
+                            description: 'description2',
+                            cost: 2000,
+                        },
+                    },
+                ]),
+            });
+
+            await strategy.initialize({
+                ...initialiseOptions,
+                stripeocs: {
+                    ...initialiseOptions.stripeocs,
+                    filterAvailableShippingOptions: (shippingOptions: ShippingOption[]) =>
+                        Promise.resolve(shippingOptions.slice(0, 1)),
+                },
+            });
+
+            stripeEventEmitter.emit(StripeElementEvent.SHIPPING_ADDRESS_CHANGE, {
+                address: {
+                    city: 'London',
+                    country: 'UK',
+                    postal_code: '091-22',
+                    state: 'CA',
+                },
+                resolve: stripeEvent,
+            });
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(1);
+            expect(stripeEvent).toHaveBeenCalledWith({
+                shippingRates: [
+                    {
+                        amount: 100000,
+                        displayName: 'description',
+                        id: 1,
+                    },
+                ],
+            });
+        });
+
+        it('resolves onShippingAddressChange with options filtered by filterAvailableShippingOptions', async () => {
+            const availableShippingOptions = [
+                {
+                    id: 1,
+                    description: 'description',
+                    cost: 1000,
+                },
+                {
+                    id: 2,
+                    description: 'description2',
+                    cost: 2000,
+                },
+                {
+                    id: 3,
+                    description: 'description3',
+                    cost: 3000,
+                },
+            ];
+            const filterAvailableShippingOptions = jest.fn((shippingOptions: ShippingOption[]) =>
+                Promise.resolve(shippingOptions.slice(0, 2)),
+            );
+
+            jest.spyOn(paymentIntegrationService, 'getState').mockReturnValue({
+                ...paymentIntegrationService.getState(),
+                getConsignments: jest.fn().mockReturnValue([
+                    {
+                        availableShippingOptions,
+                        selectedShippingOption: {
+                            id: 2,
+                            description: 'description2',
+                            cost: 2000,
+                        },
+                    },
+                ]),
+            });
+
+            await strategy.initialize({
+                ...initialiseOptions,
+                stripeocs: {
+                    ...initialiseOptions.stripeocs,
+                    filterAvailableShippingOptions,
+                },
+            });
+
+            stripeEventEmitter.emit(StripeElementEvent.SHIPPING_ADDRESS_CHANGE, {
+                address: {
+                    city: 'London',
+                    country: 'UK',
+                    postal_code: '091-22',
+                    state: 'CA',
+                },
+                resolve: stripeEvent,
+            });
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(filterAvailableShippingOptions).toHaveBeenCalledWith(availableShippingOptions);
+            expect(paymentIntegrationService.selectShippingOption).not.toHaveBeenCalled();
             expect(stripeEvent).toHaveBeenCalledWith({
                 shippingRates: [
                     {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.ts
@@ -51,6 +51,9 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
     private _linkV2Element?: StripeElement;
     private _amountTransformer?: AmountTransformer;
     private _onComplete?: (orderId?: number) => Promise<never>;
+    private _filterAvailableShippingOptions?: (
+        availableShippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
     private _loadingIndicatorContainer?: string;
     private _currencyCode?: string;
     private _captureMethod?: 'automatic' | 'manual';
@@ -82,11 +85,13 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
             params: { method: methodId },
         });
         const paymentMethod = state.getPaymentMethodOrThrow(methodId, gatewayId);
-        const { loadingContainerId, buttonHeight, onComplete } = stripeocs;
+        const { loadingContainerId, buttonHeight, onComplete, filterAvailableShippingOptions } =
+            stripeocs;
 
         this._loadingIndicatorContainer = loadingContainerId;
 
         this._onComplete = onComplete;
+        this._filterAvailableShippingOptions = filterAvailableShippingOptions;
 
         if (!isStripePaymentMethodLike(paymentMethod)) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
@@ -516,14 +521,28 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
             return;
         }
 
-        const consignment = consignments[0];
-        const options = (consignment.availableShippingOptions || []).map(
-            this._getStripeShippingOption.bind(this),
-        );
-        const recommendedShippingOption = consignment.availableShippingOptions?.find(
+        let { availableShippingOptions = [] } = consignments[0];
+        const { selectedShippingOption } = consignments[0];
+
+        if (typeof this._filterAvailableShippingOptions === 'function') {
+            try {
+                availableShippingOptions = await this._filterAvailableShippingOptions(
+                    availableShippingOptions,
+                );
+            } catch (error) {
+                // INFO: fall back to the unfiltered options so the Stripe shipping event still resolves.
+                console.error('Failed to filter available shipping options:', error);
+            }
+        }
+
+        const options = availableShippingOptions.map(this._getStripeShippingOption.bind(this));
+        const recommendedShippingOption = availableShippingOptions?.find(
             (shippingOption) => shippingOption.isRecommended,
         );
-        const selectedId = consignment.selectedShippingOption?.id;
+        const isSelectedOptionAvailable = availableShippingOptions?.some(
+            (shippingOption) => shippingOption.id === selectedShippingOption?.id,
+        );
+        const selectedId = isSelectedOptionAvailable ? selectedShippingOption?.id : undefined;
         const recommendedId = recommendedShippingOption?.id;
 
         if (selectedId) {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
@@ -7,6 +7,7 @@ import {
     PaymentIntegrationService,
     PaymentMethodCancelledError,
     RequestError,
+    ShippingOption,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getCart,
@@ -330,6 +331,47 @@ describe('StripeLinkV2CustomerStrategy', () => {
             });
         });
 
+        it('resolves onShippingAddressChange with unfiltered shipping rates if filterAvailableShippingOptions fails', async () => {
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+            await strategy.initialize({
+                ...initialiseOptions,
+                stripeocs: {
+                    ...initialiseOptions.stripeocs,
+                    filterAvailableShippingOptions: jest
+                        .fn()
+                        .mockRejectedValue(new Error('filter failed')),
+                },
+            });
+
+            stripeEventEmitter.emit(StripeElementEvent.SHIPPING_ADDRESS_CHANGE, {
+                address: {
+                    city: 'London',
+                    country: 'UK',
+                    postal_code: '091-22',
+                    state: 'CA',
+                },
+                resolve: stripeEvent,
+            });
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(stripeEvent).toHaveBeenCalledWith({
+                shippingRates: [
+                    {
+                        amount: 0,
+                        displayName: 'Flat Rate',
+                        id: '0:61d4bb52f746477e1d4fb411221318c3',
+                    },
+                ],
+            });
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'Failed to filter available shipping options:',
+                expect.any(Error),
+            );
+
+            consoleErrorSpy.mockRestore();
+        });
+
         it('calls onShippingAddressChange callback with empty address', async () => {
             await strategy.initialize(initialiseOptions);
 
@@ -453,6 +495,137 @@ describe('StripeLinkV2CustomerStrategy', () => {
             });
             await new Promise((resolve) => process.nextTick(resolve));
 
+            expect(stripeEvent).toHaveBeenCalledWith({
+                shippingRates: [
+                    {
+                        amount: 200000,
+                        displayName: 'description2',
+                        id: 2,
+                    },
+                    {
+                        amount: 100000,
+                        displayName: 'description',
+                        id: 1,
+                    },
+                ],
+            });
+        });
+
+        it('re-selects the first available option if filterAvailableShippingOptions removes the selected one', async () => {
+            jest.spyOn(paymentIntegrationService, 'getState').mockReturnValue({
+                ...paymentIntegrationService.getState(),
+                getConsignments: jest.fn().mockReturnValue([
+                    {
+                        availableShippingOptions: [
+                            {
+                                id: 1,
+                                description: 'description',
+                                cost: 1000,
+                            },
+                            {
+                                id: 2,
+                                description: 'description2',
+                                cost: 2000,
+                            },
+                        ],
+                        selectedShippingOption: {
+                            id: 2,
+                            description: 'description2',
+                            cost: 2000,
+                        },
+                    },
+                ]),
+            });
+
+            await strategy.initialize({
+                ...initialiseOptions,
+                stripeocs: {
+                    ...initialiseOptions.stripeocs,
+                    filterAvailableShippingOptions: (shippingOptions: ShippingOption[]) =>
+                        Promise.resolve(shippingOptions.slice(0, 1)),
+                },
+            });
+
+            stripeEventEmitter.emit(StripeElementEvent.SHIPPING_ADDRESS_CHANGE, {
+                address: {
+                    city: 'London',
+                    country: 'UK',
+                    postal_code: '091-22',
+                    state: 'CA',
+                },
+                resolve: stripeEvent,
+            });
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(1);
+            expect(stripeEvent).toHaveBeenCalledWith({
+                shippingRates: [
+                    {
+                        amount: 100000,
+                        displayName: 'description',
+                        id: 1,
+                    },
+                ],
+            });
+        });
+
+        it('resolves onShippingAddressChange with options filtered by filterAvailableShippingOptions', async () => {
+            const availableShippingOptions = [
+                {
+                    id: 1,
+                    description: 'description',
+                    cost: 1000,
+                },
+                {
+                    id: 2,
+                    description: 'description2',
+                    cost: 2000,
+                },
+                {
+                    id: 3,
+                    description: 'description3',
+                    cost: 3000,
+                },
+            ];
+            const filterAvailableShippingOptions = jest.fn((shippingOptions: ShippingOption[]) =>
+                Promise.resolve(shippingOptions.slice(0, 2)),
+            );
+
+            jest.spyOn(paymentIntegrationService, 'getState').mockReturnValue({
+                ...paymentIntegrationService.getState(),
+                getConsignments: jest.fn().mockReturnValue([
+                    {
+                        availableShippingOptions,
+                        selectedShippingOption: {
+                            id: 2,
+                            description: 'description2',
+                            cost: 2000,
+                        },
+                    },
+                ]),
+            });
+
+            await strategy.initialize({
+                ...initialiseOptions,
+                stripeocs: {
+                    ...initialiseOptions.stripeocs,
+                    filterAvailableShippingOptions,
+                },
+            });
+
+            stripeEventEmitter.emit(StripeElementEvent.SHIPPING_ADDRESS_CHANGE, {
+                address: {
+                    city: 'London',
+                    country: 'UK',
+                    postal_code: '091-22',
+                    state: 'CA',
+                },
+                resolve: stripeEvent,
+            });
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(filterAvailableShippingOptions).toHaveBeenCalledWith(availableShippingOptions);
+            expect(paymentIntegrationService.selectShippingOption).not.toHaveBeenCalled();
             expect(stripeEvent).toHaveBeenCalledWith({
                 shippingRates: [
                     {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
@@ -52,6 +52,9 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
     private _linkV2Element?: StripeElement;
     private _amountTransformer?: AmountTransformer;
     private _onComplete?: (orderId?: number) => Promise<never>;
+    private _filterAvailableShippingOptions?: (
+        availableShippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
     private _loadingIndicatorContainer?: string;
     private _captureMethod?: 'automatic' | 'manual';
     private _currencyCode?: string;
@@ -85,11 +88,13 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
             params: { method: methodId },
         });
         const paymentMethod = state.getPaymentMethodOrThrow(methodId, gatewayId);
-        const { loadingContainerId, buttonHeight, onComplete } = stripeocs;
+        const { loadingContainerId, buttonHeight, onComplete, filterAvailableShippingOptions } =
+            stripeocs;
 
         this._loadingIndicatorContainer = loadingContainerId;
 
         this._onComplete = onComplete;
+        this._filterAvailableShippingOptions = filterAvailableShippingOptions;
 
         if (!isStripePaymentMethodLike(paymentMethod)) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
@@ -518,14 +523,28 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
             return;
         }
 
-        const consignment = consignments[0];
-        const options = (consignment.availableShippingOptions || []).map(
-            this._getStripeShippingOption.bind(this),
-        );
-        const recommendedShippingOption = consignment.availableShippingOptions?.find(
+        let { availableShippingOptions = [] } = consignments[0];
+        const { selectedShippingOption } = consignments[0];
+
+        if (typeof this._filterAvailableShippingOptions === 'function') {
+            try {
+                availableShippingOptions = await this._filterAvailableShippingOptions(
+                    availableShippingOptions,
+                );
+            } catch (error) {
+                // INFO: fall back to the unfiltered options so the Stripe shipping event still resolves.
+                console.error('Failed to filter available shipping options:', error);
+            }
+        }
+
+        const options = availableShippingOptions.map(this._getStripeShippingOption.bind(this));
+        const recommendedShippingOption = availableShippingOptions.find(
             (shippingOption) => shippingOption.isRecommended,
         );
-        const selectedId = consignment.selectedShippingOption?.id;
+        const isSelectedOptionAvailable = availableShippingOptions.some(
+            (shippingOption) => shippingOption.id === selectedShippingOption?.id,
+        );
+        const selectedId = isSelectedOptionAvailable ? selectedShippingOption?.id : undefined;
         const recommendedId = recommendedShippingOption?.id;
 
         if (selectedId) {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-customer-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-customer-initialize-options.ts
@@ -1,3 +1,5 @@
+import { ShippingOption } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 export default interface StripeOCSCustomerInitializeOptions {
     buttonHeight?: number;
 
@@ -16,6 +18,15 @@ export default interface StripeOCSCustomerInitializeOptions {
     onComplete?: (orderId?: number) => Promise<never>;
 
     loadingContainerId?: string;
+
+    /**
+     * @param shippingOptions - The available shipping options.
+     * @returns The filtered shipping options.
+     * A function that filters the available shipping options.
+     */
+    filterAvailableShippingOptions?: (
+        shippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
 }
 
 export interface WithStripeOCSCustomerInitializeOptions {


### PR DESCRIPTION
## What/Why?

Adds an optional `filterAvailableShippingOptions` callback to `StripeOCSCustomerInitializeOptions`, consumed by both Stripe Link V2 strategies (customer and button). This lets a checkout implementation filter which shipping options are shown in the Stripe Link / Express Checkout payment sheet, e.g. to hide rates that shouldn't be offered for this payment flow:

```ts
checkoutService.initializeCustomer({
    methodId: 'stripeocs',
    stripeocs: {
        // ...
        filterAvailableShippingOptions: async (shippingOptions) =>
            shippingOptions.filter((option) => option.description !== 'Freight'),
    },
});
```

Behavior:

- The callback receives the consignment's full availableShippingOptions and returns the subset to display; it runs in _getAvailableShippingOptions before options are mapped to Stripe shipping rates.
- If the callback rejects or throws, the strategy logs the error and falls back to the unfiltered options, so the shipping-address-change event always resolves and the payment sheet never hangs.
- If the currently selected shipping option is filtered out, it is treated as unselected and the recommended (or first remaining) option is re-selected via selectShippingOption, keeping BigCommerce consignment state in sync with what the Stripe sheet displays.
- When the callback is not provided, behavior is unchanged.

## Rollout/Rollback
Rollback this PR

## Testing
Without filtering:

https://github.com/user-attachments/assets/602ddc1b-2893-4d5b-8993-4cc5380a85f1

With custom filtration

https://github.com/user-attachments/assets/d615a4fa-fa93-417e-b59f-e86fe2e5d53a



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes express-checkout shipping selection and consignment sync during Stripe Link V2 address changes; failures are mitigated by unfiltered fallback, but custom filters can still alter which rates customers see and which option is auto-selected.
> 
> **Overview**
> Adds an optional **`filterAvailableShippingOptions`** callback on `StripeOCSCustomerInitializeOptions`, used by both Stripe Link V2 **customer** and **button** strategies so checkout can control which rates appear in the Stripe express payment sheet.
> 
> During **`_getAvailableShippingOptions`**, the callback runs on the consignment’s full `availableShippingOptions` before rates are sent to Stripe. If it **throws or rejects**, the strategy logs and **falls back to unfiltered options** so the shipping-address-change handler still resolves. If filtering **drops the currently selected option**, that selection is ignored and **`selectShippingOption`** runs for the recommended or first remaining rate so BC consignment state matches the sheet. When the callback is omitted, behavior is unchanged.
> 
> Specs add coverage for failure fallback, successful filtering, and re-selection when the selected option is filtered out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336e0a218f2ffddb0e9529569988a3f3b5070687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->