### PR TITLE
CHECKOUT-9881: Tightly type customer address type

### DIFF
--- a/packages/core/src/customer/customer.ts
+++ b/packages/core/src/customer/customer.ts
@@ -21,9 +21,11 @@ export default interface Customer {
     customerGroup?: CustomerGroup;
 }
 
+export type CustomerAddressType = 'residential' | 'commercial' | 'company' | 'paypal-address';
+
 export interface CustomerAddress extends Address {
     id: number;
-    type: string;
+    type: CustomerAddressType;
     /**
      */
     isShipping?: boolean;

--- a/packages/core/src/customer/index.ts
+++ b/packages/core/src/customer/index.ts
@@ -6,7 +6,7 @@ export {
 } from './customer-request-options';
 
 export { default as InternalCustomer } from './internal-customer';
-export { default as Customer, CustomerAddress } from './customer';
+export { default as Customer, CustomerAddress, CustomerAddressType } from './customer';
 
 export { default as createCustomerStrategyRegistry } from './create-customer-strategy-registry';
 export { default as createCustomerStrategyRegistryV2 } from './create-customer-strategy-registry-v2';

--- a/packages/core/src/shipping/strategies/bigcommerce-payments/bigcommerce-payments-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/bigcommerce-payments/bigcommerce-payments-fastlane-shipping-strategy.spec.ts
@@ -15,6 +15,7 @@ import {
 import {
     Cart,
     Customer,
+    CustomerAddress,
     StoreConfig,
     UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -69,7 +70,7 @@ describe('BigCommercePaymentsFastlaneShippingStrategy', () => {
 
     const requestSender = createRequestSender();
 
-    const bcAddressMock = {
+    const bcAddressMock: CustomerAddress = {
         id: 1,
         address1: 'addressLine1',
         address2: 'addressLine2',

--- a/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/paypal-commerce/paypal-commerce-fastlane-shipping-strategy.spec.ts
@@ -3,6 +3,7 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import {
     Cart,
     Customer,
+    CustomerAddress,
     StoreConfig,
     UntrustedShippingCardVerificationType,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -69,7 +70,7 @@ describe('PayPalCommerceFastlaneShippingStrategy', () => {
 
     const requestSender = createRequestSender();
 
-    const bcAddressMock = {
+    const bcAddressMock: CustomerAddress = {
         id: 1,
         address1: 'addressLine1',
         address2: 'addressLine2',

--- a/packages/payment-integration-api/src/customer/customer.ts
+++ b/packages/payment-integration-api/src/customer/customer.ts
@@ -21,9 +21,11 @@ export default interface Customer {
     customerGroup?: CustomerGroup;
 }
 
+export type CustomerAddressType = 'residential' | 'commercial' | 'company' | 'paypal-address';
+
 export interface CustomerAddress extends Address {
     id: number;
-    type: string;
+    type: CustomerAddressType;
     /**
      */
     isShipping?: boolean;

--- a/packages/payment-integration-api/src/customer/index.ts
+++ b/packages/payment-integration-api/src/customer/index.ts
@@ -1,4 +1,4 @@
-export { default as Customer, CustomerAddress } from './customer';
+export { default as Customer, CustomerAddress, CustomerAddressType } from './customer';
 export { default as CustomerCredentials } from './customer-credentials';
 export { default as CustomerStrategy } from './customer-strategy';
 export { default as CustomerStrategyFactory } from './customer-strategy-factory';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -41,6 +41,7 @@ export {
     CustomerStrategyResolveId,
     Customer,
     CustomerAddress,
+    CustomerAddressType,
     CustomerRequestOptions,
     CustomerInitializeOptions,
     InternalCustomer,


### PR DESCRIPTION
Jira: [CHECKOUT-9881](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-9881)

## What/Why?

Narrows `CustomerAddress['type']` from `string` to a new `CustomerAddressType` union: `'residential' | 'commercial' | 'company' | 'paypal-address'`.

`'paypal-address'` is an existing value only in SDK, the rest 3 are defined by API.

## Rollout/Rollback

Type-level change only — no runtime behavior change. Rolls out with the next SDK release; rollback is a straight code revert.

## Testing

- `npx tsc --noEmit -p packages/core/tsconfig.json` passes with no errors (also compiles the fastlane utils packages via path mappings).
- Fastlane shipping strategy suites pass: 3 suites, 56 tests (`npx nx run core:test --testPathPattern="fastlane-shipping-strategy"`).
- Prettier check passes on all touched files.

[CHECKOUT-9881]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-9881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only narrowing with no runtime changes; downstream consumers may see new compile errors if they assign arbitrary strings to address type.
> 
> **Overview**
> Introduces **`CustomerAddressType`** (`'residential' | 'commercial' | 'company' | 'paypal-address'`) and replaces **`CustomerAddress['type']`** from `string` with that union in **`packages/core`** and **`packages/payment-integration-api`**, with the new type exported from customer and package entry points.
> 
> Fastlane shipping strategy specs annotate **`bcAddressMock`** as **`CustomerAddress`** so mocks align with the stricter typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d0fbe2044dd3bf6f44e533f3b42863ee0185e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->