### PR TITLE
fix(payment): Stripe, remove redundant payment intent update on checkout change

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -98,7 +98,6 @@ describe('StripeOCSPaymentStrategy', () => {
                     stripeocs: undefined,
                 }),
             ).rejects.toThrow(NotInitializedError);
-            expect(stripeIntegrationService.initCheckoutEventsSubscription).not.toHaveBeenCalled();
         });
 
         it('throws error if no container id in stripe options', async () => {
@@ -112,7 +111,6 @@ describe('StripeOCSPaymentStrategy', () => {
                     },
                 }),
             ).rejects.toThrow(NotInitializedError);
-            expect(stripeIntegrationService.initCheckoutEventsSubscription).not.toHaveBeenCalled();
         });
 
         it('throws error if no gatewayId option', async () => {
@@ -122,7 +120,6 @@ describe('StripeOCSPaymentStrategy', () => {
                     gatewayId: undefined,
                 }),
             ).rejects.toThrow(NotInitializedError);
-            expect(stripeIntegrationService.initCheckoutEventsSubscription).not.toHaveBeenCalled();
         });
 
         it('throws error if payment method does not like stripe payment method', async () => {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -91,7 +91,6 @@ describe('StripeOCSPaymentStrategy', () => {
                     stripeocs: undefined,
                 }),
             ).rejects.toThrow(NotInitializedError);
-            expect(stripeIntegrationService.initCheckoutEventsSubscription).not.toHaveBeenCalled();
         });
 
         it('throws error if no container id in stripe options', async () => {
@@ -105,7 +104,6 @@ describe('StripeOCSPaymentStrategy', () => {
                     },
                 }),
             ).rejects.toThrow(NotInitializedError);
-            expect(stripeIntegrationService.initCheckoutEventsSubscription).not.toHaveBeenCalled();
         });
 
         it('throws error if no gatewayId option', async () => {
@@ -115,7 +113,6 @@ describe('StripeOCSPaymentStrategy', () => {
                     gatewayId: undefined,
                 }),
             ).rejects.toThrow(InvalidArgumentError);
-            expect(stripeIntegrationService.initCheckoutEventsSubscription).not.toHaveBeenCalled();
         });
 
         it('throws error if payment method does not like stripe payment method', async () => {
@@ -185,7 +182,6 @@ describe('StripeOCSPaymentStrategy', () => {
             expect(onErrorMock).not.toHaveBeenCalled();
             expect(togglePreloaderMock).toHaveBeenCalled();
             expect(stripeScriptLoader.getStripeClient).toHaveBeenCalled();
-            expect(stripeIntegrationService.initCheckoutEventsSubscription).toHaveBeenCalled();
         });
 
         it('should initialize and get postal code when shipping address unavailable', async () => {
@@ -1675,7 +1671,6 @@ describe('StripeOCSPaymentStrategy', () => {
             await stripeOCSPaymentStrategy.initialize(getStripeOCSInitializeOptionsMock());
             await stripeOCSPaymentStrategy.deinitialize();
 
-            expect(stripeIntegrationService.deinitialize).toHaveBeenCalled();
             expect(unmountMock).toHaveBeenCalled();
             expect(destroyMock).toHaveBeenCalled();
         });
@@ -1690,9 +1685,7 @@ describe('StripeOCSPaymentStrategy', () => {
                 }),
             );
 
-            await stripeOCSPaymentStrategy.deinitialize();
-
-            expect(stripeIntegrationService.deinitialize).toHaveBeenCalled();
+            await expect(stripeOCSPaymentStrategy.deinitialize()).resolves.toBeUndefined();
         });
     });
 });

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -75,13 +75,6 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
                 stripeocs.onError?.(error);
             }
         }
-
-        this.stripeIntegrationService.initCheckoutEventsSubscription(
-            gatewayId,
-            methodId,
-            stripeocs,
-            this.stripeElements,
-        );
     }
 
     async execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
@@ -132,7 +125,6 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
 
         paymentElement?.unmount();
         paymentElement?.destroy();
