### PR TITLE
feat(checkout): CHECKOUT-10295 Remove throwing error from applyB2bFilter

### DIFF
--- a/packages/core/src/payment/payment-method-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-method-action-creator.spec.ts
@@ -233,6 +233,32 @@ describe('PaymentMethodActionCreator', () => {
                     },
                 ]);
             });
+
+            it('succeeds with unfiltered methods when the B2B context is incomplete', async () => {
+                jest.spyOn(store.getState().customer, 'getCustomerOrThrow').mockReturnValue({
+                    ...getCheckout().customer,
+                    isGuest: true,
+                });
+
+                const actions = await from(paymentMethodActionCreator.loadPaymentMethods()(store))
+                    .pipe(toArray())
+                    .toPromise();
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: PaymentMethodActionType.LoadPaymentMethodsRequested },
+                    {
+                        type: PaymentMethodActionType.LoadPaymentMethodsSucceeded,
+                        payload: paymentMethodsResponse.body,
+                        meta: {
+                            deviceSessionId: paymentMethodsResponse.headers['x-device-session-id'],
+                            sessionHash: paymentMethodsResponse.headers['x-session-hash'],
+                        },
+                    },
+                ]);
+            });
         });
 
         describe('with B2B invoice allow-list filtering', () => {
@@ -462,7 +488,7 @@ describe('PaymentMethodActionCreator', () => {
                 ).rejects.toThrow(MissingDataError);
             });
 
-            it('throws MissingDataError when the customer is a guest', async () => {
+            it('returns methods unfiltered when the customer is a guest', async () => {
                 const guestCustomer = {
                     ...getCheckout().customer,
                     isGuest: true,
@@ -473,12 +499,15 @@ describe('PaymentMethodActionCreator', () => {
                     guestCustomer,
                 );
 
+                const methods = [getPaymentMethod()];
+
                 await expect(
-                    (paymentMethodActionCreator as any)._applyB2bFilter(
-                        [getPaymentMethod()],
-                        store.getState(),
-                    ),
-                ).rejects.toThrow(MissingDataError);
+                    (paymentMethodActionCreator as any)._applyB2bFilter(methods, store.getState()),
+                ).resolves.toEqual(methods);
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
             });
 
             it('returns methods unfiltered when the B2B token is missing', async () => {
@@ -495,7 +524,7 @@ describe('PaymentMethodActionCreator', () => {
                 ).not.toHaveBeenCalled();
             });
 
-            it('throws MissingDataError when companyId is missing', async () => {
+            it('returns methods unfiltered when companyId is missing', async () => {
                 const noCompanyCart = {
                     ...getCheckout().cart,
                     companyId: null,
@@ -504,15 +533,18 @@ describe('PaymentMethodActionCreator', () => {
                 jest.spyOn(store.getState().cart, 'getCart').mockReturnValue(noCompanyCart);
                 jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(noCompanyCart);
 
+                const methods = [getPaymentMethod()];
+
                 await expect(
-                    (paymentMethodActionCreator as any)._applyB2bFilter(
-                        [getPaymentMethod()],
-                        store.getState(),
-                    ),
-                ).rejects.toThrow(MissingDataError);
+                    (paymentMethodActionCreator as any)._applyB2bFilter(methods, store.getState()),
+                ).resolves.toEqual(methods);
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
             });
 
-            it('throws MissingDataError when the resolved B2B base URL is empty', async () => {
+            it('returns methods unfiltered when the resolved B2B base URL is empty', async () => {
                 const baseConfig = store.getState().config.getStoreConfig()!;
 
                 jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
@@ -520,12 +552,15 @@ describe('PaymentMethodActionCreator', () => {
                     b2bApiSettings: { baseUrl: '', clientId: '' },
                 });
 
+                const methods = [getPaymentMethod()];
+
                 await expect(
-                    (paymentMethodActionCreator as any)._applyB2bFilter(
-                        [getPaymentMethod()],
-                        store.getState(),
-                    ),
-                ).rejects.toThrow(MissingDataError);
+                    (paymentMethodActionCreator as any)._applyB2bFilter(methods, store.getState()),
+                ).resolves.toEqual(methods);
+
+                expect(
+                    b2bCompanyPaymentMethodRequestSender.getB2BCompanyPaymentMethods,
+                ).not.toHaveBeenCalled();
             });
 
             it('delegates to the invoice filter when b2bPaymentMethodFilterType is Invoice', async () => {

--- a/packages/core/src/payment/payment-method-action-creator.ts
+++ b/packages/core/src/payment/payment-method-action-creator.ts
@@ -4,7 +4,6 @@ import { Observable, Observer } from 'rxjs';
 import { resolveB2bBaseUrl } from '../b2b-dev-tools';
 import { InternalCheckoutSelectors } from '../checkout';
 import { ActionOptions, cachableAction } from '../common/data-store';
-import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 import { B2BPaymentMethodFilterType } from '../config/capabilities';
 
@@ -184,11 +183,7 @@ export default class PaymentMethodActionCreator {
             state.config.getStoreConfig()?.b2bApiSettings?.baseUrl ?? '',
         );
 
-        if (customer.isGuest || !baseUrl || !cart.companyId) {
-            throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
-        }
-
-        if (!b2bToken) {
+        if (customer.isGuest || !baseUrl || !cart.companyId || !b2bToken) {
             return methods;
         }
 


### PR DESCRIPTION
## What/Why?

We return `"b2bPaymentMethodFilterType":"standard` on a b2b checkout page(custom checkout).

As a result, lacking b2b config led to an error before.

This PR removes the error, returns unfiltered payment methods, so that b2b checkout can upgrade SDK version.

## Rollout/Rollback

Revert.

## Testing
### Manual testing the changes on `b2b-checkout-app`
https://github.com/user-attachments/assets/8bfd6ac0-3836-4b7f-be11-3577c17e2d36


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout payment-method visibility when B2B filter is configured but token, company, URL, or logged-in customer data is missing—intentionally broader method lists instead of hard failures.
> 
> **Overview**
> When B2B payment method filtering is enabled (`b2bPaymentMethodFilterType` set) but checkout context is incomplete—guest customer, missing `companyId`, empty B2B base URL, or missing B2B token—**`_applyB2bFilter` no longer throws `MissingDataError`**. It returns the original payment method list without calling B2B APIs.
> 
> This fixes custom B2B checkouts that report the standard filter capability while B2B config is not fully present, so **`loadPaymentMethods` can succeed** instead of failing during filter application. Tests were updated to expect unfiltered results (and no B2B request) for those cases, plus a new `loadPaymentMethods` success path for incomplete B2B context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9d667b590236e7b79afd356ada4ffc6669f170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->