### PR TITLE
feat(payment): PAYPAL-6856 added ability to log errors into Sentry without throwing an error

### DIFF
--- a/packages/payment-integration-api/src/customer/customer-request-options.ts
+++ b/packages/payment-integration-api/src/customer/customer-request-options.ts
@@ -2,6 +2,7 @@ import { RequestOptions } from '@bigcommerce/request-sender';
 
 export interface CustomerRequestOptions extends RequestOptions {
     methodId?: string;
+    onErrorLog?: (error: unknown) => void;
 }
 
 export interface CustomerInitializeOptions extends CustomerRequestOptions {

--- a/packages/payment-integration-api/src/customer/customer-request-options.ts
+++ b/packages/payment-integration-api/src/customer/customer-request-options.ts
@@ -2,7 +2,6 @@ import { RequestOptions } from '@bigcommerce/request-sender';
 
 export interface CustomerRequestOptions extends RequestOptions {
     methodId?: string;
-    onErrorLog?: (error: unknown) => void;
 }
 
 export interface CustomerInitializeOptions extends CustomerRequestOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-initialize-options.ts
@@ -48,6 +48,11 @@ export default interface PayPalCommerceFastlaneCustomerInitializeOptions {
      * no matter which strategy was initialised first
      */
     styles?: PayPalFastlaneStylesOption;
+
+    /**
+     * Method that will only log errors with no-blocking flow
+     */
+    onErrorLog?: (error: unknown) => void;
 }
 
 export interface WithPayPalCommerceFastlaneCustomerInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
@@ -585,8 +585,8 @@ describe('PayPalCommerceFastlaneCustomerStrategy', () => {
                 ...initializationOptions,
                 paypalcommercefastlane: {
                     ...initializationOptions.paypalcommercefastlane,
+                    onErrorLog,
                 },
-                onErrorLog,
             });
 
             expect(onErrorLog).toHaveBeenCalledWith(error);
@@ -619,8 +619,8 @@ describe('PayPalCommerceFastlaneCustomerStrategy', () => {
                 ...initializationOptions,
                 paypalcommercefastlane: {
                     ...initializationOptions.paypalcommercefastlane,
+                    onErrorLog: 'not-a-function' as unknown as (error: unknown) => void,
                 },
-                onErrorLog: undefined,
             });
 
             expect(errorLogger).toHaveBeenCalledWith(error);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.spec.ts
@@ -551,4 +551,101 @@ describe('PayPalCommerceFastlaneCustomerStrategy', () => {
             expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalled();
         });
     });
