### PR TITLE
feat(payment): PAYPAL-6856 added error logger for BCP FL

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-customer-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-customer-strategy.spec.ts
@@ -550,4 +550,89 @@ describe('BigCommercePaymentsFastlaneCustomerStrategy', () => {
             expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalled();
         });
     });
+
+    describe('#handleErrorLog()', () => {
+        it('forwards Fastlane initialization error to the onErrorLog callback', async () => {
+            const error = new Error('Fastlane initialization failed');
+            const onErrorLog = jest.fn();
+
+            jest.spyOn(bigCommercePaymentsSdk, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                Promise.reject(error),
+            );
+
+            await strategy.initialize({
+                ...initializationOptions,
+                onErrorLog,
+            });
+
+            expect(onErrorLog).toHaveBeenCalledWith(error);
+        });
+
+        it('does not throw when initialization fails and no onErrorLog is configured', async () => {
+            jest.spyOn(bigCommercePaymentsSdk, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                Promise.reject(new Error('Fastlane initialization failed')),
+            );
+
+            await expect(strategy.initialize(initializationOptions)).resolves.toBeUndefined();
+        });
+
+        it('does not throw when onErrorLog is provided but is not a function', async () => {
+            jest.spyOn(bigCommercePaymentsSdk, 'getPayPalFastlaneSdk').mockImplementation(() =>
+                Promise.reject(new Error('Fastlane initialization failed')),
+            );
+
+            const options = {
+                ...initializationOptions,
+                onErrorLog: 'not a function',
+            };
+
+            await expect(
+                strategy.initialize(options as unknown as typeof initializationOptions),
+            ).resolves.toBeUndefined();
+        });
+
+        it('does not forward errors when no error occurs during initialization', async () => {
+            const onErrorLog = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                onErrorLog,
+            });
+
+            expect(onErrorLog).not.toHaveBeenCalled();
+        });
+
+        it('forwards authentication flow error to the onErrorLog callback during executePaymentMethodCheckout', async () => {
+            const error = new Error('Authentication flow failed');
+            const onErrorLog = jest.fn();
+
+            jest.spyOn(
+                bigCommercePaymentsFastlaneUtils,
+                'lookupCustomerOrThrow',
+            ).mockImplementation(() => Promise.reject(error));
+
+            await strategy.initialize({
+                ...initializationOptions,
+                onErrorLog,
+            });
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(onErrorLog).toHaveBeenCalledWith(error);
+            expect(executionOptions.continueWithCheckoutCallback).toHaveBeenCalled();
+        });
+
+        it('does not forward authentication flow errors when onErrorLog is not configured', async () => {
+            jest.spyOn(
+                bigCommercePaymentsFastlaneUtils,
+                'lookupCustomerOrThrow',
+            ).mockImplementation(() => Promise.reject(new Error('Authentication flow failed')));
+
+            await strategy.initialize(initializationOptions);
+
+            await expect(
+                strategy.executePaymentMethodCheckout(executionOptions),
+            ).resolves.toBeUndefined();
+            expect(executionOptions.continueWithCheckoutCallback).toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-customer-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-customer-strategy.ts
@@ -22,6 +22,9 @@ import BigCommercePaymentsFastlaneCustomerInitializeOptions, {
 } from './bigcommerce-payments-fastlane-customer-initialize-options';
 
 export default class BigCommercePaymentsFastlaneCustomerStrategy implements CustomerStrategy {
+    private options?: CustomerInitializeOptions &
+        WithBigCommercePaymentsFastlaneCustomerInitializeOptions;
+
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
         private bigCommercePaymentsSdk: PayPalSdkHelper,
@@ -33,6 +36,8 @@ export default class BigCommercePaymentsFastlaneCustomerStrategy implements Cust
             WithBigCommercePaymentsFastlaneCustomerInitializeOptions,
     ): Promise<void> {
         const { methodId, bigcommerce_payments_fastlane } = options;
+
+        this.options = options;
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -61,9 +66,9 @@ export default class BigCommercePaymentsFastlaneCustomerStrategy implements Cust
                 isTestModeEnabled,
                 this.getFastlaneStyles(methodId, bigcommerce_payments_fastlane),
             );
-        } catch (_) {
-            // TODO: add logger to be able to debug issues if there any
+        } catch (error) {
             // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
+            this.handleErrorLog(error);
         }
 
         return Promise.resolve();
@@ -120,9 +125,9 @@ export default class BigCommercePaymentsFastlaneCustomerStrategy implements Cust
 
             try {
                 await this.runPayPalAuthenticationFlowOrThrow(methodId);
-            } catch (_) {
-                // TODO: add logger to be able to debug issues if there any
+            } catch (error) {
                 // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
+                this.handleErrorLog(error);
             }
         }
 
@@ -234,5 +239,13 @@ export default class BigCommercePaymentsFastlaneCustomerStrategy implements Cust
             isFastlaneStylingEnabled ? fastlaneStyles : {},
             bigcommerce_payments_fastlane?.styles,
         );