-        this.stripeIntegrationService.deinitialize();
         this.stripeElements = undefined;
         this.stripeClient = undefined;
 

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -86,8 +86,6 @@ describe('StripeUPEPaymentStrategy', () => {
 
         jest.spyOn(paymentIntegrationService, 'updateBillingAddress').mockImplementation(jest.fn());
 
-        jest.spyOn(paymentIntegrationService, 'subscribe');
-
         jest.spyOn(paymentIntegrationService.getState(), 'getCart').mockReturnValue(getCart());
 
         stripeUPEIntegrationService = new StripeIntegrationService(
@@ -231,12 +229,6 @@ describe('StripeUPEPaymentStrategy', () => {
             await strategy.initialize(options);
 
             expect(stripeScriptLoader.getStripeClient).toHaveBeenCalled();
-        });
-
-        it('loads subscribe once', async () => {
-            await strategy.initialize(options);
-
-            expect(paymentIntegrationService.subscribe).toHaveBeenCalledTimes(1);
         });
 
         it('does not load stripeUPE if initialization options are not provided', async () => {

--- a/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-upe/stripe-upe-payment-strategy.ts
@@ -83,13 +83,6 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             stripeupe.onError?.(error),
         );
 
-        this.stripeIntegrationService.initCheckoutEventsSubscription(
-            gatewayId,
-            methodId,
-            stripeupe,
-            this._stripeElements,
-        );
-
         return Promise.resolve();
     }
 
@@ -162,7 +155,6 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
 
     deinitialize(): Promise<void> {
         this._stripeElements?.getElement(StripeElementType.PAYMENT)?.unmount();
-        this.stripeIntegrationService.deinitialize();
         this._stripeElements = undefined;
         this._stripeUPEClient = undefined;
 

--- a/packages/stripe-utils/src/stripe-integration-service.mock.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.mock.ts
@@ -9,8 +9,6 @@ import { getStripeJsMock } from './stripe.mock';
 
 export const getStripeIntegrationServiceMock = () =>
     ({
-        deinitialize: jest.fn(),
-        initCheckoutEventsSubscription: jest.fn(),
         mountElement: jest.fn(),
         mapAppearanceVariables: jest.fn(),
         mapInputAppearanceRules: jest.fn(),

--- a/packages/stripe-utils/src/stripe-integration-service.spec.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.spec.ts
@@ -98,171 +98,13 @@ describe('StripeIntegrationService', () => {
         jest.clearAllMocks();
     });
 
-    describe('#deinitialize', () => {
-        it('should clear subscription', () => {
-            const subscriptionMock = jest.fn();
-
-            jest.spyOn(paymentIntegrationService, 'subscribe').mockImplementation(
-                () => subscriptionMock,
-            );
-
-            stripeIntegrationService.initCheckoutEventsSubscription(
-                gatewayId,
-                methodId,
-                stripeupeMock,
-                stripeElementsMock,
-            );
-            stripeIntegrationService.deinitialize();
-
-            expect(subscriptionMock).toHaveBeenCalled();
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            expect(stripeIntegrationService['isMounted']).toBe(false);
-        });
-
-        it('should not unsibscribe when subscription is not set', () => {
-            jest.spyOn(paymentIntegrationService, 'subscribe').mockImplementation(undefined);
-
-            stripeIntegrationService.initCheckoutEventsSubscription(
-                gatewayId,
-                methodId,
-                stripeupeMock,
-                stripeElementsMock,
-            );
-            stripeIntegrationService.deinitialize();
-
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            expect(stripeIntegrationService['checkoutEventsUnsubscribe']).toBeUndefined();
-        });
-    });
-
-    describe('#initCheckoutEventsSubscription', () => {
-        beforeEach(() => {
-            const state = paymentIntegrationService.getState();
-
-            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValue(state);
-            jest.spyOn(paymentIntegrationService, 'subscribe').mockImplementation(
-                (subscriber, ...filters) => {
-                    subscriber(state);
-                    filters.forEach((filter) => filter(state));
-
-                    return jest.fn();
-                },
-            );
-            jest.spyOn(state, 'getPaymentMethodOrThrow').mockReturnValue(getStripeMock());
-        });
-
-        it('skip subscription actions if no stripe elements initialized', () => {
-            stripeIntegrationService.initCheckoutEventsSubscription(
-                gatewayId,
-                methodId,
-                stripeupeMock,
-                undefined,
-            );
-
-            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
-        });
-
-        it('skip subscription actions if no stripe payment element found', () => {
-            stripeElementsMock.getElement = () => null;
-
-            stripeIntegrationService.initCheckoutEventsSubscription(
-                gatewayId,
-                methodId,
-                stripeupeMock,
-                stripeElementsMock,
-            );
-
-            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
-        });
-
-        it('throws error if loadPaymentMethod fails', async () => {
-            stripeupeMock.onError = jest.fn();
-            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockRejectedValue(
-                new Error(),
-            );
-
-            stripeIntegrationService.initCheckoutEventsSubscription(
-                gatewayId,
-                methodId,
-                stripeupeMock,
-                stripeElementsMock,
-            );
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalled();
-            expect(stripeupeMock.onError).toHaveBeenCalled();
-            expect(stripeElementMock.unmount).not.toHaveBeenCalled();
-        });
-
-        it('unmount stripe payment element if loadPaymentMethod fails', async () => {
-            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockRejectedValue(
-                new Error(),
-            );
-            jest.spyOn(document, 'getElementById').mockReturnValue(document.createElement('div'));
-
-            stripeIntegrationService.mountElement(stripeElementMock, stripeupeMock.containerId);
-            stripeIntegrationService.initCheckoutEventsSubscription(
-                gatewayId,
-                methodId,
-                stripeupeMock,
-                stripeElementsMock,
-            );
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(stripeElementMock.unmount).toHaveBeenCalled();
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            expect(stripeIntegrationService['isMounted']).toBe(false);
-        });
-
-        it('mount stripe payment element if not mounted', async () => {
-            jest.spyOn(document, 'getElementById').mockReturnValue(document.createElement('div'));
-
-            stripeIntegrationService.initCheckoutEventsSubscription(
-                gatewayId,
-                methodId,
-                stripeupeMock,
-                stripeElementsMock,
-            );
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(stripeElementsMock.fetchUpdates).toHaveBeenCalled();
-            expect(stripeElementMock.mount).toHaveBeenCalled();
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            expect(stripeIntegrationService['isMounted']).toBe(true);
-        });
-
-        it('does not mount stripe payment element if already mounted', async () => {
-            jest.spyOn(document, 'getElementById').mockReturnValue(document.createElement('div'));
-
-            stripeIntegrationService.mountElement(stripeElementMock, stripeupeMock.containerId);
-            stripeIntegrationService.initCheckoutEventsSubscription(
-                gatewayId,
-                methodId,
-                stripeupeMock,
-                stripeElementsMock,
-            );
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(stripeElementsMock.fetchUpdates).not.toHaveBeenCalled();
-            expect(stripeElementMock.mount).toHaveBeenCalledTimes(1);
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            expect(stripeIntegrationService['isMounted']).toBe(true);
-        });
-    });
-
     describe('#mountElement', () => {
         it('should mount stripe element', () => {
             jest.spyOn(document, 'getElementById').mockReturnValue(document.createElement('div'));
 
             stripeIntegrationService.mountElement(stripeElementMock, stripeupeMock.containerId);
 
-            expect(stripeElementMock.mount).toHaveBeenCalled();
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            expect(stripeIntegrationService['isMounted']).toBe(true);
+            expect(stripeElementMock.mount).toHaveBeenCalledWith(`#${stripeupeMock.containerId}`);
         });
 
         it('should not mount stripe element if container is not found', () => {
@@ -271,8 +113,6 @@ describe('StripeIntegrationService', () => {
             stripeIntegrationService.mountElement(stripeElementMock, stripeupeMock.containerId);
 
             expect(stripeElementMock.mount).not.toHaveBeenCalled();
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            expect(stripeIntegrationService['isMounted']).toBe(false);
         });
     });
 
@@ -865,6 +705,13 @@ describe('StripeIntegrationService', () => {
     });
 
     describe('#updateStripePaymentIntent', () => {
+        beforeEach(() => {
+            const state = paymentIntegrationService.getState();
+
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValue(state);
+            jest.spyOn(state, 'getPaymentMethodOrThrow').mockReturnValue(getStripeMock());
+        });
+
         it('should trigger payment intent update', async () => {
             await stripeIntegrationService.updateStripePaymentIntent(gatewayId, methodId);
 

--- a/packages/stripe-utils/src/stripe-integration-service.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.ts
@@ -19,7 +19,6 @@ import {
     StripeConfirmPaymentData,
     StripeElement,
     StripeElements,
-    StripeElementType,
     StripeError,
     StripePaymentIntentStatus,
     StripeStringConstants,
@@ -28,57 +27,10 @@ import StripePaymentInitializeOptions from './stripe-initialize-options';
 import StripeScriptLoader from './stripe-script-loader';
 
 export default class StripeIntegrationService {
-    private isMounted = false;
-    private checkoutEventsUnsubscribe?: () => void;
-
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
         private scriptLoader: StripeScriptLoader,
     ) {}
-
-    deinitialize(): void {
-        this.checkoutEventsUnsubscribe?.();
-        this.isMounted = false;
-    }
-
-    initCheckoutEventsSubscription(
-        gatewayId: string,
-        methodId: string,
-        stripeInitializationOptions: StripePaymentInitializeOptions,
-        stripeElements?: StripeElements,
-    ): void {
-        this.checkoutEventsUnsubscribe = this.paymentIntegrationService.subscribe(
-            async () => {
-                const paymentElement = stripeElements?.getElement(StripeElementType.PAYMENT);
-
-                if (!paymentElement) {
-                    return;
-                }
-
-                try {
-                    await this.updateStripePaymentIntent(gatewayId, methodId);
-                } catch (error) {
-                    if (this.isMounted) {
-                        paymentElement.unmount();
-                        this.isMounted = false;
-                    }
-
-                    if (error instanceof Error) {
-                        stripeInitializationOptions.onError?.(error);
-                    }
-
-                    return;
-                }
-
-                if (!this.isMounted) {
-                    await stripeElements?.fetchUpdates();
-                    this.mountElement(paymentElement, stripeInitializationOptions.containerId);
-                }
-            },
-            (state) => state.getCheckout()?.outstandingBalance,
-            (state) => state.getCheckout()?.coupons,
-        );
-    }
 
     mountElement(stripeElement: StripeElement, containerId: string): void {
         if (!document.getElementById(containerId)) {
@@ -86,7 +38,6 @@ export default class StripeIntegrationService {
         }
 
         stripeElement.mount(`#${containerId}`);
-        this.isMounted = true;
     }
 
     mapAppearanceVariables(styles: NonNullable<StripePaymentInitializeOptions['style']>) {


### PR DESCRIPTION
## What/Why?
Applying a coupon or gift certificate that covers 100% of the cart total broke the
payment step with an error.

At zero total Stripe is no longer an available payment provider, so the store's
Stripe config request (`/api/storefront/payments/<gateway>?method=<method>`) returns
404. `StripeIntegrationService.initCheckoutEventsSubscription` subscribed to
`outstandingBalance` / `coupons` and called `updateStripePaymentIntent` on every
change, which issued exactly that request and surfaced the 404 to the shopper via
`onError`.

That subscription was redundant. checkout-js already reloads the payment providers
on every total change (`Payment.tsx` subscribes to `grandTotal` /
`outstandingBalance` and calls `handleCartTotalChange`), which unmounts the payment
method, reloads the methods list, and re-initializes the Stripe element with a
refreshed client token from `/api/storefront/payments` — so the payment intent is
already updated on each total change without the extra request.

Changes:

- Removed the `initCheckoutEventsSubscription` call from the Stripe OCS strategy.
- Removed it from the Stripe UPE strategy as well. Note this call was already inert
  there: `initialize` passes `this._stripeElements` before the un-awaited
  `_loadStripeElement` has assigned it, so the subscription callback always
  early-returned on its missing-elements guard.
- Deleted the now-unused `initCheckoutEventsSubscription`,
  `checkoutEventsUnsubscribe` and `isMounted` members of
  `StripeIntegrationService`. With those gone the service's `deinitialize` had an
  empty body, so it and its two call sites were removed — the strategies' own
  `deinitialize` still unmounts/destroys the element and clears its references, so
  teardown behaviour is unchanged.
- Updated the affected specs, including two `#updateStripePaymentIntent` tests that
  were only passing because a deleted `beforeEach` leaked its `loadPaymentMethod`
  spy into them; they are now self-contained.

Payment intent updates at submit time are untouched: `execute` still calls
`updateStripePaymentIntent` before `submitOrder`.

## Rollout/Rollback
Rollback this PR

## Testing
Before:

https://github.com/user-attachments/assets/766c7854-75b0-4996-9035-3c774d986998

After:
OCS

https://github.com/user-attachments/assets/a123fb6f-626f-4c58-84c1-c073ab3cce2c

UPE

https://github.com/user-attachments/assets/879c8d52-b9dd-4eae-930d-714ec47e03c9



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Stripe payment intents refresh on cart total changes—relying on checkout UI reload instead of SDK subscription—so regressions could affect coupons, gift certificates, or zero-total flows; submit-time updates are unchanged.
> 
> **Overview**
> Removes the checkout subscription that reloaded Stripe config and updated the payment intent whenever **outstanding balance** or **coupons** changed. That extra `loadPaymentMethod` call could 404 when Stripe drops off at zero balance and surface errors via `onError`.
> 
> Stripe **OCS** and **UPE** strategies no longer call `initCheckoutEventsSubscription` on initialize or `deinitialize` on the integration service; teardown still unmounts/destroys elements in each strategy. **`StripeIntegrationService`** drops `initCheckoutEventsSubscription`, `deinitialize`, and mount-tracking (`isMounted`); **`mountElement`** only mounts when the container exists.
> 
> **`updateStripePaymentIntent`** at submit (e.g. OCS `execute`) is unchanged. Specs and mocks are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e35b82d6ac3912db159f985cae94770a220ccd82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->