### PR TITLE
CHECKOUT-10346: Clarify spam protection is not gated on the merchant reCAPTCHA setting

### DIFF
--- a/packages/core/src/checkout/checkout.ts
+++ b/packages/core/src/checkout/checkout.ts
@@ -29,7 +29,15 @@ export default interface Checkout {
      * Whether the current checkout must execute spam protection
      * before placing the order.
      *
-     * Note: You need to enable Google ReCAPTCHA bot protection in your Checkout Settings.
+     * Note: **this can be `true` even when the store has no reCAPTCHA
+     * configured.** Spam protection is not limited to stores that enable
+     * Google reCAPTCHA in Checkout Settings — after repeated order creation
+     * attempts on a cart, BigCommerce requires a challenge using its own
+     * reCAPTCHA site key, served to you as
+     * `checkoutSettings.googleRecaptchaSitekey`. Always render the challenge
+     * when this flag is `true` by calling `CheckoutService#executeSpamCheck`;
+     * otherwise order creation fails with a 429 and a `spam_protection_failed`
+     * error.
      */
     shouldExecuteSpamCheck: boolean;
     handlingCostTotal: number;


### PR DESCRIPTION
Jira: [CHECKOUT-10346](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10346)

## What/Why?

The JSDoc on `Checkout#shouldExecuteSpamCheck` claimed reCAPTCHA must be enabled in Checkout Settings for spam protection to apply. It doesn't: BCApp's `CheckoutReCaptchaClient::canExecuteSpamCheck()` only exempts a cart while the setting is off **and** the cart is under 10 order attempts in 24h. Past that, every store gets a challenge using BigCommerce's own site key.

A merchant on a forked checkout-js read this note, skipped the challenge, and their shoppers hit `429 spam_protection_failed` with no way to recover the cart.

Single file on purpose: this is the source typedoc reads to generate `docs/interfaces/Checkout.md`. `docs/` and `dist/` are regenerated by the release job.

## Rollout/Rollback

Doc-only, no runtime impact. Rollback is a revert.

## Testing

`npx prettier --check` passes. Nothing to test — worth checking the wording against the BCApp logic above.

Refs CHECKOUT-10346

[CHECKOUT-10346]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only change with no runtime impact; reduces risk of incorrect forked-checkout integrations that skip spam checks.
> 
> **Overview**
> **Documentation-only** update to the JSDoc on `Checkout#shouldExecuteSpamCheck` in `checkout.ts` (source for generated typedoc).
> 
> The note no longer implies spam protection only runs when Google reCAPTCHA is enabled in Checkout Settings. It now states the flag **can be true without merchant reCAPTCHA**, that BigCommerce may require a challenge after repeated order attempts using `checkoutSettings.googleRecaptchaSitekey`, and that integrators must call **`CheckoutService#executeSpamCheck`** when the flag is true to avoid **429** / **`spam_protection_failed`**.
> 
> No runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7168d1b854d542e93103e0b8e3ab823b9ecb1e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->