### PR TITLE
fix(payment): PAYPAL-7024 BT fastlane authentication flow

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.spec.ts
@@ -519,6 +519,31 @@ describe('BraintreeFastlaneUtils', () => {
             );
         });
 
+        it('does not authenticate customer if profileData is undefined', async () => {
+            jest.spyOn(
+                braintreeFastlaneMock.identity,
+                'triggerAuthenticationFlow',
+            ).mockResolvedValue({
+                authenticationState: BraintreeFastlaneAuthenticationState.FAILED,
+                profileData: undefined,
+            });
+
+            const updatePaymentProviderCustomerPayload = {
+                authenticationState: BraintreeFastlaneAuthenticationState.FAILED,
+                addresses: [],
+                instruments: [],
+            };
+
+            await subject.initializeBraintreeFastlaneOrThrow(methodId, undefined);
+            await subject.runPayPalAuthenticationFlowOrThrow();
+
+            expect(CookieStorage.remove).toHaveBeenCalledWith('bc-fastlane-sessionId');
+            expect(braintreeFastlaneMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
+            expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith(
+                updatePaymentProviderCustomerPayload,
+            );
+        });
+
         it('preselects billing address with first paypal fastlane billing address', async () => {
             await subject.initializeBraintreeFastlaneOrThrow(methodId, undefined);
             await subject.runPayPalAuthenticationFlowOrThrow();

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-utils.ts
@@ -130,7 +130,10 @@ export default class BraintreeFastlaneUtils {
 
             const phoneNumber = profileData?.shippingAddress?.phoneNumber || '';
 
-            if (authenticationState === BraintreeFastlaneAuthenticationState.CANCELED) {
+            if (
+                authenticationState === BraintreeFastlaneAuthenticationState.CANCELED ||
+                !profileData
+            ) {
                 await this.paymentIntegrationService.updatePaymentProviderCustomer({
                     authenticationState,
                     addresses: [],

--- a/packages/braintree-utils/src/types.ts
+++ b/packages/braintree-utils/src/types.ts
@@ -515,13 +515,13 @@ export interface BraintreeFastlaneStylesOption {
 export enum BraintreeFastlaneAuthenticationState {
     SUCCEEDED = 'succeeded',
     FAILED = 'failed',
-    CANCELED = 'cancelled',
+    CANCELED = 'canceled',
     UNRECOGNIZED = 'unrecognized',
 }
 
 export interface BraintreeFastlaneAuthenticationCustomerResult {
     authenticationState: BraintreeFastlaneAuthenticationState;
-    profileData: BraintreeFastlaneProfileData;
+    profileData?: BraintreeFastlaneProfileData;
 }
 
 export interface BraintreeFastlaneProfileData {

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.spec.ts
@@ -460,6 +460,42 @@ describe('BraintreeFastlaneShippingStrategy', () => {
             });
         });
 
+        it('update payment provider customer with empty addresses if profileData is undefined', async () => {
+            const updatePaymentProviderCustomerMock = jest.fn();
+
+            const lookupCustomerByEmailMock = () => ({ customerContextId: 'asd' });
+            const triggerAuthenticationFlowMock = jest.fn().mockImplementation(() => ({
+                authenticationState: BraintreeFastlaneAuthenticationState.FAILED,
+                profileData: undefined,
+            }));
+
+            jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeFastlane').mockImplementation(
+                () => ({
+                    identity: {
+                        lookupCustomerByEmail: lookupCustomerByEmailMock,
+                        triggerAuthenticationFlow: triggerAuthenticationFlowMock,
+                    },
+                }),
+            );
+
+            jest.spyOn(
+                paymentProviderCustomerActionCreator,
+                'updatePaymentProviderCustomer',
+            ).mockImplementation(updatePaymentProviderCustomerMock);
+
+            const strategy = createStrategy();
+
+            await strategy.initialize(defaultOptions);
+
+            expect(triggerAuthenticationFlowMock).toHaveBeenCalled();
+            expect(CookieStorage.remove).toHaveBeenCalledWith('bc-fastlane-sessionId');
+            expect(updatePaymentProviderCustomerMock).toHaveBeenCalledWith({
+                authenticationState: BraintreeFastlaneAuthenticationState.FAILED,
+                addresses: [],
+                instruments: [],
+            });
+        });
+
         it('update billing address for digital product', async () => {
             const updatePaymentProviderCustomerMock = jest.fn();
             const updateBillingAddressMock = jest.fn();

--- a/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-fastlane-shipping-strategy.ts
@@ -185,7 +185,7 @@ export default class BraintreeFastlaneShippingStrategy implements ShippingStrate
             customerContextId,
         );
 
-        if (authenticationState === BraintreeFastlaneAuthenticationState.CANCELED) {
+        if (authenticationState === BraintreeFastlaneAuthenticationState.CANCELED || !profileData) {
             await this._store.dispatch(
                 this._paymentProviderCustomerActionCreator.updatePaymentProviderCustomer({
                     authenticationState,


### PR DESCRIPTION
## What/Why?
Add defensive checks for undefined profileData in authentication flow to prevent potential crashes and ensure graceful handling when PayPal returns authentication state without profile data

<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
Before

[fastlane_before_cancel_error.webm](https://github.com/user-attachments/assets/1e4f9e9e-0376-44c0-b930-0ab37144fc66)

After

[fastalane_cancel_no_error.webm](https://github.com/user-attachments/assets/3d6ae584-6b82-4476-b14e-5e7173563755)

[fastlane_success.webm](https://github.com/user-attachments/assets/8904fe03-5d1f-4b3c-b086-5c939c4766af)

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment-provider customer updates and auth state handling on the checkout critical path; the CANCELED enum string change could affect comparisons if the API still sends "cancelled".
> 
> **Overview**
> Hardens **Braintree Fastlane / PayPal** authentication when PayPal returns an auth state **without** `profileData` (e.g. cancel or failed flows), so checkout no longer tries to map addresses or instruments and avoids runtime errors.
> 
> In **`braintree-fastlane-utils`** and **`braintree-fastlane-shipping-strategy`**, the early-exit path now matches **canceled** auth: if `profileData` is missing, the payment provider customer is updated with empty addresses/instruments, the Fastlane session cookie is cleared, and address prefill is skipped.
> 
> **Types** in `braintree-utils` mark `profileData` as optional on the auth result and align `BraintreeFastlaneAuthenticationState.CANCELED` to the string **`canceled`** (was `cancelled`). Specs cover the undefined `profileData` case in both integration and shipping strategy tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e5d199653b790653fcb7659af1742e8547a29ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->