### PR TITLE
fix(checkout): CHECKOUT-10379 Export enums explicitly

### DIFF
--- a/packages/core/src/bundles/checkout-sdk.ts
+++ b/packages/core/src/bundles/checkout-sdk.ts
@@ -19,4 +19,11 @@ export type {
     CompanyAddressSearchOptions,
     CompanyAddressSearchResult,
 } from '../company';
-export { ExtensionCommandType, ExtensionQueryType, type ExtensionQueryMap } from '../extension';
+export {
+    ExtensionCommandType,
+    ExtensionMessageType,
+    ExtensionQueryType,
+    ExtensionRegion,
+    ExtensionType,
+    type ExtensionQueryMap,
+} from '../extension';

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -1,4 +1,4 @@
-export { ExtensionRegion, type Extension } from './extension';
+export { ExtensionRegion, ExtensionType, type Extension } from './extension';
 export { getExtensions } from './extension.mock';
 export { ExtensionActionType } from './extension-actions';
 export { ExtensionActionCreator } from './extension-action-creator';


### PR DESCRIPTION
## What/Why?

I tried bumping checkout-js to the latest version and it breaks our stores:

<img width="1494" height="821" alt="Screenshot 2026-09-02 at 5 16 38 PM" src="https://github.com/user-attachments/assets/df92ccb1-d9b5-4c80-8d13-c669ffadace7" />

I think this is because we changed `const enum` to plain `enum` which now became a real JS object which checkout-js looks up at runtime, so we need to explicitly export them. We also need to thing how to catch issues like these earlier, but maybe as a separate pr.

## Rollout/Rollback

Revert.

## Testing

Ran this version through npm link and looks ok now:

<img width="1494" height="821" alt="Screenshot 2026-09-02 at 5 29 15 PM" src="https://github.com/user-attachments/assets/30a24b07-9bdc-4834-bf78-352073057941" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public API surface expansion only; no logic changes, with low risk aside from ensuring the listed enums remain stable for linked checkout-js consumers.
> 
> **Overview**
> **Fixes checkout-js breakage** after extension symbols moved from `const enum` to runtime `enum` objects that downstream code imports from the public SDK bundle.
> 
> The **checkout-sdk** entry now re-exports `ExtensionMessageType`, `ExtensionRegion`, and `ExtensionType` alongside the existing extension command/query exports. The extension module barrel also exports **`ExtensionType`** from `./extension` so it can flow through that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407bf521923bdd4dff84c2a34a0a8f55f59836be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->