### PR TITLE
feat(payment): PI-5328 [Moneris][FE] Change the styling to match default BC fields

### DIFF
--- a/packages/moneris-integration/src/moneris-payment-initialize-options.ts
+++ b/packages/moneris-integration/src/moneris-payment-initialize-options.ts
@@ -15,11 +15,15 @@ import MonerisStylingProps from './moneris';
  *      moneris: {
  *          containerId: 'container',
  *          style : {
- *              cssBody: 'background:white;';
- *              cssTextbox: 'border-width:2px;';
- *              cssTextboxCardNumber: 'width:140px;';
- *              cssTextboxExpiryDate: 'width:40px;';
- *              cssTextboxCVV: 'width:40px';
+ *              cssBody: 'background:white;',
+ *              cssTextbox: 'border-width:2px;',
+ *              cssTextboxCardNumber: 'width:140px;',
+ *              cssTextboxExpiryDate: 'width:40px;',
+ *              cssTextboxCVV: 'width:40px;',
+ *              cssInputLabel: 'font-weight:500;',
+ *              cssLabelCardNumber: 'grid-column: 1 / 3; grid-row: 1;',
+ *              cssLabelExpiryDate: 'grid-column: 1; grid-row: 2;',
+ *              cssLabelCVV: 'grid-column: 2; grid-row: 2;',
  *          }
  *      }
  * });

--- a/packages/moneris-integration/src/moneris-payment-strategy.test.ts
+++ b/packages/moneris-integration/src/moneris-payment-strategy.test.ts
@@ -227,18 +227,6 @@ describe('MonerisPaymentStrategy', () => {
             expect(iframe.src).toContain(encodeURIComponent('font-family: Helvetica'));
         });
 
