### PR TITLE
feat(payment): PI-5218 [FE] [FE] Remove experiment PI-5111.google_pay_direct_pay_on_click

### DIFF
--- a/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.spec.ts
@@ -302,6 +302,8 @@ describe('GooglePayPaymentStrategy', () => {
 
             jest.spyOn(processor, 'initialize').mockImplementation(() => {
                 callOrder.push('initialize');
+
+                return Promise.resolve();
             });
 
             await strategy.initialize(options);
@@ -755,32 +757,16 @@ describe('GooglePayPaymentStrategy', () => {
             });
         });
 
-        describe('when PI-5111.google_pay_direct_pay_on_click is enabled', () => {
-            const directPayStoreConfig = {
-                ...storeConfig,
-                checkoutSettings: {
-                    ...storeConfig.checkoutSettings,
-                    features: {
-                        ...storeConfig.checkoutSettings.features,
-                        'PI-5111.google_pay_direct_pay_on_click': true,
-                    },
-                },
-            };
-
-            let interactWithPaymentSheetSpy: jest.SpyInstance;
+        describe('direct pay on click', () => {
             let completeCheckoutFlowSpy: jest.SpyInstance;
 
             beforeEach(async () => {
                 jest.spyOn(
                     paymentIntegrationService.getState(),
                     'getStoreConfigOrThrow',
-                ).mockReturnValue(directPayStoreConfig);
+                ).mockReturnValue(storeConfig);
 
                 jest.spyOn(processor, 'mapToBillingAddressRequestBody').mockReturnValue(undefined);
-
-                interactWithPaymentSheetSpy = jest
-                    .spyOn(Object.getPrototypeOf(strategy), '_interactWithPaymentSheet')
-                    .mockResolvedValue(undefined);
 
                 completeCheckoutFlowSpy = jest
                     .spyOn(Object.getPrototypeOf(strategy), '_completeCheckoutFlow')
@@ -790,7 +776,6 @@ describe('GooglePayPaymentStrategy', () => {
             });
 
             afterEach(() => {
-                interactWithPaymentSheetSpy.mockRestore();
                 completeCheckoutFlowSpy.mockRestore();
             });
 
@@ -891,7 +876,6 @@ describe('GooglePayPaymentStrategy', () => {
                         ...storeConfig.checkoutSettings,
                         features: {
                             ...storeConfig.checkoutSettings.features,
-                            'PI-5111.google_pay_direct_pay_on_click': true,
                             'PI-5031.google_pay_dont_override_address': false,
                         },
                     },
@@ -924,7 +908,6 @@ describe('GooglePayPaymentStrategy', () => {
                         ...storeConfig.checkoutSettings,
                         features: {
                             ...storeConfig.checkoutSettings.features,
-                            'PI-5111.google_pay_direct_pay_on_click': true,
                             'PI-5031.google_pay_dont_override_address': true,
                         },
                     },
@@ -1096,7 +1079,7 @@ describe('GooglePayPaymentStrategy', () => {
                 completeCheckoutFlowSpy.mockRestore();
             });
 
-            it('should run direct pay flow via _interactWithPaymentSheetAndPay without PI-5111 experiment', async () => {
+            it('should run direct pay flow via _interactWithPaymentSheetAndPay', async () => {
                 const executeSpy = jest.spyOn(strategy, 'execute');
 
                 brandedButton.click();

--- a/packages/google-pay-integration/src/google-pay-payment-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-strategy.ts
@@ -230,11 +230,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 this._googlePayPaymentProcessor.setShouldRequestShipping(false);
                 await this._googlePayPaymentProcessor.initializeWidget();
 
-                if (this._isDirectPayOnClickEnabled()) {
-                    await this._interactWithPaymentSheetAndPay();
-                } else {
-                    await this._interactWithPaymentSheet();
-                }
+                await this._interactWithPaymentSheetAndPay();
             });
 
             onPaymentSelect?.();
@@ -286,33 +282,6 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
     protected _completeCheckoutFlow(): void {
         window.location.replace('/checkout/order-confirmation');
-        this._toggleLoadingIndicator(false);
-        this._toggleBlockDeinitialization(false);
-    }
-
-    protected async _interactWithPaymentSheet(): Promise<void> {
-        const response = await this._googlePayPaymentProcessor.showPaymentSheet();
-        const state = this._paymentIntegrationService.getState();
-        const { features } = state.getStoreConfigOrThrow().checkoutSettings;
-        const isGooglePayDontOverrideAddresssExperimentOn = isExperimentEnabled(
-            features,
-            'PI-5031.google_pay_dont_override_address',
-        );
-
-        this._toggleBlockDeinitialization(true);
-        this._toggleLoadingIndicator(true);
-
-        const billingAddress =
-            this._googlePayPaymentProcessor.mapToBillingAddressRequestBody(response);
-
-        if (billingAddress && !isGooglePayDontOverrideAddresssExperimentOn) {
-            await this._paymentIntegrationService.updateBillingAddress(billingAddress);
-        }
-
-        await this._googlePayPaymentProcessor.setExternalCheckoutXhr(this._getMethodId(), response);
-
-        await this._paymentIntegrationService.loadCheckout();
-        await this._paymentIntegrationService.loadPaymentMethod(this._getMethodId());
         this._toggleLoadingIndicator(false);
         this._toggleBlockDeinitialization(false);
     }
@@ -455,14 +424,6 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         } finally {
             this._toggleBlockDeinitialization(false);
         }
-    }
-
-    private _isDirectPayOnClickEnabled(): boolean {
-        const { features } = this._paymentIntegrationService
-            .getState()
-            .getStoreConfigOrThrow().checkoutSettings;
-
-        return isExperimentEnabled(features, 'PI-5111.google_pay_direct_pay_on_click');
     }
 
     private _toggleBlockDeinitialization(isBlocked: boolean) {


### PR DESCRIPTION
…

## What/Why?

Remove experiment PI-5111.google_pay_direct_pay_on_click, after all the tickets will be done in this project PROJECT-7945: GooglePay: Remove Sign In Button and Streamline the Flow
Closed
 
## Rollout/Rollback
rollback this commit
## Testing
<img width="2311" height="1069" alt="image" src="https://github.com/user-attachments/assets/5ccd5e4f-0406-4229-81bf-df648d2ceb6a" />

https://github.com/user-attachments/assets/d732416b-b30e-40a1-8fc3-1c6185c0e2a4




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Google Pay wallet-button checkout behavior for any store that still had the experiment off, by removing the non–direct-pay path; payment submission and redirect logic are otherwise unchanged.
> 
> **Overview**
> Removes feature flag **`PI-5111.google_pay_direct_pay_on_click`** and makes the **direct pay on click** path the only wallet-button behavior.
> 
> On Google Pay wallet button click, the strategy always runs **`_interactWithPaymentSheetAndPay()`** (show sheet → optional billing update per **`PI-5031`** → external checkout → reload payment method → **`execute`** → order confirmation). The legacy **`_interactWithPaymentSheet()`** flow (sheet + **`loadCheckout`** without completing payment on click) and **`_isDirectPayOnClickEnabled()`** are deleted.
> 
> Tests are aligned: the “direct pay on click” suite no longer toggles the PI-5111 flag, and a small mock fix returns **`Promise.resolve()`** from **`processor.initialize`** in a call-order test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c7ecc924b602471e2ec887784a67b193de62e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->