+    }
+
+    private handleErrorLog(error: unknown): void {
+        const { onErrorLog } = this.options || {};
+
+        if (onErrorLog && typeof onErrorLog === 'function') {
+            onErrorLog(error);
+        }
     }
 }

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-initialize-options.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-initialize-options.ts
@@ -74,6 +74,11 @@ export default interface BigCommercePaymentsFastlanePaymentInitializeOptions {
      * no matter what strategy was initialised first
      */
     styles?: PayPalFastlaneStylesOption;
+
+    /**
+     * Method that will only log errors with no-blocking flow
+     */
+    onErrorLog?: (error: unknown) => void;
 }
 
 export interface WithBigCommercePaymentsFastlanePaymentInitializeOptions {

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.spec.ts
@@ -405,6 +405,76 @@ describe('BigCommercePaymentsFastlanePaymentStrategy', () => {
             expect(initializationOptions.bigcommerce_payments_fastlane.onInit).toHaveBeenCalled();
             expect(initializationOptions.bigcommerce_payments_fastlane.onChange).toHaveBeenCalled();
         });
+
+        describe('error logging', () => {
+            it('logs an error with the provided onErrorLog callback if the authentication flow fails, without failing initialization', async () => {
+                const error = new Error('lookupCustomerOrThrow error');
+                const onErrorLog = jest.fn();
+
+                jest.spyOn(
+                    bigCommercePaymentsFastlaneUtils,
+                    'lookupCustomerOrThrow',
+                ).mockRejectedValue(error);
+
+                await strategy.initialize({
+                    methodId,
+                    bigcommerce_payments_fastlane: {
+                        onInit: jest.fn(),
+                        onChange: jest.fn(),
+                        onErrorLog,
+                    },
+                });
+
+                expect(onErrorLog).toHaveBeenCalledWith(error);
+                expect(
+                    bigCommercePaymentsFastlaneUtils.updateStorageSessionId,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('does not throw when the authentication flow fails and no onErrorLog is configured', async () => {
+                jest.spyOn(
+                    bigCommercePaymentsFastlaneUtils,
+                    'lookupCustomerOrThrow',
+                ).mockRejectedValue(new Error('lookupCustomerOrThrow error'));
+
+                await expect(strategy.initialize(initializationOptions)).resolves.toBeUndefined();
+            });
+
+            it('does not throw when onErrorLog is provided but is not a function, for a soft-failing authentication flow error', async () => {
+                jest.spyOn(
+                    bigCommercePaymentsFastlaneUtils,
+                    'lookupCustomerOrThrow',
+                ).mockRejectedValue(new Error('lookupCustomerOrThrow error'));
+
+                const options = {
+                    methodId,
+                    bigcommerce_payments_fastlane: {
+                        onInit: jest.fn(),
+                        onChange: jest.fn(),
+                        onErrorLog: 'not a function',
+                    },
+                };
+
+                await expect(
+                    strategy.initialize(options as unknown as typeof initializationOptions),
+                ).resolves.toBeUndefined();
+            });
+
+            it('does not call onErrorLog when the authentication flow succeeds', async () => {
+                const onErrorLog = jest.fn();
+
+                await strategy.initialize({
+                    methodId,
+                    bigcommerce_payments_fastlane: {
+                        onInit: jest.fn(),
+                        onChange: jest.fn(),
+                        onErrorLog,
+                    },
+                });
+
+                expect(onErrorLog).not.toHaveBeenCalled();
+            });
+        });
     });
 
     describe('#execute()', () => {

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-fastlane/bigcommerce-payments-fastlane-payment-strategy.ts
@@ -265,6 +265,7 @@ export default class BigCommercePaymentsFastlanePaymentStrategy implements Payme
             }
         } catch (error) {
             // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
+            this.handleErrorLog(error);
         }
     }
 
@@ -541,6 +542,15 @@ export default class BigCommercePaymentsFastlanePaymentStrategy implements Payme
             typeof this.bigcommerce_payments_fastlane.onError === 'function'
         ) {
             this.bigcommerce_payments_fastlane.onError(error);
+        }
+    }
+
+    private handleErrorLog(error: unknown): void {
+        if (
+            this.bigcommerce_payments_fastlane?.onErrorLog &&
+            typeof this.bigcommerce_payments_fastlane.onErrorLog === 'function'
+        ) {
+            this.bigcommerce_payments_fastlane.onErrorLog(error);
         }
     }
 }


### PR DESCRIPTION
## What/Why?

Added error logger for BCP Fastlane

## Rollout/Rollback
Revert

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional error logging on already soft-failing Fastlane paths; payment and checkout behavior remain non-blocking.
> 
> **Overview**
> Adds an optional **`onErrorLog`** callback so integrators can record BigCommerce Payments Fastlane failures without changing the existing non-blocking checkout behavior.
> 
> On the **customer** strategy, Fastlane SDK initialization errors and guest authentication failures during `executePaymentMethodCheckout` now invoke `handleErrorLog` instead of silently swallowing errors (replacing the prior TODO). The **payment** strategy does the same when the PayPal authentication flow fails during initialize. Checkout still continues—`continueWithCheckoutCallback` and initialization still resolve—when these paths fail.
> 
> `onErrorLog` is documented on **`BigCommercePaymentsFastlanePaymentInitializeOptions`** and is only called when it is a function; invalid or missing callbacks are ignored. Unit specs cover success paths, forwarding, and soft-failure behavior for both strategies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e0e664f43a3702939c6d3bb7cd43a0f00757877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->