-        it('does not set formatting flags when custom styles are not provided', async () => {
-            paymentMethodMock.config.testMode = true;
-
-            await strategy.initialize(initializeOptions);
-
-            const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
-
-            expect(iframe).toBeTruthy();
-            expect(iframe.src).not.toContain('enable_cc_formatting=');
-            expect(iframe.src).not.toContain('enable_exp_formatting=');
-        });
-
         it('encodes css query params that contain percent characters', async () => {
             paymentMethodMock.config.testMode = true;
 

--- a/packages/moneris-integration/src/moneris-payment-strategy.test.ts
+++ b/packages/moneris-integration/src/moneris-payment-strategy.test.ts
@@ -215,8 +215,30 @@ describe('MonerisPaymentStrategy', () => {
             expect(iframe.src).toContain('css_textbox_exp=');
             expect(iframe.src).toContain('css_textbox_cvd=');
             expect(iframe.src).toContain('css_input_label=');
-            expect(iframe.src).toContain('border-radius:4px');
-            expect(iframe.src).toContain('font-family:%20Helvetica');
+            expect(iframe.src).toContain(encodeURIComponent('border-radius:4px'));
+            expect(iframe.src).toContain(encodeURIComponent('font-family: Helvetica'));
+        });
+
+        it('encodes css query params that contain percent characters', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize({
+                ...initializeOptions,
+                moneris: {
+                    ...initializeOptions.moneris!,
+                    style: {
+                        cssTextboxExpiryDate:
+                            'clear: both; float: left; margin-bottom: 0; margin-right: 12px; width: calc(50% - 12px);',
+                        cssTextboxCVV: 'float: left; margin-bottom: 0; width: calc(50% - 12px);',
+                    },
+                },
+            });
+
+            const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
+
+            expect(iframe).toBeTruthy();
+            expect(iframe.src).toContain('HPPtoken/index.php');
+            expect(iframe.src).toContain(encodeURIComponent('calc(50% - 12px)'));
         });
 
         it('fails to initialize moneris strategy when initialization options are not provided', async () => {

--- a/packages/moneris-integration/src/moneris-payment-strategy.test.ts
+++ b/packages/moneris-integration/src/moneris-payment-strategy.test.ts
@@ -202,6 +202,9 @@ describe('MonerisPaymentStrategy', () => {
                         cssTextboxExpiryDate: 'width: 120px;',
                         cssTextboxCVV: 'width: 80px;',
                         cssInputLabel: 'font-weight: 500;',
+                        cssLabelCardNumber: 'grid-column: 1 / 3; grid-row: 1;',
+                        cssLabelExpiryDate: 'grid-column: 1; grid-row: 2;',
+                        cssLabelCVV: 'grid-column: 2; grid-row: 2;',
                     },
                 },
             });
@@ -215,8 +218,25 @@ describe('MonerisPaymentStrategy', () => {
             expect(iframe.src).toContain('css_textbox_exp=');
             expect(iframe.src).toContain('css_textbox_cvd=');
             expect(iframe.src).toContain('css_input_label=');
+            expect(iframe.src).toContain('css_label_pan=');
+            expect(iframe.src).toContain('css_label_exp=');
+            expect(iframe.src).toContain('css_label_cvd=');
+            expect(iframe.src).toContain('enable_cc_formatting=1');
+            expect(iframe.src).toContain('enable_exp_formatting=1');
             expect(iframe.src).toContain(encodeURIComponent('border-radius:4px'));
             expect(iframe.src).toContain(encodeURIComponent('font-family: Helvetica'));
+        });
+
+        it('does not set formatting flags when custom styles are not provided', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize(initializeOptions);
+
+            const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
+
+            expect(iframe).toBeTruthy();
+            expect(iframe.src).not.toContain('enable_cc_formatting=');
+            expect(iframe.src).not.toContain('enable_exp_formatting=');
         });
 
         it('encodes css query params that contain percent characters', async () => {

--- a/packages/moneris-integration/src/moneris-payment-strategy.test.ts
+++ b/packages/moneris-integration/src/moneris-payment-strategy.test.ts
@@ -191,7 +191,20 @@ describe('MonerisPaymentStrategy', () => {
         it('initialize moneris iframe and sets hosted fields css', async () => {
             paymentMethodMock.config.testMode = true;
 
-            await strategy.initialize(initializeOptions);
+            await strategy.initialize({
+                ...initializeOptions,
+                moneris: {
+                    ...initializeOptions.moneris!,
+                    style: {
+                        cssBody: 'font-family: Helvetica;background: transparent;',
+                        cssTextbox: 'border-radius:4px;border:1px solid rgb(221,221,221);',
+                        cssTextboxCardNumber: 'width: 100%;',
+                        cssTextboxExpiryDate: 'width: 120px;',
+                        cssTextboxCVV: 'width: 80px;',
+                        cssInputLabel: 'font-weight: 500;',
+                    },
+                },
+            });
 
             const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
 
@@ -202,6 +215,8 @@ describe('MonerisPaymentStrategy', () => {
             expect(iframe.src).toContain('css_textbox_exp=');
             expect(iframe.src).toContain('css_textbox_cvd=');
             expect(iframe.src).toContain('css_input_label=');
+            expect(iframe.src).toContain('border-radius:4px');
+            expect(iframe.src).toContain('font-family:%20Helvetica');
         });
 
         it('fails to initialize moneris strategy when initialization options are not provided', async () => {

--- a/packages/moneris-integration/src/moneris-payment-strategy.ts
+++ b/packages/moneris-integration/src/moneris-payment-strategy.ts
@@ -274,12 +274,18 @@ export default class MonerisPaymentStrategy {
             css_input_label:
                 style?.cssInputLabel ||
                 'font-size: 10px;position: relative;top: 8px;left: 6px;background: rgb(255,255,255);padding: 3px 2px;color: rgb(66,66,66);font-weight: 600;z-index: 2;',
+            ...(style?.cssLabelCardNumber && { css_label_pan: style.cssLabelCardNumber }),
+            ...(style?.cssLabelExpiryDate && { css_label_exp: style.cssLabelExpiryDate }),
+            ...(style?.cssLabelCVV && { css_label_cvd: style.cssLabelCVV }),
             pan_label: initializationData.creditCardLabel || 'Credit Card Number',
             exp_label: initializationData.expiryDateLabel || 'Expiration',
             cvd_label: initializationData.cvdLabel || 'CVD',
         };
 
-        const queryString = map(monerisQueryParams, (value, key) => `${key}=${value}`).join('&');
+        const queryString = map(
+            monerisQueryParams,
+            (value, key) => `${key}=${encodeURIComponent(String(value))}`,
+        ).join('&');
 
         iframe.width = '100%';
         iframe.height = '100%';

--- a/packages/moneris-integration/src/moneris-payment-strategy.ts
+++ b/packages/moneris-integration/src/moneris-payment-strategy.ts
@@ -76,6 +76,7 @@ export default class MonerisPaymentStrategy {
                 monerisOptions.containerId,
                 initializationData,
                 !!config.testMode,
+                monerisOptions.style,
             );
         }
 
@@ -256,7 +257,9 @@ export default class MonerisPaymentStrategy {
             id: initializationData.profileId,
             pmmsg: true,
             display_labels: 1,
+            enable_cc_formatting: 1,
             enable_exp: 1,
+            enable_exp_formatting: 1,
             enable_cvd: 1,
             css_body:
                 style?.cssBody ||

--- a/packages/moneris-integration/src/moneris.ts
+++ b/packages/moneris-integration/src/moneris.ts
@@ -11,6 +11,10 @@
  *      cssTextboxCardNumber: 'width:140px;';
  *      cssTextboxExpiryDate: 'width:40px;';
  *      cssTextboxCVV: 'width:40px;';
+ *      cssInputLabel: 'font-weight:500;';
+ *      cssLabelCardNumber: 'grid-column: 1 / 3; grid-row: 1;';
+ *      cssLabelExpiryDate: 'grid-column: 1; grid-row: 2;';
+ *      cssLabelCVV: 'grid-column: 2; grid-row: 2;';
  * }
  * ```
  *

--- a/packages/moneris-integration/src/moneris.ts
+++ b/packages/moneris-integration/src/moneris.ts
@@ -50,7 +50,9 @@ export interface MoneriesHostedFieldsQueryParams {
     css_body: string;
     css_textbox: string;
     css_textbox_pan: string;
+    enable_cc_formatting: number;
     enable_exp: number;
+    enable_exp_formatting: number;
     css_textbox_exp: string;
     enable_cvd: number;
     css_textbox_cvd: string;

--- a/packages/moneris-integration/src/moneris.ts
+++ b/packages/moneris-integration/src/moneris.ts
@@ -42,6 +42,18 @@ export default interface MonerisStylingProps {
      * Stringified CSS to apply to input labels
      */
     cssInputLabel?: string;
+    /**
+     * Layout CSS for the card number label (`#monerisDataLabel`).
+     */
+    cssLabelCardNumber?: string;
+    /**
+     * Layout CSS for the expiry date label (`#monerisExpLabel`).
+     */
+    cssLabelExpiryDate?: string;
+    /**
+     * Layout CSS for the CVV label (`#monerisCvdLabel`).
+     */
+    cssLabelCVV?: string;
 }
 
 export interface MoneriesHostedFieldsQueryParams {
@@ -61,6 +73,9 @@ export interface MoneriesHostedFieldsQueryParams {
     exp_label: string;
     cvd_label: string;
     css_input_label: string;
+    css_label_pan?: string;
+    css_label_exp?: string;
+    css_label_cvd?: string;
 }
 
 export interface MonerisResponseData {


### PR DESCRIPTION
## What/Why?

- pass `styles` from `checkout-js` to apply them to the Moneris' iframe
- add CC number/expiry date field formatting

`checkout-js` part: https://github.com/bigcommerce/checkout-js/pull/3200

## Rollout/Rollback

Revert

## Testing
Before:
<img width="591" height="239" alt="Screenshot 2026-08-03 at 11 45 39" src="https://github.com/user-attachments/assets/f1f105eb-985a-496d-8d80-0aec00e974f5" />

After:
<img width="591" height="240" alt="Screenshot 2026-08-03 at 11 48 04" src="https://github.com/user-attachments/assets/0a5a0e83-ede1-4310-b6f4-827e1feae0a6" />

E2E:
<img width="826" height="99" alt="Screenshot 2026-08-03 at 11 58 34" src="https://github.com/user-attachments/assets/618adcea-0d95-40e3-98cc-1f8d364c0478" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect Moneris iframe URL parameters and presentation, not payment submission logic, but incorrect encoding or params could break the hosted form in checkout.
> 
> **Overview**
> **Moneris hosted card fields** now accept richer styling from `initializePayment` and send those options to the Moneris iframe URL so the form can align with default BigCommerce checkout fields.
> 
> New optional layout CSS on `MonerisStylingProps` (`cssLabelCardNumber`, `cssLabelExpiryDate`, `cssLabelCVV`) maps to Moneris query params `css_label_pan`, `css_label_exp`, and `css_label_cvd`. The iframe builder also always enables **card number and expiry formatting** (`enable_cc_formatting`, `enable_exp_formatting`).
> 
> **Query string construction** now uses `encodeURIComponent` on every param value, which fixes broken iframe URLs when custom CSS includes `%` (e.g. `calc(50% - 12px)`). Docs and tests were updated for the new style keys and encoding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edefef469e5d31544a87121daea056e609b6fdb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->