+
+    describe('#handleErrorLog()', () => {
+        it('forwards Fastlane initialization error to the errorLogger provided in the constructor', async () => {
+            const error = new Error('Fastlane initialization failed');
+            const errorLogger = jest.fn();
+
+            strategy = new PayPalCommerceFastlaneCustomerStrategy(
+                paymentIntegrationService,
+                paypalSdkScriptLoader,
+                paypalCommerceFastlaneUtils,
+                errorLogger,
+            );
+
+            jest.spyOn(paypalSdkScriptLoader, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                Promise.reject(error),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            expect(errorLogger).toHaveBeenCalledWith(error);
+        });
+
+        it('forwards Fastlane initialization error to the onErrorLog option', async () => {
+            const error = new Error('Fastlane initialization failed');
+            const onErrorLog = jest.fn();
+
+            jest.spyOn(paypalSdkScriptLoader, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                Promise.reject(error),
+            );
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercefastlane: {
+                    ...initializationOptions.paypalcommercefastlane,
+                },
+                onErrorLog,
+            });
+
+            expect(onErrorLog).toHaveBeenCalledWith(error);
+        });
+
+        it('does not throw when initialization fails and no errorLogger is configured', async () => {
+            jest.spyOn(paypalSdkScriptLoader, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                Promise.reject(new Error('Fastlane initialization failed')),
+            );
+
+            await expect(strategy.initialize(initializationOptions)).resolves.toBeUndefined();
+        });
+
+        it('keeps the constructor errorLogger when the onErrorLog option is not a function', async () => {
+            const error = new Error('Fastlane initialization failed');
+            const errorLogger = jest.fn();
+
+            strategy = new PayPalCommerceFastlaneCustomerStrategy(
+                paymentIntegrationService,
+                paypalSdkScriptLoader,
+                paypalCommerceFastlaneUtils,
+                errorLogger,
+            );
+
+            jest.spyOn(paypalSdkScriptLoader, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                Promise.reject(error),
+            );
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercefastlane: {
+                    ...initializationOptions.paypalcommercefastlane,
+                },
+                onErrorLog: undefined,
+            });
+
+            expect(errorLogger).toHaveBeenCalledWith(error);
+        });
+
+        it('forwards authentication flow error to the errorLogger during executePaymentMethodCheckout', async () => {
+            const error = new Error('Authentication flow failed');
+            const errorLogger = jest.fn();
+
+            strategy = new PayPalCommerceFastlaneCustomerStrategy(
+                paymentIntegrationService,
+                paypalSdkScriptLoader,
+                paypalCommerceFastlaneUtils,
+                errorLogger,
+            );
+
+            jest.spyOn(paypalCommerceFastlaneUtils, 'lookupCustomerOrThrow').mockImplementation(
+                () => Promise.reject(error),
+            );
+
+            await strategy.initialize(initializationOptions);
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(errorLogger).toHaveBeenCalledWith(error);
+            expect(executionOptions.continueWithCheckoutCallback).toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -26,13 +26,13 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
         private paymentIntegrationService: PaymentIntegrationService,
         private paypalSdkScriptLoader: PayPalSdkScriptLoader,
         private paypalFastlaneUtils: PayPalFastlaneUtils,
-        private errorLogger?:(error: unknown) => void,
+        private errorLogger?: (error: unknown) => void,
     ) {}
 
     async initialize(
         options: CustomerInitializeOptions & WithPayPalCommerceFastlaneCustomerInitializeOptions,
     ): Promise<void> {
-        const { methodId, paypalcommercefastlane, onErrorLog } = options;
+        const { methodId, paypalcommercefastlane } = options;
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -41,9 +41,10 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
         }
 
         if (
-            onErrorLog && typeof onErrorLog === 'function'
+            paypalcommercefastlane?.onErrorLog &&
+            typeof paypalcommercefastlane.onErrorLog === 'function'
         ) {
-            this.errorLogger = onErrorLog;
+            this.errorLogger = paypalcommercefastlane.onErrorLog;
         }
 
         try {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -26,17 +26,24 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
         private paymentIntegrationService: PaymentIntegrationService,
         private paypalSdkScriptLoader: PayPalSdkScriptLoader,
         private paypalFastlaneUtils: PayPalFastlaneUtils,
+        private errorLogger?:(error: unknown) => void,
     ) {}
 
     async initialize(
         options: CustomerInitializeOptions & WithPayPalCommerceFastlaneCustomerInitializeOptions,
     ): Promise<void> {
-        const { methodId, paypalcommercefastlane } = options;
+        const { methodId, paypalcommercefastlane, onErrorLog } = options;
 
         if (!methodId) {
             throw new InvalidArgumentError(
                 'Unable to proceed because "methodId" argument is not provided.',
             );
+        }
+
+        if (
+            onErrorLog && typeof onErrorLog === 'function'
+        ) {
+            this.errorLogger = onErrorLog;
         }
 
         try {
@@ -60,9 +67,10 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
                 isTestModeEnabled,
                 this.getFastlaneStyles(methodId, paypalcommercefastlane),
             );
-        } catch (_) {
+        } catch (error) {
             // TODO: add logger to be able to debug issues if there any
             // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
+            this.handleErrorLog(error);
         }
 
         return Promise.resolve();
@@ -119,9 +127,10 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
 
             try {
                 await this.runPayPalAuthenticationFlowOrThrow(methodId);
-            } catch (_) {
+            } catch (error) {
                 // TODO: add logger to be able to debug issues if there any
                 // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
+                this.handleErrorLog(error);
             }
         }
 
@@ -227,5 +236,11 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
             isFastlaneStylingEnabled ? fastlaneStyles : {},
             paypalcommercefastlane?.styles,
         );
+    }
+
+    private handleErrorLog(error: unknown): void {
+        if (this.errorLogger) {
+            this.errorLogger(error);
+        }
     }
 }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-customer-strategy.ts
