### PR TITLE
chore(deps): bump bigpay-client from 5.28.1 to 5.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.949.0",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.28.1",
+        "@bigcommerce/bigpay-client": "^5.29.0",
         "@bigcommerce/data-store": "^1.0.3",
         "@bigcommerce/form-poster": "^1.5.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2024,9 +2024,9 @@
       "license": "MIT"
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.28.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.28.1.tgz",
-      "integrity": "sha512-FCY7WCqBG/N+f9QIr1XG/qZLW1AVlS/A3y5nUNVjJsUW0wKrnINPss72M8V79HmogSdNHlImAbt8dFx0089NwQ==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.29.0.tgz",
+      "integrity": "sha512-nW9qOPm/sTIjJ7YQzWULBL9QG4EAm4/SPWZV2O/LABOu4/Z9CRBLeupfGHIXKXqRfp3jTi+VU2+dVoM/k4gHGg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "addFileAttribute": "true"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^5.28.1",
+    "@bigcommerce/bigpay-client": "^5.29.0",
     "@bigcommerce/data-store": "^1.0.3",
     "@bigcommerce/form-poster": "^1.5.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
bump bigpay-client from 5.28.1 to 5.29.0

## Rollout/Rollback
Rollback

## Testing
unite tests
