### PR TITLE
fix(checkout): CHECKOUT-10281 Fix Shipping Option Issues

### DIFF
--- a/packages/core/src/common/http-request/merge-includes.spec.ts
+++ b/packages/core/src/common/http-request/merge-includes.spec.ts
@@ -1,0 +1,27 @@
+import mergeIncludes from './merge-includes';
+
+describe('mergeIncludes()', () => {
+    const baseIncludes: string[] = ['foo', 'bar'];
+
+    it('returns base includes when dictionary is not provided', () => {
+        expect(mergeIncludes(baseIncludes)).toBe('foo,bar');
+    });
+
+    it('appends includes that are turned on in the dictionary', () => {
+        expect(mergeIncludes(baseIncludes, { hello: true, world: true })).toBe(
+            'foo,bar,hello,world',
+        );
+    });
+
+    it('removes base includes that are turned off in the dictionary', () => {
+        expect(mergeIncludes(baseIncludes, { bar: false })).toBe('foo');
+    });
+
+    it('does not duplicate base includes that are turned on in the dictionary', () => {
+        expect(mergeIncludes(baseIncludes, { bar: true })).toBe('foo,bar');
+    });
+
+    it('applies additions and deletions from the same dictionary', () => {
+        expect(mergeIncludes(baseIncludes, { foo: false, hello: true })).toBe('bar,hello');
+    });
+});

--- a/packages/core/src/common/http-request/merge-includes.ts
+++ b/packages/core/src/common/http-request/merge-includes.ts
@@ -1,4 +1,4 @@
-import { difference, filter, keys, pickBy } from 'lodash';
+import { difference, keys, pickBy } from 'lodash';
 
 import joinIncludes from './join-includes';
 
@@ -11,7 +11,7 @@ export default function mergeIncludes<T extends string>(
     includesDictionary?: { [key in T]?: boolean },
 ): string {
     const deletions = keys(pickBy(includesDictionary, (on) => !on));
-    const additions = keys(filter(includesDictionary));
+    const additions = keys(pickBy(includesDictionary, (on) => on));
 
     return joinIncludes([...difference(baseIncludes, deletions), ...additions]);
 }

--- a/packages/core/src/shipping/consignment-reducer.spec.ts
+++ b/packages/core/src/shipping/consignment-reducer.spec.ts
@@ -1,4 +1,5 @@
 import { createAction } from '@bigcommerce/data-store';
+import { omit } from 'lodash';
 
 import { CheckoutActionType } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
@@ -6,6 +7,7 @@ import { CouponActionType } from '../coupon';
 
 import { ConsignmentActionType } from './consignment-actions';
 import consignmentReducer from './consignment-reducer';
+import { getConsignment } from './consignments.mock';
 
 import { ConsignmentState } from '.';
 
@@ -276,6 +278,51 @@ describe('consignmentReducer', () => {
 
         expect(consignmentReducer(initialState, action)).toMatchObject({
             data: action.payload && action.payload.consignments,
+        });
+    });
+
+    it.each([
+        ConsignmentActionType.LoadShippingOptionsSucceeded,
+        ConsignmentActionType.CreateConsignmentsSucceeded,
+        ConsignmentActionType.UpdateConsignmentSucceeded,
+        ConsignmentActionType.DeleteConsignmentSucceeded,
+        ConsignmentActionType.UpdateShippingOptionSucceeded,
+        CouponActionType.ApplyCouponSucceeded,
+        CouponActionType.RemoveCouponSucceeded,
+    ])(
+        'resets available shipping options when %s returns consignments without them',
+        (actionType) => {
+            const action = createAction(
+                actionType,
+                {
+                    ...getCheckout(),
+                    consignments: [omit(getConsignment(), 'availableShippingOptions')],
+                },
+                { id },
+            );
+
+            expect(
+                consignmentReducer({ ...initialState, data: [getConsignment()] }, action),
+            ).toMatchObject({
+                data: [expect.objectContaining({ availableShippingOptions: [] })],
+            });
+        },
+    );
+
+    it('keeps previously loaded available shipping options when checkout is loaded without them', () => {
+        const action = createAction(CheckoutActionType.LoadCheckoutSucceeded, {
+            ...getCheckout(),
+            consignments: [omit(getConsignment(), 'availableShippingOptions')],
+        });
+
+        expect(
+            consignmentReducer({ ...initialState, data: [getConsignment()] }, action),
+        ).toMatchObject({
+            data: [
+                expect.objectContaining({
+                    availableShippingOptions: getConsignment().availableShippingOptions,
+                }),
+            ],
         });
     });
 });