@@ -26,7 +26,7 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
         private paymentIntegrationService: PaymentIntegrationService,
         private paypalSdkScriptLoader: PayPalSdkScriptLoader,
         private paypalFastlaneUtils: PayPalFastlaneUtils,
-        private errorLogger?:(error: unknown) => void,
+        private errorLogger?: (error: unknown) => void,
     ) {}
 
     async initialize(
@@ -40,9 +40,7 @@ export default class PayPalCommerceFastlaneCustomerStrategy implements CustomerS
             );
         }
 
-        if (
-            onErrorLog && typeof onErrorLog === 'function'
-        ) {
+        if (onErrorLog && typeof onErrorLog === 'function') {
             this.errorLogger = onErrorLog;
         }
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-initialize-options.ts
@@ -74,6 +74,11 @@ export default interface PayPalCommerceFastlanePaymentInitializeOptions {
      * no matter what strategy was initialised first
      */
     styles?: PayPalFastlaneStylesOption;
+
+    /**
+     * Method that will only log errors with no-blocking flow
+     */
+    onErrorLog?: (error: unknown) => void;
 }
 
 export interface WithPayPalCommerceFastlanePaymentInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -397,58 +397,27 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
         });
 
         describe('error logging', () => {
-            it('does not throw when onErrorLog is provided but is not a function', async () => {
+            it('rejects initialization and does not wire onInit/onChange if initializing PayPal Fastlane fails', async () => {
                 const error = new Error('initializePayPalFastlane error');
+                const onInit = jest.fn();
+                const onChange = jest.fn();
 
                 jest.spyOn(paypalFastlaneUtils, 'initializePayPalFastlane').mockRejectedValue(
                     error,
                 );
-
-                const options = {
-                    methodId,
-                    paypalcommercefastlane: {
-                        onInit: jest.fn(),
-                        onChange: jest.fn(),
-                        onErrorLog: 'not a function',
-                    },
-                };
 
                 await expect(
-                    strategy.initialize(options as unknown as typeof initializationOptions),
-                ).resolves.toBeUndefined();
+                    strategy.initialize({
+                        methodId,
+                        paypalcommercefastlane: { onInit, onChange },
+                    }),
+                ).rejects.toThrow(error);
+
+                expect(onInit).not.toHaveBeenCalled();
+                expect(onChange).not.toHaveBeenCalled();
             });
 
-            it('does not throw and does not call onErrorLog when it is not provided and an error occurs', async () => {
-                const error = new Error('initializePayPalFastlane error');
-
-                jest.spyOn(paypalFastlaneUtils, 'initializePayPalFastlane').mockRejectedValue(
-                    error,
-                );
-
-                await expect(strategy.initialize(initializationOptions)).resolves.toBeUndefined();
-            });
-
-            it('logs an error with the provided onErrorLog callback if initializing PayPal Fastlane fails', async () => {
-                const error = new Error('initializePayPalFastlane error');
-                const onErrorLog = jest.fn();
-
-                jest.spyOn(paypalFastlaneUtils, 'initializePayPalFastlane').mockRejectedValue(
-                    error,
-                );
-
-                await strategy.initialize({
-                    methodId,
-                    paypalcommercefastlane: {
-                        onInit: jest.fn(),
-                        onChange: jest.fn(),
-                        onErrorLog,
-                    },
-                });
-
-                expect(onErrorLog).toHaveBeenCalledWith(error);
-            });
-
-            it('logs an error with the provided onErrorLog callback if the authentication flow fails', async () => {
+            it('logs an error with the provided onErrorLog callback if the authentication flow fails, without failing initialization', async () => {
                 const error = new Error('lookupCustomerOrThrow error');
                 const onErrorLog = jest.fn();
 
@@ -467,22 +436,41 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
                 expect(paypalFastlaneUtils.updateStorageSessionId).not.toHaveBeenCalled();
             });
 
-            it('logs an error with the provided onErrorLog callback if initializing the card component fails', async () => {
-                const error = new Error('FastlaneCardComponent error');
-                const onErrorLog = jest.fn();
+            it('does not throw when onErrorLog is provided but is not a function, for a soft-failing authentication flow error', async () => {
+                const error = new Error('lookupCustomerOrThrow error');
 
-                jest.spyOn(paypalFastlane, 'FastlaneCardComponent').mockRejectedValue(error);
+                jest.spyOn(paypalFastlaneUtils, 'lookupCustomerOrThrow').mockRejectedValue(error);
 
-                await strategy.initialize({
+                const options = {
                     methodId,
                     paypalcommercefastlane: {
                         onInit: jest.fn(),
                         onChange: jest.fn(),
-                        onErrorLog,
+                        onErrorLog: 'not a function',
                     },
-                });
+                };
 
-                expect(onErrorLog).toHaveBeenCalledWith(error);
+                await expect(
+                    strategy.initialize(options as unknown as typeof initializationOptions),
+                ).resolves.toBeUndefined();
+            });
+
+            it('rejects initialization and does not wire onInit/onChange if initializing the card component fails', async () => {
+                const error = new Error('FastlaneCardComponent error');
+                const onInit = jest.fn();
+                const onChange = jest.fn();
+
+                jest.spyOn(paypalFastlane, 'FastlaneCardComponent').mockRejectedValue(error);
+
+                await expect(
+                    strategy.initialize({
+                        methodId,
+                        paypalcommercefastlane: { onInit, onChange },
+                    }),
+                ).rejects.toThrow(error);
+
+                expect(onInit).not.toHaveBeenCalled();
+                expect(onChange).not.toHaveBeenCalled();
             });
         });
     });
@@ -908,6 +896,35 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
             const paypalFastlaneComponent = await paypalFastlane.FastlaneCardComponent({});
 
             expect(paypalFastlaneComponent.render).toHaveBeenCalledWith(containerId);
+        });
+
+        it('logs an error with the provided onErrorLog callback if rendering the card component fails, without throwing', async () => {
+            const containerId = 'containerIdMock';
+            const error = new Error('render error');
+            const onErrorLog = jest.fn();
+            let onInitCallback: (container: string) => void = noop;
+
+            const onInitImplementation = (renderComponentCallback: (container: string) => void) => {
+                onInitCallback = renderComponentCallback;
+            };
+
+            await strategy.initialize({
+                methodId,
+                paypalcommercefastlane: {
+                    onInit: jest.fn(onInitImplementation),
+                    onChange: jest.fn(),
+                    onErrorLog,
+                },
+            });
+
+            const paypalFastlaneComponent = await paypalFastlane.FastlaneCardComponent({});
+
+            jest.spyOn(paypalFastlaneComponent, 'render').mockImplementationOnce(() => {
+                throw error;
+            });
+
+            expect(() => onInitCallback(containerId)).not.toThrow();
+            expect(onErrorLog).toHaveBeenCalledWith(error);
         });
     });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.spec.ts
