### PR TITLE
feat(provider): STRIPE-1555 report order placement start event for all orders (with correct Stripe OCS payment method)

### DIFF
--- a/packages/core/src/checkout/checkout-action-creator.spec.ts
+++ b/packages/core/src/checkout/checkout-action-creator.spec.ts
@@ -50,6 +50,10 @@ describe('CheckoutActionCreator', () => {
             Promise.resolve(getResponse(getCheckout())),
         );
 
+        jest.spyOn(checkoutRequestSender, 'reportCheckoutEvent').mockReturnValue(
+            Promise.resolve(getResponse(undefined)),
+        );
+
         configActionCreator = new ConfigActionCreator(configRequestSender);
 
         jest.spyOn(configActionCreator, 'loadConfig');
@@ -283,6 +287,65 @@ describe('CheckoutActionCreator', () => {
                     payload: getErrorResponse(),
                 },
             ]);
+        });
+    });
+
+    describe('#reportCheckoutEvent', () => {
+        it('calls checkout request sender with the current checkout id', async () => {
+            await from(
+                actionCreator.reportCheckoutEvent({ event: 'order_placement_started' })(store),
+            )
+                .pipe(toArray())
+                .toPromise();
+
+            expect(checkoutRequestSender.reportCheckoutEvent).toHaveBeenCalledWith(
+                'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                { event: 'order_placement_started' },
+                undefined,
+            );
+        });
+
+        it('emits action to notify reporting progress', async () => {
+            const actions = await from(
+                actionCreator.reportCheckoutEvent({ event: 'order_placement_started' })(store),
+            )
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: CheckoutActionType.ReportCheckoutEventRequested },
+                { type: CheckoutActionType.ReportCheckoutEventSucceeded },
+            ]);
+        });
+
+        it('emits a failed action but does not throw if the request fails', async () => {
+            jest.spyOn(checkoutRequestSender, 'reportCheckoutEvent').mockReturnValue(
+                Promise.reject(getErrorResponse()),
+            );
+
+            const actions = await from(
+                actionCreator.reportCheckoutEvent({ event: 'order_placement_started' })(store),
+            )
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: CheckoutActionType.ReportCheckoutEventRequested },
+                { type: CheckoutActionType.ReportCheckoutEventFailed },
+            ]);
+        });
+
+        it('completes without emitting an action if there is no current checkout', async () => {
+            store = createCheckoutStore();
+
+            const actions = await from(
+                actionCreator.reportCheckoutEvent({ event: 'order_placement_started' })(store),
+            )
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([]);
+            expect(checkoutRequestSender.reportCheckoutEvent).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/core/src/checkout/checkout-action-creator.ts
+++ b/packages/core/src/checkout/checkout-action-creator.ts
@@ -8,11 +8,12 @@ import { RequestOptions } from '../common/http-request';
 import { ConfigActionCreator } from '../config';
 import { FormFieldsActionCreator } from '../form';
 
-import Checkout, { CheckoutRequestBody } from './checkout';
+import Checkout, { CheckoutEventRequestBody, CheckoutRequestBody } from './checkout';
 import {
     CheckoutActionType,
     DeleteCheckoutAction,
     LoadCheckoutAction,
+    ReportCheckoutEventAction,
     UpdateCheckoutAction,
 } from './checkout-actions';
 import { withCapabilityIncludes } from './checkout-capability-includes';
@@ -160,6 +161,38 @@ export default class CheckoutActionCreator {
                         observer.error(
                             createErrorAction(CheckoutActionType.DeleteCheckoutFailed, response),
                         );
+                    });
+            });
+    }
+
+    reportCheckoutEvent(
+        body: CheckoutEventRequestBody,
+        options?: RequestOptions,
+    ): ThunkAction<ReportCheckoutEventAction, InternalCheckoutSelectors> {
+        return (store) =>
+            new Observable((observer) => {
+                const state = store.getState();
+                const checkout = state.checkout.getCheckout();
+
+                if (!checkout) {
+                    observer.complete();
+
+                    return;
+                }
+
+                observer.next(createAction(CheckoutActionType.ReportCheckoutEventRequested));
+
+                this._checkoutRequestSender
+                    .reportCheckoutEvent(checkout.id, body, options)
+                    .then(() => {
+                        observer.next(
+                            createAction(CheckoutActionType.ReportCheckoutEventSucceeded),
+                        );
+                        observer.complete();
+                    })
+                    .catch(() => {
+                        observer.next(createAction(CheckoutActionType.ReportCheckoutEventFailed));
+                        observer.complete();
                     });
             });
     }

