### PR TITLE
feat(payment): PAYPAL-6856 added error logger for BT FL

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-initialize-options.ts
@@ -48,11 +48,6 @@ export default interface BraintreeFastlaneCustomerInitializeOptions {
      * no matter what strategy was initialised first
      */
     styles?: BraintreeFastlaneStylesOption;
-
-    /**
-     * Method that will only log errors with no-blocking flow
-     */
-    onErrorLog?: (error: unknown) => void;
 }
 
 export interface WithBraintreeFastlaneCustomerInitializeOptions {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-initialize-options.ts
@@ -48,6 +48,11 @@ export default interface BraintreeFastlaneCustomerInitializeOptions {
      * no matter what strategy was initialised first
      */
     styles?: BraintreeFastlaneStylesOption;
+
+    /**
+     * Method that will only log errors with no-blocking flow
+     */
+    onErrorLog?: (error: unknown) => void;
 }
 
 export interface WithBraintreeFastlaneCustomerInitializeOptions {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
@@ -310,6 +310,19 @@ describe('BraintreeFastlaneCustomerStrategy', () => {
             expect(braintreeFastlaneUtils.runPayPalAuthenticationFlowOrThrow).toHaveBeenCalled();
         });
 
+        it('forwards onErrorLog to runPayPalAuthenticationFlowOrThrow so auth failures are logged', async () => {
+            const onErrorLog = jest.fn();
+
+            await strategy.initialize({ ...initializationOptions, onErrorLog });
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(braintreeFastlaneUtils.runPayPalAuthenticationFlowOrThrow).toHaveBeenCalledWith(
+                undefined,
+                true,
+                { onErrorLog },
+            );
+        });
+
         it('does not authenticate customer with PayPal Fastlane if it should not run due to A/B testing', async () => {
             const mockPaymentMethod = {
                 ...paymentMethod,

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
@@ -206,6 +206,40 @@ describe('BraintreeFastlaneCustomerStrategy', () => {
                 expect(error).toBeUndefined();
             }
         });
+
+        it('logs the error via onErrorLog and does not throw when Fastlane initialization fails', async () => {
+            const error = new Error('Fastlane initialization failed');
+            const onErrorLog = jest.fn();
+
+            jest.spyOn(
+                braintreeFastlaneUtils,
+                'initializeBraintreeFastlaneOrThrow',
+            ).mockRejectedValue(error);
+
+            await expect(
+                strategy.initialize({ ...initializationOptions, onErrorLog }),
+            ).resolves.toBeUndefined();
+
+            expect(onErrorLog).toHaveBeenCalledWith(error);
+        });
+
+        it('does not call onErrorLog when Fastlane initialization succeeds', async () => {
+            const onErrorLog = jest.fn();
+
+            await strategy.initialize({ ...initializationOptions, onErrorLog });
+
+            expect(braintreeFastlaneUtils.initializeBraintreeFastlaneOrThrow).toHaveBeenCalled();
+            expect(onErrorLog).not.toHaveBeenCalled();
+        });
+
+        it('does not throw when Fastlane initialization fails and onErrorLog is not provided', async () => {
+            jest.spyOn(
+                braintreeFastlaneUtils,
+                'initializeBraintreeFastlaneOrThrow',
+            ).mockRejectedValue(new Error('Fastlane initialization failed'));
+
+            await expect(strategy.initialize(initializationOptions)).resolves.toBeUndefined();
+        });
     });
 
     describe('#executePaymentMethodCheckout()', () => {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -13,11 +13,12 @@ import {
     RequestOptions,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { WithBraintreeFastlaneCustomerInitializeOptions } from './braintree-fastlane-customer-initialize-options';
+import  { WithBraintreeFastlaneCustomerInitializeOptions } from './braintree-fastlane-customer-initialize-options';
 import BraintreeFastlaneUtils from './braintree-fastlane-utils';
 
 export default class BraintreeFastlaneCustomerStrategy implements CustomerStrategy {
     private isAcceleratedCheckoutEnabled = false;
+    private onErrorLog?: (error: unknown) => void;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
@@ -27,6 +28,7 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
     async initialize({
         methodId,
         braintreefastlane,
+        onErrorLog,
     }: CustomerInitializeOptions & WithBraintreeFastlaneCustomerInitializeOptions): Promise<void> {
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -44,6 +46,7 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
             : undefined;
 
         this.isAcceleratedCheckoutEnabled = !!isAcceleratedCheckoutEnabled;
+        this.onErrorLog = onErrorLog;
 
         try {
             if (this.isAcceleratedCheckoutEnabled) {
@@ -57,8 +60,9 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
                     fastlaneStyles,
                 );
             }
-        } catch (_) {
+        } catch (error) {
             // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
+            this.handleErrorLog(error);
         }
 
         return Promise.resolve();
@@ -149,5 +153,11 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
         return this.paymentIntegrationService
             .getState()
             .getPaymentMethodOrThrow<BraintreeInitializationData>(validPaymentMethodId);
+    }
+
+    private handleErrorLog(error: unknown): void {
+        if (this.onErrorLog && typeof this.onErrorLog === 'function') {
+            this.onErrorLog(error);
+        }
     }
 }

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -108,6 +108,7 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
                 await this.braintreeFastlaneUtils.runPayPalAuthenticationFlowOrThrow(
                     undefined,
                     true,
+                    { onErrorLog: this.onErrorLog },
                 );
             }
         }

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -13,7 +13,7 @@ import {
     RequestOptions,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import  { WithBraintreeFastlaneCustomerInitializeOptions } from './braintree-fastlane-customer-initialize-options';
+import { WithBraintreeFastlaneCustomerInitializeOptions } from './braintree-fastlane-customer-initialize-options';
 import BraintreeFastlaneUtils from './braintree-fastlane-utils';
 
 export default class BraintreeFastlaneCustomerStrategy implements CustomerStrategy {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-initialize-options.ts
@@ -71,6 +71,7 @@ export default interface BraintreeFastlanePaymentInitializeOptions {
      */
     styles?: BraintreeFastlaneStylesOption;
     onError?: (error: Error) => void;
+    onErrorLog?: (error: unknown) => void;
 }
 
 export interface WithBraintreeFastlanePaymentInitializeOptions {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-payment-strategy.ts
@@ -108,7 +108,11 @@ export default class BraintreeFastlanePaymentStrategy implements PaymentStrategy
         );
 
         if (this.shouldRunAuthenticationFlow()) {
-            await this.braintreeFastlaneUtils.runPayPalAuthenticationFlowOrThrow();
+            await this.braintreeFastlaneUtils.runPayPalAuthenticationFlowOrThrow(
+                undefined,
+                undefined,
+                braintreefastlane,
+            );
         }
 
         await this.initializeCardComponent();

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
@@ -623,6 +623,44 @@ describe('BraintreeFastlaneUtils', () => {
                 customFields: [],
             });
         });
+
+        it('logs the error via onErrorLog and does not throw if the authentication flow fails', async () => {
+            const error = new Error('Authentication flow failed');
+            const onErrorLog = jest.fn();
+
+            jest.spyOn(
+                braintreeFastlaneMock.identity,
+                'triggerAuthenticationFlow',
+            ).mockRejectedValue(error);
+
+            await subject.initializeBraintreeFastlaneOrThrow(methodId);
+
+            await expect(
+                subject.runPayPalAuthenticationFlowOrThrow(undefined, undefined, { onErrorLog }),
+            ).resolves.toBeUndefined();
+
+            expect(onErrorLog).toHaveBeenCalledWith(error);
+        });
+
+        it('does not call onErrorLog if the authentication flow succeeds', async () => {
+            const onErrorLog = jest.fn();
+
+            await subject.initializeBraintreeFastlaneOrThrow(methodId);
+            await subject.runPayPalAuthenticationFlowOrThrow(undefined, undefined, { onErrorLog });
+
+            expect(onErrorLog).not.toHaveBeenCalled();
+        });
+
+        it('does not throw if the authentication flow fails and onErrorLog is not provided', async () => {
+            jest.spyOn(
+                braintreeFastlaneMock.identity,
+                'triggerAuthenticationFlow',
+            ).mockRejectedValue(new Error('Authentication flow failed'));
+
+            await subject.initializeBraintreeFastlaneOrThrow(methodId);
+
+            await expect(subject.runPayPalAuthenticationFlowOrThrow()).resolves.toBeUndefined();
+        });
     });
 
     describe('#getDeviceSessionId', () => {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
@@ -21,6 +21,7 @@ import {
     UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { CookieStorage } from '@bigcommerce/checkout-sdk/storage';
+
 import BraintreeFastlanePaymentInitializeOptions from './braintree-fastlane-payment-initialize-options';
 
 export default class BraintreeFastlaneUtils {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
@@ -21,6 +21,7 @@ import {
     UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { CookieStorage } from '@bigcommerce/checkout-sdk/storage';
+import BraintreeFastlanePaymentInitializeOptions from './braintree-fastlane-payment-initialize-options';
 
 export default class BraintreeFastlaneUtils {
     private braintreeFastlane?: BraintreeFastlane;
@@ -90,6 +91,7 @@ export default class BraintreeFastlaneUtils {
     async runPayPalAuthenticationFlowOrThrow(
         email?: string,
         shouldSetShippingOption?: boolean,
+        braintreeFastlaneOptions?: BraintreeFastlanePaymentInitializeOptions,
     ): Promise<void> {
         try {
             const methodId = this.getMethodIdOrThrow();
@@ -192,6 +194,7 @@ export default class BraintreeFastlaneUtils {
         } catch (error) {
             // TODO: we should figure out what to do here
             // TODO: because we should not to stop the flow if the error occurs on paypal side
+            this.handleErrorLog(error, braintreeFastlaneOptions);
         }
     }
 
@@ -368,6 +371,18 @@ export default class BraintreeFastlaneUtils {
             const selectedOption = recommendedShippingOption || availableShippingOptions[0];
 
             await this.paymentIntegrationService.selectShippingOption(selectedOption.id);
+        }
+    }
+
+    private handleErrorLog(
+        error: unknown,
+        braintreeFastlaneOptions?: BraintreeFastlanePaymentInitializeOptions,
+    ): void {
+        if (
+            braintreeFastlaneOptions?.onErrorLog &&
+            typeof braintreeFastlaneOptions.onErrorLog === 'function'
+        ) {
+            braintreeFastlaneOptions.onErrorLog(error);
         }
     }
 }


### PR DESCRIPTION
## What/Why?
Added error logger for Braintree Fastlane

## Rollout/Rollback
Revert

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change on existing non-blocking error paths; no new throws or payment payload changes.
> 
> **Overview**
> Adds an optional **`onErrorLog`** hook so merchants can record Braintree Fastlane failures without changing checkout behavior—initialization and PayPal authentication errors are still swallowed so guests can continue checkout.
> 
> **Customer strategy** accepts `onErrorLog` on initialize, logs Fastlane init failures via `handleErrorLog`, and passes the same callback into `runPayPalAuthenticationFlowOrThrow` during accelerated checkout.
> 
> **Payment path** extends `BraintreeFastlanePaymentInitializeOptions` with `onErrorLog` (alongside existing `onError`) and forwards the full `braintreefastlane` options object into the auth flow so PayPal-side errors invoke `onErrorLog` in `BraintreeFastlaneUtils`.
> 
> Unit tests cover logging on failure, no logging on success, and no throw when the callback is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5d0d66c6ff158fb3a2ec6cc4e7f2e2df01bed6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->