### PR TITLE
feat(checkout): CHECKOUT-9981 Add Company Address Type Filters

### DIFF
--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -796,7 +796,7 @@ export default class CheckoutService {
      * @param searchQuery - The text to match addresses against. Pass an empty
      * string to list the most recently created addresses instead of searching.
      * @param options - Options for the search, such as the maximum number of
-     * addresses to return.
+     * addresses to return, or restricting results to shipping/billing addresses.
      * @returns A promise that resolves to the search payload returned by the
      * GraphQL API. `company` is `null` when the shopper is not signed in or
      * the store does not have B2B enabled.

--- a/packages/core/src/company/company-address-request-sender.spec.ts
+++ b/packages/core/src/company/company-address-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout } from '@bigcommerce/request-sender';
 
-import { SearchCompanyAddressesDocument } from '../generated-codegen/graphql';
 import { GraphQLRequestSender } from '../common/http-request';
+import { SearchCompanyAddressesDocument } from '../generated-codegen/graphql';
 
 import { CompanyAddressSearchResult } from './company-address';
 import CompanyAddressRequestSender from './company-address-request-sender';
@@ -27,15 +27,32 @@ describe('CompanyAddressRequestSender', () => {
             const output = await companyAddressRequestSender.searchAddresses(
                 'b2b-token',
                 'main st',
-                { first: 5, timeout },
+                { first: 5, isShipping: true, timeout },
             );
 
             expect(graphQLRequestSender.query).toHaveBeenCalledWith(
                 SearchCompanyAddressesDocument,
-                { searchQuery: 'main st', first: 5 },
+                { searchQuery: 'main st', first: 5, isShipping: true, isBilling: undefined },
                 { token: 'b2b-token', timeout },
             );
             expect(output).toEqual(result);
+        });
+
+        it('forwards the billing filter as a query variable', async () => {
+            await companyAddressRequestSender.searchAddresses('b2b-token', 'main st', {
+                isBilling: true,
+            });
+
+            expect(graphQLRequestSender.query).toHaveBeenCalledWith(
+                SearchCompanyAddressesDocument,
+                {
+                    searchQuery: 'main st',
+                    first: undefined,
+                    isShipping: undefined,
+                    isBilling: true,
+                },
+                { token: 'b2b-token', timeout: undefined },
+            );
         });
 
         it('omits the search filter when the query is empty', async () => {
@@ -43,7 +60,12 @@ describe('CompanyAddressRequestSender', () => {
 
             expect(graphQLRequestSender.query).toHaveBeenCalledWith(
                 SearchCompanyAddressesDocument,
-                { searchQuery: null, first: undefined },
+                {
+                    searchQuery: null,
+                    first: undefined,
+                    isShipping: undefined,
+                    isBilling: undefined,
+                },
                 { token: 'b2b-token', timeout: undefined },
             );
         });

--- a/packages/core/src/company/company-address-request-sender.ts
+++ b/packages/core/src/company/company-address-request-sender.ts
@@ -11,13 +11,15 @@ export default class CompanyAddressRequestSender {
         searchQuery: string,
         options?: CompanyAddressSearchOptions,
     ): Promise<CompanyAddressSearchResult> {
-        const { first, timeout } = options || {};
+        const { first, isShipping, isBilling, timeout } = options || {};
 
         return this._graphQLRequestSender.query(
             SearchCompanyAddressesDocument,
             {
                 searchQuery: searchQuery || null,
                 first,
+                isShipping,
+                isBilling,
             },
             { token, timeout },
         );

--- a/packages/core/src/company/company-address-service.spec.ts
+++ b/packages/core/src/company/company-address-service.spec.ts
@@ -43,7 +43,11 @@ describe('CompanyAddressService', () => {
             const service = createService(store);
             const timeout = createTimeout();
 
-            const output = await service.searchAddresses('main st', { first: 5, timeout });
+            const output = await service.searchAddresses('main st', {
+                first: 5,
+                isBilling: true,
+                timeout,
+            });
 
             expect(storefrontTokenRequestSender.createStorefrontToken).toHaveBeenCalledWith(
                 'b2b-token',
@@ -59,7 +63,7 @@ describe('CompanyAddressService', () => {
             expect(requestSender.searchAddresses).toHaveBeenCalledWith(
                 'storefront-token',
                 'main st',
-                { first: 5, timeout },
+                { first: 5, isBilling: true, timeout },
             );
             expect(output).toEqual(result);
         });

--- a/packages/core/src/company/company-address.ts
+++ b/packages/core/src/company/company-address.ts
@@ -9,4 +9,6 @@ export type CompanyAddress = NonNullable<
 
 export interface CompanyAddressSearchOptions extends RequestOptions {
     first?: number;
+    isShipping?: boolean;
+    isBilling?: boolean;
 }

--- a/packages/core/src/company/queries/search-company-addresses.graphql
+++ b/packages/core/src/company/queries/search-company-addresses.graphql
@@ -1,8 +1,13 @@
-query SearchCompanyAddresses($searchQuery: String, $first: Int = 10) {
+query SearchCompanyAddresses(
+    $searchQuery: String
+    $first: Int = 10
+    $isShipping: Boolean
+    $isBilling: Boolean
+) {
     company {
         addresses(
             first: $first
-            filters: { searchQuery: $searchQuery }
+            filters: { searchQuery: $searchQuery, isShipping: $isShipping, isBilling: $isBilling }
             sort: [{ field: CREATED_AT, direction: DESC }]
         ) {
             edges {


### PR DESCRIPTION
## What/Why?

Pass address type filter when searching company address book.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional API extension on an alpha B2B search path with no changes to checkout state or auth; backward compatible when filters are omitted.
> 
> **Overview**
> **Company address book search** can now be scoped with optional **`isShipping`** and **`isBilling`** flags on `CompanyAddressSearchOptions`, passed through `searchCompanyAddresses` / `CompanyAddressService` into the `SearchCompanyAddresses` GraphQL query address filters.
> 
> Existing callers that omit these options behave as before; only documentation on `searchCompanyAddresses` is updated to mention the new filters. Specs cover forwarding both filters and empty-query behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5171a51b234b51efa4f1c7b350a844d698b2b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->