--- a/packages/core/src/checkout/checkout-actions.ts
+++ b/packages/core/src/checkout/checkout-actions.ts
@@ -17,9 +17,17 @@ export enum CheckoutActionType {
     DeleteCheckoutRequested = 'DELETE_CHECKOUT_REQUESTED',
     DeleteCheckoutSucceeded = 'DELETE_CHECKOUT_SUCCEEDED',
     DeleteCheckoutFailed = 'DELETE_CHECKOUT_FAILED',
+
+    ReportCheckoutEventRequested = 'REPORT_CHECKOUT_EVENT_REQUESTED',
+    ReportCheckoutEventSucceeded = 'REPORT_CHECKOUT_EVENT_SUCCEEDED',
+    ReportCheckoutEventFailed = 'REPORT_CHECKOUT_EVENT_FAILED',
 }
 
-export type CheckoutAction = LoadCheckoutAction | UpdateCheckoutAction | DeleteCheckoutAction;
+export type CheckoutAction =
+    | LoadCheckoutAction
+    | UpdateCheckoutAction
+    | DeleteCheckoutAction
+    | ReportCheckoutEventAction;
 
 export type LoadCheckoutAction =
     | LoadCheckoutRequestedAction
@@ -37,6 +45,11 @@ export type DeleteCheckoutAction =
     | DeleteCheckoutRequestedAction
     | DeleteCheckoutSucceededAction
     | DeleteCheckoutFailedAction;
+
+export type ReportCheckoutEventAction =
+    | ReportCheckoutEventRequestedAction
+    | ReportCheckoutEventSucceededAction
+    | ReportCheckoutEventFailedAction;
 
 export interface LoadCheckoutRequestedAction extends Action {
     type: CheckoutActionType.LoadCheckoutRequested;
@@ -72,4 +85,16 @@ export interface DeleteCheckoutSucceededAction extends Action {
 
 export interface DeleteCheckoutFailedAction extends Action<Error> {
     type: CheckoutActionType.DeleteCheckoutFailed;
+}
+
+export interface ReportCheckoutEventRequestedAction extends Action {
+    type: CheckoutActionType.ReportCheckoutEventRequested;
+}
+
+export interface ReportCheckoutEventSucceededAction extends Action {
+    type: CheckoutActionType.ReportCheckoutEventSucceeded;
+}
+
+export interface ReportCheckoutEventFailedAction extends Action {
+    type: CheckoutActionType.ReportCheckoutEventFailed;
 }

--- a/packages/core/src/checkout/checkout-request-sender.spec.ts
+++ b/packages/core/src/checkout/checkout-request-sender.spec.ts
@@ -169,4 +169,42 @@ describe('CheckoutRequestSender', () => {
             ).rejects.toThrow(EmptyCartError);
         });
     });
+
+    describe('reportCheckoutEvent', () => {
+        beforeEach(() => {
+            jest.spyOn(requestSender, 'post').mockResolvedValue(getResponse(undefined));
+        });
+
+        it('sends expected params to requestSender', async () => {
+            await checkoutRequestSender.reportCheckoutEvent(
+                '6cb62bfc-c92d-45f5-869b-d3d9681a58d4',
+                { event: 'order_placement_started' },
+            );
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                '/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4/event',
+                {
+                    body: { event: 'order_placement_started' },
+                    headers: {
+                        Accept: ContentType.JsonV1,
+                        ...SDK_VERSION_HEADERS,
+                    },
+                    timeout: undefined,
+                },
+            );
+        });
+
+        it('returns the response of the requestSender', async () => {
+            const eventResponse = getResponse(undefined);
+
+            jest.spyOn(requestSender, 'post').mockResolvedValue(eventResponse);
+
+            expect(
+                await checkoutRequestSender.reportCheckoutEvent(
+                    '6cb62bfc-c92d-45f5-869b-d3d9681a58d4',
+                    { event: 'order_placement_started' },
+                ),
+            ).toEqual(eventResponse);
+        });
+    });
 });

--- a/packages/core/src/checkout/checkout-request-sender.ts
+++ b/packages/core/src/checkout/checkout-request-sender.ts
@@ -8,7 +8,7 @@ import {
     SDK_VERSION_HEADERS,
 } from '../common/http-request';
 
-import Checkout, { CheckoutRequestBody } from './checkout';
+import Checkout, { CheckoutEventRequestBody, CheckoutRequestBody } from './checkout';
 import CHECKOUT_DEFAULT_INCLUDES from './checkout-default-includes';
 import CheckoutParams from './checkout-params';
 import { CheckoutNotAvailableError } from './errors';
@@ -80,5 +80,19 @@ export default class CheckoutRequestSender {
         };
 
         return this._requestSender.delete<void>(url, { headers, timeout });
