### PR TITLE
feat(payment): Stripe CS checkout session sync and store credit optimization

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -13,7 +13,6 @@ import {
 import {
     getBillingAddress,
     getCart,
-    getCheckout,
     getErrorPaymentResponseBody,
     getResponse,
     getShippingAddress,
@@ -216,6 +215,32 @@ describe('StripeOCSPaymentStrategy', () => {
             expect(togglePreloaderMock).toHaveBeenCalled();
             expect(stripeScriptLoader.getStripeClient).toHaveBeenCalled();
             expect(stripeIntegrationService.mountElement).toHaveBeenCalled();
+        });
+
+        it('triggers stripe checkout session server update on initialize', async () => {
+            const runServerUpdateMock = jest.fn(async (update: () => Promise<unknown>) => {
+                await update();
+
+                return { type: StripeLoadActionsResultType.SUCCESS };
+            });
+
+            jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                Promise.resolve({
+                    ...getStripeCheckoutInstanceMock(),
+                    loadActions: () =>
+                        Promise.resolve({
+                            type: StripeLoadActionsResultType.SUCCESS,
+                            actions: {
+                                ...getStripeCheckoutSessionActionsMock(),
+                                runServerUpdate: runServerUpdateMock,
+                            },
+                        }),
+                }),
+            );
+
+            await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+            expect(runServerUpdateMock).toHaveBeenCalledTimes(1);
         });
 
         it('should call render when payment element ready event fires', async () => {
@@ -989,19 +1014,100 @@ describe('StripeOCSPaymentStrategy', () => {
             ).rejects.toThrow(InvalidArgumentError);
         });
 
-        it('execute with store credits', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getCheckoutOrThrow',
-            ).mockReturnValueOnce({
-                ...getCheckout(),
-                isStoreCreditApplied: true,
+        it('applies store credit via stripe integration service', async () => {
+            await stripeCSPaymentStrategy.initialize(stripeOptions);
+            await stripeCSPaymentStrategy.execute({
+                ...getStripeOCSOrderRequestBodyMock(methodId),
+                useStoreCredit: true,
             });
 
+            expect(stripeIntegrationService.applyStoreCreditIfNeeded).toHaveBeenCalledWith(true);
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                expect.objectContaining({ useStoreCredit: true }),
+                undefined,
+            );
+        });
+
+        it('calls applyStoreCreditIfNeeded with undefined when useStoreCredit is not provided', async () => {
             await stripeCSPaymentStrategy.initialize(stripeOptions);
             await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
 
-            expect(paymentIntegrationService.applyStoreCredit).toHaveBeenCalledWith(true);
+            expect(stripeIntegrationService.applyStoreCreditIfNeeded).toHaveBeenCalledWith(
+                undefined,
+            );
+        });
+
+        it('throws error if stripe checkout session server update fails', async () => {
+            const runServerUpdateMock = jest
+                .fn()
+                .mockResolvedValueOnce({ type: StripeLoadActionsResultType.SUCCESS })
+                .mockResolvedValue({
+                    type: StripeLoadActionsResultType.ERROR,
+                    error: { message: 'stripe server update error' },
+                });
+
+            jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                Promise.resolve({
+                    ...getStripeCheckoutInstanceMock(),
+                    loadActions: () =>
+                        Promise.resolve({
+                            type: StripeLoadActionsResultType.SUCCESS,
+                            actions: {
+                                ...getStripeCheckoutSessionActionsMock(),
+                                runServerUpdate: runServerUpdateMock,
+                            },
+                        }),
+                }),
+            );
+
+            await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+            await expect(
+                stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+            ).rejects.toThrow(PaymentMethodFailedError);
+
+            expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+        });
+
+        it('throws not initialized error on execute if initialization failed', async () => {
+            const onErrorMock = jest.fn();
+
+            jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                Promise.resolve({
+                    ...getStripeCheckoutInstanceMock(),
+                    loadActions: () =>
+                        Promise.resolve({
+                            type: StripeLoadActionsResultType.SUCCESS,
+                            actions: {
+                                ...getStripeCheckoutSessionActionsMock(),
+                                runServerUpdate: jest.fn(() =>
+                                    Promise.resolve({
+                                        type: StripeLoadActionsResultType.ERROR,
+                                        error: { message: 'stripe server update error' },
+                                    }),
+                                ),
+                            },
+                        }),
+                }),
+            );
+
+            await stripeCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeocs: {
+                    ...stripeOptions.stripeocs,
+                    containerId: 'containerId',
+                    render: jest.fn(),
+                    onError: onErrorMock,
+                },
+            });
+
+            expect(onErrorMock).toHaveBeenCalledWith(expect.any(PaymentMethodFailedError));
+
+            await expect(
+                stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId)),
+            ).rejects.toThrow(NotInitializedError);
+
+            expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
         });
 
         it('execute without additional actions with selected method in accordion', async () => {

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -34,6 +34,7 @@ import {
     StripeInitializationData,
     StripeIntegrationService,
     StripeJsVersion,
+    StripeLoadActionsResultType,
     StripePaymentMethodType,
     StripeScriptLoader,
     StripeSelectedPaymentMethod,
@@ -87,9 +88,13 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
             const stripeActions = await this._getStripeActionsOrThrow();
 
             await this._updateStripeShopperData(stripeActions);
+            await this._updateStripeCheckoutSessionState(stripeActions);
+
             this._initializePaymentElement(stripeocs, paymentMethod);
             this._initializeAdaptivePricingElement(stripeocs, paymentMethod);
         } catch (error) {
+            await this.deinitialize();
+
             if (error instanceof Error) {
                 stripeocs.onError?.(error);
             }
@@ -98,6 +103,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
     async execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
         const { payment, ...order } = orderRequest;
+        const { useStoreCredit } = orderRequest;
         const { methodId, gatewayId } = payment || {};
 
         if (!this.stripeClient) {
@@ -111,7 +117,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         }
 
         const [, stripeActions] = await Promise.all([
-            this._applyStoreCreditIfNeeded(),
+            this.stripeIntegrationService.applyStoreCreditIfNeeded(useStoreCredit),
             this._getStripeActionsOrThrow(),
         ]);
 
@@ -249,16 +255,6 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         );
     }
 
-    private async _applyStoreCreditIfNeeded(): Promise<void> {
-        const { isStoreCreditApplied } = this.paymentIntegrationService
-            .getState()
-            .getCheckoutOrThrow();
-
-        if (isStoreCreditApplied) {
-            await this.paymentIntegrationService.applyStoreCredit(isStoreCreditApplied);
-        }
-    }
-
     private async _getStripeActionsOrThrow(): Promise<StripeCheckoutSessionActions> {
         if (!this.stripeCheckout) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
@@ -308,9 +304,11 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         await this._updateStripeShopperData(stripeActions);
 
         // INFO: to trigger checkout session data update on the BE side we need to make stripe config request
-        await this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
-            params: { method: methodId },
-        });
+        await this._updateStripeCheckoutSessionState(stripeActions, () =>
+            this.paymentIntegrationService.loadPaymentMethod(gatewayId, {
+                params: { method: methodId },
+            }),
+        );
     }
 
     private _getPaymentPayload(
@@ -429,6 +427,17 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         await this._updateStripeEmail(stripeActions);
         await this._updateStripeShippingAddress(stripeActions);
         await this._updateStripeBillingAddress(stripeActions);
+    }
+
+    private async _updateStripeCheckoutSessionState(
+        stripeActions: StripeCheckoutSessionActions,
+        updateFn: () => Promise<unknown> = () => Promise.resolve(),
+    ): Promise<void> {
+        const { type, error } = await stripeActions.runServerUpdate(updateFn);
+
+        if (error || type === StripeLoadActionsResultType.ERROR) {
+            throw new PaymentMethodFailedError(error?.message);
+        }
     }
 
     private async _updateStripeEmail(stripeActions: StripeCheckoutSessionActions): Promise<void> {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -11,7 +11,6 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getCart,
-    getCheckout,
     getErrorPaymentResponseBody,
     getResponse,
     PaymentIntegrationServiceMock,
@@ -551,19 +550,27 @@ describe('StripeOCSPaymentStrategy', () => {
             ).rejects.toThrow(InvalidArgumentError);
         });
 
