### PR TITLE
feat(payment): PAYPAL-6494 add BCP pay later wallet strategy

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-wallet-initialize-options.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-wallet-initialize-options.ts
@@ -1,0 +1,12 @@
+export default interface BigCommercePaymentsPayLaterWalletInitializeOptions {
+    cartId: string;
+    currency: {
+        code: string;
+    };
+    initializationData: string;
+    clientToken: string;
+}
+
+export interface WithBigCommercePaymentsPayLaterWalletInitializeOptions {
+    bigcommerce_paymentspaypalcredit?: BigCommercePaymentsPayLaterWalletInitializeOptions;
+}

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-wallet-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-wallet-strategy.spec.ts
@@ -1,0 +1,326 @@
+import {
+    CheckoutButtonInitializeOptions,
+    InvalidArgumentError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaypalCommerceWalletService } from '@bigcommerce/checkout-sdk/paypal-utils';
+
+import { getPayPalSDKMock } from '../mocks';
+
+import { WithBigCommercePaymentsPayLaterWalletInitializeOptions } from './bigcommerce-payments-paylater-wallet-initialize-options';
+import BigCommercePaymentsPayLaterWalletStrategy from './bigcommerce-payments-paylater-wallet-strategy';
+
+describe('BigCommercePaymentsPayLaterWalletStrategy', () => {
+    let strategy: BigCommercePaymentsPayLaterWalletStrategy;
+    let bigCommercePaymentsPayLaterWalletService: jest.Mocked<PaypalCommerceWalletService>;
+
+    const defaultContainerId = 'bigcommerce-payments-paylater-wallet-button';
+    const defaultMethodId = 'bigcommerce_paymentspaypalcredit';
+    const defaultProviderId = 'bigcommerce_payments.paypalcredit';
+    const defaultCartId = 'abc123';
+    const defaultOrderId = 'ORDER_ID';
+    const defaultButtonStyle = { color: 'gold', label: 'checkout' };
+
+    const orderDetails = {
+        payer: {
+            name: { given_name: 'John', surname: 'Doe' },
+            email_address: 'john@doe.com',
+            address: {
+                address_line_1: '123 Main St',
+                address_line_2: 'Suite 100',
+                admin_area_2: 'Austin',
+                admin_area_1: 'TX',
+                postal_code: '73301',
+                country_code: 'US',
+            },
+        },
+        purchase_units: [],
+    };
+    const mappedBillingAddress = { firstName: 'John', lastName: 'Doe' };
+
+    const initializationOptions: CheckoutButtonInitializeOptions &
+        WithBigCommercePaymentsPayLaterWalletInitializeOptions = {
+        methodId: defaultMethodId,
+        containerId: defaultContainerId,
+        bigcommerce_paymentspaypalcredit: {
+            cartId: defaultCartId,
+            currency: {
+                code: 'USD',
+            },
+            initializationData: btoa(
+                JSON.stringify({
+                    initializationData: {
+                        clientId: 'test-client-id',
+                        paymentButtonStyles: {
+                            cartButtonStyles: defaultButtonStyle,
+                        },
+                    },
+                }),
+            ),
+            clientToken: 'test-client-token',
+        },
+    };
+
+    beforeEach(() => {
+        const paypalSdk = getPayPalSDKMock();
+
+        bigCommercePaymentsPayLaterWalletService = {
+            addBillingAddress: jest.fn(),
+            createPaymentOrderIntent: jest.fn().mockResolvedValue(defaultOrderId),
+            getPayPalSdkOrThrow: jest.fn().mockReturnValue(paypalSdk),
+            getValidButtonStyle: jest.fn().mockReturnValue({ height: 45 }),
+            loadPayPalSdk: jest.fn(),
+            mapOrderDetailsToBillingAddress: jest.fn().mockReturnValue(mappedBillingAddress),
+            proxyTokenizationPayment: jest.fn(),
+            removeElement: jest.fn(),
+        } as unknown as jest.Mocked<PaypalCommerceWalletService>;
+
+        strategy = new BigCommercePaymentsPayLaterWalletStrategy(
+            bigCommercePaymentsPayLaterWalletService,
+        );
+    });
+
+    it('throws when methodId is not provided', async () => {
+        const optionsWithoutMethodId = {
+            ...initializationOptions,
+            methodId: undefined,
+        } as unknown as CheckoutButtonInitializeOptions &
+            WithBigCommercePaymentsPayLaterWalletInitializeOptions;
+
+        await expect(strategy.initialize(optionsWithoutMethodId)).rejects.toEqual(
+            new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            ),
+        );
+    });
+
+    it('throws when containerId is not provided', async () => {
+        const optionsWithoutContainerId = {
+            ...initializationOptions,
+            containerId: undefined,
+        } as unknown as CheckoutButtonInitializeOptions &
+            WithBigCommercePaymentsPayLaterWalletInitializeOptions;
+
+        await expect(strategy.initialize(optionsWithoutContainerId)).rejects.toEqual(
+            new InvalidArgumentError(
+                `Unable to initialize payment because "options.containerId" argument is not provided.`,
+            ),
+        );
+    });
+
+    it('throws when bigcommerce_paymentspaypalcredit options are not provided', async () => {
+        const optionsWithoutPayLaterOptions = {
+            ...initializationOptions,
+            bigcommerce_paymentspaypalcredit: undefined,
+        } as unknown as CheckoutButtonInitializeOptions &
+            WithBigCommercePaymentsPayLaterWalletInitializeOptions;
+
+        await expect(strategy.initialize(optionsWithoutPayLaterOptions)).rejects.toEqual(
+            new InvalidArgumentError(
+                `Unable to initialize payment because "options.bigcommerce_paymentspaypalcredit" argument is not provided.`,
+            ),
+        );
+    });
+
+    it('throws when payment method initializationData cannot be parsed', async () => {
+        const invalidInitializationOptions = {
+            ...initializationOptions,
+            bigcommerce_paymentspaypalcredit: {
+                ...initializationOptions.bigcommerce_paymentspaypalcredit!,
+                initializationData: '%%%invalid-base64%%%',
+            },
+        };
+
+        await expect(strategy.initialize(invalidInitializationOptions)).rejects.toEqual(
+            new InvalidArgumentError("Failed to parse payment method 'initializationData'."),
+        );
+    });
+
+    it('loads PayPal SDK with parsed initialization data and currency', async () => {
+        await strategy.initialize(initializationOptions);
+
+        expect(bigCommercePaymentsPayLaterWalletService.loadPayPalSdk).toHaveBeenCalledWith(
+            expect.objectContaining({
+                initializationData: expect.objectContaining({ clientId: 'test-client-id' }),
+            }),
+            'USD',
+            false,
+        );
+    });
+
+    it('renders paylater button with PAYLATER as first eligible funding source', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = bigCommercePaymentsPayLaterWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        const buttonOptions = buttonsSpy.mock.calls[0][0];
+
+        expect(buttonOptions.fundingSource).toEqual(paypalSdk.FUNDING.PAYLATER);
+        expect(paypalButtons.render).toHaveBeenCalledWith(`#${defaultContainerId}`);
+    });
+
+    it('renders button with CREDIT funding source when PAYLATER is not eligible', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = bigCommercePaymentsPayLaterWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockImplementation((options: any) => {
+            if (options.fundingSource === paypalSdk.FUNDING.PAYLATER) {
+                return {
+                    ...paypalButtons,
+                    isEligible: jest.fn().mockReturnValue(false),
+                };
+            }
+
+            return paypalButtons;
+        });
+
+        await strategy.initialize(initializationOptions);
+
+        const creditButtonOptions = buttonsSpy.mock.calls[1][0];
+
+        expect(creditButtonOptions.fundingSource).toEqual(paypalSdk.FUNDING.CREDIT);
+        expect(paypalButtons.render).toHaveBeenCalledWith(`#${defaultContainerId}`);
+    });
+
+    it('applies cart button styles from parsed initializationData', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = bigCommercePaymentsPayLaterWalletService.getPayPalSdkOrThrow();
+
+        jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        expect(bigCommercePaymentsPayLaterWalletService.getValidButtonStyle).toHaveBeenCalledWith(
+            defaultButtonStyle,
+        );
+    });
+
+    it('creates payment order intent with correct provider ID', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = bigCommercePaymentsPayLaterWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        const buttonOptions = buttonsSpy.mock.calls[0][0];
+
+        await buttonOptions.createOrder();
+
+        expect(
+            bigCommercePaymentsPayLaterWalletService.createPaymentOrderIntent,
+        ).toHaveBeenCalledWith(defaultProviderId, defaultCartId);
+    });
+
+    it('adds billing address and proxies tokenization on approve', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = bigCommercePaymentsPayLaterWalletService.getPayPalSdkOrThrow();
+        const buttonsSpy = jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        const buttonOptions = buttonsSpy.mock.calls[0][0];
+
+        await buttonOptions.onApprove?.(
+            { orderID: defaultOrderId },
+            {
+                order: {
+                    get: jest.fn().mockResolvedValue(orderDetails),
+                },
+            },
+        );
+
+        expect(
+            bigCommercePaymentsPayLaterWalletService.mapOrderDetailsToBillingAddress,
+        ).toHaveBeenCalledWith(orderDetails);
+        expect(bigCommercePaymentsPayLaterWalletService.addBillingAddress).toHaveBeenCalledWith(
+            defaultCartId,
+            mappedBillingAddress,
+        );
+        expect(
+            bigCommercePaymentsPayLaterWalletService.proxyTokenizationPayment,
+        ).toHaveBeenCalledWith(
+            defaultCartId,
+            defaultProviderId,
+            'bigcommerce_payments_paylater',
+            defaultOrderId,
+        );
+    });
+
+    it('removes element when no funding source is eligible', async () => {
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(false),
+            render: jest.fn(),
+        };
+        const paypalSdk = bigCommercePaymentsPayLaterWalletService.getPayPalSdkOrThrow();
+
+        jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(initializationOptions);
+
+        expect(bigCommercePaymentsPayLaterWalletService.removeElement).toHaveBeenCalledWith(
+            defaultContainerId,
+        );
+    });
+
+    it('uses fallback style when cartButtonStyles is not provided', async () => {
+        const optionsWithoutButtonStyle: CheckoutButtonInitializeOptions &
+            WithBigCommercePaymentsPayLaterWalletInitializeOptions = {
+            methodId: defaultMethodId,
+            containerId: defaultContainerId,
+            bigcommerce_paymentspaypalcredit: {
+                cartId: defaultCartId,
+                currency: {
+                    code: 'USD',
+                },
+                initializationData: btoa(
+                    JSON.stringify({
+                        initializationData: {
+                            clientId: 'test-client-id',
+                        },
+                    }),
+                ),
+                clientToken: 'test-client-token',
+            },
+        };
+
+        const paypalButtons = {
+            close: jest.fn(),
+            isEligible: jest.fn().mockReturnValue(true),
+            render: jest.fn(),
+        };
+        const paypalSdk = bigCommercePaymentsPayLaterWalletService.getPayPalSdkOrThrow();
+
+        jest.spyOn(paypalSdk, 'Buttons').mockReturnValue(paypalButtons);
+
+        await strategy.initialize(optionsWithoutButtonStyle);
+
+        expect(bigCommercePaymentsPayLaterWalletService.getValidButtonStyle).toHaveBeenCalledWith(
+            undefined,
+        );
+    });
+
+    it('resolves on deinitialize', async () => {
+        await expect(strategy.deinitialize()).resolves.toBeUndefined();
+    });
+});

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-wallet-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/bigcommerce-payments-paylater-wallet-strategy.ts
@@ -1,0 +1,140 @@
+import {
+    CheckoutButtonInitializeOptions,
+    CheckoutButtonStrategy,
+    InvalidArgumentError,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaypalCommerceWalletService } from '@bigcommerce/checkout-sdk/paypal-utils';
+
+import {
+    ApproveCallbackActions,
+    ApproveCallbackPayload,
+    BigCommercePaymentsButtonsOptions,
+    BigCommercePaymentsInitializationData,
+    PayPalButtonStyleOptions,
+} from '../bigcommerce-payments-types';
+
+import { WithBigCommercePaymentsPayLaterWalletInitializeOptions } from './bigcommerce-payments-paylater-wallet-initialize-options';
+
+export default class BigCommercePaymentsPayLaterWalletStrategy implements CheckoutButtonStrategy {
+    constructor(private bigCommercePaymentsPayLaterWalletService: PaypalCommerceWalletService) {}
+
+    async initialize(
+        options: CheckoutButtonInitializeOptions &
+            WithBigCommercePaymentsPayLaterWalletInitializeOptions,
+    ): Promise<void> {
+        const { bigcommerce_paymentspaypalcredit, containerId, methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.containerId" argument is not provided.`,
+            );
+        }
+
+        if (!bigcommerce_paymentspaypalcredit) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.bigcommerce_paymentspaypalcredit" argument is not provided.`,
+            );
+        }
+
+        let parsedInitializationData: PaymentMethod<BigCommercePaymentsInitializationData>;
+
+        try {
+            parsedInitializationData = JSON.parse(
+                atob(bigcommerce_paymentspaypalcredit.initializationData),
+            );
+        } catch {
+            throw new InvalidArgumentError("Failed to parse payment method 'initializationData'.");
+        }
+
+        const buttonStyle =
+            parsedInitializationData.initializationData?.paymentButtonStyles?.cartButtonStyles;
+
+        await this.bigCommercePaymentsPayLaterWalletService.loadPayPalSdk(
+            parsedInitializationData,
+            bigcommerce_paymentspaypalcredit.currency.code,
+            false,
+        );
+
+        this.renderButton(
+            containerId,
+            'bigcommerce_payments.paypalcredit',
+            bigcommerce_paymentspaypalcredit.cartId,
+            buttonStyle,
+        );
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    private renderButton(
+        containerId: string,
+        providerId: string,
+        cartId: string,
+        buttonStyle?: PayPalButtonStyleOptions,
+    ): void {
+        const paypalSdk = this.bigCommercePaymentsPayLaterWalletService.getPayPalSdkOrThrow();
+        const fundingSources = [paypalSdk.FUNDING.PAYLATER, paypalSdk.FUNDING.CREDIT];
+
+        const defaultCallbacks = {
+            createOrder: () =>
+                this.bigCommercePaymentsPayLaterWalletService.createPaymentOrderIntent(
+                    providerId,
+                    cartId,
+                ),
+            onApprove: async (
+                { orderID }: ApproveCallbackPayload,
+                actions: ApproveCallbackActions,
+            ) => {
+                const orderDetails = await actions.order.get();
+                const billingAddress =
+                    this.bigCommercePaymentsPayLaterWalletService.mapOrderDetailsToBillingAddress(
+                        orderDetails,
+                    );
+
+                await this.bigCommercePaymentsPayLaterWalletService.addBillingAddress(
+                    cartId,
+                    billingAddress,
+                );
+                await this.bigCommercePaymentsPayLaterWalletService.proxyTokenizationPayment(
+                    cartId,
+                    providerId,
+                    'bigcommerce_payments_paylater',
+                    orderID,
+                );
+            },
+        };
+
+        let hasRenderedSmartButton = false;
+
+        fundingSources.forEach((fundingSource) => {
+            if (!hasRenderedSmartButton) {
+                const buttonRenderOptions: BigCommercePaymentsButtonsOptions = {
+                    fundingSource,
+                    style: this.bigCommercePaymentsPayLaterWalletService.getValidButtonStyle(
+                        buttonStyle,
+                    ),
+                    ...defaultCallbacks,
+                };
+
+                const paypalButton = paypalSdk.Buttons(buttonRenderOptions);
+
+                if (paypalButton.isEligible()) {
+                    paypalButton.render(`#${containerId}`);
+                    hasRenderedSmartButton = true;
+                }
+            }
+        });
+
+        if (!hasRenderedSmartButton) {
+            this.bigCommercePaymentsPayLaterWalletService.removeElement(containerId);
+        }
+    }
+}

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/create-bigcommerce-payments-paylater-wallet-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/create-bigcommerce-payments-paylater-wallet-strategy.spec.ts
@@ -1,0 +1,23 @@
+import {
+    createWalletButtonIntegrationService,
+    WalletButtonIntegrationService,
+} from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import BigCommercePaymentsPayLaterWalletStrategy from './bigcommerce-payments-paylater-wallet-strategy';
+import createBigCommercePaymentsPayLaterWalletStrategy from './create-bigcommerce-payments-paylater-wallet-strategy';
+
+describe('createBigCommercePaymentsPayLaterWalletStrategy', () => {
+    let walletButtonIntegrationService: WalletButtonIntegrationService;
+
+    beforeEach(() => {
+        walletButtonIntegrationService = createWalletButtonIntegrationService('/graphql');
+    });
+
+    it('instantiates BigCommercePaymentsPayLaterWalletStrategy', () => {
+        const strategy = createBigCommercePaymentsPayLaterWalletStrategy(
+            walletButtonIntegrationService,
+        );
+
+        expect(strategy).toBeInstanceOf(BigCommercePaymentsPayLaterWalletStrategy);
+    });
+});

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/create-bigcommerce-payments-paylater-wallet-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments-paylater/create-bigcommerce-payments-paylater-wallet-strategy.ts
@@ -1,0 +1,23 @@
+import { toResolvableModule } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    createPayPalSdkScriptLoader,
+    PaypalCommerceWalletService,
+} from '@bigcommerce/checkout-sdk/paypal-utils';
+import { WalletPaymentButtonStrategyFactory } from '@bigcommerce/checkout-sdk/wallet-button-integration';
+
+import BigCommercePaymentsPayLaterWalletStrategy from './bigcommerce-payments-paylater-wallet-strategy';
+
+const createBigCommercePaymentsPayLaterWalletStrategy: WalletPaymentButtonStrategyFactory<
+    BigCommercePaymentsPayLaterWalletStrategy
+> = (walletButtonIntegrationService) =>
+    new BigCommercePaymentsPayLaterWalletStrategy(
+        new PaypalCommerceWalletService(
+            walletButtonIntegrationService,
+            createPayPalSdkScriptLoader(),
+            'BigcommercePaymentWalletIntentData',
+        ),
+    );
+
+export default toResolvableModule(createBigCommercePaymentsPayLaterWalletStrategy, [
+    { id: 'bigcommerce_paymentspaypalcredit' },
+]);

