### PR TITLE
feat(checkout): CHECKOUT-10308 rename checkoutV2Theme to enhancedCheckoutThemeV1

### DIFF
--- a/docs/interfaces/UserExperienceSettings.md
+++ b/docs/interfaces/UserExperienceSettings.md
@@ -8,9 +8,9 @@
 
 ## Properties
 
-### checkoutV2Theme
+### enhancedCheckoutThemeV1
 
-> **checkoutV2Theme**: `boolean`
+> **enhancedCheckoutThemeV1**: `boolean`
 
 ***
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -102,7 +102,7 @@ export interface StoreCurrency {
 }
 
 export interface UserExperienceSettings {
-    checkoutV2Theme: boolean;
+    enhancedCheckoutThemeV1: boolean;
     walletButtonsOnTop: boolean;
     floatingLabelEnabled: boolean;
 }

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -22,7 +22,7 @@ export function getConfig(): Config {
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
                 checkoutUserExperienceSettings: {
-                    checkoutV2Theme: false,
+                    enhancedCheckoutThemeV1: false,
                     walletButtonsOnTop: false,
                     floatingLabelEnabled: false,
                 },

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -101,7 +101,7 @@ export interface StoreCurrency {
 }
 
 export interface UserExperienceSettings {
-    checkoutV2Theme: boolean;
+    enhancedCheckoutThemeV1: boolean;
     walletButtonsOnTop: boolean;
     floatingLabelEnabled: boolean;
 }

--- a/packages/payment-integration-api/src/mocks/config.mock.ts
+++ b/packages/payment-integration-api/src/mocks/config.mock.ts
@@ -19,7 +19,7 @@ export default function getConfig(): Config {
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
                 checkoutUserExperienceSettings: {
-                    checkoutV2Theme: false,
+                    enhancedCheckoutThemeV1: false,
                     walletButtonsOnTop: false,
                     floatingLabelEnabled: false,
                 },

--- a/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
@@ -19,7 +19,7 @@ export default function getConfig(): Config {
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
                 checkoutUserExperienceSettings: {
-                    checkoutV2Theme: false,
+                    enhancedCheckoutThemeV1: false,
                     walletButtonsOnTop: false,
                     floatingLabelEnabled: false,
                 },


### PR DESCRIPTION
## What/Why?

Rename checkoutV2Theme to enhancedCheckoutThemeV1- #3366

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public SDK interface rename with no runtime logic, but consumers still using `checkoutV2Theme` will break at compile time.
> 
> **Overview**
> Renames the `UserExperienceSettings` flag from `checkoutV2Theme` to `enhancedCheckoutThemeV1` in core and payment-integration config types, matching mocks, and generated docs.
> 
> This is a **breaking public type change** for SDK consumers that read `checkoutUserExperienceSettings.checkoutV2Theme`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbda3819bef56f3298d1828c4606546f2abc6cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->