### PR TITLE
fix(payment): PAYPAL-7021 removed logger to avoid error spamming

### DIFF
--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.spec.ts
@@ -8,6 +8,8 @@ import {
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
     PaymentIntegrationService,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
@@ -221,6 +223,22 @@ describe('BraintreeFastlaneCustomerStrategy', () => {
             ).resolves.toBeUndefined();
 
             expect(onErrorLog).toHaveBeenCalledWith(error);
+        });
+
+        it('does not log the error via onErrorLog when clientToken not defined', async () => {
+            const error = new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            const onErrorLog = jest.fn();
+
+            jest.spyOn(
+                braintreeFastlaneUtils,
+                'initializeBraintreeFastlaneOrThrow',
+            ).mockRejectedValue(error);
+
+            await expect(
+                strategy.initialize({ ...initializationOptions, onErrorLog }),
+            ).resolves.toBeUndefined();
+
+            expect(onErrorLog).not.toHaveBeenCalled();
         });
 
         it('does not call onErrorLog when Fastlane initialization succeeds', async () => {

--- a/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-fastlane/braintree-fastlane-customer-strategy.ts
@@ -8,6 +8,8 @@ import {
     CustomerStrategy,
     ExecutePaymentMethodCheckoutOptions,
     InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
     PaymentIntegrationService,
     PaymentMethod,
     RequestOptions,
@@ -62,7 +64,13 @@ export default class BraintreeFastlaneCustomerStrategy implements CustomerStrate
             }
         } catch (error) {
             // Info: Do not throw anything here to avoid blocking customer from passing checkout flow
-            this.handleErrorLog(error);
+            const isMissingPaymentMethodError =
+                error instanceof MissingDataError &&
+                error.subtype === MissingDataErrorType.MissingPaymentMethod;
+
+            if (!isMissingPaymentMethodError) {
+                this.handleErrorLog(error);
+            }
         }
 
         return Promise.resolve();


### PR DESCRIPTION
## What/Why?
Removed logger to avoid `MissingDataError` error spamming

## Rollout/Rollback
Revert

## Testing
Unit test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to error-logging behavior during optional Fastlane init; checkout flow and logging for other errors are unchanged.
> 
> **Overview**
> **Braintree Fastlane customer `initialize`** still swallows Fastlane init failures so checkout can continue, but it no longer forwards **`MissingDataError` / `MissingPaymentMethod`** (e.g. when no client token is available) to the optional **`onErrorLog`** callback. Other initialization errors are still logged the same way.
> 
> A unit test asserts that **`onErrorLog` is not invoked** when Fastlane init rejects with that missing-payment-method error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc72a222a52accdeb9111414331cbfd40d82e407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->