### PR TITLE
feat(payment): PAYMENTS-11912 Use channel's SF origin for hosted field iframe src in headless SF

### DIFF
--- a/packages/hosted-form-v2/src/create-hosted-form-stored-card-service.ts
+++ b/packages/hosted-form-v2/src/create-hosted-form-stored-card-service.ts
@@ -5,9 +5,13 @@ import StoredCardHostedFormService from './stored-card-hosted-form-service';
  * Creates an instance of `StoredCardHostedFormService`.
  *
  *
- * @param host - Host url string parameter.
+ * @param host - Payments origin. Used for postMessage validation: the hosted-fields route
+ * redirects to the payment provider, so this is the iframe's actual document origin.
+ * @param storefrontHost - Origin serving the hosted-fields route, used only to build the iframe
+ * src. Only needed by headless storefronts, where that route is not on the page's own origin.
+ * Omit it to keep the relative-URL behaviour that resolves same-origin on a standard storefront.
  * @returns An instance of `StoredCardHostedFormService`.
  */
-export default function createStoredCardHostedFormService(host: string) {
-    return new StoredCardHostedFormService(host, new HostedFormFactory());
+export default function createStoredCardHostedFormService(host: string, storefrontHost = '') {
+    return new StoredCardHostedFormService(host, new HostedFormFactory(), storefrontHost);
 }

--- a/packages/hosted-form-v2/src/hosted-field.spec.ts
+++ b/packages/hosted-form-v2/src/hosted-field.spec.ts
@@ -25,6 +25,7 @@ describe('HostedField', () => {
     let eventPoster: Pick<IframeEventPoster<HostedFieldEvent>, 'post' | 'setTarget'>;
     let eventListener: Pick<IframeEventListener<HostedInputEventMap>, 'listen'>;
     let orderId: number;
+    let storefrontHost: string;
 
     beforeEach(() => {
         container = document.createElement('div');
@@ -32,6 +33,7 @@ describe('HostedField', () => {
         eventPoster = { post: jest.fn(), setTarget: jest.fn() };
         eventListener = { listen: jest.fn() };
         orderId = 1;
+        storefrontHost = 'https://channel.storefront.canonical.com';
 
         container.id = 'field-container-id';
         document.body.appendChild(container);
@@ -46,6 +48,7 @@ describe('HostedField', () => {
             eventListener as IframeEventListener<HostedInputEventMap>,
             detachmentObserver as DetachmentObserver,
             orderId,
+            storefrontHost,
         );
 
         field = new HostedField(
@@ -57,6 +60,8 @@ describe('HostedField', () => {
             eventPoster as IframeEventPoster<HostedFieldEvent>,
             eventListener as IframeEventListener<HostedInputEventMap>,
             detachmentObserver as DetachmentObserver,
+            undefined,
+            storefrontHost,
         );
     });
 
@@ -70,8 +75,37 @@ describe('HostedField', () => {
         expect(document.querySelector('#field-container-id iframe')).toBeDefined();
     });
 
-    it('sets iframe URL with version param', () => {
+    it('sets iframe URL with version param prefixed with the given storefront host when called from shopper account page', () => {
         field.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(document.querySelector<HTMLIFrameElement>('#field-container-id iframe')!.src).toBe(
+            'https://channel.storefront.canonical.com/account/stored-instruments/hosted-fields?version=1.0.0',
+        );
+    });
+
+    it('ignores the storefront host for the Control Panel iframe URL keeping it same-origin', () => {
+        controlPannelField.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(document.querySelector<HTMLIFrameElement>('#field-container-id iframe')!.src).toBe(
+            `${location.origin}/admin/payments/${orderId}/hosted-form-field?version=1.0.0`,
+        );
+    });
+
+    it('falls back to a location-relative iframe URL when no storefront host is provided', () => {
+        const fieldWithoutHost = new HostedField(
+            HostedFieldType.CardNumber,
+            'field-container-id',
+            'Enter your card number here',
+            'Card number',
+            { default: { color: 'rgb(0, 0, 0)', fontFamily: 'Open Sans, Arial' } },
+            eventPoster as IframeEventPoster<HostedFieldEvent>,
+            eventListener as IframeEventListener<HostedInputEventMap>,
+            detachmentObserver as DetachmentObserver,
+        );
+
+        fieldWithoutHost.attach();
 
         // tslint:disable-next-line:no-non-null-assertion
         expect(document.querySelector<HTMLIFrameElement>('#field-container-id iframe')!.src).toBe(
@@ -79,12 +113,25 @@ describe('HostedField', () => {
         );
     });
 
-    it('sets iframe URL with version param for Control Panel Iframe', () => {
-        controlPannelField.attach();
+    it('falls back to a location-relative iframe URL when host is an empty string', () => {
+        const fieldWithEmptyHost = new HostedField(
+            HostedFieldType.CardNumber,
+            'field-container-id',
+            'Enter your card number here',
+            'Card number',
+            { default: { color: 'rgb(0, 0, 0)', fontFamily: 'Open Sans, Arial' } },
+            eventPoster as IframeEventPoster<HostedFieldEvent>,
+            eventListener as IframeEventListener<HostedInputEventMap>,
+            detachmentObserver as DetachmentObserver,
+            undefined,
+            '',
+        );
+
+        fieldWithEmptyHost.attach();
 
         // tslint:disable-next-line:no-non-null-assertion
         expect(document.querySelector<HTMLIFrameElement>('#field-container-id iframe')!.src).toBe(
-            `${location.origin}/admin/payments/${orderId}/hosted-form-field?version=1.0.0`,
+            `${location.origin}/account/stored-instruments/hosted-fields?version=1.0.0`,
         );
     });
 

--- a/packages/hosted-form-v2/src/hosted-field.ts
+++ b/packages/hosted-form-v2/src/hosted-field.ts
@@ -47,6 +47,7 @@ export default class HostedField {
         private _eventListener: IframeEventListener<HostedInputEventMap>,
         private _detachmentObserver: DetachmentObserver,
         private _orderId?: number,
+        private _storefrontHost = '',
     ) {
         this._iframe = document.createElement('iframe');
 
@@ -60,7 +61,7 @@ export default class HostedField {
     private getFrameSrc(orderId?: number): string {
         return typeof orderId !== 'undefined'
             ? `/admin/payments/${this._orderId}/hosted-form-field?version=${LIBRARY_VERSION}`
-            : `/account/stored-instruments/hosted-fields?version=${LIBRARY_VERSION}`;
+            : `${this._storefrontHost}/account/stored-instruments/hosted-fields?version=${LIBRARY_VERSION}`;
     }
 
     getType(): HostedFieldType {

--- a/packages/hosted-form-v2/src/hosted-form-factory.ts
+++ b/packages/hosted-form-v2/src/hosted-form-factory.ts
@@ -8,7 +8,13 @@ import HostedForm from './hosted-form';
 import HostedFormOptions from './hosted-form-options';
 
 export default class HostedFormFactory {
-    create(host: string, options: HostedFormOptions): HostedForm {
+    /**
+     * @param host - (Payments origin) Used for postMessage target/source validation, because the
+     * hosted-fields route redirects there, making it the iframe's actual document origin.
+     * @param storefrontHost - (Channel's storefront origin) Serving the hosted-fields route,
+     * used only for the iframe src. Only needed by headless storefronts, where it differs from the page's own origin.
+     */
+    create(host: string, options: HostedFormOptions, storefrontHost = ''): HostedForm {
         const fieldTypes = Object.keys(options.fields) as HostedFieldType[];
         const fields = fieldTypes.reduce<HostedField[]>((result, type) => {
             const fields = options.fields;
@@ -30,6 +36,7 @@ export default class HostedFormFactory {
                     new IframeEventListener(host),
                     new DetachmentObserver(new MutationObserverFactory()),
                     options.orderId,
+                    storefrontHost,
                 ),
             ];
         }, []);

--- a/packages/hosted-form-v2/src/stored-card-hosted-form-service.spec.ts
+++ b/packages/hosted-form-v2/src/stored-card-hosted-form-service.spec.ts
@@ -60,6 +60,23 @@ describe('StoredCardHostedFormService', () => {
             expect(formFactory.create).toHaveBeenCalledWith(
                 'https://bigpay.integration.zone',
                 initializeOptions,
+                '',
+            );
+        });
+
+        it('forwards the storefront host separately from the payments host', async () => {
+            const headlessService = new StoredCardHostedFormService(
+                'https://bigpay.integration.zone',
+                formFactory,
+                'https://channel.storefront.canonical.com',
+            );
+
+            await headlessService.initialize(initializeOptions);
+
+            expect(formFactory.create).toHaveBeenCalledWith(
+                'https://bigpay.integration.zone',
+                initializeOptions,
+                'https://channel.storefront.canonical.com',
             );
         });
 

--- a/packages/hosted-form-v2/src/stored-card-hosted-form-service.ts
+++ b/packages/hosted-form-v2/src/stored-card-hosted-form-service.ts
@@ -9,7 +9,11 @@ import {
 
 export default class StoredCardHostedFormService {
     protected _hostedForm?: HostedForm;
-    constructor(protected _host: string, protected _hostedFormFactory: HostedFormFactory) {}
+    constructor(
+        protected _host: string,
+        protected _hostedFormFactory: HostedFormFactory,
+        protected _storefrontHost = '',
+    ) {}
 
     async submitStoredCard(
         fields: StoredCardHostedFormInstrumentFields,
@@ -25,7 +29,7 @@ export default class StoredCardHostedFormService {
     }
 
     initialize(options: LegacyHostedFormOptions): Promise<void> {
-        const form = this._hostedFormFactory.create(this._host, options);
+        const form = this._hostedFormFactory.create(this._host, options, this._storefrontHost);
 
         return form.attach().then(() => {
             this._hostedForm = form;


### PR DESCRIPTION
## What/Why?
The hosted card fields  currently don't work on a headless storefront. This  change makes them work, without changing anything for existing Stencil storefronts.

When the SDK renders hosted card fields, it creates an iframe pointing at `/account/stored-instruments/hosted-fields`. That path was hardcoded with no host on it, so the browser resolved it against whatever page it was on. On a stencil storefront, that's fine as the page and that route live on the same domain, so it just works. On a headless storefront, the page is on the merchant's own domain which has no such route. So, the iframe gives 404 error and no card fields appear.

This PR adds a new optional `storefrontHost` param to be used as the origin serving the hosted-fields route only to build the iframe src. It defaults to `''` so anything not passing it keeps the exact relative URL it has today, keeping stencil SF scenario untouched.

## Rollout/Rollback
Revert

## Testing
Unit tests
Screen record
https://github.com/user-attachments/assets/633e1ebe-2321-45ae-acec-cce3fdbd7c33



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment iframe URL construction for stored cards; wrong storefrontHost could break fields on headless while defaults preserve existing Stencil behavior.
> 
> **Overview**
> Adds an optional **`storefrontHost`** so stored-card hosted fields can load the iframe from the channel storefront origin while **`host`** still targets the payments origin for `postMessage` validation.
> 
> **`HostedField`** now prefixes the shopper-account iframe path with `storefrontHost` when set; admin Control Panel URLs stay same-origin and ignore it. When `storefrontHost` is omitted or empty, behaviour matches today (relative `/account/stored-instruments/hosted-fields` resolved against the page).
> 
> The parameter is threaded through **`createStoredCardHostedFormService`**, **`StoredCardHostedFormService`**, and **`HostedFormFactory.create`**, with docs clarifying the split between payments vs storefront origins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb5b3761da8e26be1b02833c76674a78b2bdcd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->