@@ -395,6 +395,96 @@ describe('PayPalCommerceFastlanePaymentStrategy', () => {
             expect(initializationOptions.paypalcommercefastlane.onInit).toHaveBeenCalled();
             expect(initializationOptions.paypalcommercefastlane.onChange).toHaveBeenCalled();
         });
+
+        describe('error logging', () => {
+            it('does not throw when onErrorLog is provided but is not a function', async () => {
+                const error = new Error('initializePayPalFastlane error');
+
+                jest.spyOn(paypalFastlaneUtils, 'initializePayPalFastlane').mockRejectedValue(
+                    error,
+                );
+
+                const options = {
+                    methodId,
+                    paypalcommercefastlane: {
+                        onInit: jest.fn(),
+                        onChange: jest.fn(),
+                        onErrorLog: 'not a function',
+                    },
+                };
+
+                await expect(
+                    strategy.initialize(options as unknown as typeof initializationOptions),
+                ).resolves.toBeUndefined();
+            });
+
+            it('does not throw and does not call onErrorLog when it is not provided and an error occurs', async () => {
+                const error = new Error('initializePayPalFastlane error');
+
+                jest.spyOn(paypalFastlaneUtils, 'initializePayPalFastlane').mockRejectedValue(
+                    error,
+                );
+
+                await expect(strategy.initialize(initializationOptions)).resolves.toBeUndefined();
+            });
+
+            it('logs an error with the provided onErrorLog callback if initializing PayPal Fastlane fails', async () => {
+                const error = new Error('initializePayPalFastlane error');
+                const onErrorLog = jest.fn();
+
+                jest.spyOn(paypalFastlaneUtils, 'initializePayPalFastlane').mockRejectedValue(
+                    error,
+                );
+
+                await strategy.initialize({
+                    methodId,
+                    paypalcommercefastlane: {
+                        onInit: jest.fn(),
+                        onChange: jest.fn(),
+                        onErrorLog,
+                    },
+                });
+
+                expect(onErrorLog).toHaveBeenCalledWith(error);
+            });
+
+            it('logs an error with the provided onErrorLog callback if the authentication flow fails', async () => {
+                const error = new Error('lookupCustomerOrThrow error');
+                const onErrorLog = jest.fn();
+
+                jest.spyOn(paypalFastlaneUtils, 'lookupCustomerOrThrow').mockRejectedValue(error);
+
+                await strategy.initialize({
+                    methodId,
+                    paypalcommercefastlane: {
+                        onInit: jest.fn(),
+                        onChange: jest.fn(),
+                        onErrorLog,
+                    },
+                });
+
+                expect(onErrorLog).toHaveBeenCalledWith(error);
+                expect(paypalFastlaneUtils.updateStorageSessionId).not.toHaveBeenCalled();
+            });
+
+            it('logs an error with the provided onErrorLog callback if initializing the card component fails', async () => {
+                const error = new Error('FastlaneCardComponent error');
+                const onErrorLog = jest.fn();
+
+                jest.spyOn(paypalFastlane, 'FastlaneCardComponent').mockRejectedValue(error);
+
+                await strategy.initialize({
+                    methodId,
+                    paypalcommercefastlane: {
+                        onInit: jest.fn(),
+                        onChange: jest.fn(),
+                        onErrorLog,
+                    },
+                });
+
+                expect(onErrorLog).toHaveBeenCalledWith(error);
+            });
+        });
     });
 
     describe('#execute()', () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -46,7 +46,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
     private paypalcommercefastlane?: PayPalCommerceFastlanePaymentInitializeOptions;
     private orderId?: string;
     private methodId?: string;
-    private errorLogger?:(error: unknown) => void;
+    private errorLogger?: (error: unknown) => void;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
@@ -130,28 +130,22 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
             paypalcommercefastlane?.styles,
         );
 
