### PR TITLE
fix(payment): Stripe Link V2, cache the resolved method id to survive payment methods reload

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.spec.ts
@@ -46,6 +46,18 @@ describe('StripeLinkV2CustomerStrategy', () => {
     let stripeIntegrationService: StripeIntegrationService;
     let loadingIndicator: LoadingIndicator;
     const stripePaymentMethod = getStripeOCSMock('optimized_checkout');
+    const checkoutSessionGatewayMock = {
+        ...getStripeOCSMock('checkout_session'),
+        initializationData: {
+            ...getStripeOCSMock().initializationData,
+            checkoutSessionEnabled: true,
+        },
+    };
+    const throwOnGatewayMethod = (methodId: string) => {
+        if (methodId === 'stripeocs') {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+    };
 
     const isLoading = jest.fn();
     let confirmPaymentMock: jest.Mock;
@@ -324,16 +336,11 @@ describe('StripeLinkV2CustomerStrategy', () => {
             jest.spyOn(
                 paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',
-            ).mockReturnValue({
-                ...getStripeOCSMock('checkout_session'),
-                initializationData: {
-                    ...getStripeOCSMock().initializationData,
-                    checkoutSessionEnabled: true,
-                },
-            });
+            ).mockReturnValue(checkoutSessionGatewayMock);
 
             await strategy.initialize(initialiseOptions);
 
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledTimes(1);
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith('stripeocs', {
                 params: { method: 'checkout_session' },
             });
@@ -342,9 +349,106 @@ describe('StripeLinkV2CustomerStrategy', () => {
         it('loads optimized_checkout payment method if checkout session is disabled and no stripe method is loaded yet', async () => {
             await strategy.initialize(initialiseOptions);
 
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledTimes(1);
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith('stripeocs', {
                 params: { method: 'optimized_checkout' },
             });
+        });
+
+        it('reuses the resolved method id when the gateway payment method is no longer in the state', async () => {
+            await strategy.initialize(initialiseOptions);
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockImplementation((methodId) => {
+                throwOnGatewayMethod(methodId);
+
+                return stripePaymentMethod;
+            });
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledTimes(2);
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenNthCalledWith(
+                2,
+                'stripeocs',
+                { params: { method: 'optimized_checkout' } },
+            );
+            expect(element.mount).toHaveBeenCalledWith('#checkout-button');
+        });
+
+        it('reuses the id of the already loaded stripe method when the state no longer has any stripe method', async () => {
+            const cachedPaymentMethod = getStripeOCSMock('checkout_session');
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockImplementation(
+                (methodId) => (methodId === 'checkout_session' ? cachedPaymentMethod : undefined),
+            );
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockReturnValue(
+                undefined,
+            );
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockImplementation((methodId) => {
+                throwOnGatewayMethod(methodId);
+
+                return cachedPaymentMethod;
+            });
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledTimes(1);
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith('stripeocs', {
+                params: { method: 'checkout_session' },
+            });
+            expect(element.mount).toHaveBeenCalledWith('#checkout-button');
+        });
+
+        it('reuses the resolved checkout_session method id when the gateway payment method is no longer in the state', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(checkoutSessionGatewayMock);
+
+            await strategy.initialize(initialiseOptions);
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockImplementation((methodId) => {
+                throwOnGatewayMethod(methodId);
+
+                return checkoutSessionGatewayMock;
+            });
+
+            await strategy.initialize(initialiseOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledTimes(2);
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenNthCalledWith(
+                2,
+                'stripeocs',
+                { params: { method: 'checkout_session' } },
+            );
+            expect(element.mount).toHaveBeenCalledWith('#checkout-button');
+        });
+
+        it('throws if the gateway payment method is not in the state and no method id has been resolved yet', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockImplementation(() => {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            });
+
+            await expect(strategy.initialize(initialiseOptions)).rejects.toThrow(MissingDataError);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
         });
 
         it('submits payment with the id of the already loaded payment method', async () => {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-link-v2-customer-strategy.ts
@@ -59,6 +59,7 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
     private _loadingIndicatorContainer?: string;
     private _captureMethod?: 'automatic' | 'manual';
     private _currencyCode?: string;
+    private _cachedMethodId?: string;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
@@ -621,19 +622,24 @@ export default class StripeLinkV2CustomerStrategy implements CustomerStrategy {
             );
 
         if (stripePaymentMethod) {
+            this._cachedMethodId = stripePaymentMethod.id;
+
             return stripePaymentMethod;
         }
 
-        const { initializationData } =
-            state.getPaymentMethodOrThrow<StripeInitializationData>(gatewayId);
-        const methodId = initializationData?.checkoutSessionEnabled
-            ? StripePaymentMethodType.CHECKOUT_SESSION
-            : StripePaymentMethodType.OCS;
+        if (!this._cachedMethodId) {
+            const { initializationData } =
+                state.getPaymentMethodOrThrow<StripeInitializationData>(gatewayId);
+
+            this._cachedMethodId = initializationData?.checkoutSessionEnabled
+                ? StripePaymentMethodType.CHECKOUT_SESSION
+                : StripePaymentMethodType.OCS;
+        }
 
         state = await this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
-            params: { method: methodId },
+            params: { method: this._cachedMethodId },
         });
 
-        return state.getPaymentMethodOrThrow(methodId, gatewayId);
+        return state.getPaymentMethodOrThrow(this._cachedMethodId, gatewayId);
     }
 }


### PR DESCRIPTION
## What/Why?
When a gift certificate covers 100% of the cart total no payment methods are returned,
and loading the list replaces the whole state array. Re-initializing the express checkout
button after the shopper removes the certificate then threw `MissingDataError` and blocked
checkout with *"Unable to proceed because payment method data is unavailable or not properly
configured"*.

`_getPaymentMethod()` now remembers the resolved method id on the strategy instance
(`_cachedMethodId`, set on both resolution paths) and reuses it when neither the specific
method nor the gateway entry is in state, instead of reading the gateway config again. Strategy
instances are cached by the registry, so the id survives any number of state reloads on a page.
No additional requests are made.

## Rollout/Rollback
Rollback this PR

## Testing
Before:

https://github.com/user-attachments/assets/e973d592-f753-4111-9d21-4580a7ab22d9

After:

https://github.com/user-attachments/assets/861a86f3-22d2-4f8f-a393-4a2a4f976609






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe Link V2 express-checkout initialization and payment-method loading when checkout state is empty; scoped change with strong test coverage but affects a critical checkout path.
> 
> **Overview**
> Fixes checkout blocking with *"Unable to proceed because payment method data is unavailable"* when Stripe Link V2 re-initializes after payment methods were cleared from state (e.g. a 100% gift certificate, then removing it).
> 
> **`StripeLinkV2CustomerStrategy`** now stores **`_cachedMethodId`** on the strategy instance when a Stripe method is found in state or when the gateway config is first read (`checkout_session` vs `optimized_checkout`). **`_getPaymentMethod()`** reuses that id for **`loadPaymentMethod`** and **`getPaymentMethodOrThrow`** when neither the specific method nor the gateway entry is in state, instead of calling **`getPaymentMethodOrThrow(gatewayId)`** again (which threw **`MissingDataError`**). If nothing was ever resolved and the gateway is missing, behavior is unchanged: throw without loading.
> 
> Specs cover re-init after state wipe for both OCS variants, call-count expectations on existing load tests, and the no-cache failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d162c5e83ecc620deaa004fd59a0815e30585e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->