### PR TITLE
feat(payment): PAYPAL-6698 add BigCommercePayments Invoices payment strategy

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/bigcommerce-payments-invoices-payment-initialize-options.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/bigcommerce-payments-invoices-payment-initialize-options.ts
@@ -1,0 +1,17 @@
+/**
+ * A set of options that are required to initialize the BigCommercePayments Invoices payment
+ * method.
+ *
+ * ```js
+ * service.initializePayment({
+ *     methodId: 'bigcommerce_payments_invoices',
+ *     bigcommerce_payments_invoices: {},
+ * });
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export default interface BigCommercePaymentsInvoicesPaymentInitializeOptions {}
+
+export interface WithBigCommercePaymentsInvoicesPaymentInitializeOptions {
+    bigcommerce_payments_invoices?: BigCommercePaymentsInvoicesPaymentInitializeOptions;
+}

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/bigcommerce-payments-invoices-payment-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/bigcommerce-payments-invoices-payment-strategy.spec.ts
@@ -1,0 +1,106 @@
+import {
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getOrderRequestBody,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BigCommercePaymentsInvoicesPaymentStrategy from './bigcommerce-payments-invoices-payment-strategy';
+
+describe('BigCommercePaymentsInvoicesPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+    let strategy: BigCommercePaymentsInvoicesPaymentStrategy;
+
+    const defaultMethodId = 'bigcommerce_payments_invoices';
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        strategy = new BigCommercePaymentsInvoicesPaymentStrategy(paymentIntegrationService);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('creates an instance of the BigCommercePayments Invoices payment strategy', () => {
+        expect(strategy).toBeInstanceOf(BigCommercePaymentsInvoicesPaymentStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('initializes the strategy successfully', async () => {
+            const result = await strategy.initialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('#execute()', () => {
+        it('throws an error if payload.payment is not provided', async () => {
+            try {
+                await strategy.execute({ ...getOrderRequestBody(), payment: undefined });
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
+            }
+        });
+
+        it('throws an error if payload.payment.methodId is not provided', async () => {
+            const payload = {
+                ...getOrderRequestBody(),
+                payment: { methodId: undefined },
+            } as unknown as OrderRequestBody;
+
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
+            }
+        });
+
+        it('submits order with provided data', async () => {
+            const payload = {
+                ...getOrderRequestBody(),
+                payment: { methodId: defaultMethodId },
+            };
+            const { payment, ...order } = payload;
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(order, undefined);
+        });
+
+        it('submits payment with formatted payload', async () => {
+            const payload = {
+                ...getOrderRequestBody(),
+                payment: { methodId: defaultMethodId },
+            };
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: defaultMethodId,
+                paymentData: {
+                    formattedPayload: {},
+                },
+            });
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy', async () => {
+            const result = await strategy.deinitialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+});

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/bigcommerce-payments-invoices-payment-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/bigcommerce-payments-invoices-payment-strategy.spec.ts
@@ -41,11 +41,9 @@ describe('BigCommercePaymentsInvoicesPaymentStrategy', () => {
 
     describe('#execute()', () => {
         it('throws an error if payload.payment is not provided', async () => {
-            try {
-                await strategy.execute({ ...getOrderRequestBody(), payment: undefined });
-            } catch (error) {
-                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
-            }
+            await expect(
+                strategy.execute({ ...getOrderRequestBody(), payment: undefined }),
+            ).rejects.toBeInstanceOf(PaymentArgumentInvalidError);
         });
 
         it('throws an error if payload.payment.methodId is not provided', async () => {
@@ -54,11 +52,9 @@ describe('BigCommercePaymentsInvoicesPaymentStrategy', () => {
                 payment: { methodId: undefined },
             } as unknown as OrderRequestBody;
 
-            try {
-                await strategy.execute(payload);
-            } catch (error) {
-                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
-            }
+            await expect(strategy.execute(payload)).rejects.toBeInstanceOf(
+                PaymentArgumentInvalidError,
+            );
         });
 
         it('submits order with provided data', async () => {

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/bigcommerce-payments-invoices-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/bigcommerce-payments-invoices-payment-strategy.ts
@@ -1,0 +1,44 @@
+import {
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    Payment,
+    PaymentArgumentInvalidError,
+    PaymentIntegrationService,
+    PaymentRequestOptions,
+    PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default class BigCommercePaymentsInvoicesPaymentStrategy implements PaymentStrategy {
+    constructor(private paymentIntegrationService: PaymentIntegrationService) {}
+
+    async initialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
+        const { payment, ...order } = payload;
+        const { methodId } = payment || {};
+
+        if (!payment || !methodId) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        const submitPaymentPayload: Payment = {
+            methodId,
+            paymentData: {
+                formattedPayload: {},
+            },
+        };
+
+        await this.paymentIntegrationService.submitOrder(order, options);
+        await this.paymentIntegrationService.submitPayment(submitPaymentPayload);
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+}

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/create-bigcommerce-payments-invoices-payment-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/create-bigcommerce-payments-invoices-payment-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BigCommercePaymentsInvoicesPaymentStrategy from './bigcommerce-payments-invoices-payment-strategy';
+import createBigCommercePaymentsInvoicesPaymentStrategy from './create-bigcommerce-payments-invoices-payment-strategy';
+
+describe('createBigCommercePaymentsInvoicesPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates BigCommercePayments invoices payment strategy', () => {
+        const strategy =
+            createBigCommercePaymentsInvoicesPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(BigCommercePaymentsInvoicesPaymentStrategy);
+    });
+});

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/create-bigcommerce-payments-invoices-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-invoices/create-bigcommerce-payments-invoices-payment-strategy.ts
@@ -1,0 +1,15 @@
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BigCommercePaymentsInvoicesPaymentStrategy from './bigcommerce-payments-invoices-payment-strategy';
+
+const createBigCommercePaymentsInvoicesPaymentStrategy: PaymentStrategyFactory<
+    BigCommercePaymentsInvoicesPaymentStrategy
+> = (paymentIntegrationService) =>
+    new BigCommercePaymentsInvoicesPaymentStrategy(paymentIntegrationService);
+
+export default toResolvableModule(createBigCommercePaymentsInvoicesPaymentStrategy, [
+    { id: 'bigcommerce_payments_invoices' },
+]);

--- a/packages/bigcommerce-payments-integration/src/index.ts
+++ b/packages/bigcommerce-payments-integration/src/index.ts
@@ -62,6 +62,14 @@ export { WithBigCommercePaymentsCreditCardsPaymentInitializeOptions } from './bi
 
 /**
  *
+ * BigCommercePayments Invoices strategy
+ *
+ */
+export { default as createBigCommercePaymentsInvoicesPaymentStrategy } from './bigcommerce-payments-invoices/create-bigcommerce-payments-invoices-payment-strategy';
+export { WithBigCommercePaymentsInvoicesPaymentInitializeOptions } from './bigcommerce-payments-invoices/bigcommerce-payments-invoices-payment-initialize-options';
+
+/**
+ *
  * BigCommercePayments Alternative methods strategies
  *
  */


