### PR TITLE
CHECKOUT-10191: Run npm release job on Node 24 to fix EACCES

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,12 @@ aliases:
         name: node/node
         node-version: "22.13.0"
 
-  # npm trusted publishing (OIDC) requires Node >= 22.14.0 and npm >= 11.5.1
+  # npm trusted publishing (OIDC) requires Node >= 22.14.0 and npm >= 11.5.1.
+  # No Node 22.x bundles npm 11, so the release job runs on Node 24 instead.
   - &node_publish_executor
       executor:
         name: node/node
-        node-version: "22.20.0"
+        node-version: "24.19.0"
 
 version: 2.1
 
@@ -109,13 +110,9 @@ jobs:
           command: |
             git push --follow-tags origin $CIRCLE_BRANCH
       - run:
-          name: "Upgrade npm for trusted publishing"
-          command: |
-            npm install --global npm@^11.5.1
-            npm --version
-      - run:
           name: "Publish release to NPM"
           command: |
+            npm --version
             export NPM_ID_TOKEN="$(
               circleci run oidc get \
                 --claims '{"aud": "npm:registry.npmjs.org"}'


### PR DESCRIPTION
Jira: [CHECKOUT-10191](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10191)

Follow-up to #3367, which is merged but left the publish path broken.

## What/Why?

#3367 added a `npm install --global npm@^11.5.1` step to satisfy trusted publishing's npm >= 11.5.1 requirement. That step cannot work on this executor: `/usr/local/lib/node_modules` is root-owned while the job runs as `circleci`, so it fails with `EACCES` on rename (exit 243). It did exactly that on the 1.963.1 release at 04:25:59Z.

Node 24.5.0+ bundles npm >= 11.5.1 (24.19.0 ships 11.17.0), so pointing the release executor at Node 24 satisfies the requirement with nothing to install and no `sudo`. Other jobs stay on 22.13.0.

`npm --version` now logs at the top of the publish step so the npm version is visible in the job output.

## Rollout/Rollback

Applies to the next `approve_npm_release` -> `npm_release` run on master. The npmjs.com trusted publisher is configured, so this should be the last blocker on the publish path.

Rollback is reverting this commit, but note that reverting returns the job to the EACCES failure — a true rollback of the publish path means reverting #3367 as well and restoring `NPM_AUTH_TOKEN`.

Known state going in: 1.962.0, 1.963.0 and 1.963.1 are tagged on master but were never published (npm `latest` is 1.961.0). Per triage we're letting the next successful release supersede them rather than backfilling.

## Testing

Not testable pre-merge — the publish path only runs during a real release.

Verified locally: config parses and `npm_release` resolves the Node 24 alias (`js-yaml`); bundled npm versions checked against `nodejs.org/dist/index.json`, confirming 24.5.0 is the floor satisfying npm >= 11.5.1 and that no 22.x qualifies.

On the next release, confirm the publish step logs npm `11.x`, the OIDC exchange succeeds, and the new version appears on npm.

Refs CHECKOUT-10191

[CHECKOUT-10191]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production npm publish job (OIDC trusted publishing). Scope is small CI config only, but a bad Node/npm combo would block or mis-publish releases.
> 
> **Overview**
> Fixes the broken npm publish path by running `npm_release` on **Node 24.19.0** so the bundled npm already meets trusted publishing (`npm >= 11.5.1`). Other jobs stay on Node 22.13.0.
> 
> Removes the global `npm install --global npm@^11.5.1` step that failed with **EACCES** on the CircleCI executor. The publish step now logs `npm --version` before the OIDC token exchange.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d732281541c496a480279b58ad3c849698d176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->