--- a/packages/bigcommerce-payments-integration/src/index.ts
+++ b/packages/bigcommerce-payments-integration/src/index.ts
@@ -44,6 +44,9 @@ export { WithBigCommercePaymentsPayLaterCustomerInitializeOptions } from './bigc
 export { default as createBigCommercePaymentsPayLaterPaymentStrategy } from './bigcommerce-payments-paylater/create-bigcommerce-payments-paylater-payment-strategy';
 export { WithBigCommercePaymentsPayLaterPaymentInitializeOptions } from './bigcommerce-payments-paylater/bigcommerce-payments-paylater-payment-initialize-options';
 
+export { default as createBigCommercePaymentsPayLaterWalletStrategy } from './bigcommerce-payments-paylater/create-bigcommerce-payments-paylater-wallet-strategy';
+export { WithBigCommercePaymentsPayLaterWalletInitializeOptions } from './bigcommerce-payments-paylater/bigcommerce-payments-paylater-wallet-initialize-options';
+
 /**
  *
  * BigCommercePayments RatePay strategy

--- a/packages/paypal-utils/src/paypal-sdk-script-loader.spec.ts
+++ b/packages/paypal-utils/src/paypal-sdk-script-loader.spec.ts
@@ -274,6 +274,24 @@ describe('PayPalSdkLoader', () => {
             });
         });
 
+        it('filters afterpay and klarna from disable-funding APMs', async () => {
+            const paymentMethodProp = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    availableAlternativePaymentMethods: ['bancontact', 'afterpay', 'klarna'],
+                    enabledAlternativePaymentMethods: ['bancontact'],
+                },
+            };
+
+            await subject.getPayPalSDK(paymentMethodProp, 'USD', 'en-US');
+
+            const paypalSdkScriptSrc =
+                'https://www.paypal.com/sdk/js?client-id=abc&merchant-id=JTS4DY7XFSQZE&enable-funding=bancontact&disable-funding=card%2Ccredit%2Cpaylater%2Cvenmo&commit=true&components=buttons%2Chosted-fields%2Cpayment-fields%2Clegal%2Ccard-fields&currency=USD&intent=capture&locale=en_US';
+
+            expect(loader.loadScript).toHaveBeenCalledWith(paypalSdkScriptSrc, expect.any(Object));
+        });
+
         it('loads PayPalSDK script with commit flag as false', async () => {
             await subject.getPayPalSDK(paymentMethod, 'USD', 'en-US', false);
 

--- a/packages/paypal-utils/src/paypal-sdk-script-loader.ts
+++ b/packages/paypal-utils/src/paypal-sdk-script-loader.ts
@@ -216,18 +216,18 @@ export default class PayPalSdkScriptLoader {
         const cardFieldsComponent: PayPalSdkComponents = initializesOnCheckoutPage
             ? ['card-fields']
             : [];
-        const disableFunding: FundingType = [
+        const disableFunding: FundingType = this.filterFundingOptions([
             ...disableCardFunding,
             ...disableCreditFunding,
             ...disableVenmoFunding,
             ...disableAPMsFunding,
-        ];
-        const enableFunding: FundingType = [
+        ]);
+        const enableFunding: FundingType = this.filterFundingOptions([
             ...enableCardFunding,
             ...enableCreditFunding,
             ...enableVenmoFunding,
             ...enabledAlternativePaymentMethods,
-        ];
+        ]);
 
         const locale = transformLocaleToPayPalFormat(storeLanguage);
 
@@ -366,9 +366,11 @@ export default class PayPalSdkScriptLoader {
             enabledAlternativePaymentMethods = [],
         } = initializationData;
 
-        const enableAPMsFunding = enabledAlternativePaymentMethods;
-        const disableAPMsFunding = availableAlternativePaymentMethods.filter(
-            (apm: string) => !enabledAlternativePaymentMethods.includes(apm),
+        const enableAPMsFunding = this.filterFundingOptions(enabledAlternativePaymentMethods);
+        const disableAPMsFunding = this.filterFundingOptions(
+            availableAlternativePaymentMethods.filter(
+                (apm: string) => !enabledAlternativePaymentMethods.includes(apm),
+            ),
         );
 
         const locale = transformLocaleToPayPalFormat(storeLanguage);
@@ -430,6 +432,18 @@ export default class PayPalSdkScriptLoader {
      * Utils methods
      *
      */
