### PR TITLE
feat(payment): PI-4870 [FE] Remove experiment PI-4789.afterpay_script_use_https

### DIFF
--- a/packages/afterpay-integration/src/afterpay-payment-strategy.spec.ts
+++ b/packages/afterpay-integration/src/afterpay-payment-strategy.spec.ts
@@ -32,7 +32,6 @@ describe('AfterpayPaymentStrategy', () => {
     let scriptLoader: AfterpayScriptLoader;
     let strategy: AfterpayPaymentStrategy;
     const storeConfig = getConfig().storeConfig;
-    const withHttpsExperimentName = 'PI-4789.afterpay_script_use_https';
 
     const afterpaySdk = {
         initialize: jest.fn(),
@@ -70,16 +69,9 @@ describe('AfterpayPaymentStrategy', () => {
             paymentMethod,
         );
 
-        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfigOrThrow').mockReturnValue({
-            ...storeConfig,
-            checkoutSettings: {
-                ...storeConfig.checkoutSettings,
-                features: {
-                    ...storeConfig.checkoutSettings.features,
-                    [withHttpsExperimentName]: true,
-                },
-            },
-        });
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfigOrThrow').mockReturnValue(
+            storeConfig,
+        );
     });
 
     afterEach(() => {
@@ -106,30 +98,7 @@ describe('AfterpayPaymentStrategy', () => {
                 gatewayId: paymentMethod.gateway,
             });
 
-            expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod, 'US', true);
-        });
-
-        it('loads script when initializing strategy with NO https', async () => {
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getStoreConfigOrThrow',
-            ).mockReturnValue({
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        ...storeConfig.checkoutSettings.features,
-                        [withHttpsExperimentName]: false,
-                    },
-                },
-            });
-
-            await strategy.initialize({
-                methodId: paymentMethod.id,
-                gatewayId: paymentMethod.gateway,
-            });
-
-            expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod, 'US', false);
+            expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod, 'US');
         });
 
         it('loads script when initializing strategy with NZD', async () => {
@@ -143,7 +112,7 @@ describe('AfterpayPaymentStrategy', () => {
                 gatewayId: paymentMethod.gateway,
             });
 
-            expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod, 'NZ', true);
+            expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod, 'NZ');
         });
     });
 

