### PR TITLE
feat(payment): PAYPAL-6634 Improve Error Messaging for Bank-Declined 3DS Authentication (PayPal PPCP)

### DIFF
--- a/packages/payment-integration-api/src/errors/index.ts
+++ b/packages/payment-integration-api/src/errors/index.ts
@@ -10,6 +10,7 @@ export {
 export { default as OrderFinalizationNotCompletedError } from './order-finalization-not-completed-error';
 export { default as OrderFinalizationNotRequiredError } from './order-finalization-not-required-error';
 export { default as PaymentArgumentInvalidError } from './payment-argument-invalid-error';
+export { default as PaymentMethodBankDeclinedAuthenticationError } from './payment-method-bank-declined-authentication-error';
 export { default as PaymentMethodCancelledError } from './payment-method-cancelled-error';
 export { default as PaymentMethodClientUnavailableError } from './payment-method-client-unavailable-error';
 export { default as PaymentMethodFailedError } from './payment-method-failed-error';

--- a/packages/payment-integration-api/src/errors/payment-method-bank-declined-authentication-error.spec.ts
+++ b/packages/payment-integration-api/src/errors/payment-method-bank-declined-authentication-error.spec.ts
@@ -1,0 +1,15 @@
+import PaymentMethodBankDeclinedAuthenticationError from './payment-method-bank-declined-authentication-error';
+
+describe('PaymentMethodBankDeclinedAuthenticationError', () => {
+    it('returns error name', () => {
+        const error = new PaymentMethodBankDeclinedAuthenticationError();
+
+        expect(error.name).toBe('PaymentMethodBankDeclinedAuthenticationError');
+    });
+
+    it('returns error type', () => {
+        const error = new PaymentMethodBankDeclinedAuthenticationError();
+
+        expect(error.type).toBe('bank_declined_authentication');
+    });
+});

--- a/packages/payment-integration-api/src/errors/payment-method-bank-declined-authentication-error.ts
+++ b/packages/payment-integration-api/src/errors/payment-method-bank-declined-authentication-error.ts
@@ -1,0 +1,16 @@
+import StandardError from './standard-error';
+
+/**
+ * This error should be thrown when a shopper's bank declines 3DS
+ * authentication (e.g.: a PayPal `liabilityShift` of `NO` or `UNKNOWN`).
+ * The decline is issuer-side, so retrying with the same card in the same
+ * session will not succeed and the shopper should use a different card.
+ */
+export default class PaymentMethodBankDeclinedAuthenticationError extends StandardError {
+    constructor() {
+        super('Your bank declined authentication, please use a different card.');
+
+        this.name = 'PaymentMethodBankDeclinedAuthenticationError';
+        this.type = 'bank_declined_authentication';
+    }
+}

--- a/packages/payment-integration-api/src/errors/payment-method-bank-declined-authentication-error.ts
+++ b/packages/payment-integration-api/src/errors/payment-method-bank-declined-authentication-error.ts
@@ -1,11 +1,5 @@
 import StandardError from './standard-error';
 
-/**
- * This error should be thrown when a shopper's bank declines 3DS
- * authentication (e.g.: a PayPal `liabilityShift` of `NO` or `UNKNOWN`).
- * The decline is issuer-side, so retrying with the same card in the same
- * session will not succeed and the shopper should use a different card.
- */
 export default class PaymentMethodBankDeclinedAuthenticationError extends StandardError {
     constructor() {
         super('Your bank declined authentication, please use a different card.');

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -70,6 +70,7 @@ export {
     PaymentExecuteError,
     PaymentInvalidFormError,
     type PaymentInvalidFormErrorDetails,
+    PaymentMethodBankDeclinedAuthenticationError,
     PaymentMethodCancelledError,
     PaymentMethodClientUnavailableError,
     PaymentMethodInvalidError,

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.spec.ts
@@ -524,10 +524,6 @@ describe('PayPalCommerceCreditCardsPaymentStrategy', () => {
         );
 
         it('surfaces the actionable bank-declined error from submitHostedForm', async () => {
-            // Reproduce the real PayPal SDK behaviour: `submit()` invokes
-            // `onApprove` with a bank decline, swallows the error it throws and
-            // rejects with its own error. The strategy must still surface the
-            // actionable bank-declined error rather than the generic one.
             jest.spyOn(paypalSdk, 'CardFields').mockImplementation(
                 (options: PaypalCardFieldsConfig) => {
                     return Promise.resolve({

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.spec.ts
@@ -13,6 +13,8 @@ import {
     PaymentIntegrationService,
     PaymentInvalidFormError,
     PaymentMethod,
+    PaymentMethodBankDeclinedAuthenticationError,
+    PaymentMethodFailedError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBillingAddress,
@@ -495,6 +497,88 @@ describe('PayPalCommerceCreditCardsPaymentStrategy', () => {
             } catch (error) {
                 expect(error).toBeDefined();
             }
+        });
+
+        it.each([LiabilityShiftEnum.No, LiabilityShiftEnum.Unknown])(
+            'throws an actionable bank-declined error when liabilityShift is %s',
+            async (liabilityShift) => {
+                let onApproveCallback: PaypalCardFieldsConfig['onApprove'] | undefined;
+
+                jest.spyOn(paypalSdk, 'CardFields').mockImplementation(
+                    (options: PaypalCardFieldsConfig) => {
+                        onApproveCallback = options.onApprove;
+
+                        return Promise.resolve(cardFieldsInstanceMock);
+                    },
+                );
+
+                await strategy.initialize(initializationOptions);
+
+                expect(() =>
+                    onApproveCallback?.({
+                        orderID: hostedFormOrderId,
+                        liabilityShift,
+                    }),
+                ).toThrow(new PaymentMethodBankDeclinedAuthenticationError());
+            },
+        );
+
+        it('surfaces the actionable bank-declined error from submitHostedForm', async () => {
+            // Reproduce the real PayPal SDK behaviour: `submit()` invokes
+            // `onApprove` with a bank decline, swallows the error it throws and
+            // rejects with its own error. The strategy must still surface the
+            // actionable bank-declined error rather than the generic one.
+            jest.spyOn(paypalSdk, 'CardFields').mockImplementation(
+                (options: PaypalCardFieldsConfig) => {
+                    return Promise.resolve({
+                        ...cardFieldsInstanceMock,
+                        submit: jest.fn(() => {
+                            try {
+                                options.onApprove?.({
+                                    orderID: hostedFormOrderId,
+                                    liabilityShift: LiabilityShiftEnum.No,
+                                });
+                            } catch (_) {
+                                // swallowed by the PayPal SDK
+                            }
+
+                            return Promise.reject(new Error('sdk error'));
+                        }),
+                    });
+                },
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            await expect(
+                strategy.execute({
+                    payment: {
+                        methodId: 'paypalcommercecreditcards',
+                        paymentData: {},
+                    },
+                }),
+            ).rejects.toThrow(new PaymentMethodBankDeclinedAuthenticationError());
+        });
+
+        it('falls back to the generic error when submitHostedForm fails for other reasons', async () => {
+            jest.spyOn(cardFieldsInstanceMock, 'submit').mockRejectedValueOnce(
+                new Error('network'),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            await expect(
+                strategy.execute({
+                    payment: {
+                        methodId: 'paypalcommercecreditcards',
+                        paymentData: {},
+                    },
+                }),
+            ).rejects.toThrow(
+                new PaymentMethodFailedError(
+                    'Failed authentication. Please try to authorize again.',
+                ),
+            );
         });
 
         it('submits payment with vaulted(stored) instrument', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
@@ -30,6 +30,7 @@ import {
     PaymentIntegrationService,
     PaymentInvalidFormError,
     PaymentInvalidFormErrorDetails,
+    PaymentMethodBankDeclinedAuthenticationError,
     PaymentMethodFailedError,
     PaymentRequestOptions,
     PaymentStrategy,
@@ -71,6 +72,7 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
     private hostedFormOptions?: HostedFormOptions;
     private returnedOrderId?: string;
     private returnedVaultedToken?: string;
+    private isBankDeclinedAuthentication = false;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
@@ -234,7 +236,12 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
                     liabilityShift === LiabilityShiftEnum.No ||
                     liabilityShift === LiabilityShiftEnum.Unknown
                 ) {
-                    throw new Error();
+                    // The PayPal SDK swallows errors thrown here and rejects
+                    // `submit()` with its own error, so we record the decline
+                    // and surface the actionable error from `submitHostedForm`.
+                    this.isBankDeclinedAuthentication = true;
+
+                    throw new PaymentMethodBankDeclinedAuthenticationError();
                 }
 
                 return this.handleApprove({ orderID, vaultSetupToken });
@@ -462,6 +469,8 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
             },
         };
 
+        this.isBankDeclinedAuthentication = false;
+
         try {
             if (this.isCreditCardVaultedForm) {
                 await cardFields.submit();
@@ -469,6 +478,10 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
                 await cardFields.submit(submitConfig);
             }
         } catch (_) {
+            if (this.isBankDeclinedAuthentication) {
+                throw new PaymentMethodBankDeclinedAuthenticationError();
+            }
+
             throw new PaymentMethodFailedError(
                 'Failed authentication. Please try to authorize again.',
             );

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
@@ -236,9 +236,6 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
                     liabilityShift === LiabilityShiftEnum.No ||
                     liabilityShift === LiabilityShiftEnum.Unknown
                 ) {
-                    // The PayPal SDK swallows errors thrown here and rejects
-                    // `submit()` with its own error, so we record the decline
-                    // and surface the actionable error from `submitHostedForm`.
                     this.isBankDeclinedAuthentication = true;
 
                     throw new PaymentMethodBankDeclinedAuthenticationError();


### PR DESCRIPTION
## What/Why?

Improve Error Messaging for Bank-Declined 3DS Authentication (PayPal PPCP)

## Rollout/Rollback

Revert

## Testing

https://github.com/user-attachments/assets/3f2b96e7-bcbd-4a06-8d32-902211acb97d

https://github.com/user-attachments/assets/ad8a7ae0-615e-4e12-b28b-89111a5f3c3a



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment failure classification during 3DS for a live PayPal PPCP path; incorrect mapping could show the wrong message or mask real SDK failures.
> 
> **Overview**
> When PayPal Card Fields reports **3DS liability shift** as `No` or `Unknown`, checkout now fails with a dedicated **`PaymentMethodBankDeclinedAuthenticationError`** (type `bank_declined_authentication`, user-facing message to try another card) instead of a generic failure.
> 
> The new error is exported from **payment-integration-api** and wired in **PayPal Commerce credit cards** `onApprove` and **`submitHostedForm`**. A **`isBankDeclinedAuthentication`** flag preserves that outcome when the PayPal SDK swallows the `onApprove` throw and `submit` rejects; other submit failures still raise **`PaymentMethodFailedError`** with the existing authentication retry message.
> 
> Tests cover liability-shift cases, surfacing the bank-declined error through submit, and the generic-error fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c515866c65aecba404bfc3058f5b1d46772fabf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->