-        it('execute with store credits', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getCheckoutOrThrow',
-            ).mockReturnValueOnce({
-                ...getCheckout(),
-                isStoreCreditApplied: true,
+        it('applies store credit via stripe integration service', async () => {
+            await stripeOCSPaymentStrategy.initialize(stripeOptions);
+            await stripeOCSPaymentStrategy.execute({
+                ...getStripeOCSOrderRequestBodyMock(),
+                useStoreCredit: true,
             });
 
+            expect(stripeIntegrationService.applyStoreCreditIfNeeded).toHaveBeenCalledWith(true);
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                expect.objectContaining({ useStoreCredit: true }),
+                undefined,
+            );
+        });
+
+        it('calls applyStoreCreditIfNeeded with undefined when useStoreCredit is not provided', async () => {
             await stripeOCSPaymentStrategy.initialize(stripeOptions);
             await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
 
-            expect(paymentIntegrationService.applyStoreCredit).toHaveBeenCalledWith(true);
+            expect(stripeIntegrationService.applyStoreCreditIfNeeded).toHaveBeenCalledWith(
+                undefined,
+            );
         });
 
         it('execute without additional actions with selected method in accordion', async () => {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -79,6 +79,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
 
     async execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
         const { payment, ...order } = orderRequest;
+        const { useStoreCredit } = orderRequest;
         const { methodId, gatewayId } = payment || {};
 
         if (!this.stripeClient) {
@@ -91,13 +92,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
             );
         }
 
-        const { isStoreCreditApplied } = this.paymentIntegrationService
-            .getState()
-            .getCheckoutOrThrow();
-
-        if (isStoreCreditApplied) {
-            await this.paymentIntegrationService.applyStoreCredit(isStoreCreditApplied);
-        }
+        await this.stripeIntegrationService.applyStoreCreditIfNeeded(useStoreCredit);
 
         await this.stripeIntegrationService.updateStripePaymentIntent(gatewayId, methodId);
 

--- a/packages/stripe-utils/src/stripe-integration-service.mock.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.mock.ts
@@ -40,6 +40,7 @@ export const getStripeIntegrationServiceMock = () =>
         isRedirectAction: jest.fn(() => false),
         isOnPageAdditionalAction: jest.fn(() => false),
         updateStripePaymentIntent: jest.fn(() => Promise.resolve()),
+        applyStoreCreditIfNeeded: jest.fn(() => Promise.resolve()),
         throwStripeError: jest.fn(() => {
             throw new Error('throw stripe error');
         }),

--- a/packages/stripe-utils/src/stripe-integration-service.spec.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.spec.ts
@@ -735,6 +735,48 @@ describe('StripeIntegrationService', () => {
         });
     });
 
