### PR TITLE
fix(checkout): CHECKOUT-10262 Add B2B legacyProviderCodeMap

### DIFF
--- a/packages/core/src/payment/b2b-company-payment-method-filter-transformer.spec.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-filter-transformer.spec.ts
@@ -59,6 +59,24 @@ describe('filterPaymentMethodsByB2BCompanyAllowList', () => {
         expect(filterPaymentMethodsByB2BCompanyAllowList(methods, body)).toEqual([]);
     });
 
+    it('maps quickbooks to qbmsv2 when matching against the allow-list', () => {
+        const methods = [makeMethod('quickbooks')];
+        const body: B2BCompanyPaymentMethodsResponseBody = {
+            data: [{ code: 'qbmsv2', name: 'QuickBooks', isEnabled: '1', paymentId: 1 }],
+        };
+
+        expect(filterPaymentMethodsByB2BCompanyAllowList(methods, body)).toEqual(methods);
+    });
+
+    it('maps elavon to myvirtualmerchant when matching against the allow-list', () => {
+        const methods = [makeMethod('elavon')];
+        const body: B2BCompanyPaymentMethodsResponseBody = {
+            data: [{ code: 'myvirtualmerchant', name: 'Elavon', isEnabled: '1', paymentId: 1 }],
+        };
+
+        expect(filterPaymentMethodsByB2BCompanyAllowList(methods, body)).toEqual(methods);
+    });
+
     it('preserves the order of the input methods', () => {
         const methods = [makeMethod('stripev3'), makeMethod('braintree'), makeMethod('cheque')];
         const body: B2BCompanyPaymentMethodsResponseBody = {

--- a/packages/core/src/payment/b2b-company-payment-method-filter-transformer.ts
+++ b/packages/core/src/payment/b2b-company-payment-method-filter-transformer.ts
@@ -1,10 +1,16 @@
 import { B2BCompanyPaymentMethodsResponseBody } from './b2b-company-payment-method-request-sender';
 import PaymentMethod from './payment-method';
 
+const legacyProviderCodeMap: { [methodId: string]: string } = {
+    quickbooks: 'qbmsv2',
+    elavon: 'myvirtualmerchant',
+};
+
 /**
  * Intersects the storefront payment method list against a B2B company's
- * allow-list. Matches on `PaymentMethod.id === b2bMethod.code` and drops
- * disabled methods (`isEnabled !== '1'`).
+ * allow-list. Matches on `PaymentMethod.id === b2bMethod.code` (translating
+ * legacy provider IDs whose setup code differs from their checkout ID) and
+ * drops disabled methods (`isEnabled !== '1'`).
  */
 export default function filterPaymentMethodsByB2BCompanyAllowList(
     methods: PaymentMethod[],
@@ -12,5 +18,7 @@ export default function filterPaymentMethodsByB2BCompanyAllowList(
 ): PaymentMethod[] {
     const allowedCodes = new Set(body.data.filter((m) => m.isEnabled === '1').map((m) => m.code));
 
-    return methods.filter((method) => allowedCodes.has(method.id));
+    return methods.filter((method) =>
+        allowedCodes.has(legacyProviderCodeMap[method.id] ?? method.id),
+    );
 }


### PR DESCRIPTION
## What/Why?

Add `legacyProviderCodeMap` to support B2B merchants.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which payment methods appear for B2B checkout; scope is small and mapped to two known legacy pairs with tests, but incorrect mapping could hide or expose payment options.
> 
> **Overview**
> B2B company payment allow-list filtering now **translates legacy checkout payment IDs** before comparing to B2B API codes, so QuickBooks and Elavon methods are not incorrectly dropped when the allow-list uses setup/provider codes.
> 
> `filterPaymentMethodsByB2BCompanyAllowList` applies `legacyProviderCodeMap` (`quickbooks` → `qbmsv2`, `elavon` → `myvirtualmerchant`) when checking `allowedCodes`, instead of matching `PaymentMethod.id` directly to `b2bMethod.code`. Specs cover both mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3680d816a18c3393798b64900bce3f818ea4aaa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->