### PR TITLE
feat(payment): PI-5537 Send Adyen checkoutAttemptId for vaulted instruments

### DIFF
--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -356,6 +356,7 @@ describe('AdyenV3PaymentStrategy', () => {
                                     screen_width: 0,
                                     time_zone_offset: expect.anything(),
                                 },
+                                checkout_attempt_id: 'CHECKOUT_ATTEMPT_ID',
                             }),
                         },
                     }),

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -16,6 +16,7 @@ import {
     AdyenV3PaymentMethodInitializationData,
     AdyenV3ScriptLoader,
     CardStateErrors,
+    FAILED_CHECKOUT_ATTEMPT_ID,
     isBoletoState,
     isCardState,
     WithAdyenV3PaymentInitializeOptions,
@@ -189,6 +190,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
                             },
                             origin: window.location.origin,
                             browser_info: getBrowserInfo(),
+                            checkout_attempt_id: this._getCheckoutAttemptId(componentState),
                             set_as_default_stored_instrument: shouldSetAsDefaultInstrument || null,
                         },
                     },
@@ -276,6 +278,20 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
 
     private _updateComponentState(componentState: AdyenComponentEventState) {
         this.componentState = componentState;
+    }
+
+    private _getCheckoutAttemptId(componentState?: AdyenComponentEventState): string | null {
+        if (!componentState || !isCardState(componentState)) {
+            return null;
+        }
+
+        const { checkoutAttemptId } = componentState.data.paymentMethod;
+
+        if (!checkoutAttemptId || checkoutAttemptId === FAILED_CHECKOUT_ATTEMPT_ID) {
+            return null;
+        }
+
+        return checkoutAttemptId;
     }
 
     private _getLocale(): string | undefined {

--- a/packages/adyen-utils/src/adyenv3/adyenv3.mock.ts
+++ b/packages/adyen-utils/src/adyenv3/adyenv3.mock.ts
@@ -119,6 +119,7 @@ export function getComponentCCEventState(isValid = true): AdyenComponentEventSta
                 encryptedSecurityCode: 'ENCRYPTED_CVV',
                 holderName: 'John Smith',
                 type: AdyenPaymentMethodType.CreditCard,
+                checkoutAttemptId: 'CHECKOUT_ATTEMPT_ID',
             },
             installments: {
                 value: 10,

--- a/packages/adyen-utils/src/types.ts
+++ b/packages/adyen-utils/src/types.ts
@@ -90,8 +90,11 @@ export enum ResultCode {
     IdentifyShopper = 'IdentifyShopper',
 }
 
+export const FAILED_CHECKOUT_ATTEMPT_ID = 'fetch-checkoutAttemptId-failed';
+
 interface AdyenPaymentMethodState {
     type: string;
+    checkoutAttemptId?: string;
 }
 
 interface WechatDataPaymentMethodState {


### PR DESCRIPTION
Jira: [PI-5604](https://bigcommercecloud.atlassian.net/browse/PI-5604)

Spike it came from: [PI-5537](https://bigcommercecloud.atlassian.net/browse/PI-5537)

## What/Why?
Forwards Adyen's `checkoutAttemptId` when paying with a vaulted instrument.

Adyen lists `checkoutAttemptId` as required for the Advanced flow in its [Uplift requirements](https://docs.adyen.com/uplift/uplift-requirements): it links the client-side telemetry to the payment, which the Personalize module (dynamic payment method ordering, bigcommerce/bigpay#11071, [PI-5602](https://bigcommercecloud.atlassian.net/browse/PI-5602)) depends on.

Adyen Web already sets it for us: `BaseElement`'s `data` getter injects it into `componentData.paymentMethod`, so for a normal card payment it rides along inside `credit_card_token` and BigPay forwards the whole `paymentMethod` verbatim. Confirmed on the wire: it is present in BigPay's recorded Adyen cassettes today.

The vaulted branch is the exception, and the gap is on our side rather than Adyen's: it hand-picks four encrypted fields off the component state instead of forwarding `componentState.data.paymentMethod`, so the id is dropped. That matters because a returning shopper paying with a saved card is exactly the audience personalisation is for.

`FAILED_CHECKOUT_ATTEMPT_ID` guards Adyen's own sentinel. When its analytics call fails, `BaseElement` substitutes the literal `'fetch-checkoutAttemptId-failed'` rather than omitting the field, so it has to be filtered instead of forwarded as a real id.

Verified against `Adyen/adyen-web` on `main` as well as `v5.71.1`: the constant and the injection point are unchanged, so this stays correct after an eventual Web v6 upgrade. BigPay strips the same sentinel defensively on the non-vaulted path.

## Rollout/Rollback
No experiment on this side. The SDK has no LaunchDarkly access, and it does not need it: the only place the value is consumed is gated by `PI-5537.adyenv3_dynamic_payment_method_ordering` in BigPay ([PI-5602](https://bigcommercecloud.atlassian.net/browse/PI-5602)), and that flag dark-launches serving `false`, so this is inert until then. Adding one key to the payload for an existing, already-authenticated flow does not change payment behaviour.

Rollback: revert this PR.

## Testing
<img width="1601" height="1989" alt="Screenshot 2026-08-11 at 11 18 59" src="https://github.com/user-attachments/assets/9f7f4749-e365-415b-8123-dd04332fcb38" />
<img width="1597" height="1988" alt="Screenshot 2026-08-11 at 11 17 21" src="https://github.com/user-attachments/assets/014a69d7-7924-4e5b-8449-06b17e799989" />
<img width="1597" height="1989" alt="Screenshot 2026-08-11 at 11 16 51" src="https://github.com/user-attachments/assets/a7ce8807-1906-41c7-b4a5-94534571a2fd" />

https://github.com/user-attachments/assets/41ef0448-44c5-463d-9cc8-26d618effd04

[PI-5604]: https://bigcommercecloud.atlassian.net/browse/PI-5604




[PI-5537]: https://bigcommercecloud.atlassian.net/browse/PI-5537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PI-5602]: https://bigcommercecloud.atlassian.net/browse/PI-5602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PI-5602]: https://bigcommercecloud.atlassian.net/browse/PI-5602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds one optional payload field on an existing vaulted-card path; behavior is unchanged when the id is absent or invalid, and downstream use is feature-flagged in BigPay.
> 
> **Overview**
> Vaulted Adyen v3 card payments now include **`checkout_attempt_id`** on the `submitPayment` formatted payload, alongside the existing encrypted fields and `browser_info`. That closes a gap where new-card flows already forwarded Adyen’s telemetry id but saved-card flows did not.
> 
> A new **`_getCheckoutAttemptId`** helper reads `checkoutAttemptId` from card component state, returns `null` when state is not card-shaped or the id is missing, and drops Adyen’s failure sentinel **`FAILED_CHECKOUT_ATTEMPT_ID`** (`fetch-checkoutAttemptId-failed`). Types and test mocks were extended accordingly; the vaulted-instrument spec asserts the id is passed through as `checkout_attempt_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac8ee7e666e8eba68181958a13f98910b02146d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->