-        try {
-            await this.paypalFastlaneUtils.initializePayPalFastlane(
-                this.paypalFastlaneSdk,
-                !!isDeveloperModeApplicable,
-                fastlaneStyles,
-            );
+        await this.paypalFastlaneUtils.initializePayPalFastlane(
+            this.paypalFastlaneSdk,
+            !!isDeveloperModeApplicable,
+            fastlaneStyles,
+        );
 
-            if (this.shouldRunAuthenticationFlow()) {
-                await this.runPayPalAuthenticationFlowOrThrow(methodId);
-            }
-
-            await this.initializePayPalPaymentComponent();
-
-            paypalcommercefastlane.onInit((container: string) =>
-                this.renderPayPalPaymentComponent(container),
-            );
-            paypalcommercefastlane.onChange(() =>
-                this.handlePayPalStoredInstrumentChange(methodId),
-            );
-        } catch (error) {
-            this.handleErrorLog(error);
+        if (this.shouldRunAuthenticationFlow()) {
+            await this.runPayPalAuthenticationFlowOrThrow(methodId);
         }
+
+        await this.initializePayPalPaymentComponent();
+
+        paypalcommercefastlane.onInit((container: string) =>
+            this.renderPayPalPaymentComponent(container),
+        );
+        paypalcommercefastlane.onChange(() => this.handlePayPalStoredInstrumentChange(methodId));
     }
 
     async execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
@@ -317,7 +311,11 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
             );
         }
 
-        paypalComponentMethods.render(container);
+        try {
+            paypalComponentMethods.render(container);
+        } catch (error) {
+            this.handleErrorLog(error);
+        }
     }
 
     private getPayPalComponentMethodsOrThrow(): PayPalFastlaneCardComponentMethods {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -97,7 +97,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
         }
 
         if (
-            paypalcommercefastlane.onErrorLog ||
+            paypalcommercefastlane.onErrorLog &&
             typeof paypalcommercefastlane.onErrorLog === 'function'
         ) {
             this.errorLogger = paypalcommercefastlane.onErrorLog;
@@ -130,22 +130,28 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
             paypalcommercefastlane?.styles,
         );
 
