### PR TITLE
chore(customer): CHECKOUT-10277 Flatten b2b address fields

### DIFF
--- a/packages/core/src/address/map-to-address-request-body.spec.ts
+++ b/packages/core/src/address/map-to-address-request-body.spec.ts
@@ -37,17 +37,15 @@ describe('mapToAddressRequestBody()', () => {
         });
     });
 
-    it('strips CustomerAddress b2b metadata and hoists extraFields', () => {
+    it('strips flat CustomerAddress B2B fields and keeps top-level extraFields', () => {
         const customerAddress = {
             ...baseAddress,
-            b2b: {
-                isShipping: true,
-                isBilling: false,
-                isDefaultShipping: true,
-                isDefaultBilling: false,
-                label: 'Head Office',
-                extraFields: [{ fieldId: '100', fieldValue: 'Acme' }],
-            },
+            extraFields: [{ fieldId: '100', fieldValue: 'Acme' }],
+            label: 'Head Office',
+            isShipping: true,
+            isBilling: false,
+            isDefaultShipping: true,
+            isDefaultBilling: false,
         };
 
         const result = mapToAddressRequestBody(customerAddress);
@@ -55,48 +53,13 @@ describe('mapToAddressRequestBody()', () => {
         expect(result).toEqual({
             ...baseAddress,
             extraFields: [{ fieldId: '100', fieldValue: 'Acme' }],
+            label: 'Head Office',
             shouldSaveAddress: false,
         });
-        expect(result).not.toHaveProperty('b2b');
-        expect(result).not.toHaveProperty('label');
-    });
-
-    it('does not overwrite top-level extraFields with b2b values', () => {
-        const customerAddress = {
-            ...baseAddress,
-            extraFields: [{ fieldId: '200', fieldValue: 'Explicit' }],
-            b2b: {
-                isShipping: true,
-                isBilling: false,
-                isDefaultShipping: true,
-                isDefaultBilling: false,
-                label: 'Head Office',
-                extraFields: [{ fieldId: '100', fieldValue: 'Acme' }],
-            },
-        };
-
-        const result = mapToAddressRequestBody(customerAddress);
-
-        expect(result).toHaveProperty('extraFields', [{ fieldId: '200', fieldValue: 'Explicit' }]);
-    });
-
-    it('falls back to b2b extraFields when top-level extraFields is empty', () => {
-        const customerAddress = {
-            ...baseAddress,
-            extraFields: [],
-            b2b: {
-                isShipping: true,
-                isBilling: false,
-                isDefaultShipping: true,
-                isDefaultBilling: false,
-                label: 'Head Office',
-                extraFields: [{ fieldId: '100', fieldValue: 'Acme' }],
-            },
-        };
-
-        const result = mapToAddressRequestBody(customerAddress);
-
-        expect(result).toHaveProperty('extraFields', [{ fieldId: '100', fieldValue: 'Acme' }]);
+        expect(result).not.toHaveProperty('isShipping');
+        expect(result).not.toHaveProperty('isBilling');
+        expect(result).not.toHaveProperty('isDefaultShipping');
+        expect(result).not.toHaveProperty('isDefaultBilling');
     });
 
     it('preserves id and type', () => {

--- a/packages/core/src/address/map-to-address-request-body.ts
+++ b/packages/core/src/address/map-to-address-request-body.ts
@@ -2,44 +2,37 @@ import { CustomerAddress } from '../customer';
 
 import Address, { AddressRequestBody } from './address';
 
-type AddressWithB2BMetadata = Partial<Address> & Pick<Partial<CustomerAddress>, 'b2b'>;
+type AddressWithB2BFields = Partial<Address> &
+    Pick<
+        Partial<CustomerAddress>,
+        'isShipping' | 'isBilling' | 'isDefaultShipping' | 'isDefaultBilling'
+    >;
 
 /**
- * Strips the `CustomerAddress`-only `b2b` metadata object from an address-like
- * object so it can be sent to the API, hoisting its `extraFields` to the top
- * level of the payload where the API accepts them. Every other field —
- * including `id`, `type`, `country` and `shouldSaveAddress` — is preserved,
+ * Strips the `CustomerAddress`-only B2B fields (`isShipping`, `isBilling`,
+ * `isDefaultShipping`, `isDefaultBilling`) from an address-like object so it
+ * can be sent to the API. Every other field — including `id`, `type`,
+ * `country`, `label`, `extraFields` and `shouldSaveAddress` — is preserved,
  * so this is a behaviour-safe replacement for callers that previously
  * forwarded a selected `CustomerAddress` straight to an update call.
  */
 export default function mapToAddressRequestBody(
-    address: AddressRequestBody & AddressWithB2BMetadata,
+    address: AddressRequestBody & AddressWithB2BFields,
 ): AddressRequestBody;
 
 export default function mapToAddressRequestBody(
-    address: AddressWithB2BMetadata,
+    address: AddressWithB2BFields,
 ): Partial<AddressRequestBody>;
 
 export default function mapToAddressRequestBody(
-    address: AddressWithB2BMetadata,
+    address: AddressWithB2BFields,
 ): Partial<AddressRequestBody> {
-    const { b2b, ...requestBody } = address;
+    const { isShipping, isBilling, isDefaultShipping, isDefaultBilling, ...requestBody } = address;
 
     // The API currently defaults shouldSaveAddress to true. We decided to handle this on the FE
     // by consistently sending false as the default on 24 July 2026.
-    const requestBodyWithSaveFlag = {
+    return {
         ...requestBody,
         shouldSaveAddress: requestBody.shouldSaveAddress ?? false,
-    };
-
-    if (!b2b) {
-        return requestBodyWithSaveFlag;
-    }
-
-    return {
-        ...requestBodyWithSaveFlag,
-        extraFields: requestBodyWithSaveFlag.extraFields?.length
-            ? requestBodyWithSaveFlag.extraFields
-            : b2b.extraFields,
     };
 }

--- a/packages/core/src/billing/billing-address-request-sender.spec.ts
+++ b/packages/core/src/billing/billing-address-request-sender.spec.ts
@@ -16,14 +16,10 @@ import BillingAddressRequestSender from './billing-address-request-sender';
 import { getBillingAddress } from './billing-addresses.mock';
 
 const CUSTOMER_ADDRESS_METADATA = {
-    b2b: {
-        isShipping: true,
-        isBilling: false,
-        isDefaultShipping: true,
-        isDefaultBilling: false,
-        label: 'Head Office',
-        extraFields: [],
-    },
+    isShipping: true,
+    isBilling: false,
+    isDefaultShipping: true,
+    isDefaultBilling: false,
 };
 
 describe('BillingAddressRequestSender', () => {
@@ -91,7 +87,7 @@ describe('BillingAddressRequestSender', () => {
             );
         });
 
-        it('strips CustomerAddress b2b metadata from the request body', async () => {
+        it('strips CustomerAddress B2B fields from the request body', async () => {
             await addressRequestSender.updateAddress('foo', {
                 ...getBillingAddress(),
                 ...CUSTOMER_ADDRESS_METADATA,
@@ -99,7 +95,10 @@ describe('BillingAddressRequestSender', () => {
 
             const { body } = (requestSender.put as jest.Mock).mock.calls[0][1];
 
-            expect(body).not.toHaveProperty('b2b');
+            for (const key of Object.keys(CUSTOMER_ADDRESS_METADATA)) {
+                expect(body).not.toHaveProperty(key);
+            }
+
             expect(body).toHaveProperty('address1', address.address1);
         });
 
@@ -164,7 +163,7 @@ describe('BillingAddressRequestSender', () => {
             );
         });
 
-        it('strips CustomerAddress b2b metadata from the request body', async () => {
+        it('strips CustomerAddress B2B fields from the request body', async () => {
             await addressRequestSender.createAddress('foo', {
                 ...getBillingAddress(),
                 ...CUSTOMER_ADDRESS_METADATA,
@@ -172,7 +171,10 @@ describe('BillingAddressRequestSender', () => {
 
             const { body } = (requestSender.post as jest.Mock).mock.calls[0][1];
 
-            expect(body).not.toHaveProperty('b2b');
+            for (const key of Object.keys(CUSTOMER_ADDRESS_METADATA)) {
+                expect(body).not.toHaveProperty(key);
+            }
+
             expect(body).toHaveProperty('address1', address.address1);
         });
 

--- a/packages/core/src/customer/customer.ts
+++ b/packages/core/src/customer/customer.ts
@@ -1,5 +1,4 @@
 import { Address } from '../address';
-import { AddressExtraFieldValue } from '../form';
 
 export default interface Customer {
     id: number;
@@ -26,19 +25,13 @@ export interface CustomerAddress extends Address {
     id: number;
     type: string;
     /**
-     * Company address metadata returned only for B2B company addresses, and
-     * only when the `addresses.b2b` include is requested from the API.
+     * Indicates whether this address is used for shipping. Present only for
+     * B2B company addresses when the `addresses.b2b` include is requested.
      */
-    b2b?: CustomerAddressB2B;
-}
-
-export interface CustomerAddressB2B {
-    isShipping: boolean;
-    isBilling: boolean;
-    isDefaultShipping: boolean;
-    isDefaultBilling: boolean;
-    label: string;
-    extraFields: AddressExtraFieldValue[];
+    isShipping?: boolean;
+    isBilling?: boolean;
+    isDefaultShipping?: boolean;
+    isDefaultBilling?: boolean;
 }
 
 export interface CustomerGroup {

--- a/packages/core/src/customer/customer.ts
+++ b/packages/core/src/customer/customer.ts
@@ -25,8 +25,6 @@ export interface CustomerAddress extends Address {
     id: number;
     type: string;
     /**
-     * Indicates whether this address is used for shipping. Present only for
-     * B2B company addresses when the `addresses.b2b` include is requested.
      */
     isShipping?: boolean;
     isBilling?: boolean;

--- a/packages/core/src/customer/index.ts
+++ b/packages/core/src/customer/index.ts
@@ -6,7 +6,7 @@ export {
 } from './customer-request-options';
 
 export { default as InternalCustomer } from './internal-customer';
-export { default as Customer, CustomerAddress, CustomerAddressB2B } from './customer';
+export { default as Customer, CustomerAddress } from './customer';
 
 export { default as createCustomerStrategyRegistry } from './create-customer-strategy-registry';
 export { default as createCustomerStrategyRegistryV2 } from './create-customer-strategy-registry-v2';

--- a/packages/core/src/shipping/consignment-request-sender.spec.ts
+++ b/packages/core/src/shipping/consignment-request-sender.spec.ts
@@ -10,14 +10,10 @@ import ConsignmentRequestSender from './consignment-request-sender';
 import { getConsignmentRequestBody } from './consignments.mock';
 
 const CUSTOMER_ADDRESS_METADATA = {
-    b2b: {
-        isShipping: true,
-        isBilling: false,
-        isDefaultShipping: true,
-        isDefaultBilling: false,
-        label: 'Head Office',
-        extraFields: [],
-    },
+    isShipping: true,
+    isBilling: false,
+    isDefaultShipping: true,
+    isDefaultBilling: false,
 };
 
 describe('ConsignmentRequestSender', () => {
@@ -134,7 +130,7 @@ describe('ConsignmentRequestSender', () => {
             );
         });
 
-        it('strips CustomerAddress b2b metadata from consignment addresses', async () => {
+        it('strips CustomerAddress B2B fields from consignment addresses', async () => {
             await consignmentRequestSender.createConsignments(checkoutId, [
                 {
                     ...consignments[0],
@@ -148,8 +144,11 @@ describe('ConsignmentRequestSender', () => {
 
             const { body } = (requestSender.post as jest.Mock).mock.calls[0][1];
 
-            expect(body[0].address).not.toHaveProperty('b2b');
-            expect(body[0].shippingAddress).not.toHaveProperty('b2b');
+            for (const key of Object.keys(CUSTOMER_ADDRESS_METADATA)) {
+                expect(body[0].address).not.toHaveProperty(key);
+                expect(body[0].shippingAddress).not.toHaveProperty(key);
+            }
+
             expect(body[0].address).toHaveProperty('address1', consignments[0].address.address1);
         });
 
@@ -245,7 +244,7 @@ describe('ConsignmentRequestSender', () => {
             );
         });
 
-        it('strips CustomerAddress b2b metadata from the consignment address', async () => {
+        it('strips CustomerAddress B2B fields from the consignment address', async () => {
             await consignmentRequestSender.updateConsignment(checkoutId, {
                 ...consignment,
                 address: { ...consignment.address, ...CUSTOMER_ADDRESS_METADATA },
@@ -253,7 +252,10 @@ describe('ConsignmentRequestSender', () => {
 
             const { body: sentBody } = (requestSender.put as jest.Mock).mock.calls[0][1];
 
-            expect(sentBody.address).not.toHaveProperty('b2b');
+            for (const key of Object.keys(CUSTOMER_ADDRESS_METADATA)) {
+                expect(sentBody.address).not.toHaveProperty(key);
+            }
+
             expect(sentBody.address).toHaveProperty('address1', consignment.address?.address1);
         });
 

--- a/packages/payment-integration-api/src/customer/customer.ts
+++ b/packages/payment-integration-api/src/customer/customer.ts
@@ -1,5 +1,4 @@
 import { Address } from '../address';
-import { AddressExtraFieldValue } from '../form';
 
 export default interface Customer {
     id: number;
@@ -26,19 +25,13 @@ export interface CustomerAddress extends Address {
     id: number;
     type: string;
     /**
-     * Company address metadata returned only for B2B company addresses, and
-     * only when the `addresses.b2b` include is requested from the API.
+     * Indicates whether this address is used for shipping. Present only for
+     * B2B company addresses when the `addresses.b2b` include is requested.
      */
-    b2b?: CustomerAddressB2B;
-}
-
-export interface CustomerAddressB2B {
-    isShipping: boolean;
-    isBilling: boolean;
-    isDefaultShipping: boolean;
-    isDefaultBilling: boolean;
-    label: string;
-    extraFields: AddressExtraFieldValue[];
+    isShipping?: boolean;
+    isBilling?: boolean;
+    isDefaultShipping?: boolean;
+    isDefaultBilling?: boolean;
 }
 
 export interface CustomerGroup {

--- a/packages/payment-integration-api/src/customer/customer.ts
+++ b/packages/payment-integration-api/src/customer/customer.ts
@@ -25,8 +25,6 @@ export interface CustomerAddress extends Address {
     id: number;
     type: string;
     /**
-     * Indicates whether this address is used for shipping. Present only for
-     * B2B company addresses when the `addresses.b2b` include is requested.
      */
     isShipping?: boolean;
     isBilling?: boolean;

--- a/packages/payment-integration-api/src/customer/index.ts
+++ b/packages/payment-integration-api/src/customer/index.ts
@@ -1,4 +1,4 @@
-export { default as Customer, CustomerAddress, CustomerAddressB2B } from './customer';
+export { default as Customer, CustomerAddress } from './customer';
 export { default as CustomerCredentials } from './customer-credentials';
 export { default as CustomerStrategy } from './customer-strategy';
 export { default as CustomerStrategyFactory } from './customer-strategy-factory';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -41,7 +41,6 @@ export {
     CustomerStrategyResolveId,
     Customer,
     CustomerAddress,
-    CustomerAddressB2B,
     CustomerRequestOptions,
     CustomerInitializeOptions,
     InternalCustomer,


### PR DESCRIPTION
## What/Why?
Flatten b2b address fields as we have updated the API to not have a b2b property as a wrapper.

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking type/export change for `CustomerAddressB2B` and any code still reading `address.b2b`; address API payloads change behavior if callers relied on hoisting `extraFields` from the old nested object.
> 
> **Overview**
> Aligns the SDK with the updated customer-address API by **removing the nested `b2b` object** on `CustomerAddress` and exposing B2B flags as optional top-level fields (`isShipping`, `isBilling`, `isDefaultShipping`, `isDefaultBilling`). The `CustomerAddressB2B` type and its exports are dropped from **core** and **payment-integration-api**.
> 
> **`mapToAddressRequestBody`** no longer unwraps `b2b` or merges `extraFields` / `label` from that wrapper; it only strips those four B2B flags before sending checkout address payloads. **`label` and `extraFields` stay on the request body** when present on the input.
> 
> Billing and consignment request-sender tests were updated to use flat B2B metadata and assert each stripped field is omitted from outbound bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb0804e426f30497c48ed211b3ec1f2a24a2909. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->