### PR TITLE
feat(payment): PI-5626 Enable cybersource test url

### DIFF
--- a/packages/cardinal-integration/src/cardinal-client.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-client.spec.ts
@@ -118,6 +118,7 @@ describe('CardinalClient', () => {
                     2,
                     expect.stringMatching(/^provider/),
                     true,
+                    false,
                 );
                 expect(sdk.on).toHaveBeenCalledTimes(4);
                 expect(sdk.setup).toHaveBeenCalledTimes(2);
@@ -127,7 +128,12 @@ describe('CardinalClient', () => {
                 await client.configure('sameToken');
                 await client.configure('sameToken');
 
-                expect(cardinalScriptLoader.load).toHaveBeenNthCalledWith(1, 'provider', true);
+                expect(cardinalScriptLoader.load).toHaveBeenNthCalledWith(
+                    1,
+                    'provider',
+                    true,
+                    false,
+                );
                 expect(sdk.on).toHaveBeenCalledTimes(2);
                 expect(sdk.setup).toHaveBeenCalledTimes(1);
             });

--- a/packages/cardinal-integration/src/cardinal-client.ts
+++ b/packages/cardinal-integration/src/cardinal-client.ts
@@ -45,17 +45,27 @@ export interface CardinalOrderData {
 export default class CardinalClient {
     private _provider = '';
     private _testMode = false;
+    private _isCyberSourceUpdatedTestUrlEnabled = false;
     private _sdk?: Promise<CardinalSDK>;
     private _configurationToken = '';
 
     constructor(private _scriptLoader: CardinalScriptLoader) {}
 
-    load(provider: string, testMode = false): Promise<void> {
+    load(
+        provider: string,
+        testMode = false,
+        isCyberSourceUpdatedTestUrlEnabled = false,
+    ): Promise<void> {
         this._provider = provider;
         this._testMode = testMode;
+        this._isCyberSourceUpdatedTestUrlEnabled = isCyberSourceUpdatedTestUrlEnabled;
 
         if (!this._sdk) {
-            this._sdk = this._scriptLoader.load(provider, testMode);
+            this._sdk = this._scriptLoader.load(
+                provider,
+                testMode,
+                isCyberSourceUpdatedTestUrlEnabled,
+            );
         }
 
         return this._sdk.then(noop);
@@ -67,7 +77,11 @@ export default class CardinalClient {
                 return Promise.resolve();
             }
 
-            this._sdk = this._scriptLoader.load(`${this._provider}.${Date.now()}`, this._testMode);
+            this._sdk = this._scriptLoader.load(
+                `${this._provider}.${Date.now()}`,
+                this._testMode,
+                this._isCyberSourceUpdatedTestUrlEnabled,
+            );
         }
 
         return this._getClientSDK().then(

--- a/packages/cardinal-integration/src/cardinal-script-loader.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-script-loader.spec.ts
@@ -27,6 +27,16 @@ describe('CardinalScriptLoader', () => {
         );
     });
 
+    it('loads widget experiment test script when the experiment is on', () => {
+        const testMode = true;
+
+        cardinalScriptLoader.load('provider', testMode, true);
+
+        expect(loadScript).toHaveBeenCalledWith(
+            'https://cas.static.client.cardinaltrusted.com/songbird/v2.0.0/songbird.js?v=provider',
+        );
+    });
+
     it('loads widget production script', () => {
         const testMode = false;
 

--- a/packages/cardinal-integration/src/cardinal-script-loader.ts
+++ b/packages/cardinal-integration/src/cardinal-script-loader.ts
@@ -6,13 +6,21 @@ import { CardinalSDK, CardinalWindow } from './cardinal';
 
 const SDK_TEST_URL = 'https://songbirdstag.cardinalcommerce.com/edge/v1/songbird.js';
 
+const SDK_UPDATED_TEST_URL =
+    'https://cas.static.client.cardinaltrusted.com/songbird/v2.0.0/songbird.js';
+
 const SDK_PROD_URL = 'https://static.client.cardinaltrusted.com/songbird/v2.0.0/songbird.js';
 
 export default class CardinalScriptLoader {
     constructor(private _scriptLoader: ScriptLoader, private _window: CardinalWindow = window) {}
 
-    load(provider: string, testMode?: boolean): Promise<CardinalSDK> {
-        const url = testMode ? SDK_TEST_URL : SDK_PROD_URL;
+    load(
+        provider: string,
+        testMode?: boolean,
+        isCyberSourceUpdatedTestUrlEnabled?: boolean,
+    ): Promise<CardinalSDK> {
+        const testUrl = isCyberSourceUpdatedTestUrlEnabled ? SDK_UPDATED_TEST_URL : SDK_TEST_URL;
+        const url = testMode ? testUrl : SDK_PROD_URL;
 
         return this._scriptLoader.loadScript(`${url}?v=${provider}`).then(() => {
             if (!this._window.Cardinal) {

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.spec.ts
@@ -56,12 +56,28 @@ describe('CardinalBarclaysThreeDSecureFlow', () => {
     });
 
     describe('#prepare', () => {
-        it('loads Cardinal client', async () => {
+        it('loads Cardinal client with the CyberSource test url disabled by default', async () => {
             await threeDSecureFlow.prepare(paymentMethod);
 
             expect(cardinalClient.load).toHaveBeenCalledWith(
                 paymentMethod.id,
                 paymentMethod.config.testMode,
+                false,
+            );
+        });
+
+        it('loads Cardinal client with the CyberSource test url enabled from initializationData', async () => {
+            paymentMethod = {
+                ...paymentMethod,
+                initializationData: { isCyberSourceUpdatedTestUrlEnabled: true },
+            };
+
+            await threeDSecureFlow.prepare(paymentMethod);
+
+            expect(cardinalClient.load).toHaveBeenCalledWith(
+                paymentMethod.id,
+                paymentMethod.config.testMode,
+                true,
             );
         });
     });

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow-v2.ts
@@ -14,7 +14,7 @@ import {
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { CardinalThreeDSecureToken } from './cardinal';
+import { CardinalThreeDSecureInitializationData, CardinalThreeDSecureToken } from './cardinal';
 import CardinalClient, { CardinalOrderData } from './cardinal-client';
 
 export default class CardinalThreeDSecureFlowV2 {
@@ -24,7 +24,14 @@ export default class CardinalThreeDSecureFlowV2 {
     ) {}
 
     async prepare(method: PaymentMethod): Promise<void> {
-        await this._cardinalClient.load(method.id, method.config.testMode);
+        const initializationData: CardinalThreeDSecureInitializationData =
+            method.initializationData ?? {};
+
+        await this._cardinalClient.load(
+            method.id,
+            method.config.testMode,
+            Boolean(initializationData.isCyberSourceUpdatedTestUrlEnabled),
+        );
     }
 
     async start(

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow.spec.ts
@@ -63,12 +63,28 @@ describe('CardinalThreeDSecureFlow', () => {
     });
 
     describe('#prepare', () => {
-        it('loads Cardinal client', async () => {
+        it('loads Cardinal client with the CyberSource test url disabled by default', async () => {
             await threeDSecureFlow.prepare(paymentMethod);
 
             expect(cardinalClient.load).toHaveBeenCalledWith(
                 paymentMethod.id,
                 paymentMethod.config.testMode,
+                false,
+            );
+        });
+
+        it('loads Cardinal client with the CyberSource test url enabled from initializationData', async () => {
+            paymentMethod = {
+                ...paymentMethod,
+                initializationData: { isCyberSourceUpdatedTestUrlEnabled: true },
+            };
+
+            await threeDSecureFlow.prepare(paymentMethod);
+
+            expect(cardinalClient.load).toHaveBeenCalledWith(
+                paymentMethod.id,
+                paymentMethod.config.testMode,
+                true,
             );
         });
 

--- a/packages/cardinal-integration/src/cardinal-three-d-secure-flow.ts
+++ b/packages/cardinal-integration/src/cardinal-three-d-secure-flow.ts
@@ -11,6 +11,7 @@ import {
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
+import { CardinalThreeDSecureInitializationData } from './cardinal';
 import CardinalClient, { CardinalOrderData } from './cardinal-client';
 
 export default class CardinalThreeDSecureFlow {
@@ -20,7 +21,14 @@ export default class CardinalThreeDSecureFlow {
     ) {}
 
     async prepare(method: PaymentMethod): Promise<void> {
-        await this._cardinalClient.load(method.id, method.config.testMode);
+        const initializationData: CardinalThreeDSecureInitializationData =
+            method.initializationData ?? {};
+
+        await this._cardinalClient.load(
+            method.id,
+            method.config.testMode,
+            Boolean(initializationData.isCyberSourceUpdatedTestUrlEnabled),
+        );
         await this._cardinalClient.configure(await this._getClientToken(method));
     }
 

--- a/packages/cardinal-integration/src/cardinal.ts
+++ b/packages/cardinal-integration/src/cardinal.ts
@@ -2,6 +2,10 @@ import { ThreeDSecure, ThreeDSecureToken } from '@bigcommerce/checkout-sdk/payme
 
 export const CardinalSignatureValidationErrors = [100004, 1010, 1011, 1020];
 
+export interface CardinalThreeDSecureInitializationData {
+    isCyberSourceUpdatedTestUrlEnabled?: boolean;
+}
+
 export interface CardinalSDK {
     configure(params: CardinalConfiguration): void;
     on(params: CardinalEventType, callback: CardinalEventMap[CardinalEventType]): void;


### PR DESCRIPTION
## What/Why?

 Enable cybersource test url https://cas.static.client.cardinaltrusted.com/songbird/v2.0.0/songbird.js

## Rollout/Rollback

rollback this commit

## Testing
<img width="1434" height="455" alt="image" src="https://github.com/user-attachments/assets/14b74f03-5dac-4caa-852c-31f44161c5b4" />
before 

https://github.com/user-attachments/assets/8cbabed4-4f81-4ef6-8901-3c7770831afa

after

https://github.com/user-attachments/assets/c924f29d-7379-4694-888b-bddf033a32cb



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches 3DS Cardinal script loading in payment checkout; risk is limited because the new URL is opt-in via initialization data and defaults off, but wrong flag rollout could break CyberSource test payments.
> 
> **Overview**
> Adds an optional **`isCyberSourceUpdatedTestUrlEnabled`** flag on Cardinal payment method **`initializationData`** so test-mode checkout can load Songbird from the CyberSource CAS URL (`cas.static.client.cardinaltrusted.com`) instead of the legacy **`songbirdstag.cardinalcommerce.com`** endpoint.
> 
> **`CardinalScriptLoader`**, **`CardinalClient`**, and both **`CardinalThreeDSecureFlow`** / **V2** **`prepare`** paths pass the flag through on initial load and SDK reconfiguration. Production still uses the existing **`static.client.cardinaltrusted.com`** URL; when the flag is off, test behavior stays on the old staging URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3e3fb4177b7456e5910fc3a2c8ac8634e57ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->