### PR TITLE
fix(payment): resolve Stripe Link V2 method from state and verify completion by intent token

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.spec.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 
 import {
     MissingDataError,
+    MissingDataErrorType,
     NotInitializedError,
     PaymentIntegrationService,
     PaymentMethodCancelledError,
@@ -43,7 +44,7 @@ describe('StripeLinkV2ButtonStrategy', () => {
     let stripeEventEmitter: EventEmitter;
     let stripeIntegrationService: StripeIntegrationService;
     let loadingIndicator: LoadingIndicator;
-    const stripePaymentMethod = getStripeOCSMock();
+    const stripePaymentMethod = getStripeOCSMock('optimized_checkout');
 
     const isLoading = jest.fn();
     let confirmPaymentMock: jest.Mock;
@@ -146,8 +147,11 @@ describe('StripeLinkV2ButtonStrategy', () => {
         jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
             stripePaymentMethod,
         );
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockReturnValue(
+            undefined,
+        );
         jest.spyOn(paymentIntegrationService.getState(), 'getCartLocale').mockReturnValue('en');
-        jest.spyOn(stripeIntegrationService, 'isPaymentCompleted').mockReturnValue(
+        jest.spyOn(stripeIntegrationService, 'isPaymentCompletedByToken').mockReturnValue(
             Promise.resolve(false),
         );
 
@@ -250,6 +254,106 @@ describe('StripeLinkV2ButtonStrategy', () => {
                 mode: 'payment',
             });
             expect(element.mount).toHaveBeenCalledWith('#checkout-button');
+        });
+    });
+
+    describe('payment method loading', () => {
+        it('does not load payment method if checkout_session method is already loaded', async () => {
+            const cachedPaymentMethod = getStripeOCSMock('checkout_session');
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockImplementation(
+                (methodId) => (methodId === 'checkout_session' ? cachedPaymentMethod : undefined),
+            );
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+            expect(scriptLoader.getStripeClient).toHaveBeenCalledWith(
+                cachedPaymentMethod.initializationData,
+                'en',
+                StripeJsVersion.CLOVER,
+            );
+        });
+
+        it('initializes from the already loaded stripe method when the generic gateway method is no longer in state', async () => {
+            const cachedPaymentMethod = getStripeOCSMock('checkout_session');
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockImplementation(
+                (methodId) => (methodId === 'checkout_session' ? cachedPaymentMethod : undefined),
+            );
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockImplementation(() => {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            });
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+            expect(element.mount).toHaveBeenCalledWith('#checkout-button');
+        });
+
+        it('does not load payment method if optimized_checkout method is already loaded', async () => {
+            const cachedPaymentMethod = getStripeOCSMock('optimized_checkout');
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockImplementation(
+                (methodId) => (methodId === 'optimized_checkout' ? cachedPaymentMethod : undefined),
+            );
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+            expect(scriptLoader.getStripeClient).toHaveBeenCalledWith(
+                cachedPaymentMethod.initializationData,
+                'en',
+                StripeJsVersion.CLOVER,
+            );
+        });
+
+        it('loads checkout_session payment method if checkout session is enabled and no stripe method is loaded yet', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...getStripeOCSMock('checkout_session'),
+                initializationData: {
+                    ...getStripeOCSMock().initializationData,
+                    checkoutSessionEnabled: true,
+                },
+            });
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith('stripeocs', {
+                params: { method: 'checkout_session' },
+            });
+        });
+
+        it('loads optimized_checkout payment method if checkout session is disabled and no stripe method is loaded yet', async () => {
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith('stripeocs', {
+                params: { method: 'optimized_checkout' },
+            });
+        });
+
+        it('submits payment with the id of the already loaded payment method', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockImplementation(
+                (methodId) =>
+                    methodId === 'checkout_session'
+                        ? getStripeOCSMock('checkout_session')
+                        : undefined,
+            );
+
+            await strategy.initialize(initialiseOptions);
+
+            stripeEventEmitter.emit(StripeElementEvent.CONFIRM, mockStripeAddress);
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                expect.objectContaining({ methodId: 'checkout_session' }),
+            );
         });
     });
 