+    private filterFundingOptions(fundingOptions: FundingType | undefined): FundingType {
+        const unsupportedFundingTypes = ['klarna', 'afterpay'];
+
+        if (!fundingOptions) {
+            return [];
+        }
+
+        return fundingOptions.filter(
+            (fundingOption) => !unsupportedFundingTypes.includes(fundingOption),
+        );
+    }
+
     private transformConfig<T extends Record<string, unknown>>(config: T): Record<string, string> {
         let transformedConfig = {};
 


### PR DESCRIPTION
## What/Why?
Add BigCommercePayments PayLater Wallet strategy
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
Unit 

[screen-capture (6).webm](https://github.com/user-attachments/assets/9499e36c-2657-4924-a66a-3f6770b29c20)

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New payment wallet path touches order intent, billing, and tokenization proxying; PayPal SDK funding filter changes could affect which APMs load globally for all PayPal integrations.
> 
> **Overview**
> Adds a **wallet checkout button strategy** for BigCommerce Payments Pay Later (`bigcommerce_paymentspaypalcredit`), wired through a factory and package exports so cart/wallet flows can show Pay Later / PayPal Credit smart buttons.
> 
> On initialize, the strategy validates options, decodes `initializationData`, loads the PayPal SDK (non-commit), and renders the first eligible button from **PAYLATER** then **CREDIT**. **createOrder** creates a payment order intent; **onApprove** maps billing from PayPal, updates the cart, and proxies tokenization as `bigcommerce_payments_paylater`. If neither funding source is eligible, the container element is removed. Unit tests cover validation, rendering fallbacks, and approve flow.
> 
> In **paypal-utils**, PayPal SDK script configuration now **filters `klarna` and `afterpay`** out of enable/disable funding lists (main SDK and APM configs), with a spec asserting they are not passed in `disable-funding` when listed as available APMs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6dbc149a9339520231ff6b3507c8f2284bd607d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->