+    }
+
+    reportCheckoutEvent(
+        id: string,
+        body: CheckoutEventRequestBody,
+        { timeout }: RequestOptions = {},
+    ): Promise<Response<void>> {
+        const url = `/api/storefront/checkout/${id}/event`;
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
+
+        return this._requestSender.post<void>(url, { body, headers, timeout });
     }
 }

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -121,6 +121,7 @@ import { StoreCreditActionCreator, StoreCreditRequestSender } from '../store-cre
 import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subscription';
 
 import CheckoutActionCreator from './checkout-action-creator';
+import { CheckoutActionType } from './checkout-actions';
 import CheckoutInitialState from './checkout-initial-state';
 import CheckoutRequestSender from './checkout-request-sender';
 import CheckoutSelectors from './checkout-selectors';
@@ -324,6 +325,9 @@ describe('CheckoutService', () => {
         jest.spyOn(checkoutRequestSender, 'updateCheckout').mockResolvedValue(
             getResponse(getCheckout()),
         );
+        jest.spyOn(checkoutRequestSender, 'reportCheckoutEvent').mockResolvedValue(
+            getResponse(undefined),
+        );
 
         couponRequestSender = new CouponRequestSender(requestSender);
 
@@ -449,6 +453,8 @@ describe('CheckoutService', () => {
             orderActionCreator,
             spamProtectionActionCreator,
             paymentIntegrationService,
+            store,
+            checkoutActionCreator,
         );
 
         shippingStrategyActionCreator = new ShippingStrategyActionCreator(
@@ -638,6 +644,39 @@ describe('CheckoutService', () => {
             const state = await checkoutService.loadCheckout();
 
             expect(state.data.getCheckout()).toEqual(store.getState().checkout.getCheckout());
+        });
+    });
+
+    describe('#reportCheckoutEvent()', () => {
+        const body = { event: 'order_placement_started' };
+
+        beforeEach(() => {
+            jest.spyOn(checkoutActionCreator, 'reportCheckoutEvent');
+        });
+
+        it('calls reportCheckoutEvent action creator with the given body', () => {
+            checkoutService.reportCheckoutEvent(body);
+
+            expect(checkoutActionCreator.reportCheckoutEvent).toHaveBeenCalledWith(body, undefined);
+        });
+
+        it('dispatches on its own queue so it never blocks other checkout actions', () => {
+            const action = () => of(createAction(CheckoutActionType.ReportCheckoutEventRequested));
+
+            jest.spyOn(checkoutActionCreator, 'reportCheckoutEvent').mockReturnValue(action);
+            jest.spyOn(store, 'dispatch');
+
+            checkoutService.reportCheckoutEvent(body);
+
+            expect(store.dispatch).toHaveBeenCalledWith(action, {
+                queueId: 'reportCheckoutEvent',
+            });
+        });
+
+        it('returns a promise that resolves to the current state', async () => {
+            const state = await checkoutService.reportCheckoutEvent(body);
+
+            expect(state).toEqual(checkoutService.getState());
         });
     });
 

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -68,7 +68,7 @@ import { SpamProtectionActionCreator, SpamProtectionOptions } from '../spam-prot
 import { StoreCreditActionCreator } from '../store-credit';
 import { Subscriptions, SubscriptionsActionCreator } from '../subscription';
 
-import { CheckoutRequestBody } from './checkout';
+import { CheckoutEventRequestBody, CheckoutRequestBody } from './checkout';
 import CheckoutActionCreator from './checkout-action-creator';
 import CheckoutInitialState from './checkout-initial-state';
 import CheckoutParams from './checkout-params';
@@ -284,6 +284,15 @@ export default class CheckoutService {
         const action = this._checkoutActionCreator.deleteCheckout(options);
 
         return this._dispatch(action);
+    }
+
+    reportCheckoutEvent(
+        body: CheckoutEventRequestBody,
+        options?: RequestOptions,
+    ): Promise<CheckoutSelectors> {
+        const action = this._checkoutActionCreator.reportCheckoutEvent(body, options);
+
+        return this._dispatch(action, { queueId: 'reportCheckoutEvent' });
     }
 
     /**

--- a/packages/core/src/checkout/checkout.ts
+++ b/packages/core/src/checkout/checkout.ts
@@ -64,6 +64,12 @@ export interface CheckoutRequestBody {
     customerMessage: string;
 }
 
+export interface CheckoutEventRequestBody {
+    event: string;
+    payment_provider_id?: string;
+    payment_method_id?: string;
+}
+
 export interface CheckoutPayment {
     detail: {
         step: string;

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -224,6 +224,8 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
             orderActionCreator,
             spamProtectionActionCreator,
             paymentIntegrationService,
+            store,
+            checkoutActionCreator,
         ),
         new PickupOptionActionCreator(new PickupOptionRequestSender(experimentRequestSender)),
         new ShippingCountryActionCreator(

--- a/packages/core/src/checkout/index.ts
+++ b/packages/core/src/checkout/index.ts
@@ -1,7 +1,7 @@
 export * from './checkout-actions';
 export * from './checkout-hydrate-actions';
 
-export type { default as Checkout, CheckoutPayment } from './checkout';
+export type { default as Checkout, CheckoutEventRequestBody, CheckoutPayment } from './checkout';
 export { getCapabilityIncludes, withCapabilityIncludes } from './checkout-capability-includes';
 export { default as CHECKOUT_DEFAULT_INCLUDES } from './checkout-default-includes';
 export { default as CheckoutActionCreator } from './checkout-action-creator';

--- a/packages/core/src/payment/payment-strategy-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import {
+    CheckoutActionCreator,
     CheckoutRequestSender,
     CheckoutStore,
     CheckoutStoreState,
@@ -34,6 +35,7 @@ import {
 } from '../checkout/checkouts.mock';
 import { MissingDataError } from '../common/error/errors';
 import { ResolveIdRegistry } from '../common/registry';
+import { getConfig } from '../config/configs.mock';
 import { getCustomerState } from '../customer/customers.mock';
 import * as paymentStrategyFactories from '../generated/payment-strategies';
 import { HostedFormFactory } from '../hosted-form';
@@ -56,7 +58,9 @@ import PaymentActionCreator from './payment-action-creator';
 import { getPaymentMethod } from './payment-methods.mock';
 import PaymentRequestSender from './payment-request-sender';
 import PaymentRequestTransformer from './payment-request-transformer';
-import PaymentStrategyActionCreator from './payment-strategy-action-creator';
+import PaymentStrategyActionCreator, {
+    ORDER_PLACEMENT_START_SERVER_EVENT,
+} from './payment-strategy-action-creator';
 import { PaymentStrategyActionType } from './payment-strategy-actions';
 import PaymentStrategyRegistry from './payment-strategy-registry';
 import { PaymentStrategy } from './strategies';
@@ -78,6 +82,7 @@ describe('PaymentStrategyActionCreator', () => {
     let paymentHumanVerificationHandler: PaymentHumanVerificationHandler;
     let actionCreator: PaymentStrategyActionCreator;
     let paymentIntegrationService: PaymentIntegrationService;
+    let checkoutActionCreator: CheckoutActionCreator;
 
     beforeEach(() => {
         state = getCheckoutStoreState();
@@ -120,12 +125,19 @@ describe('PaymentStrategyActionCreator', () => {
             spamProtection,
             new SpamProtectionRequestSender(requestSender),
         );
+        checkoutActionCreator = {
+            reportCheckoutEvent: jest
+                .fn()
+                .mockReturnValue(of(createAction('REPORT_CHECKOUT_EVENT'))),
+        } as unknown as CheckoutActionCreator;
         actionCreator = new PaymentStrategyActionCreator(
             registry,
             registryV2,
             orderActionCreator,
             spamProtectionActionCreator,
             paymentIntegrationService,
+            store,
+            checkoutActionCreator,
         );
 
         jest.spyOn(registry, 'getByMethod').mockReturnValue(strategy);
@@ -269,6 +281,8 @@ describe('PaymentStrategyActionCreator', () => {
                     orderActionCreator,
                     spamProtectionActionCreator,
                     paymentIntegrationService,
+                    store,
+                    checkoutActionCreator,
                 );
             });
 
@@ -701,6 +715,88 @@ describe('PaymentStrategyActionCreator', () => {
             ]);
         });
 
+        describe('order placement start event', () => {
+            const enableExperiment = (enabled: boolean) => {
+                jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                    ...getConfig().storeConfig,
+                    checkoutSettings: {
+                        ...getConfig().storeConfig.checkoutSettings,
+                        features: {
+                            [ORDER_PLACEMENT_START_SERVER_EVENT]: enabled,
+                        },
+                    },
+                });
+            };
+
+            it('reports the event when the experiment is enabled', async () => {
+                enableExperiment(true);
+
+                const payload = getOrderRequestBody();
+
+                await from(actionCreator.execute(payload)(store)).toPromise();
+
+                expect(checkoutActionCreator.reportCheckoutEvent).toHaveBeenCalledWith({
+                    event: 'order_placement_started',
+                    payment_provider_id: 'authorizenet',
+                    payment_method_id: 'authorizenet',
+                });
+            });
+
+            it('dispatches the event on its own queue', async () => {
+                enableExperiment(true);
+                jest.spyOn(store, 'dispatch');
+
+                const payload = getOrderRequestBody();
+
+                await from(actionCreator.execute(payload)(store)).toPromise();
+
+                expect(store.dispatch).toHaveBeenCalledWith(expect.anything(), {
+                    queueId: 'reportCheckoutEvent',
+                });
+            });
+
+            it('does not report the event when the experiment is disabled', async () => {
+                enableExperiment(false);
+
+                const payload = getOrderRequestBody();
+
+                await from(actionCreator.execute(payload)(store)).toPromise();
+
+                expect(checkoutActionCreator.reportCheckoutEvent).not.toHaveBeenCalled();
+            });
+
+            it('does not report the event when the feature key is missing entirely', async () => {
+                jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                    ...getConfig().storeConfig,
+                    checkoutSettings: {
+                        ...getConfig().storeConfig.checkoutSettings,
+                        features: {},
+                    },
+                });
+
+                const payload = getOrderRequestBody();
+
+                await from(actionCreator.execute(payload)(store)).toPromise();
+
+                expect(checkoutActionCreator.reportCheckoutEvent).not.toHaveBeenCalled();
+            });
+
+            it('uses the sub-method id exposed by the strategy when available', async () => {
+                enableExperiment(true);
+                (
+                    strategy as unknown as { getSelectedSubMethodId: () => string }
+                ).getSelectedSubMethodId = jest.fn().mockReturnValue('klarna');
+
+                const payload = getOrderRequestBody();
+
+                await from(actionCreator.execute(payload)(store)).toPromise();
+
+                expect(checkoutActionCreator.reportCheckoutEvent).toHaveBeenCalledWith(
+                    expect.objectContaining({ payment_method_id: 'klarna' }),
+                );
+            });
+        });
+
         it('throws error if payment method is not found or loaded', async () => {
             store = createCheckoutStore({
                 ...state,
@@ -714,6 +810,8 @@ describe('PaymentStrategyActionCreator', () => {
                 orderActionCreator,
                 spamProtectionActionCreator,
                 paymentIntegrationService,
+                store,
+                checkoutActionCreator,
             );
 
             try {
@@ -743,6 +841,8 @@ describe('PaymentStrategyActionCreator', () => {
                 orderActionCreator,
                 spamProtectionActionCreator,
                 paymentIntegrationService,
+                store,
+                checkoutActionCreator,
             );
             const payload = { ...getOrderRequestBody(), useStoreCredit: true };
 
@@ -752,6 +852,50 @@ describe('PaymentStrategyActionCreator', () => {
             expect(noPaymentDataStrategy.execute).toHaveBeenCalledWith(payload, {
                 methodId: payload.payment && payload.payment.methodId,
                 gatewayId: payload.payment && payload.payment.gatewayId,
+            });
+        });
+
+        it('reports the event when the nopaymentrequired strategy is used', async () => {
+            store = createCheckoutStore({
+                ...state,
+                customer: merge({}, getCustomerState(), {
+                    data: {
+                        storeCredit: 9999,
+                    },
+                }),
+            });
+
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                checkoutSettings: {
+                    ...getConfig().storeConfig.checkoutSettings,
+                    features: {
+                        [ORDER_PLACEMENT_START_SERVER_EVENT]: true,
+                    },
+                },
+            });
+
+            registry = createPaymentStrategyRegistry(store, paymentClient, requestSender);
+
+            jest.spyOn(registryV2, 'get').mockReturnValue(noPaymentDataStrategy);
+
+            const actionCreator = new PaymentStrategyActionCreator(
+                registry,
+                registryV2,
+                orderActionCreator,
+                spamProtectionActionCreator,
+                paymentIntegrationService,
+                store,
+                checkoutActionCreator,
+            );
+            const payload = { ...getOrderRequestBody(), useStoreCredit: true };
+
+            await from(actionCreator.execute(payload)(store)).toPromise();
+
+            expect(checkoutActionCreator.reportCheckoutEvent).toHaveBeenCalledWith({
+                event: 'order_placement_started',
+                payment_provider_id: 'authorizenet',
+                payment_method_id: 'authorizenet',
             });
         });
     });
@@ -853,6 +997,8 @@ describe('PaymentStrategyActionCreator', () => {
                 orderActionCreator,
                 spamProtectionActionCreator,
                 paymentIntegrationService,
+                store,
+                checkoutActionCreator,
             );
             const strategyV2 = new CreditCardPaymentStrategyV2(
                 createPaymentIntegrationService(store),
@@ -886,6 +1032,8 @@ describe('PaymentStrategyActionCreator', () => {
                 orderActionCreator,
                 spamProtectionActionCreator,
                 paymentIntegrationService,
+                store,
+                checkoutActionCreator,
             );
 
             try {

--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -7,7 +7,12 @@ import {
     PaymentStrategy as PaymentStrategyV2,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
+import {
+    CheckoutActionCreator,
+    CheckoutStore,
+    InternalCheckoutSelectors,
+    ReadableCheckoutStore,
+} from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
@@ -42,6 +47,8 @@ import PaymentStrategyType from './payment-strategy-type';
 import PaymentStrategyWidgetActionCreator from './payment-strategy-widget-action-creator';
 import { PaymentStrategy } from './strategies';
 
+export const ORDER_PLACEMENT_START_SERVER_EVENT = 'PROJECT-8686.order_placement_start_server_event';
+
 export default class PaymentStrategyActionCreator {
     private _paymentStrategyWidgetActionCreator: PaymentStrategyWidgetActionCreator;
 
@@ -58,6 +65,8 @@ export default class PaymentStrategyActionCreator {
         private _orderActionCreator: OrderActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator,
         private _paymentIntegrationService: PaymentIntegrationService,
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
     ) {
         this._paymentStrategyWidgetActionCreator = new PaymentStrategyWidgetActionCreator();
     }
@@ -99,6 +108,8 @@ export default class PaymentStrategyActionCreator {
                             id: PaymentStrategyType.NO_PAYMENT_DATA_REQUIRED,
                         });
                     }
+
+                    this._reportOrderPlacementStart(strategy, payment);
 
                     const promise: Promise<InternalCheckoutSelectors | void> = strategy.execute(
                         payload,
@@ -313,6 +324,31 @@ export default class PaymentStrategyActionCreator {
 
     private _getCacheKey(methodId: string, gatewayId?: string): string {
         return gatewayId ? `${methodId}.${gatewayId}` : methodId;
+    }
+
+    private _reportOrderPlacementStart(
+        strategy: PaymentStrategy | PaymentStrategyV2,
+        payment: OrderPaymentRequestBody,
+    ): void {
+        const checkoutSettings = this._store.getState().config.getStoreConfig()?.checkoutSettings;
+
+        if (!checkoutSettings?.features[ORDER_PLACEMENT_START_SERVER_EVENT]) {
+            return;
+        }
+
+        const selectedSubMethodId =
+            'getSelectedSubMethodId' in strategy ? strategy.getSelectedSubMethodId?.() : undefined;
+
+        this._store
+            .dispatch(
+                this._checkoutActionCreator.reportCheckoutEvent({
+                    event: 'order_placement_started',
+                    payment_provider_id: payment.gatewayId ?? payment.methodId,
+                    payment_method_id: selectedSubMethodId ?? payment.methodId,
+                }),
+                { queueId: 'reportCheckoutEvent' },
+            )
+            .catch(() => {});
     }
 
     private _getStrategy(method: PaymentMethod): PaymentStrategy | PaymentStrategyV2 {

--- a/packages/payment-integration-api/src/payment/payment-strategy.ts
+++ b/packages/payment-integration-api/src/payment/payment-strategy.ts
@@ -11,4 +11,6 @@ export default interface PaymentStrategy {
     initialize(options?: PaymentInitializeOptions): Promise<void>;
 
     deinitialize(options?: PaymentRequestOptions): Promise<void>;
+
+    getSelectedSubMethodId?(): string | undefined;
 }

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -922,6 +922,12 @@ describe('StripeOCSPaymentStrategy', () => {
         });
     });
 
+    describe('#getSelectedSubMethodId()', () => {
+        it('returns undefined before any payment method has been selected', () => {
+            expect(stripeCSPaymentStrategy.getSelectedSubMethodId()).toBeUndefined();
+        });
+    });
+
     describe('#deinitialize()', () => {
         let unmountMock: jest.Mock;
         let destroyMock: jest.Mock;
@@ -1311,7 +1317,60 @@ describe('StripeOCSPaymentStrategy', () => {
                     },
                 },
             });
-            expect(paymentMethodSelectMock).toHaveBeenCalledWith(`${gatewayId}-${methodId}`);
+            expect(paymentMethodSelectMock).toHaveBeenCalledWith(
+                `${gatewayId}-${methodId}`,
+                StripePaymentMethodType.CreditCard,
+            );
+        });
+
+        it('passes the selected sub method type to paymentMethodSelect', async () => {
+            const eventMock = {
+                ...StripeEventMock,
+                collapsed: false,
+                value: {
+                    type: StripePaymentMethodType.ACH,
+                },
+            };
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(eventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+            }));
+            const paymentMethodSelectMock = jest.fn();
+
+            jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
+                Promise.resolve({
+                    ...getStripeCheckoutInstanceMock(),
+                    createPaymentElement: jest.fn(() => createMock()),
+                }),
+            );
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(getStripeOCSMock(methodId));
+
+            await stripeCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                methodId,
+                stripeocs: {
+                    ...stripeOptions.stripeocs,
+                    render: jest.fn(),
+                    containerId: 'containerId',
+                    paymentMethodSelect: paymentMethodSelectMock,
+                },
+            });
+            await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
+
+            expect(paymentMethodSelectMock).toHaveBeenCalledWith(
+                `${gatewayId}-${methodId}`,
+                StripePaymentMethodType.ACH,
+            );
+            expect(stripeCSPaymentStrategy.getSelectedSubMethodId()).toBe(
+                StripePaymentMethodType.ACH,
+            );
         });
 
         it('does not change selected payment method id if accordion collapsed', async () => {

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -161,6 +161,10 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         return Promise.resolve();
     }
 
+    getSelectedSubMethodId(): string | undefined {
+        return this.selectedMethod?.type;
+    }
+
     private async _initStripeCheckoutSession(
         stripe: StripeOCSPaymentInitializeOptions,
         paymentMethod: PaymentMethod<StripeInitializationData>,
@@ -280,14 +284,14 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         event: StripeEventType,
         gatewayId: string,
         methodId: string,
-        paymentMethodSelect?: (id: string) => void,
+        paymentMethodSelect?: (id: string, selectedSubMethod?: string) => void,
     ) {
         if (!isStripePaymentEvent(event) || event.collapsed) {
             return;
         }
 
         this.selectedMethod = event.value;
-        paymentMethodSelect?.(`${gatewayId}-${methodId}`);
+        paymentMethodSelect?.(`${gatewayId}-${methodId}`, this.selectedMethod?.type);
     }
 
     private _collapseStripeElement() {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
@@ -63,7 +63,7 @@ export default interface StripeOCSPaymentInitializeOptions extends StripePayment
 
     render(): void;
 
-    paymentMethodSelect?(id: string): void;
+    paymentMethodSelect?(methodId: string, selectedSubMethod?: string): void;
 
     handleClosePaymentMethod?(collapseElement: () => void): void;
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -25,6 +25,7 @@ import {
     StripeInstrumentSetupFutureUsage,
     StripeIntegrationService,
     StripeJsVersion,
+    StripePaymentMethodType,
     StripePIPaymentMethodOptions,
     StripeScriptLoader,
     StripeStringConstants,
@@ -690,7 +691,53 @@ describe('StripeOCSPaymentStrategy', () => {
                     },
                 },
             });
-            expect(paymentMethodSelectMock).toHaveBeenCalledWith(`${gatewayId}-${methodId}`);
+            expect(paymentMethodSelectMock).toHaveBeenCalledWith(
+                `${gatewayId}-${methodId}`,
+                StripePaymentMethodType.CreditCard,
+            );
+        });
+
+        it('passes the selected sub method type to paymentMethodSelect', async () => {
+            const eventMock = {
+                ...StripeEventMock,
+                collapsed: false,
+                value: {
+                    type: StripePaymentMethodType.ACH,
+                },
+            };
+            const createMock = jest.fn().mockImplementation(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback(eventMock)),
+                update: jest.fn(),
+                destroy: jest.fn(),
+            }));
+            const paymentMethodSelectMock = jest.fn();
+
+            jest.spyOn(stripeScriptLoader, 'getElements').mockReturnValue(
+                Promise.resolve({
+                    ...stripeUPEJsMock.elements({}),
+                    create: createMock,
+                }),
+            );
+
+            await stripeOCSPaymentStrategy.initialize({
+                ...stripeOptions,
+                stripeocs: {
+                    render: jest.fn(),
+                    containerId: 'containerId',
+                    paymentMethodSelect: paymentMethodSelectMock,
+                },
+            });
+            await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+            expect(paymentMethodSelectMock).toHaveBeenCalledWith(
+                `${gatewayId}-${methodId}`,
+                StripePaymentMethodType.ACH,
+            );
+            expect(stripeOCSPaymentStrategy.getSelectedSubMethodId()).toBe(
+                StripePaymentMethodType.ACH,
+            );
         });
 
         it('does not change selected payment method id if accordion collapsed', async () => {
@@ -1746,6 +1793,12 @@ describe('StripeOCSPaymentStrategy', () => {
             await expect(stripeOCSPaymentStrategy.finalize()).rejects.toBeInstanceOf(
                 OrderFinalizationNotRequiredError,
             );
+        });
+    });
+
+    describe('#getSelectedSubMethodId()', () => {
+        it('returns undefined before any payment method has been selected', () => {
+            expect(stripeOCSPaymentStrategy.getSelectedSubMethodId()).toBeUndefined();
         });
     });
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -126,6 +126,10 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         return Promise.resolve();
     }
 
+    getSelectedSubMethodId(): string | undefined {
+        return this.selectedMethodId;
+    }
+
     private async _initializeStripeElement(
         stripe: StripeOCSPaymentInitializeOptions,
         gatewayId: string,
@@ -381,14 +385,14 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         event: StripeEventType,
         gatewayId: string,
         methodId: string,
-        paymentMethodSelect?: (id: string) => void,
+        paymentMethodSelect?: (id: string, selectedSubMethod?: string) => void,
     ) {
         if (!isStripePaymentEvent(event) || event.collapsed) {
             return;
         }
 
         this.selectedMethodId = event.value.type;
-        paymentMethodSelect?.(`${gatewayId}-${methodId}`);
+        paymentMethodSelect?.(`${gatewayId}-${methodId}`, this.selectedMethodId);
     }
 
     private _shouldSaveInstrument(paymentMethodOptions?: StripePIPaymentMethodSavingOptions) {

--- a/packages/stripe-utils/src/index.ts
+++ b/packages/stripe-utils/src/index.ts
@@ -53,7 +53,10 @@ export {
     getStripeCheckoutInstanceMock,
     getStripeCheckoutSessionActionsMock,
 } from './stripe.mock';
-export type { default as StripePaymentInitializeOptions } from './stripe-initialize-options';
+export type {
+    default as StripePaymentInitializeOptions,
+    WithSelectedSubMethod,
+} from './stripe-initialize-options';
 export { default as StripeIntegrationService } from './stripe-integration-service';
 export { default as StripeScriptLoader } from './stripe-script-loader';
 export { default as formatStripeLocale } from './format-locale';

--- a/packages/stripe-utils/src/stripe-initialize-options.ts
+++ b/packages/stripe-utils/src/stripe-initialize-options.ts
@@ -15,3 +15,7 @@ export default interface StripePaymentInitializeOptions {
 
     render(): void;
 }
+
+export interface WithSelectedSubMethod {
+    paymentMethodSelect?(methodId: string, selectedSubMethod?: string): void;
+}


### PR DESCRIPTION
## What/Why?

Checks for `PROJECT-8686.order_placement_start_server_event` feature key in the checkout settings. If it's set to `true`, clicking on Place order button will emit a non-blocking request to `event` endpoint (`api/storefront/checkout/{checkout_id}/event`) with following payload:
`{event: "order_placement_started", payment_provider_id: "(provider)", payment_method_id: "(method)"}`.
That data is later used internally for measuring end-to-end checkout performance ([related PR](https://github.com/bigcommerce/bigcommerce/pull/69970))

## Rollout/Rollback

Revert

## Testing

Unit tests; manual

<img width="1888" height="1092" alt="2026-09-03_18-50" src="https://github.com/user-attachments/assets/f95ae23e-a096-440f-92bd-a34ea8aa17d4" />

Pay attention that the difference between event report, and the next request is couple of milliseconds due to non-blocking nature of the first request:

<img width="1028" height="161" alt="2026-09-03_18-52" src="https://github.com/user-attachments/assets/cf8599f5-9ad5-42c6-892a-0eb70b1d1a9c" />

<img width="1002" height="460" alt="2026-09-03_18-53" src="https://github.com/user-attachments/assets/8e6ad283-fb59-48a9-81e9-5ac22001c0e0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the payment execute path and adds async side effects before order placement; failures are isolated but incorrect method IDs could skew metrics.
> 
> **Overview**
> Adds **non-blocking checkout event reporting** for end-to-end performance measurement. When store config enables `PROJECT-8686.order_placement_start_server_event`, **Place order** triggers a fire-and-forget `POST` to `/api/storefront/checkout/{id}/event` with `order_placement_started` and payment provider/method identifiers—dispatched on a dedicated `reportCheckoutEvent` queue so it does not delay payment execution.
> 
> The SDK exposes this through `CheckoutService.reportCheckoutEvent`, wired from `CheckoutRequestSender` through new Redux-style actions (success and failure are swallowed so reporting never breaks checkout).
> 
> **Payment execute** calls the reporter immediately before the strategy runs (including no-payment-required / store-credit paths). `payment_method_id` prefers an optional strategy `getSelectedSubMethodId()` so Stripe OCS/CS can send the real sub-type (e.g. ACH vs card); Stripe integrations also pass that sub-method into `paymentMethodSelect`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25992ba72d80a4e9e8a8427e3971ae96a732987d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->