### PR TITLE
feat(payment): Stripe OCS, make payment validation request non-blocking

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -1,4 +1,5 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
+import { noop } from 'lodash';
 
 import {
     BillingAddress,
@@ -1930,6 +1931,113 @@ describe('StripeOCSPaymentStrategy', () => {
                         }),
                     }),
                 );
+            });
+        });
+
+        describe('asyncPaymentValidation', () => {
+            const mockPaymentMethodWithFlag = (asyncPaymentValidation: boolean) => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...getStripeOCSMock(),
+                    initializationData: {
+                        ...getStripeOCSMock().initializationData,
+                        asyncPaymentValidation,
+                    },
+                });
+            };
+
+            const mockStripeCheckoutWithConfirm = (confirmFn: jest.Mock) => {
+                jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                    Promise.resolve({
+                        ...getStripeCheckoutInstanceMock(),
+                        loadActions: () =>
+                            Promise.resolve({
+                                type: StripeLoadActionsResultType.SUCCESS,
+                                actions: {
+                                    ...getStripeCheckoutSessionActionsMock(),
+                                    confirm: confirmFn,
+                                },
+                            }),
+                    }),
+                );
+            };
+
+            it('resolves without waiting for the second submitPayment response when flag is true', async () => {
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
+                    new Promise<never>(noop),
+                );
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    session: {
+                        id: 'paymentIntentId',
+                        status: {
+                            paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
+                        },
+                    },
+                });
+                mockStripeCheckoutWithConfirm(confirmPaymentMock);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).resolves.not.toThrow();
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            });
+
+            it('resolves and ignores error when second submitPayment fails and order already paid on the stripe side', async () => {
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                mockFirstPaymentRequest(new Error('second submitPayment error'));
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    session: {
+                        id: 'paymentIntentId',
+                        status: {
+                            paymentStatus: StripeCheckoutSessionPaymentStatus.Paid,
+                        },
+                    },
+                });
+                mockStripeCheckoutWithConfirm(confirmPaymentMock);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).resolves.not.toThrow();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(
+                    stripeIntegrationService.throwPaymentConfirmationProceedMessage,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('waits for the second submitPayment response when flag is false', async () => {
+                mockPaymentMethodWithFlag(false);
+                mockFirstPaymentRequest(errorResponse);
+                mockFirstPaymentRequest(new Error('second submitPayment error'));
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    session: {
+                        id: 'paymentIntentId',
+                        status: {
+                            paymentStatus: StripeCheckoutSessionPaymentStatus.UnPaid,
+                        },
+                    },
+                });
+                mockStripeCheckoutWithConfirm(confirmPaymentMock);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+                ).rejects.toThrow('second submitPayment error');
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
             });
         });
 

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, merge } from 'lodash';
+import { cloneDeep, merge, noop } from 'lodash';
 
 import {
     InvalidArgumentError,
@@ -368,7 +368,8 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         const { initializationData } = this.paymentIntegrationService
             .getState()
             .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
-        const { sendSecondPaymentRequestOnStripeError } = initializationData || {};
+        const { sendSecondPaymentRequestOnStripeError, asyncPaymentValidation } =
+            initializationData || {};
 
         if (stripeError || !stripeCheckoutSession) {
             if (sendSecondPaymentRequestOnStripeError) {
@@ -393,6 +394,15 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
             }
 
             throw new PaymentMethodFailedError(stripeError?.message);
+        }
+
+        if (asyncPaymentValidation) {
+            // INFO: await is skipped and errors are ignored here intentionally, because the payment
+            // is already confirmed on the Stripe side, so the order status will be updated
+            // by webhooks even if this request fails.
+            this.paymentIntegrationService.submitPayment(paymentPayload).catch(noop);
+
+            return;
         }
 
         try {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -1,4 +1,5 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
+import { noop } from 'lodash';
 
 import {
     InvalidArgumentError,
@@ -1360,6 +1361,105 @@ describe('StripeOCSPaymentStrategy', () => {
                         }),
                     }),
                 );
+            });
+        });
+
+        describe('asyncPaymentValidation', () => {
+            const mockPaymentMethodWithFlag = (asyncPaymentValidation: boolean) => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...getStripeOCSMock(),
+                    initializationData: {
+                        ...getStripeOCSMock().initializationData,
+                        asyncPaymentValidation,
+                    },
+                });
+            };
+
+            const mockStripeClientWithConfirm = (confirmFn: jest.Mock) => {
+                stripeUPEJsMock = {
+                    ...getStripeJsMock(),
+                    confirmPayment: confirmFn,
+                    retrievePaymentIntent: jest.fn(),
+                };
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockImplementation(
+                    jest.fn(() => Promise.resolve(stripeUPEJsMock)),
+                );
+            };
+
+            it('resolves without waiting for the second submitPayment response when flag is true', async () => {
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
+                    new Promise<never>(noop),
+                );
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: {
+                        id: 'paymentIntentId',
+                        client_secret: 'paymentIntentClientSecret',
+                    },
+                });
+                mockStripeClientWithConfirm(confirmPaymentMock);
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).resolves.not.toThrow();
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+            });
+
+            it('resolves and ignores error when second submitPayment request fails', async () => {
+                mockPaymentMethodWithFlag(true);
+                mockFirstPaymentRequest(errorResponse);
+                mockFirstPaymentRequest(new Error('second submitPayment error'));
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: {
+                        id: 'paymentIntentId',
+                        client_secret: 'paymentIntentClientSecret',
+                    },
+                });
+                mockStripeClientWithConfirm(confirmPaymentMock);
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).resolves.not.toThrow();
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(
+                    stripeIntegrationService.throwPaymentConfirmationProceedMessage,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('waits for the second submitPayment response when flag is false', async () => {
+                mockPaymentMethodWithFlag(false);
+                mockFirstPaymentRequest(errorResponse);
+                mockFirstPaymentRequest(new Error('second submitPayment error'));
+                confirmPaymentMock = jest.fn().mockResolvedValue({
+                    paymentIntent: {
+                        id: 'paymentIntentId',
+                        client_secret: 'paymentIntentClientSecret',
+                    },
+                });
+                mockStripeClientWithConfirm(confirmPaymentMock);
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                await expect(
+                    stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock()),
+                ).rejects.toThrow(PaymentMethodFailedError);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(2);
+                expect(
+                    stripeIntegrationService.throwPaymentConfirmationProceedMessage,
+                ).toHaveBeenCalled();
             });
         });
     });

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import { merge, noop } from 'lodash';
 
 import {
     InvalidArgumentError,
@@ -313,13 +313,13 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
             paymentIntentClientSecret || token,
             paymentMethodOptions,
         );
