### PR TITLE
feat(checkout): CHECKOUT-10199 deinitialize the initialized strategy on method lost after reload

### DIFF
--- a/packages/core/src/payment/payment-strategy-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.spec.ts
@@ -455,11 +455,147 @@ describe('PaymentStrategyActionCreator', () => {
         });
 
         it('throws error if payment method has not been loaded', async () => {
+            expect.assertions(2);
+
             try {
                 await from(actionCreator.deinitialize({ methodId: 'unknown' })(store)).toPromise();
             } catch (action) {
                 expect((action as Action).payload).toBeInstanceOf(MissingDataError);
             }
+
+            expect(strategy.deinitialize).not.toHaveBeenCalled();
+        });
+
+        describe('when the payment method is removed after initialization', () => {
+            let storeWithMethodRemoved: CheckoutStore;
+
+            beforeEach(async () => {
+                jest.spyOn(strategy, 'initialize').mockReturnValue(
+                    Promise.resolve(store.getState()),
+                );
+
+                // Must run against a store where the method is not already initialized,
+                // otherwise `initialize` short-circuits and nothing is cached.
+                await from(
+                    actionCreator.initialize({
+                        methodId: method.id,
+                        gatewayId: method.gateway,
+                    })(createCheckoutStore(state)),
+                ).toPromise();
+
+                // Do not `merge` the payment methods data - lodash merges arrays
+                // element-wise, which would leave the method in place.
+                storeWithMethodRemoved = createCheckoutStore({
+                    ...merge({}, state, {
+                        paymentStrategies: {
+                            data: { [method.id]: { isInitialized: true } },
+                        },
+                    }),
+                    paymentMethods: { ...state.paymentMethods, data: [] },
+                });
+            });
+
+            it('deinitializes the strategy using the cached payment method', async () => {
+                const actions = await from(
+                    actionCreator.deinitialize({
+                        methodId: method.id,
+                        gatewayId: method.gateway,
+                    })(storeWithMethodRemoved),
+                )
+                    .pipe(toArray())
+                    .toPromise();
+
+                expect(strategy.deinitialize).toHaveBeenCalled();
+                expect(actions).toEqual([
+                    {
+                        type: PaymentStrategyActionType.DeinitializeRequested,
+                        meta: { methodId: method.id, gatewayId: method.gateway },
+                    },
+                    {
+                        type: PaymentStrategyActionType.DeinitializeSucceeded,
+                        meta: { methodId: method.id, gatewayId: method.gateway },
+                    },
+                ]);
+            });
+
+            it('resolves the same strategy instance that was initialized', async () => {
+                await from(
+                    actionCreator.deinitialize({
+                        methodId: method.id,
+                        gatewayId: method.gateway,
+                    })(storeWithMethodRemoved),
+                ).toPromise();
+
+                expect(registry.getByMethod).toHaveBeenCalledWith(method);
+            });
+
+            it('does nothing if the removed method was never initialized', async () => {
+                const storeWithoutInitialization = createCheckoutStore({
+                    ...state,
+                    paymentMethods: { ...state.paymentMethods, data: [] },
+                });
+
+                const actions = await from(
+                    actionCreator.deinitialize({
+                        methodId: method.id,
+                        gatewayId: method.gateway,
+                    })(storeWithoutInitialization),
+                )
+                    .pipe(toArray())
+                    .toPromise();
+
+                expect(actions).toEqual([]);
+                expect(strategy.deinitialize).not.toHaveBeenCalled();
+            });
+        });
+
+        it('deinitializes a removed method that was initialized with a gateway', async () => {
+            const gatewayMethod = { ...method, id: 'credit_card', gateway: 'checkoutcom' };
+            // The strategy selector keys gateway methods as `methodId.gatewayId`.
+            const cacheKey = `${gatewayMethod.id}.${gatewayMethod.gateway}`;
+
+            const storeWithGatewayMethod = createCheckoutStore({
+                ...state,
+                paymentMethods: { ...state.paymentMethods, data: [gatewayMethod] },
+            });
+
+            jest.spyOn(strategy, 'initialize').mockReturnValue(Promise.resolve(store.getState()));
+
+            await from(
+                actionCreator.initialize({
+                    methodId: gatewayMethod.id,
+                    gatewayId: gatewayMethod.gateway,
+                })(storeWithGatewayMethod),
+            ).toPromise();
+
+            const storeWithMethodRemoved = createCheckoutStore({
+                ...merge({}, state, {
+                    paymentStrategies: { data: { [cacheKey]: { isInitialized: true } } },
+                }),
+                paymentMethods: { ...state.paymentMethods, data: [] },
+            });
+
+            const actions = await from(
+                actionCreator.deinitialize({
+                    methodId: gatewayMethod.id,
+                    gatewayId: gatewayMethod.gateway,
+                })(storeWithMethodRemoved),
+            )
+                .pipe(toArray())
+                .toPromise();
+
+            expect(registry.getByMethod).toHaveBeenCalledWith(gatewayMethod);
+            expect(strategy.deinitialize).toHaveBeenCalled();
+            expect(actions).toEqual([
+                {
+                    type: PaymentStrategyActionType.DeinitializeRequested,
+                    meta: { methodId: gatewayMethod.id, gatewayId: gatewayMethod.gateway },
+                },
+                {
+                    type: PaymentStrategyActionType.DeinitializeSucceeded,
+                    meta: { methodId: gatewayMethod.id, gatewayId: gatewayMethod.gateway },
+                },
+            ]);
         });
     });
 

