### PR TITLE
feat(checkout): Add version to Cart and Checkout interfaces

### DIFF
--- a/packages/core/src/cart/cart.ts
+++ b/packages/core/src/cart/cart.ts
@@ -38,4 +38,5 @@ export default interface Cart {
     updatedTime: string;
     source?: CartSource;
     locale: string;
+    version: number;
 }

--- a/packages/core/src/cart/carts.mock.ts
+++ b/packages/core/src/cart/carts.mock.ts
@@ -29,6 +29,7 @@ export function getCart(): Cart {
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',
         locale: 'en',
+        version: 1,
     };
 }
 

--- a/packages/payment-integration-api/src/cart/cart.ts
+++ b/packages/payment-integration-api/src/cart/cart.ts
@@ -23,4 +23,5 @@ export default interface Cart {
     updatedTime: string;
     source?: CartSource;
     locale: string;
+    version: number;
 }

--- a/packages/payment-integration-api/src/checkout/checkout.ts
+++ b/packages/payment-integration-api/src/checkout/checkout.ts
@@ -49,6 +49,7 @@ export default interface Checkout {
     channelId: number;
     fees: Fee[];
     totalDiscount: number;
+    version: number;
 }
 
 export interface CheckoutRequestBody {

--- a/packages/payment-integration-api/src/mocks/carts.mock.ts
+++ b/packages/payment-integration-api/src/mocks/carts.mock.ts
@@ -33,6 +33,7 @@ export default function getCart(): Cart {
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',
         locale: 'en',
+        version: 1,
     };
 }
 

--- a/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
@@ -33,6 +33,7 @@ export default function getCart(): Cart {
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',
         locale: 'en',
+        version: 1,
     };
 }
 

--- a/packages/payment-integrations-test-utils/src/test-utils/checkouts.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/checkouts.mock.ts
@@ -55,6 +55,7 @@ export default function getCheckout(): Checkout {
             },
         ],
         totalDiscount: 0,
+        version: 1,
     };
 }
 


### PR DESCRIPTION
## What/Why?
The storefront checkout API already returns version on both the cart and the checkout — Cart/CartTransformer.php and CheckoutTransformer.php emit it unconditionally, and CartInterface::getVersion(): int is non-nullable. The data has always been in the payload; our interfaces just didn't declare it, so it was invisible to consumers.

This adds it so the types match what the API actually sends:

- Cart.version in packages/core and packages/payment-integration-api
- Checkout.version in packages/payment-integration-api, mirroring core, which already had it
- version in the five cart/checkout mocks

Core's Cart has to move together with the payment-integration-api one, since createPaymentIntegrationSelectors hands core's types back as the payment integration API's — a mismatch breaks getCart, getCheckout and validateCheckout.

Declared as required, not optional, because that's the contract: always present, never null. A follow-up Stripe PR is the first consumer.

## Rollout/Rollback
Rollback this PR

## Testing
CI results.
and in the related [Stripe PR ](https://github.com/bigcommerce/checkout-sdk-js/pull/3395)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type and mock-only changes that reflect an existing API field; no runtime logic or security paths are modified.
> 
> **Overview**
> Aligns TypeScript **Cart** and **Checkout** types with the storefront checkout API, which already returns a non-null `version` on both entities.
> 
> Adds required `version: number` to **Cart** in `packages/core` and `packages/payment-integration-api`, and to **Checkout** in `packages/payment-integration-api` (core’s `Checkout` already declared it). Updates cart and checkout test mocks across core, payment-integration-api, and payment-integrations-test-utils so fixtures satisfy the new fields.
> 
> Keeping core and payment-integration-api **Cart** in sync matters because payment integration selectors expose those types to consumers such as `getCart`, `getCheckout`, and checkout validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d0066c64cf239ce571ab7d4b4766819853a0cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->