### PR DESCRIPTION
## What/Why?

Jira: [PAYPAL-6698](https://bigcommercecloud.atlassian.net/browse/PAYPAL-6698)

Adds a new `bigcommerce_payments_invoices` payment method to the checkout SDK. This strategy
submits the order and payment with an empty formatted payload, following the same shape as
other BigCommercePayments strategies, and is registered/exported via the package's public
`index.ts` alongside the existing BCP strategies.

### Changes
- Added `BigCommercePaymentsInvoicesPaymentStrategy` implementing `initialize`, `execute`,
  `finalize` (rejects with `OrderFinalizationNotRequiredError`), and `deinitialize`.
- Added `createBigCommercePaymentsInvoicesPaymentStrategy` factory registered for
  `bigcommerce_payments_invoices`.
- Added `BigCommercePaymentsInvoicesPaymentInitializeOptions` (empty options interface) and its
  `WithBigCommercePaymentsInvoicesPaymentInitializeOptions` extension.
- Exported the new factory and options type from
  `packages/bigcommerce-payments-integration/src/index.ts`.

## Rollout/Rollback
Rollout
Under experiment `PROJECT-8681.bcp_invoices_checkout_implementation`

## Testing

**checkout-js:** - https://github.com/bigcommerce/checkout-js/pull/3249

**Enable experiment `PROJECT-8681.bcp_invoices_checkout_implementation`**

**Enable Invoices in BCP CP**

<img width="1197" height="196" alt="Screenshot 2026-08-13 at 15 24 30" src="https://github.com/user-attachments/assets/5322991b-d8ac-45cf-a6c5-a8ad66e23e26" />


**Invoices for guest shopper**

https://github.com/user-attachments/assets/ef57add3-bac1-44e6-93c4-715e49c81e65

**Invoices for member shopper**

https://github.com/user-attachments/assets/a9f51bc6-1036-4ae5-8ec8-53c574ea9397

**Invoices with promotions**

https://github.com/user-attachments/assets/7c953582-d794-428b-9996-0a313d14783e

**Invoices with enabled stored instruments**

https://github.com/user-attachments/assets/d292b8cb-50f2-4f5a-bee9-04cdf595f7e8



[PAYPAL-6698]: https://bigcommercecloud.atlassian.net/browse/PAYPAL-6698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the payment execution path for a new method ID; behavior is simple but incorrect registration or submit sequencing could affect checkout when the invoices experiment is enabled.
> 
> **Overview**
> Adds checkout SDK support for **`bigcommerce_payments_invoices`** via a new payment strategy module in `bigcommerce-payments-integration`.
> 
> On **execute**, the strategy validates `payment` / `methodId`, **submits the order**, then **submits payment** with an empty `formattedPayload`—the same payload shape used by other BigCommercePayments strategies. **Finalize** rejects with `OrderFinalizationNotRequiredError`; initialize and deinitialize are no-ops.
> 
> A factory registers the strategy for `bigcommerce_payments_invoices`, with empty initialize options and **exports** from the package `index.ts` alongside existing BCP strategies. Unit tests cover validation, submit order/payment, and finalize behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afbadec4983dd7bb6661e0e217736c39d0bc0393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->