### PR TITLE
fix(payment): PAYPAL-6983 Attempting to use PayPal Checkout on cart page results in user being returned to cart page with no order placed

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -11,6 +11,7 @@ import {
     getBuyNowCart,
     getBuyNowCartRequestBody,
     getCart,
+    getCheckout,
     getConfig,
     getConsignment,
     getShippingOption,
@@ -351,6 +352,39 @@ describe('PayPalCommerceButtonStrategy', () => {
             await strategy.initialize(buyNowInitializationOptions);
 
             expect(paymentIntegrationService.loadDefaultCheckout).not.toHaveBeenCalled();
+        });
+
+        it('verifies checkout spam protection when spam check should be executed', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCheckoutOrThrow').mockReturnValue({
+                ...getCheckout(),
+                shouldExecuteSpamCheck: true,
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentIntegrationService.verifyCheckoutSpamProtection).toHaveBeenCalled();
+        });
+
+        it('does not verify checkout spam protection when spam check should not be executed', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCheckoutOrThrow').mockReturnValue({
+                ...getCheckout(),
+                shouldExecuteSpamCheck: false,
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentIntegrationService.verifyCheckoutSpamProtection).not.toHaveBeenCalled();
+        });
+
+        it('does not verify checkout spam protection for Buy Now flow', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCheckoutOrThrow').mockReturnValue({
+                ...getCheckout(),
+                shouldExecuteSpamCheck: true,
+            });
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            expect(paymentIntegrationService.verifyCheckoutSpamProtection).not.toHaveBeenCalled();
         });
 
         it('loads paypal commerce sdk script', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -66,6 +66,11 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
             // Info: default checkout should not be loaded for BuyNow flow,
             // since there is no checkout session available for that.
             await this.paymentIntegrationService.loadDefaultCheckout();
+
+            const checkout = this.paymentIntegrationService.getState().getCheckoutOrThrow();
+            if (checkout.shouldExecuteSpamCheck) {
+                await this.paymentIntegrationService.verifyCheckoutSpamProtection();
+            }
         }
 
         // Info: we are using provided currency code for buy now cart,


### PR DESCRIPTION
## What/Why?

Fix for `Attempting to use PayPal Checkout on cart page results in user being returned to cart page with no order placed`
https://bigcommercecloud.atlassian.net/browse/PAYPAL-6873

## Rollout/Rollback

Revert

## Testing

https://github.com/user-attachments/assets/45a68c15-ed48-49ee-8a2f-284e57bd01de


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment checkout timing and bot-protection gating; mis-timed calls could block legitimate PayPal clicks or skip required verification.
> 
> **Overview**
> **Fixes PayPal Checkout on the cart page** when ReCAPTCHA spam protection is required: orders were failing and shoppers were sent back to the cart because spam verification never ran on that path.
> 
> After the default checkout is loaded during PayPal Commerce button **initialize** (not Buy Now), the strategy now calls `verifyCheckoutSpamProtection` when `checkout.shouldExecuteSpamCheck` is true. **Buy Now** still skips spam check on initialize (no checkout session yet).
> 
> For **Buy Now**, the same check runs in `paypal-button-creation-service` inside `createOrder`, after `loadCheckout` for the new buy-now cart, so spam protection runs before `createOrder` proceeds.
> 
> Specs cover spam check on/off, and that Buy Now initialize does not verify spam protection even when the flag is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa29c74cb11e83100f9e8ae236b0c1dbeb770ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->