+        const { initializationData } = this.paymentIntegrationService
+            .getState()
+            .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
+        const { sendSecondPaymentRequestOnStripeError, asyncPaymentValidation } =
+            initializationData || {};
 
         if (stripeError || !paymentIntent) {
-            const { initializationData } = this.paymentIntegrationService
-                .getState()
-                .getPaymentMethodOrThrow<StripeInitializationData>(methodId, gatewayId);
-            const { sendSecondPaymentRequestOnStripeError } = initializationData || {};
-
             if (sendSecondPaymentRequestOnStripeError) {
                 // INFO: even in case when stripe payment confirmation was declined
                 // we need to send submitPayment request to update status of checkout session on BE side.
@@ -340,6 +340,15 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
             }
 
             this.stripeIntegrationService.throwStripeError(stripeError);
+        }
+
+        if (asyncPaymentValidation) {
+            // INFO: await is skipped and errors are ignored here intentionally, because the payment
+            // is already confirmed on the Stripe side, so the order status will be updated
+            // by webhooks even if this request fails.
+            this.paymentIntegrationService.submitPayment(paymentPayload).catch(noop);
+
+            return;
         }
 
         try {

--- a/packages/stripe-utils/src/stripe.ts
+++ b/packages/stripe-utils/src/stripe.ts
@@ -804,6 +804,7 @@ export interface StripeInitializationData {
     sendSecondPaymentRequestOnStripeError?: boolean;
     adaptivePricingEnabled?: boolean;
     hasSectionOnTopOfPaymentsList?: boolean;
+    asyncPaymentValidation?: boolean;
 }
 
 export interface StripeElementUpdateOptions {


### PR DESCRIPTION
## What/Why?
After a successful client-side Stripe confirmation, the Stripe CS and OCS payment
strategies send a second `submitPayment` request so the backend can validate the
payment and finalize the order. This round trip can be slow, and the shopper is kept
waiting on a payment that Stripe has already confirmed.

This PR adds an optional `asyncPaymentValidation` flag to `StripeInitializationData`.
When enabled, both strategies send the second `submitPayment` request without awaiting
the response and resolve `execute()` immediately, letting checkout proceed to order
confirmation. Errors from that request are intentionally ignored (`.catch(noop)`): the
payment is already confirmed on the Stripe side, so the order status is reconciled by
Stripe webhooks even if the validation request fails or doesn't complete.

Only the success path is affected. Declined/failed Stripe confirmations behave exactly
as before: the error-status update request is still awaited and the error is thrown to
the shopper.

## Rollout/Rollback
- The flag is computed and served by the backend via the payment method's
  `initializationData`, gated by the `PROJECT-8987.ocs_async_payment_validation`
  experiment. The backend sends `asyncPaymentValidation: true` only when the experiment
  is enabled for the store and the merchant has Stripe webhooks configured — since
  webhooks become the finalization path whenever the non-blocking request doesn't
  complete (e.g. interrupted by the redirect to order confirmation), stores without
  webhooks never receive the flag.
- With the experiment off (default), behavior is unchanged.
- Rollback is ramping down / disabling the experiment; no code revert required.

## Testing
### Stipe OCS + Checkout Session
Before:

https://github.com/user-attachments/assets/e597aca0-64f3-426f-b6f2-bcc4db2c2c7f

After:

https://github.com/user-attachments/assets/f3f62627-a01c-44cb-920b-8c31dc42486d

### Stripe OCS + Payment Intent
Before:

https://github.com/user-attachments/assets/066d990d-e616-421a-bfc3-372c28257868

After:

https://github.com/user-attachments/assets/3c903b8f-1aec-417f-8db4-d43ff79b9497

 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-confirmation payment finalization timing; when enabled, order completion may depend on webhooks if the background validation request fails.
> 
> **Overview**
> Adds optional **`asyncPaymentValidation`** on `StripeInitializationData` so Stripe Checkout Session and OCS (Payment Intent) strategies can finish checkout without waiting on backend validation after Stripe confirms the payment.
> 
> When the flag is **true** and confirmation succeeds, both strategies still issue the second **`submitPayment`**, but they **fire-and-forget** it (`submitPayment(...).catch(noop)`) and **`execute()` resolves immediately**. Declines and other Stripe error paths are unchanged—they still await error-status updates and surface failures to the shopper.
> 
> When the flag is **false** or unset, behavior stays the same: the second **`submitPayment`** is awaited, and failures still trigger the existing “proceed” / error handling (including CS paid-session handling).
> 
> Unit tests cover flag-on (non-blocking, ignored second-request errors) vs flag-off (await and propagate errors) for CS and OCS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bbac19a261754cde23ac49e31460ae85b110a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->