--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -45,6 +45,13 @@ import { PaymentStrategy } from './strategies';
 export default class PaymentStrategyActionCreator {
     private _paymentStrategyWidgetActionCreator: PaymentStrategyWidgetActionCreator;
 
+    /**
+     * Methods with a live strategy. A payment methods reload can drop a method from
+     * state while its strategy is still running, and tearing that strategy down needs
+     * the original method object to resolve it.
+     */
+    private _initializedMethodsCache = new Map<string, PaymentMethod>();
+
     constructor(
         private _strategyRegistry: PaymentStrategyRegistry,
         private _strategyRegistryV2: PaymentStrategyRegistryV2,
@@ -207,12 +214,22 @@ export default class PaymentStrategyActionCreator {
                             gatewayId,
                         }),
                     ),
-                    promise.then(() =>
-                        createAction(PaymentStrategyActionType.InitializeSucceeded, undefined, {
-                            methodId,
-                            gatewayId,
-                        }),
-                    ),
+                    promise.then(() => {
+                        // Retained on success only, so this mirrors `isInitialized`.
+                        this._initializedMethodsCache.set(
+                            this._getCacheKey(methodId, gatewayId),
+                            method,
+                        );
+
+                        return createAction(
+                            PaymentStrategyActionType.InitializeSucceeded,
+                            undefined,
+                            {
+                                methodId,
+                                gatewayId,
+                            },
+                        );
+                    }),
                 );
             }).pipe(
                 catchError((error) =>
@@ -232,7 +249,13 @@ export default class PaymentStrategyActionCreator {
         return (store) =>
             defer(() => {
                 const state = store.getState();
-                const method = state.paymentMethods.getPaymentMethod(methodId, gatewayId);
+                const cacheKey = this._getCacheKey(methodId, gatewayId);
+
+                // Anything never initialized is not cached, so an unknown method still
+                // throws below exactly as it did before.
+                const method =
+                    state.paymentMethods.getPaymentMethod(methodId, gatewayId) ??
+                    this._initializedMethodsCache.get(cacheKey);
 
                 if (!method) {
                     throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
@@ -257,12 +280,19 @@ export default class PaymentStrategyActionCreator {
                             gatewayId,
                         }),
                     ),
-                    promise.then(() =>
-                        createAction(PaymentStrategyActionType.DeinitializeSucceeded, undefined, {
-                            methodId,
-                            gatewayId,
-                        }),
-                    ),
+                    promise.then(() => {
+                        // Kept on failure, so a failed teardown can be retried.
+                        this._initializedMethodsCache.delete(cacheKey);
+
+                        return createAction(
+                            PaymentStrategyActionType.DeinitializeSucceeded,
+                            undefined,
+                            {
+                                methodId,
+                                gatewayId,
+                            },
+                        );
+                    }),
                 );
             }).pipe(
                 catchError((error) =>
@@ -279,6 +309,10 @@ export default class PaymentStrategyActionCreator {
         options?: PaymentRequestOptions,
     ): Observable<PaymentStrategyWidgetAction> {
         return this._paymentStrategyWidgetActionCreator.widgetInteraction(method, options);
+    }
+
+    private _getCacheKey(methodId: string, gatewayId?: string): string {
+        return gatewayId ? `${methodId}.${gatewayId}` : methodId;
     }
 
     private _getStrategy(method: PaymentMethod): PaymentStrategy | PaymentStrategyV2 {


### PR DESCRIPTION
## What/Why?

- If a payment methods reload removes the method the shopper had selected (changing billing country usually), its component unmounts and calls deinitializePayment. That looked the method up in state, didn't find it, and threw MissingPaymentMethod — so you'd get an error modal for no good reason, and the strategy never actually got torn down, so its iframe stuck around.
- Fix is to hang on to the method we initialized with and use that when it's no longer in state. Same strategy instance, proper teardown.
- Kept it tight on purpose: only a method that was initialized and then vanished behaves differently. Anything unknown or never initialized throws like it always did.
- Also rewrote the "throws if method not loaded" test — it was green even when nothing threw.
- The checkout-js half of this ticket drops a temporary suppression hack and needs this released first. https://github.com/bigcommerce/checkout-js/pull/3248

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment strategy initialize/deinitialize lifecycle during checkout; scoped change with tests, but incorrect cache or teardown could leave strategies running or block cleanup.
> 
> **Overview**
> Fixes teardown when **payment methods are reloaded** and a method disappears from store while its strategy is still initialized.
> 
> `PaymentStrategyActionCreator` now keeps an **`_initializedMethodsCache`** keyed by `methodId` or `methodId.gatewayId`. Entries are added only after **initialize succeeds** and removed after **deinitialize succeeds**, so unknown methods still throw `MissingDataError` and failed teardowns can be retried.
> 
> **Deinitialize** resolves the `PaymentMethod` from the store first, then falls back to the cache so `registry.getByMethod` still gets the original object. If the method was never initialized, behavior is unchanged (no actions, no `deinitialize` call).
> 
> Specs cover removed methods after init, gateway cache keys, and the unknown-method path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a84836222b4ff2db7aeafb30b6789ef44bd147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->