### PR TITLE
feat(checkout): CHECKOUT-10232 Add disableWalletButtons capability

### DIFF
--- a/packages/core/src/config/capabilities.ts
+++ b/packages/core/src/config/capabilities.ts
@@ -13,6 +13,7 @@ export interface Capabilities {
         disableEditCart: boolean;
         disableGiftCertificate: boolean;
         disableStoreCredit: boolean;
+        disableWalletButtons: boolean;
         hasCompanyAddressBook: boolean;
         hasAddressExtraFields: boolean;
         hasOrderExtraFields: boolean;

--- a/packages/payment-integration-api/src/config/capabilities.ts
+++ b/packages/payment-integration-api/src/config/capabilities.ts
@@ -13,6 +13,7 @@ export interface Capabilities {
         disableEditCart: boolean;
         disableGiftCertificate: boolean;
         disableStoreCredit: boolean;
+        disableWalletButtons: boolean;
         hasCompanyAddressBook: boolean;
         hasAddressExtraFields: boolean;
         hasOrderExtraFields: boolean;


### PR DESCRIPTION
## What/Why?

This PR: https://github.com/bigcommerce/bigcommerce/pull/69687 introduced a new capability called `disableWalletButtons `. This PR threads this capability through our SDK so that it can be used on the checkout-js side.

## Rollout/Rollback

Revert the PR.

## Testing

Type only change - will be tested on the checkout-js side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only interface extension with no runtime logic in this repo; behavior depends on checkout-js consumption.
> 
> **Overview**
> Adds **`disableWalletButtons`** to **`Capabilities.userJourney`** in **`packages/core`** and **`packages/payment-integration-api`** (kept in sync per existing duplication pattern).
> 
> This exposes the platform capability from upstream so checkout-js can read it and hide wallet payment buttons when configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd6a70e0de1adbc81cf693d8a0d0d699132bbf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->