+    describe('#applyStoreCreditIfNeeded', () => {
+        it('applies store credit when useStoreCredit is true and store credit is not applied', async () => {
+            await stripeIntegrationService.applyStoreCreditIfNeeded(true);
+
+            expect(paymentIntegrationService.applyStoreCredit).toHaveBeenCalledWith(true);
+        });
+
+        it('removes store credit when useStoreCredit is false and store credit is applied', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getCheckoutOrThrow',
+            ).mockReturnValueOnce({
+                ...getCheckout(),
+                isStoreCreditApplied: true,
+            });
+
+            await stripeIntegrationService.applyStoreCreditIfNeeded(false);
+
+            expect(paymentIntegrationService.applyStoreCredit).toHaveBeenCalledWith(false);
+        });
+
+        it('does not apply store credit when useStoreCredit matches checkout state', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getCheckoutOrThrow',
+            ).mockReturnValueOnce({
+                ...getCheckout(),
+                isStoreCreditApplied: true,
+            });
+
+            await stripeIntegrationService.applyStoreCreditIfNeeded(true);
+
+            expect(paymentIntegrationService.applyStoreCredit).not.toHaveBeenCalled();
+        });
+
+        it('does not apply store credit when useStoreCredit is not provided', async () => {
+            await stripeIntegrationService.applyStoreCreditIfNeeded();
+
+            expect(paymentIntegrationService.applyStoreCredit).not.toHaveBeenCalled();
+        });
+    });
+
     describe('#mapStripeAddress', () => {
         it('should map address fields to Stripe format', () => {
             const address = getShippingAddress();

--- a/packages/stripe-utils/src/stripe-integration-service.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.ts
@@ -209,6 +209,16 @@ export default class StripeIntegrationService {
         this.scriptLoader.updateStripeElements({ clientSecret: clientToken });
     }
 
+    async applyStoreCreditIfNeeded(useStoreCredit?: boolean): Promise<void> {
+        const { isStoreCreditApplied } = this.paymentIntegrationService
+            .getState()
+            .getCheckoutOrThrow();
+
+        if (useStoreCredit !== undefined && useStoreCredit !== isStoreCreditApplied) {
+            await this.paymentIntegrationService.applyStoreCredit(useStoreCredit);
+        }
+    }
+
     mapStripeAddress(address?: Address): AddressOptions {
         if (address) {
             const {

--- a/packages/stripe-utils/src/stripe.mock.ts
+++ b/packages/stripe-utils/src/stripe.mock.ts
@@ -177,6 +177,11 @@ export function getStripeCheckoutSessionActionsMock(): StripeCheckoutSessionActi
         confirm: jest.fn(),
         updateShippingAddress: jest.fn(),
         updateBillingAddress: jest.fn(),
+        runServerUpdate: jest.fn(async (update: () => Promise<unknown>) => {
+            await update();
+
+            return { type: StripeLoadActionsResultType.SUCCESS };
+        }),
     };
 }
 

--- a/packages/stripe-utils/src/stripe.ts
+++ b/packages/stripe-utils/src/stripe.ts
@@ -576,6 +576,7 @@ export interface StripeCheckoutSessionActions {
     confirm(
         options: StripeCheckoutSessionConfirmPaymentData,
     ): Promise<StripeCheckoutSessionActionResult>;
+    runServerUpdate(update: () => Promise<unknown>): Promise<StripeCheckoutSessionActionResult>;
 }
 
 export interface StripeSavedPaymentMethod {


### PR DESCRIPTION
## What/Why?
### Stripe checkout session sync (`runServerUpdate`)

Changes on the BigCommerce side (e.g. price updates) were not reflected in the
mounted Stripe payment element, because Stripe was never told to re-fetch its
checkout session after our backend mutated it.

- `StripeCheckoutSessionActions.runServerUpdate` is now properly typed:
  `runServerUpdate(update: () => Promise<unknown>): Promise<StripeCheckoutSessionActionResult>`.
- `initialize()` runs a session sync after shopper data is pushed, so the
  element renders against the latest session state.
- `execute()` wraps the config request (`loadPaymentMethod`) in
  `runServerUpdate`, so the session update triggered on the BE side is pulled
  into the Stripe element before order submission.
- The result is checked: a `{ type: 'error' }` response throws a typed
  `PaymentMethodFailedError` **before** `submitOrder`, instead of silently
  proceeding against an unsynced session.

### Store credit request optimization

`execute()` previously re-applied store credit on every order whenever
`isStoreCreditApplied` was `true` — a blocking `POST .../store-credit`
round trip that is a server-side no-op (the flag is persisted on the cart, so
it can be `true` even for guest carts, and the BE early-returns when the state
already matches). Hosted checkout applies/removes store credit eagerly when the
shopper toggles the checkbox, so the strategy-level call added latency to every
Place Order click without changing anything.

- New shared `StripeIntegrationService.applyStoreCreditIfNeeded(useStoreCredit?)`,
  used by both `stripe-cs` and `stripe-ocs` (keeps the same-gateway strategies
  in sync): the API is called only when `useStoreCredit` is explicitly provided
  in the order request **and** differs from the current checkout state.
- Hosted checkout does not pass the flag → one blocking request removed from
  every order submission.
- Headless consumers passing `useStoreCredit` now get correct semantics,
  including credit **removal** on `false` (previously impossible).
- `useStoreCredit` is still passed through to `submitOrder` in the order body
  (pinned by tests).

### Safer initialization failure handling

A failure during `initialize()` (e.g. a failed session sync) now tears the
strategy down via `deinitialize()` before reporting through `onError`. A
subsequent `execute()` throws `NotInitializedError` instead of creating an
order against a strategy whose payment element never mounted.

## Rollout/Rollback
- No experiment/feature flag; ships with the next SDK release and reaches
  storefronts as checkout consumes the new version.
- Rollback: revert this PR / pin the previous SDK version. No BE changes or
  migrations; the store-credit and session-sync behavior is fully client-side.

## Testing
### Stripe OCS

https://github.com/user-attachments/assets/bb3760a6-32a8-4be9-ab15-2066e4abe849


https://github.com/user-attachments/assets/8d6b7875-9de4-4a1e-b128-9bbda7fdd07f


https://github.com/user-attachments/assets/7cb146e5-2725-4a27-81fc-3af1d645e879

### Stripe CS

https://github.com/user-attachments/assets/0491b4d4-1624-474f-8d4f-94bc2a7f105e


https://github.com/user-attachments/assets/91747779-888b-499f-bc09-a900100b32c7


https://github.com/user-attachments/assets/62d17a24-d44a-485b-8d1c-8fee9285109e



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect Stripe CS payment initialization, execute order flow, and store credit timing on place order; session sync failures now block submission, which is safer but alters failure modes at checkout.
> 
> **Overview**
> **Stripe Checkout Session (CS)** now keeps the mounted payment element aligned with BigCommerce backend changes by calling Stripe’s **`runServerUpdate`** after shopper data on **initialize**, and wrapping **`loadPaymentMethod`** in **`runServerUpdate`** on **execute**. Failed syncs raise **`PaymentMethodFailedError`** before **`submitOrder`**. Failed **initialize** now **`deinitialize()`**s first so a later **execute** throws **`NotInitializedError`** instead of submitting against an unmounted element.
> 
> **Store credit** is centralized in **`StripeIntegrationService.applyStoreCreditIfNeeded(useStoreCredit?)`**, used by both **stripe-cs** and **stripe-ocs**. Store credit is applied or removed only when **`useStoreCredit`** is explicitly set and differs from checkout state—avoiding redundant **`applyStoreCredit`** calls on every place order when hosted checkout already synced the cart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f7c7689fc5f7726dc012204c027b37c82f3d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->