@@ -800,7 +904,7 @@ describe('StripeLinkV2ButtonStrategy', () => {
                 jest.spyOn(stripeIntegrationService, 'isAdditionalActionError').mockReturnValue(
                     true,
                 );
-                jest.spyOn(stripeIntegrationService, 'isPaymentCompleted').mockReturnValue(
+                jest.spyOn(stripeIntegrationService, 'isPaymentCompletedByToken').mockReturnValue(
                     Promise.resolve(false),
                 );
                 errorResponse = new RequestError(
@@ -1013,7 +1117,7 @@ describe('StripeLinkV2ButtonStrategy', () => {
                     paymentIntegrationService.getState(),
                     'getPaymentMethodOrThrow',
                 ).mockReturnValue({
-                    ...getStripeOCSMock(),
+                    ...getStripeOCSMock('checkout_session'),
                     initializationData: {
                         ...getStripeOCSMock().initializationData,
                         checkoutSessionEnabled: true,
@@ -1046,6 +1150,44 @@ describe('StripeLinkV2ButtonStrategy', () => {
                 });
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
                     methodId: 'checkout_session',
+                    paymentData: {
+                        formattedPayload: {
+                            cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                            credit_card_token: {
+                                token: 'paymentIntentId',
+                            },
+                            confirm: false,
+                            method: 'link',
+                        },
+                    },
+                });
+            });
+
+            it('skips stripe confirmation and uses retrieved payment intent if payment is already completed', async () => {
+                jest.spyOn(stripeIntegrationService, 'isPaymentCompletedByToken').mockReturnValue(
+                    Promise.resolve(true),
+                );
+                retrievePaymentIntentMock.mockResolvedValue({
+                    paymentIntent: {
+                        id: 'paymentIntentId',
+                    },
+                });
+
+                mockFirstPaymentRequest(errorResponse);
+                await strategy.initialize(initialiseOptions);
+
+                stripeEventEmitter.emit(StripeElementEvent.CONFIRM, mockStripeAddress);
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(stripeIntegrationService.isPaymentCompletedByToken).toHaveBeenCalledWith(
+                    'token',
+                    stripeClient,
+                );
+                expect(confirmPaymentMock).not.toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).toHaveBeenCalledWith('token');
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                    methodId: 'optimized_checkout',
                     paymentData: {
                         formattedPayload: {
                             cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-button-strategy.ts
@@ -11,6 +11,7 @@ import {
     NotInitializedErrorType,
     Payment,
     PaymentIntegrationService,
+    PaymentMethod,
     PaymentMethodCancelledError,
     PaymentMethodFailedError,
     ShippingOption,
@@ -80,11 +81,7 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const methodId = this._getMethodId(gatewayId);
-        const state = await this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
-            params: { method: methodId },
-        });
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId, gatewayId);
+        const paymentMethod = await this._getPaymentMethod(gatewayId);
         const { loadingContainerId, buttonHeight, onComplete, filterAvailableShippingOptions } =
             stripeocs;
 
@@ -97,13 +94,13 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const { initializationData } = paymentMethod;
+        const { initializationData, id: methodId } = paymentMethod;
         const { captureMethod } = initializationData;
 
         this._captureMethod = captureMethod;
         this._stripeClient = await this.scriptLoader.getStripeClient(
             initializationData,
-            state.getCartLocale(),
+            this.paymentIntegrationService.getState().getCartLocale(),
             StripeJsVersion.CLOVER,
         );
 
@@ -374,10 +371,7 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
         const { data: additionalActionData } = error.body.additional_action_required;
         const { token } = additionalActionData;
 
-        const { paymentIntent } = await this._confirmStripePaymentOrThrow(
-            additionalActionData,
-            methodId,
-        );
+        const { paymentIntent } = await this._confirmStripePaymentOrThrow(additionalActionData);
 
         const paymentPayload = this._getPaymentPayload(methodId, paymentIntent?.id || token);
 
@@ -394,7 +388,6 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
 
     private async _confirmStripePaymentOrThrow(
         additionalActionData: StripeAdditionalActionRequired['data'],
-        methodId: string,
     ): Promise<StripeResult | never> {
         const { token, redirect_url } = additionalActionData;
         const stripePaymentData = this.stripeIntegrationService.mapStripePaymentData(
@@ -404,10 +397,11 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
         let stripeError: StripeError | undefined;
 
         try {
-            const isPaymentCompleted = await this.stripeIntegrationService.isPaymentCompleted(
-                methodId,
-                this._stripeClient,
-            );
+            const isPaymentCompleted =
+                await this.stripeIntegrationService.isPaymentCompletedByToken(
+                    token,
+                    this._stripeClient,
+                );
 
             const confirmationResult = !isPaymentCompleted
                 ? await this._stripeClient?.confirmPayment({
@@ -610,14 +604,34 @@ export default class StripeLinkV2ButtonStrategy implements CheckoutButtonStrateg
         }
     }
 
-    private _getMethodId(gatewayId: string): string {
-        const { initializationData: { checkoutSessionEnabled } = {} } =
-            this.paymentIntegrationService
-                .getState()
-                .getPaymentMethodOrThrow<StripeInitializationData>(gatewayId);
+    private async _getPaymentMethod(
+        gatewayId: string,
+    ): Promise<PaymentMethod<StripeInitializationData>> {
+        let state = this.paymentIntegrationService.getState();
+        const stripePaymentMethod =
+            state.getPaymentMethod<StripeInitializationData>(
+                StripePaymentMethodType.CHECKOUT_SESSION,
+                gatewayId,
+            ) ||
+            state.getPaymentMethod<StripeInitializationData>(
+                StripePaymentMethodType.OCS,
+                gatewayId,
+            );
 
-        return checkoutSessionEnabled
+        if (stripePaymentMethod) {
+            return stripePaymentMethod;
+        }
+
+        const { initializationData } =
+            state.getPaymentMethodOrThrow<StripeInitializationData>(gatewayId);
+        const methodId = initializationData?.checkoutSessionEnabled
             ? StripePaymentMethodType.CHECKOUT_SESSION
             : StripePaymentMethodType.OCS;
+
+        state = await this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
+            params: { method: methodId },
+        });
+
+        return state.getPaymentMethodOrThrow(methodId, gatewayId);
     }
 }

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import {
     InvalidArgumentError,
     MissingDataError,
+    MissingDataErrorType,
     NotInitializedError,
     PaymentIntegrationService,
     PaymentMethodCancelledError,
@@ -44,7 +45,7 @@ describe('StripeLinkV2CustomerStrategy', () => {
     let stripeEventEmitter: EventEmitter;
     let stripeIntegrationService: StripeIntegrationService;
     let loadingIndicator: LoadingIndicator;
-    const stripePaymentMethod = getStripeOCSMock();
+    const stripePaymentMethod = getStripeOCSMock('optimized_checkout');
 
     const isLoading = jest.fn();
     let confirmPaymentMock: jest.Mock;
@@ -146,8 +147,11 @@ describe('StripeLinkV2CustomerStrategy', () => {
         jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
             stripePaymentMethod,
         );
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockReturnValue(
+            undefined,
+        );
         jest.spyOn(paymentIntegrationService.getState(), 'getCartLocale').mockReturnValue('en');
-        jest.spyOn(stripeIntegrationService, 'isPaymentCompleted').mockReturnValue(
+        jest.spyOn(stripeIntegrationService, 'isPaymentCompletedByToken').mockReturnValue(
             Promise.resolve(false),
         );
 
@@ -259,6 +263,106 @@ describe('StripeLinkV2CustomerStrategy', () => {
                 mode: 'payment',
             });
             expect(element.mount).toHaveBeenCalledWith('#checkout-button');
+        });
+    });
+
+    describe('payment method loading', () => {
+        it('does not load payment method if checkout_session method is already loaded', async () => {
+            const cachedPaymentMethod = getStripeOCSMock('checkout_session');
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockImplementation(
+                (methodId) => (methodId === 'checkout_session' ? cachedPaymentMethod : undefined),
+            );
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+            expect(scriptLoader.getStripeClient).toHaveBeenCalledWith(
+                cachedPaymentMethod.initializationData,
+                'en',
+                StripeJsVersion.CLOVER,
+            );
+        });
+
+        it('initializes from the already loaded stripe method when the generic gateway method is no longer in state', async () => {
+            const cachedPaymentMethod = getStripeOCSMock('checkout_session');
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockImplementation(
+                (methodId) => (methodId === 'checkout_session' ? cachedPaymentMethod : undefined),
+            );
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockImplementation(() => {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            });
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+            expect(element.mount).toHaveBeenCalledWith('#checkout-button');
+        });
+
+        it('does not load payment method if optimized_checkout method is already loaded', async () => {
+            const cachedPaymentMethod = getStripeOCSMock('optimized_checkout');
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockImplementation(
+                (methodId) => (methodId === 'optimized_checkout' ? cachedPaymentMethod : undefined),
+            );
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+            expect(scriptLoader.getStripeClient).toHaveBeenCalledWith(
+                cachedPaymentMethod.initializationData,
+                'en',
+                StripeJsVersion.CLOVER,
+            );
+        });
+
+        it('loads checkout_session payment method if checkout session is enabled and no stripe method is loaded yet', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...getStripeOCSMock('checkout_session'),
+                initializationData: {
+                    ...getStripeOCSMock().initializationData,
+                    checkoutSessionEnabled: true,
+                },
+            });
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith('stripeocs', {
+                params: { method: 'checkout_session' },
+            });
+        });
+
+        it('loads optimized_checkout payment method if checkout session is disabled and no stripe method is loaded yet', async () => {
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith('stripeocs', {
+                params: { method: 'optimized_checkout' },
+            });
+        });
+
+        it('submits payment with the id of the already loaded payment method', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockImplementation(
+                (methodId) =>
+                    methodId === 'checkout_session'
+                        ? getStripeOCSMock('checkout_session')
+                        : undefined,
+            );
+
+            await strategy.initialize(initialiseOptions);
+
+            stripeEventEmitter.emit(StripeElementEvent.CONFIRM, mockStripeAddress);
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                expect.objectContaining({ methodId: 'checkout_session' }),
+            );
         });
     });
 
@@ -809,7 +913,7 @@ describe('StripeLinkV2CustomerStrategy', () => {
                 jest.spyOn(stripeIntegrationService, 'isAdditionalActionError').mockReturnValue(
                     true,
                 );
-                jest.spyOn(stripeIntegrationService, 'isPaymentCompleted').mockReturnValue(
+                jest.spyOn(stripeIntegrationService, 'isPaymentCompletedByToken').mockReturnValue(
                     Promise.resolve(false),
                 );
                 errorResponse = new RequestError(
@@ -1022,7 +1126,7 @@ describe('StripeLinkV2CustomerStrategy', () => {
                     paymentIntegrationService.getState(),
                     'getPaymentMethodOrThrow',
                 ).mockReturnValue({
-                    ...getStripeOCSMock(),
+                    ...getStripeOCSMock('checkout_session'),
                     initializationData: {
                         ...getStripeOCSMock().initializationData,
                         checkoutSessionEnabled: true,
@@ -1055,6 +1159,44 @@ describe('StripeLinkV2CustomerStrategy', () => {
                 });
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
                     methodId: 'checkout_session',
+                    paymentData: {
+                        formattedPayload: {
+                            cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                            credit_card_token: {
+                                token: 'paymentIntentId',
+                            },
+                            confirm: false,
+                            method: 'link',
+                        },
+                    },
+                });
+            });
+
+            it('skips stripe confirmation and uses retrieved payment intent if payment is already completed', async () => {
+                jest.spyOn(stripeIntegrationService, 'isPaymentCompletedByToken').mockReturnValue(
+                    Promise.resolve(true),
+                );
+                retrievePaymentIntentMock.mockResolvedValue({
+                    paymentIntent: {
+                        id: 'paymentIntentId',
+                    },
+                });
+
+                mockFirstPaymentRequest(errorResponse);
+                await strategy.initialize(initialiseOptions);
+
+                stripeEventEmitter.emit(StripeElementEvent.CONFIRM, mockStripeAddress);
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(stripeIntegrationService.isPaymentCompletedByToken).toHaveBeenCalledWith(
+                    'token',
+                    stripeClient,
+                );
+                expect(confirmPaymentMock).not.toHaveBeenCalled();
+                expect(retrievePaymentIntentMock).toHaveBeenCalledWith('token');
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                    methodId: 'optimized_checkout',
                     paymentData: {
                         formattedPayload: {
                             cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
@@ -12,6 +12,7 @@ import {
     NotInitializedErrorType,
     Payment,
     PaymentIntegrationService,
+    PaymentMethod,
     PaymentMethodCancelledError,
     PaymentMethodFailedError,
     ShippingOption,
@@ -83,11 +84,7 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        const methodId = this._getMethodId(gatewayId);
-        const state = await this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
-            params: { method: methodId },
-        });
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId, gatewayId);
+        const paymentMethod = await this._getPaymentMethod(gatewayId);
         const { loadingContainerId, buttonHeight, onComplete, filterAvailableShippingOptions } =
             stripeocs;
 
@@ -100,13 +97,13 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const { initializationData } = paymentMethod;
+        const { initializationData, id: methodId } = paymentMethod;
         const { captureMethod } = initializationData;
 
         this._captureMethod = captureMethod;
         this._stripeClient = await this.scriptLoader.getStripeClient(
             initializationData,
-            state.getCartLocale(),
+            this.paymentIntegrationService.getState().getCartLocale(),
             StripeJsVersion.CLOVER,
         );
 
@@ -377,10 +374,7 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
         const { data: additionalActionData } = error.body.additional_action_required;
         const { token } = additionalActionData;
 
-        const { paymentIntent } = await this._confirmStripePaymentOrThrow(
-            additionalActionData,
-            methodId,
-        );
+        const { paymentIntent } = await this._confirmStripePaymentOrThrow(additionalActionData);
 
         const paymentPayload = this._getPaymentPayload(methodId, paymentIntent?.id || token);
 
@@ -397,7 +391,6 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
 
     private async _confirmStripePaymentOrThrow(
         additionalActionData: StripeAdditionalActionRequired['data'],
-        methodId: string,
     ): Promise<StripeResult | never> {
         const { token, redirect_url } = additionalActionData;
         const stripePaymentData = this.stripeIntegrationService.mapStripePaymentData(
@@ -407,10 +400,11 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
         let stripeError: StripeError | undefined;
 
         try {
-            const isPaymentCompleted = await this.stripeIntegrationService.isPaymentCompleted(
-                methodId,
-                this._stripeClient,
-            );
+            const isPaymentCompleted =
+                await this.stripeIntegrationService.isPaymentCompletedByToken(
+                    token,
+                    this._stripeClient,
+                );
 
             const confirmationResult = !isPaymentCompleted
                 ? await this._stripeClient?.confirmPayment({
@@ -612,14 +606,34 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
         }
     }
 
-    private _getMethodId(gatewayId: string): string {
-        const { initializationData: { checkoutSessionEnabled } = {} } =
-            this.paymentIntegrationService
-                .getState()
-                .getPaymentMethodOrThrow<StripeInitializationData>(gatewayId);
+    private async _getPaymentMethod(
+        gatewayId: string,
+    ): Promise<PaymentMethod<StripeInitializationData>> {
+        let state = this.paymentIntegrationService.getState();
+        const stripePaymentMethod =
+            state.getPaymentMethod<StripeInitializationData>(
+                StripePaymentMethodType.CHECKOUT_SESSION,
+                gatewayId,
+            ) ||
+            state.getPaymentMethod<StripeInitializationData>(
+                StripePaymentMethodType.OCS,
+                gatewayId,
+            );
 
-        return checkoutSessionEnabled
+        if (stripePaymentMethod) {
+            return stripePaymentMethod;
+        }
+
+        const { initializationData } =
+            state.getPaymentMethodOrThrow<StripeInitializationData>(gatewayId);
+        const methodId = initializationData?.checkoutSessionEnabled
             ? StripePaymentMethodType.CHECKOUT_SESSION
             : StripePaymentMethodType.OCS;
+
+        state = await this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
+            params: { method: methodId },
+        });
+
+        return state.getPaymentMethodOrThrow(methodId, gatewayId);
     }
 }

--- a/packages/stripe-utils/src/stripe-integration-service.mock.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.mock.ts
@@ -22,6 +22,7 @@ export const getStripeIntegrationServiceMock = () =>
         }),
         isCancellationError: jest.fn(() => false),
         isPaymentCompleted: jest.fn(() => Promise.resolve(false)),
+        isPaymentCompletedByToken: jest.fn(() => Promise.resolve(false)),
         mapStripePaymentData: jest.fn((return_url?: string) => ({
             elements: getStripeJsMock().elements({}),
             redirect: StripeStringConstants.IF_REQUIRED,

--- a/packages/stripe-utils/src/stripe-integration-service.spec.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.spec.ts
@@ -537,6 +537,96 @@ describe('StripeIntegrationService', () => {
         });
     });
 
+    describe('#isPaymentCompletedByToken', () => {
+        const setConfirmationExperiment = (enabled = true) => {
+            const storeConfig: StoreConfig = {
+                ...getConfig().storeConfig,
+                checkoutSettings: {
+                    ...getConfig().storeConfig.checkoutSettings,
+                    features: {
+                        'PI-626.Block_unnecessary_payment_confirmation_for_StripeUPE': enabled,
+                    },
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getStoreConfigOrThrow',
+            ).mockReturnValue(storeConfig);
+        };
+
+        beforeEach(() => {
+            setConfirmationExperiment(true);
+            stripeUPEJsMock = {
+                ...getStripeJsMock(),
+                retrievePaymentIntent: jest.fn().mockResolvedValue({
+                    paymentIntent: {
+                        status: 'succeeded',
+                    },
+                }),
+            };
+        });
+
+        it('returns true if payment intent already completed', async () => {
+            expect(
+                await stripeIntegrationService.isPaymentCompletedByToken('token', stripeUPEJsMock),
+            ).toBe(true);
+
+            expect(stripeUPEJsMock.retrievePaymentIntent).toHaveBeenCalledWith('token');
+        });
+
+        it('returns false if no token provided', async () => {
+            expect(
+                await stripeIntegrationService.isPaymentCompletedByToken(
+                    undefined,
+                    stripeUPEJsMock,
+                ),
+            ).toBe(false);
+        });
+
+        it('returns false if no stripe client', async () => {
+            expect(
+                await stripeIntegrationService.isPaymentCompletedByToken('token', undefined),
+            ).toBe(false);
+        });
+
+        it('returns false if experiment disabled', async () => {
+            setConfirmationExperiment(false);
+
+            expect(
+                await stripeIntegrationService.isPaymentCompletedByToken('token', stripeUPEJsMock),
+            ).toBe(false);
+        });
+
+        it('returns false if no payment intent retrieved', async () => {
+            stripeUPEJsMock = {
+                ...getStripeJsMock(),
+                retrievePaymentIntent: jest.fn().mockResolvedValue({
+                    paymentIntent: undefined,
+                }),
+            };
+
+            expect(
+                await stripeIntegrationService.isPaymentCompletedByToken('token', stripeUPEJsMock),
+            ).toBe(false);
+        });
+
+        it('returns false if payment status not succeed', async () => {
+            stripeUPEJsMock = {
+                ...getStripeJsMock(),
+                retrievePaymentIntent: jest.fn().mockResolvedValue({
+                    paymentIntent: {
+                        status: 'failed',
+                    },
+                }),
+            };
+
+            expect(
+                await stripeIntegrationService.isPaymentCompletedByToken('token', stripeUPEJsMock),
+            ).toBe(false);
+        });
+    });
+
     describe('#mapStripePaymentData', () => {
         beforeEach(() => {
             jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue(

--- a/packages/stripe-utils/src/stripe-integration-service.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.ts
@@ -163,6 +163,26 @@ export default class StripeIntegrationService {
         return paymentIntent?.status === StripePaymentIntentStatus.SUCCEEDED;
     }
 
+    async isPaymentCompletedByToken(
+        token?: string,
+        stripeUPEClient?: StripeClient,
+    ): Promise<boolean> {
+        const state = this.paymentIntegrationService.getState();
+        const { features } = state.getStoreConfigOrThrow().checkoutSettings;
+
+        if (
+            !token ||
+            !stripeUPEClient ||
+            !features['PI-626.Block_unnecessary_payment_confirmation_for_StripeUPE']
+        ) {
+            return false;
+        }
+
+        const { paymentIntent } = await stripeUPEClient.retrievePaymentIntent(token);
+
+        return paymentIntent?.status === StripePaymentIntentStatus.SUCCEEDED;
+    }
+
     mapStripePaymentData(
         stripeElements?: StripeElements,
         returnUrl?: string,


### PR DESCRIPTION
## What/Why?
### Resolve the Stripe payment method from state before loading it

The Stripe Link V2 (Express Checkout) customer and button strategies always requested the
gateway payment method with a `?method=` param during `initialize()`, deriving the method id
from the gateway-level config entry (`stripeocs`). That entry is only guaranteed to be in
state on page initialization — after the shopper visits the payments step, other payment
requests replace the payment-methods state: the generic `stripeocs` entry disappears while
the previously loaded specific method (`checkout_session` / `optimized_checkout`) remains.
Re-initializing the wallet button in that state threw `MissingDataError` and also performed
a redundant network request when the specific method was already available.

Both strategies now resolve the payment method via a new `_getPaymentMethod(gatewayId)`:

1. Return the specific `checkout_session` / `optimized_checkout` method if it is already in
   state (covers the post-payments-step phase and skips the redundant reload).
2. Otherwise read `checkoutSessionEnabled` from the gateway config entry and load the
   required method with `loadPaymentMethod(gatewayId, { params: { method } })`.

`methodId` used for events and payment submission is now taken from the resolved payment
method's `id` instead of being derived separately.

### Verify payment completion by the payment intent token

During the additional-action (3DS) confirmation flow, the strategies previously called
`isPaymentCompleted(methodId)`, which reads `clientToken` from the state-loaded method — a
different intent than the one being confirmed, and it depends on the method being present in
state. The new `StripeIntegrationService#isPaymentCompletedByToken(token)` checks the exact
payment intent identified by the `additional_action_required` token (the same secret passed
to `confirmPayment`), with no state lookup. The existing method-based check remains in place
for the OCS/UPE payment strategies, whose confirmation target is the method's `clientToken`.

## Rollout/Rollback
Rollback this PR

## Testing
### Stripe Link V2 with Payment Intent (optimise_checkout)

#### Buttons in the customer step

https://github.com/user-attachments/assets/6eedecb8-ad59-4c89-aadb-8997cb5d540e


https://github.com/user-attachments/assets/491027dc-ca06-42cb-a504-4f4fb5fc8c49

#### Buttons on top of checkout

https://github.com/user-attachments/assets/aa27048b-7ee7-44d4-b21d-545170e019b4


https://github.com/user-attachments/assets/1a74d9aa-c720-4096-bd85-87ba869ecf88

### Stripe Link V2 with Checkout Session (checkout_session)

#### Buttons in the customer step

https://github.com/user-attachments/assets/2c36a2a9-e6e2-46a0-853d-b75f842d6b9f


https://github.com/user-attachments/assets/522d6527-60db-47bd-aa11-c28ccfe69412


#### Buttons on top of checkout

https://github.com/user-attachments/assets/91ad320c-678b-4e41-bb50-fec66e3310b9


https://github.com/user-attachments/assets/da46b274-9ba5-4508-8592-a6aa885165bc



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Stripe Link V2 initialize and payment-confirmation paths; behavior is covered by new tests but still touches checkout payment submission and 3DS handling.
> 
> **Overview**
> Fixes Stripe Link V2 express checkout when payment-methods state no longer includes the generic `stripeocs` gateway entry after the shopper visits the payments step.
> 
> **Payment method resolution:** Button and customer strategies no longer always call `loadPaymentMethod` during `initialize()`. They use `_getPaymentMethod` to reuse `checkout_session` or `optimized_checkout` from state when already loaded, and only load the specific method when needed. Payment submission and event wiring use the resolved method’s `id`.
> 
> **3DS / additional-action flow:** Confirmation now uses `isPaymentCompletedByToken` with the `additional_action_required` token instead of `isPaymentCompleted(methodId)`, so completion is checked on the intent being confirmed. When the intent already succeeded (under the PI-626 experiment), `confirmPayment` is skipped and the payment intent is retrieved instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5927d26d05b2989e8aca499d7cc3ceaaafec4770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->