### PR TITLE
CHECKOUT-10191: Publish to NPM using trusted publishing (OIDC)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,12 @@ aliases:
         name: node/node
         node-version: "22.13.0"
 
+  # npm trusted publishing (OIDC) requires Node >= 22.14.0 and npm >= 11.5.1
+  - &node_publish_executor
+      executor:
+        name: node/node
+        node-version: "22.20.0"
+
 version: 2.1
 
 orbs:
@@ -80,7 +86,7 @@ jobs:
             - docs
 
   npm_release:
-    <<: *node_executor
+    <<: *node_publish_executor
     resource_class: medium+
     steps:
       - ci/pre-setup
@@ -103,10 +109,18 @@ jobs:
           command: |
             git push --follow-tags origin $CIRCLE_BRANCH
       - run:
+          name: "Upgrade npm for trusted publishing"
+          command: |
+            npm install --global npm@^11.5.1
+            npm --version
+      - run:
           name: "Publish release to NPM"
           command: |
-            echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > .npmrc
-            npm publish
+            export NPM_ID_TOKEN="$(
+              circleci run oidc get \
+                --claims '{"aud": "npm:registry.npmjs.org"}'
+            )"
+            npm publish --access public
 
   build_cdn:
     <<: *node_executor


### PR DESCRIPTION
Jira: [CHECKOUT-10191](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10191)

## What/Why?

Replace the long-lived `NPM_AUTH_TOKEN` in `.npmrc` with a short-lived OIDC token minted by CircleCI, so no npm credential is stored or rotated.

Trusted publishing requires Node >= 22.14.0 and npm >= 11.5.1, and no Node 22.x release bundles npm 11 (all ship 10.9.x). So `npm_release` gets its own executor alias on Node 24.19.0, which bundles npm 11.17.0. Other jobs stay on 22.13.0, leaving the test/build environment unchanged.

Installing npm globally instead was tried and doesn't work — `/usr/local/lib/node_modules` is root-owned while the job runs as `circleci`, so `npm install --global` fails with EACCES.

**Draft until the trusted publisher is configured on npmjs.com** for `@bigcommerce/checkout-sdk` (Trusted publisher -> CircleCI -> `bigcommerce/checkout-sdk-js`). Merging before that breaks the next release. Needs npm org admin.

Reviewer checks:
- `npm_release` has no CircleCI context — confirm `circleci run oidc get` works without one.
- `package.json` declares `engines: { node: "22", npm: "10" }`, so the release job will emit EBADENGINE warnings on Node 24. Harmless unless something sets `engine-strict`.
- Provenance isn't supported for CircleCI trusted publishing. Not a regression; we don't use `--provenance` today.
- Remove the `NPM_AUTH_TOKEN` env var and revoke the token once verified.

## Rollout/Rollback

Applies to the next `approve_npm_release` -> `npm_release` run on master, which is manually gated and serves as the verification point. Rollback is reverting these commits and restoring `NPM_AUTH_TOKEN`.

Note: if publish fails, the earlier steps have already tagged and pushed the version commit, so recovery is re-running the publish, not the job.

## Testing

Not testable pre-merge — this path only runs during a real release and the OIDC exchange can't be exercised locally.

Verified locally: config parses and `npm_release` resolves the new alias (`js-yaml`); publish step passes `bash -n`; bundled npm versions checked against `nodejs.org/dist/index.json` (Node 24.5.0+ is the floor that satisfies npm >= 11.5.1).

The publish step logs `npm --version` first — on the first release after merge, confirm it reports `11.x` and that publish succeeds with no `.npmrc`.

Refs CHECKOUT-10191

[CHECKOUT-10191]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