### PR TITLE
fix(checkout): CHECKOUT-10281 Revert normalizeAvailableShippingOptions

### DIFF
--- a/packages/core/src/shipping/consignment-reducer.spec.ts
+++ b/packages/core/src/shipping/consignment-reducer.spec.ts
@@ -1,5 +1,4 @@
 import { createAction } from '@bigcommerce/data-store';
-import { omit } from 'lodash';
 
 import { CheckoutActionType } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
@@ -7,7 +6,6 @@ import { CouponActionType } from '../coupon';
 
 import { ConsignmentActionType } from './consignment-actions';
 import consignmentReducer from './consignment-reducer';
-import { getConsignment } from './consignments.mock';
 
 import { ConsignmentState } from '.';
 
@@ -278,51 +276,6 @@ describe('consignmentReducer', () => {
 
         expect(consignmentReducer(initialState, action)).toMatchObject({
             data: action.payload && action.payload.consignments,
-        });
-    });
-
-    it.each([
-        ConsignmentActionType.LoadShippingOptionsSucceeded,
-        ConsignmentActionType.CreateConsignmentsSucceeded,
-        ConsignmentActionType.UpdateConsignmentSucceeded,
-        ConsignmentActionType.DeleteConsignmentSucceeded,
-        ConsignmentActionType.UpdateShippingOptionSucceeded,
-        CouponActionType.ApplyCouponSucceeded,
-        CouponActionType.RemoveCouponSucceeded,
-    ])(
-        'resets available shipping options when %s returns consignments without them',
-        (actionType) => {
-            const action = createAction(
-                actionType,
-                {
-                    ...getCheckout(),
-                    consignments: [omit(getConsignment(), 'availableShippingOptions')],
-                },
-                { id },
-            );
-
-            expect(
-                consignmentReducer({ ...initialState, data: [getConsignment()] }, action),
-            ).toMatchObject({
-                data: [expect.objectContaining({ availableShippingOptions: [] })],
-            });
-        },
-    );
-
-    it('keeps previously loaded available shipping options when checkout is loaded without them', () => {
-        const action = createAction(CheckoutActionType.LoadCheckoutSucceeded, {
-            ...getCheckout(),
-            consignments: [omit(getConsignment(), 'availableShippingOptions')],
-        });
-
-        expect(
-            consignmentReducer({ ...initialState, data: [getConsignment()] }, action),
-        ).toMatchObject({
-            data: [
-                expect.objectContaining({
-                    availableShippingOptions: getConsignment().availableShippingOptions,
-                }),
-            ],
         });
     });
 });

--- a/packages/core/src/shipping/consignment-reducer.ts
+++ b/packages/core/src/shipping/consignment-reducer.ts
@@ -42,6 +42,7 @@ function dataReducer(
         | CheckoutHydrateAction,
 ): Consignment[] | undefined {
     switch (action.type) {
+        case CheckoutActionType.LoadCheckoutSucceeded:
         case ConsignmentActionType.LoadShippingOptionsSucceeded:
         case ConsignmentActionType.CreateConsignmentsSucceeded:
         case ConsignmentActionType.UpdateConsignmentSucceeded:
@@ -49,12 +50,6 @@ function dataReducer(
         case ConsignmentActionType.UpdateShippingOptionSucceeded:
         case CouponActionType.ApplyCouponSucceeded:
         case CouponActionType.RemoveCouponSucceeded:
-            return arrayReplace(
-                data,
-                normalizeAvailableShippingOptions(action.payload?.consignments),
-            );
-
-        case CheckoutActionType.LoadCheckoutSucceeded:
             return arrayReplace(data, action.payload && action.payload.consignments);
 
         case CustomerActionType.SignOutCustomerSucceeded:
@@ -66,18 +61,6 @@ function dataReducer(
         default:
             return data;
     }
-}
-
-function normalizeAvailableShippingOptions(
-    consignments?: Consignment[],
-): Consignment[] | undefined {
-    return (
-        consignments &&
-        consignments.map((consignment) => ({
-            ...consignment,
-            availableShippingOptions: consignment.availableShippingOptions ?? [],
-        }))
-    );
 }
 
 function errorsReducer(


### PR DESCRIPTION
## What/Why?

Revert `normalizeAvailableShippingOptions` changes because:
- Non-shipping-related consignment updates causes existing shipping options to disappear when users edit fields such as phone number, first name, or last name.
   - This limitation can sometimes cause the UI to show an incorrect shipping option.
- To avoid introducing a breaking behavioural change, this PR preserves the existing behaviour for now.

This is to revert half of the PR:
- https://github.com/bigcommerce/checkout-sdk-js/pull/3344

The other half of the PR seems working as expected.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout shipping UI state when consignments are updated without `availableShippingOptions` in the response; fixes a user-visible bug but restores prior merge behavior that may leave stale options in some load-checkout cases.
> 
> **Overview**
> Reverts **`normalizeAvailableShippingOptions`** in the consignment reducer so consignment updates no longer force empty `availableShippingOptions` when the API omits them.
> 
> **`dataReducer`** now replaces consignment data directly from checkout payloads for load checkout, shipping options, consignment CRUD, shipping option updates, and coupon actions—without defaulting missing options to `[]`. **`LoadCheckoutSucceeded`** is handled the same way as those actions instead of preserving prior options when a reload lacks them.
> 
> Related spec coverage for normalization and merge behavior is removed; remaining tests still assert plain payload replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b797bc7199686b6d2ddeb5373d3891486d1c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->