### PR TITLE
CHECKOUT-10191: Fix npm publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
       - run:
           name: "Upgrade npm for trusted publishing"
           command: |
-            npm install --global npm@^11.5.1
+            sudo npm install --global npm@^11.5.1
             npm --version
       - run:
           name: "Publish release to NPM"
@@ -190,5 +190,7 @@ workflows:
             - lint
             - build
       - npm_release:
+          context:
+            - npmjs-publish
           requires:
             - approve_npm_release


### PR DESCRIPTION
## What/Why?
Fix npm publish

## Rollout/Rollback
Merge / revert

## Testing
CI after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production npm publish pipeline (OIDC/trusted publishing and CircleCI context). Scope is small, but a misconfig could block or incorrectly authorize releases.
> 
> **Overview**
> Fixes the CircleCI `npm_release` job so trusted publishing can actually run.
> 
> Installs the required global npm (`^11.5.1`) with `sudo` so the upgrade succeeds on the executor. Attaches the `npmjs-publish` context so OIDC credentials are available for `npm publish`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b39b2a7f4147d66f47f781042b519ccdd1589f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->