--- a/packages/afterpay-integration/src/afterpay-payment-strategy.ts
+++ b/packages/afterpay-integration/src/afterpay-payment-strategy.ts
@@ -17,7 +17,6 @@ import {
     RequestError,
     RequestOptions,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { isExperimentEnabled } from '@bigcommerce/checkout-sdk/utility';
 
 import AfterpayScriptLoader from './afterpay-script-loader';
 import AfterpaySdk from './afterpay-sdk';
@@ -35,19 +34,12 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
         const paymentMethod = state.getPaymentMethod(options.methodId, options.gatewayId);
         const currencyCode = state.getCart()?.currency.code || '';
         const countryCode = this._mapCurrencyToISO2(currencyCode);
-        const features = state.getStoreConfigOrThrow().checkoutSettings.features;
-        const withHttpsExperimentName = 'PI-4789.afterpay_script_use_https';
-        const withHttps = isExperimentEnabled(features, withHttpsExperimentName, false);
 
         if (!paymentMethod) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        this._afterpaySdk = await this._afterpayScriptLoader.load(
-            paymentMethod,
-            countryCode,
-            withHttps,
-        );
+        this._afterpaySdk = await this._afterpayScriptLoader.load(paymentMethod, countryCode);
     }
 
     deinitialize(): Promise<void> {

--- a/packages/afterpay-integration/src/afterpay-script-loader.spec.ts
+++ b/packages/afterpay-integration/src/afterpay-script-loader.spec.ts
@@ -25,98 +25,46 @@ describe('AfterpayScriptLoader', () => {
         await afterpayScriptLoader.load(method, 'AU');
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            '//portal.afterpay.com/afterpay-async.js',
+            'https://portal.afterpay.com/afterpay-async.js',
         );
 
-        await afterpayScriptLoader.load(method, 'NZ', false);
+        await afterpayScriptLoader.load(method, 'NZ');
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            '//portal.afterpay.com/afterpay-async.js',
+            'https://portal.afterpay.com/afterpay-async.js',
         );
     });
 
     it('loads sandbox widget script if in test mode for AU & NZ', async () => {
         const method = merge({}, getAfterpay(), { config: { testMode: true } });
 
-        await afterpayScriptLoader.load(method, 'AU', false);
+        await afterpayScriptLoader.load(method, 'AU');
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            '//portal.sandbox.afterpay.com/afterpay.js',
+            'https://portal.sandbox.afterpay.com/afterpay.js',
         );
 
         await afterpayScriptLoader.load(method, 'NZ');
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            '//portal.sandbox.afterpay.com/afterpay.js',
+            'https://portal.sandbox.afterpay.com/afterpay.js',
         );
     });
 
     it('loads widget script for US', async () => {
         const method = getAfterpay();
 
-        await afterpayScriptLoader.load(method, 'US', false);
+        await afterpayScriptLoader.load(method, 'US');
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            '//portal.afterpay.com/afterpay-async.js',
+            'https://portal.afterpay.com/afterpay-async.js',
         );
     });
 
     it('loads sandbox widget script if in test mode for US', async () => {
         const method = merge({}, getAfterpay(), { config: { testMode: true } });
 
-        await afterpayScriptLoader.load(method, 'US', false);
-
-        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            '//portal.sandbox.afterpay.com/afterpay.js',
-        );
-    });
-
-    it('loads widget script with HTTPS for AU & NZ', async () => {
-        const method = getAfterpay();
-
-        await afterpayScriptLoader.load(method, 'AU', true);
-
-        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            'https://portal.afterpay.com/afterpay-async.js',
-        );
-
-        await afterpayScriptLoader.load(method, 'NZ');
-
-        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            'https://portal.afterpay.com/afterpay-async.js',
-        );
-    });
-
-    it('loads sandbox widget script with HTTPS if in test mode for AU & NZ', async () => {
-        const method = merge({}, getAfterpay(), { config: { testMode: true } });
-
-        await afterpayScriptLoader.load(method, 'AU', true);
-
-        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            'https://portal.sandbox.afterpay.com/afterpay.js',
-        );
-
-        await afterpayScriptLoader.load(method, 'NZ');
-
-        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            'https://portal.sandbox.afterpay.com/afterpay.js',
-        );
-    });
-
-    it('loads widget script with HTTPS for US', async () => {
-        const method = getAfterpay();
-
-        await afterpayScriptLoader.load(method, 'US', true);
-
-        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            'https://portal.afterpay.com/afterpay-async.js',
-        );
-    });
-
-    it('loads sandbox widget script with HTTPS if in test mode for US', async () => {
-        const method = merge({}, getAfterpay(), { config: { testMode: true } });
-
-        await afterpayScriptLoader.load(method, 'US', true);
+        await afterpayScriptLoader.load(method, 'US');
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
             'https://portal.sandbox.afterpay.com/afterpay.js',

--- a/packages/afterpay-integration/src/afterpay-script-loader.ts
+++ b/packages/afterpay-integration/src/afterpay-script-loader.ts
@@ -9,17 +9,13 @@ import AfterpaySdk from './afterpay-sdk';
 import isAfterpayWindow from './is-afterpay-window';
 
 enum SCRIPTS_DEFAULT {
-    PROD = '//portal.afterpay.com/afterpay-async.js',
-    SANDBOX = '//portal.sandbox.afterpay.com/afterpay.js',
-    HTTPS_PROD = 'https://portal.afterpay.com/afterpay-async.js',
-    HTTPS_SANDBOX = 'https://portal.sandbox.afterpay.com/afterpay.js',
+    PROD = 'https://portal.afterpay.com/afterpay-async.js',
+    SANDBOX = 'https://portal.sandbox.afterpay.com/afterpay.js',
 }
 
 enum SCRIPTS_US {
-    PROD = '//portal.afterpay.com/afterpay-async.js',
-    SANDBOX = '//portal.sandbox.afterpay.com/afterpay.js',
-    HTTPS_PROD = 'https://portal.afterpay.com/afterpay-async.js',
-    HTTPS_SANDBOX = 'https://portal.sandbox.afterpay.com/afterpay.js',
+    PROD = 'https://portal.afterpay.com/afterpay-async.js',
+    SANDBOX = 'https://portal.sandbox.afterpay.com/afterpay.js',
 }
 
 /** Class responsible for loading the Afterpay SDK */
@@ -31,13 +27,9 @@ export default class AfterpayScriptLoader {
      *
      * @param {PaymentMethod} method the payment method data
      */
-    async load(
-        method: PaymentMethod,
-        countryCode: string,
-        withHttps = false,
-    ): Promise<AfterpaySdk> {
+    async load(method: PaymentMethod, countryCode: string): Promise<AfterpaySdk> {
         const testMode = method.config.testMode || false;
-        const scriptURI = this._getScriptURI(countryCode, testMode, withHttps);
+        const scriptURI = this._getScriptURI(countryCode, testMode);
 
         return this._scriptLoader.loadScript(scriptURI).then(() => {
             if (!isAfterpayWindow(window)) {
@@ -48,17 +40,9 @@ export default class AfterpayScriptLoader {
         });
     }
 
-    private _getScriptURI(countryCode: string, testMode: boolean, withHttps = false): string {
+    private _getScriptURI(countryCode: string, testMode: boolean): string {
         if (countryCode === 'US') {
-            if (withHttps) {
-                return testMode ? SCRIPTS_US.HTTPS_SANDBOX : SCRIPTS_US.HTTPS_PROD;
-            }
-
             return testMode ? SCRIPTS_US.SANDBOX : SCRIPTS_US.PROD;
-        }
-
-        if (withHttps) {
-            return testMode ? SCRIPTS_DEFAULT.HTTPS_SANDBOX : SCRIPTS_DEFAULT.HTTPS_PROD;
         }
 
         return testMode ? SCRIPTS_DEFAULT.SANDBOX : SCRIPTS_DEFAULT.PROD;


### PR DESCRIPTION
…

## What/Why?

remove experiment PI-4789.afterpay_script_use_https

## Rollout/Rollback

rollback this commit 

## Testing

<img width="1495" height="396" alt="image" src="https://github.com/user-attachments/assets/a1b4a10a-3f2c-41fc-aecb-028483c8af5f" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Afterpay script URL is loaded at checkout initialization; behavior is standardized to HTTPS rather than altering payment submission or redirect logic.
> 
> **Overview**
> Removes the **`PI-4789.afterpay_script_use_https`** feature flag and makes Afterpay SDK loading always use **HTTPS** script URLs.
> 
> `AfterpayPaymentStrategy` no longer reads checkout experiment features or passes a `withHttps` flag into the script loader. `AfterpayScriptLoader` drops the third `withHttps` argument and the duplicate `HTTPS_*` enum entries; prod and sandbox URLs are now always `https://portal…` (and US sandbox), instead of protocol-relative `//` URLs when the experiment was off.
> 
> Specs are updated to mock plain store config, expect `load(paymentMethod, countryCode)` only, and assert HTTPS URLs in all cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831bef0047b5dd10f8479549c5b96871aeb4ab06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->