-        await this.paypalFastlaneUtils.initializePayPalFastlane(
-            this.paypalFastlaneSdk,
-            !!isDeveloperModeApplicable,
-            fastlaneStyles,
-        );
+        try {
+            await this.paypalFastlaneUtils.initializePayPalFastlane(
+                this.paypalFastlaneSdk,
+                !!isDeveloperModeApplicable,
+                fastlaneStyles,
+            );
 
-        if (this.shouldRunAuthenticationFlow()) {
-            await this.runPayPalAuthenticationFlowOrThrow(methodId);
+            if (this.shouldRunAuthenticationFlow()) {
+                await this.runPayPalAuthenticationFlowOrThrow(methodId);
+            }
+
+            await this.initializePayPalPaymentComponent();
+
+            paypalcommercefastlane.onInit((container: string) =>
+                this.renderPayPalPaymentComponent(container),
+            );
+            paypalcommercefastlane.onChange(() =>
+                this.handlePayPalStoredInstrumentChange(methodId),
+            );
+        } catch (error) {
+            this.handleErrorLog(error);
         }
-
-        await this.initializePayPalPaymentComponent();
-
-        paypalcommercefastlane.onInit((container: string) =>
-            this.renderPayPalPaymentComponent(container),
-        );
-        paypalcommercefastlane.onChange(() => this.handlePayPalStoredInstrumentChange(methodId));
     }
 
     async execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
@@ -266,6 +272,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
             }
         } catch (error) {
             // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
+            this.handleErrorLog(error);
         }
     }
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-fastlane/paypal-commerce-fastlane-payment-strategy.ts
@@ -46,6 +46,7 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
     private paypalcommercefastlane?: PayPalCommerceFastlanePaymentInitializeOptions;
     private orderId?: string;
     private methodId?: string;
+    private errorLogger?:(error: unknown) => void;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
@@ -93,6 +94,13 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
             throw new InvalidArgumentError(
                 'Unable to initialize payment because "options.paypalcommercefastlane.onChange" argument is not provided or it is not a function.',
             );
+        }
+
+        if (
+            paypalcommercefastlane.onErrorLog ||
+            typeof paypalcommercefastlane.onErrorLog === 'function'
+        ) {
+            this.errorLogger = paypalcommercefastlane.onErrorLog;
         }
 
         await this.paymentIntegrationService.loadPaymentMethod(methodId);
@@ -512,6 +520,12 @@ export default class PaypalCommerceFastlanePaymentStrategy implements PaymentStr
             typeof this.paypalcommercefastlane.onError === 'function'
         ) {
             this.paypalcommercefastlane.onError(error);
+        }
+    }
+
+    private handleErrorLog(error: unknown): void {
+        if (this.errorLogger) {
+            this.errorLogger(error);
         }
     }
 }


### PR DESCRIPTION
## What/Why?
Added ability to log errors into Sentry without throwing an error

## Rollout/Rollback
Revert

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive callbacks on existing swallow-error paths in PayPal Fastlane strategies; checkout flow behavior when logging is omitted stays the same.
> 
> **Overview**
> Adds an optional **`onErrorLog`** callback so checkout can record PayPal Fastlane failures (e.g. Sentry) without changing the existing **non-blocking** behavior when SDK init or guest authentication fails.
> 
> **`CustomerRequestOptions`** now includes `onErrorLog`; the Fastlane **customer strategy** stores initialize options and invokes it from the same catch blocks that previously swallowed errors during initialization and `executePaymentMethodCheckout`. The **payment strategy** adds `onErrorLog` on `paypalcommercefastlane` options and calls it when the soft-failing authentication path errors; **`onError`** remains for blocking/user-facing payment errors.
> 
> Unit tests cover forwarding errors, missing callbacks, invalid callback types, and that hard failures (card component init/render) still throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53be1b8a4232b3a743208ae04f9097ad4381f42a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->