### PR TITLE
chore(deps): bump bigpay-client from 5.28.1 to 5.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.950.0",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.28.1",
+        "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",
         "@bigcommerce/form-poster": "^1.5.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2024,9 +2024,9 @@
       "license": "MIT"
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.28.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.28.1.tgz",
-      "integrity": "sha512-FCY7WCqBG/N+f9QIr1XG/qZLW1AVlS/A3y5nUNVjJsUW0wKrnINPss72M8V79HmogSdNHlImAbt8dFx0089NwQ==",
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.31.0.tgz",
+      "integrity": "sha512-HIXRu150rZIQYcof+GyYZe24ApeaLRzoPmfuc1Cwqf/7LwJjQZe2AFx+Ozj4Y+yDZHZiv207FPYOM8JV/wbOsg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "addFileAttribute": "true"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^5.28.1",
+    "@bigcommerce/bigpay-client": "^5.31.0",
     "@bigcommerce/data-store": "^1.0.3",
     "@bigcommerce/form-poster": "^1.5.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

bump bigpay-client from 5.28.1 to 5.31.0

latest [bigpay-client 5.31.0](https://www.npmjs.com/package/@bigcommerce/bigpay-client)

## Rollout/Rollback

Rollout

## Testing

Unit test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `bigpay-client` drives BigPay payment requests from checkout; a minor version jump can change payloads or behavior even without local code edits, so regression testing on payment flows is warranted.
> 
> **Overview**
> Updates the **`@bigcommerce/bigpay-client`** dependency from **5.28.1** to **5.31.0** in `package.json` and `package-lock.json`. There are **no changes** to checkout SDK source code in this PR—only the resolved registry version and integrity hash for the client package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e7d27412f88e002bd1d0ccef031a690e0b65d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->