--- a/packages/core/src/shipping/consignment-reducer.ts
+++ b/packages/core/src/shipping/consignment-reducer.ts
@@ -42,7 +42,6 @@ function dataReducer(
         | CheckoutHydrateAction,
 ): Consignment[] | undefined {
     switch (action.type) {
-        case CheckoutActionType.LoadCheckoutSucceeded:
         case ConsignmentActionType.LoadShippingOptionsSucceeded:
         case ConsignmentActionType.CreateConsignmentsSucceeded:
         case ConsignmentActionType.UpdateConsignmentSucceeded:
@@ -50,6 +49,12 @@ function dataReducer(
         case ConsignmentActionType.UpdateShippingOptionSucceeded:
         case CouponActionType.ApplyCouponSucceeded:
         case CouponActionType.RemoveCouponSucceeded:
+            return arrayReplace(
+                data,
+                normalizeAvailableShippingOptions(action.payload?.consignments),
+            );
+
+        case CheckoutActionType.LoadCheckoutSucceeded:
             return arrayReplace(data, action.payload && action.payload.consignments);
 
         case CustomerActionType.SignOutCustomerSucceeded:
@@ -61,6 +66,18 @@ function dataReducer(
         default:
             return data;
     }
+}
+
+function normalizeAvailableShippingOptions(
+    consignments?: Consignment[],
+): Consignment[] | undefined {
+    return (
+        consignments &&
+        consignments.map((consignment) => ({
+            ...consignment,
+            availableShippingOptions: consignment.availableShippingOptions ?? [],
+        }))
+    );
 }
 
 function errorsReducer(


### PR DESCRIPTION
## What/Why?

Fix two bugs:
- `mergeIncludes` had a bug where include params passed as `{ key: true }` were dropped and replaced
  with junk array indices (`0,1,2,3,4`).
- The consignment reducer merged API responses key-by-key, so when a consignment/coupon request
  came back without `availableShippingOptions` values, the store kept the stale shipping options. 
     - This becomes a bug when there is really no available shipping options.

## Rollout/Rollback

Revert.

## Testing
### Manual Testing
#### 1. Sending correct `include` params.
Before (current OOPC), missing:
- `consignments.availableShippingOptions`
- `billingAddress.extraFields`
- `consignments.address.extraFields`
- `consignments.shippingAddress.extraFields`
- `customer.addresses.b2b`

<img width="1510" height="825" alt="Screenshot 2026-08-05 at 11 27 00" src="https://github.com/user-attachments/assets/e5bea198-e506-4832-8cc3-2886fcef92b5" />

After
<img width="1510" height="825" alt="Screenshot 2026-08-05 at 11 20 04" src="https://github.com/user-attachments/assets/71211f8a-ab50-49bf-8051-5760ba4e74c0" />


#### 2. Remove invalid shipping options
https://github.com/user-attachments/assets/fb646c6f-e80b-425d-aaeb-4f6b0ab6e3fd



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout HTTP include construction and shipping-option store semantics; incorrect behavior could break API includes or show wrong shipping choices, but scope is limited and well-tested.
> 
> **Overview**
> Fixes checkout shipping issues by correcting how API `include` query params are built and how consignment state handles missing `availableShippingOptions` on partial API responses.
> 
> **`mergeIncludes`** now derives additions with `pickBy(..., on => on)` instead of `filter(includesDictionary)`, which previously treated the dictionary like an array and produced bogus include keys (e.g. `0,1,2…`). New unit tests cover base includes, toggles, and combined add/remove behavior.
> 
> **Consignment reducer** routes consignment/coupon success actions through `normalizeAvailableShippingOptions`, which sets `availableShippingOptions` to `[]` when the payload omits or nulls the field—so stale options are not kept when the API truly has none. **`LoadCheckoutSucceeded`** still merges consignments as before (no normalization), preserving options already loaded when checkout reload omits them. Tests assert reset behavior across the affected action types and the checkout-load exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c8f3f28405ada6f3887627735df219e5d92ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->