### PR TITLE
feat(payment): Stripe CS, skip unchanged checkout session update

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -218,7 +218,7 @@ describe('StripeOCSPaymentStrategy', () => {
             expect(stripeIntegrationService.mountElement).toHaveBeenCalled();
         });
 
-        it('triggers stripe checkout session server update on initialize', async () => {
+        it('does not trigger stripe checkout session server update on initialize', async () => {
             const runServerUpdateMock = jest.fn(async (update: () => Promise<unknown>) => {
                 await update();
 
@@ -241,7 +241,7 @@ describe('StripeOCSPaymentStrategy', () => {
 
             await stripeCSPaymentStrategy.initialize(stripeOptions);
 
-            expect(runServerUpdateMock).toHaveBeenCalledTimes(1);
+            expect(runServerUpdateMock).not.toHaveBeenCalled();
         });
 
         it('should call render when payment element ready event fires', async () => {
@@ -1039,13 +1039,10 @@ describe('StripeOCSPaymentStrategy', () => {
         });
 
         it('throws error if stripe checkout session server update fails', async () => {
-            const runServerUpdateMock = jest
-                .fn()
-                .mockResolvedValueOnce({ type: StripeLoadActionsResultType.SUCCESS })
-                .mockResolvedValue({
-                    type: StripeLoadActionsResultType.ERROR,
-                    error: { message: 'stripe server update error' },
-                });
+            const runServerUpdateMock = jest.fn().mockResolvedValue({
+                type: StripeLoadActionsResultType.ERROR,
+                error: { message: 'stripe server update error' },
+            });
 
             jest.spyOn(stripeScriptLoader, 'getStripeCheckout').mockReturnValue(
                 Promise.resolve({
@@ -1078,16 +1075,8 @@ describe('StripeOCSPaymentStrategy', () => {
                     ...getStripeCheckoutInstanceMock(),
                     loadActions: () =>
                         Promise.resolve({
-                            type: StripeLoadActionsResultType.SUCCESS,
-                            actions: {
-                                ...getStripeCheckoutSessionActionsMock(),
-                                runServerUpdate: jest.fn(() =>
-                                    Promise.resolve({
-                                        type: StripeLoadActionsResultType.ERROR,
-                                        error: { message: 'stripe server update error' },
-                                    }),
-                                ),
-                            },
+                            type: StripeLoadActionsResultType.ERROR,
+                            error: { message: 'stripe checkout actions error' },
                         }),
                 }),
             );
@@ -1109,6 +1098,47 @@ describe('StripeOCSPaymentStrategy', () => {
             ).rejects.toThrow(NotInitializedError);
 
             expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+        });
+
+        describe('skipUnchangedCheckoutSessionUpdate', () => {
+            const configRequest = [gatewayId, { params: { method: methodId } }];
+
+            it('updates checkout session data if the checkout state changed', async () => {
+                jest.spyOn(
+                    stripeIntegrationService,
+                    'shouldSkipCheckoutStateUpdate',
+                ).mockReturnValue(false);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+                await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
+
+                expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
+                    ...configRequest,
+                );
+            });
+
+            it('skips checkout session data update if the checkout state is unchanged', async () => {
+                jest.spyOn(
+                    stripeIntegrationService,
+                    'shouldSkipCheckoutStateUpdate',
+                ).mockReturnValue(true);
+
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+                await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
+
+                expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
+                expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+            });
+
+            it('caches checkout state versions on initialize and clears them on deinitialize', async () => {
+                await stripeCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(stripeIntegrationService.cacheCheckoutStateVersions).toHaveBeenCalled();
+
+                await stripeCSPaymentStrategy.deinitialize();
+
+                expect(stripeIntegrationService.clearCheckoutStateVersions).toHaveBeenCalled();
+            });
         });
 
         it('execute without additional actions with selected method in accordion', async () => {

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -81,6 +81,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         }
 
         this.stripeInitializationOptions = stripeocs;
+        this.stripeIntegrationService.cacheCheckoutStateVersions();
 
         try {
             await this._initStripeCheckoutSession(stripeocs, paymentMethod);
@@ -88,7 +89,6 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
             const stripeActions = await this._getStripeActionsOrThrow();
 
             await this._updateStripeShopperData(stripeActions);
-            await this._updateStripeCheckoutSessionState(stripeActions);
 
             this._initializePaymentElement(stripeocs, paymentMethod);
             this._initializeAdaptivePricingElement(stripeocs, paymentMethod);
@@ -121,7 +121,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
             this._getStripeActionsOrThrow(),
         ]);
 
-        await this._updateCheckoutSessionData(gatewayId, methodId, stripeActions);
+        await this._updateCheckoutSessionDataBeforePay(gatewayId, methodId, stripeActions);
         await this.paymentIntegrationService.submitOrder(order, options);
 
         const { id: stripeSessionId } = await stripeActions.getSession();
@@ -157,6 +157,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         this.stripeClient = undefined;
         this.selectedMethod = undefined;
         this.stripeInitializationOptions = undefined;
+        this.stripeIntegrationService.clearCheckoutStateVersions();
 
         return Promise.resolve();
     }
@@ -296,11 +297,15 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         stripeElement?.collapse();
     }
 
-    private async _updateCheckoutSessionData(
+    private async _updateCheckoutSessionDataBeforePay(
         gatewayId: string,
         methodId: string,
         stripeActions: StripeCheckoutSessionActions,
     ): Promise<void> {
+        if (this.stripeIntegrationService.shouldSkipCheckoutStateUpdate(methodId, gatewayId)) {
+            return;
+        }
+
         await this._updateStripeShopperData(stripeActions);
 
         // INFO: to trigger checkout session data update on the BE side we need to make stripe config request
@@ -441,7 +446,7 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
 
     private async _updateStripeCheckoutSessionState(
         stripeActions: StripeCheckoutSessionActions,
-        updateFn: () => Promise<unknown> = () => Promise.resolve(),
+        updateFn: () => Promise<unknown>,
     ): Promise<void> {
         const { type, error } = await stripeActions.runServerUpdate(updateFn);
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -574,6 +574,46 @@ describe('StripeOCSPaymentStrategy', () => {
             );
         });
 
+        describe('skipUnchangedCheckoutSessionUpdate', () => {
+            it('updates stripe payment intent if the checkout state changed', async () => {
+                jest.spyOn(
+                    stripeIntegrationService,
+                    'shouldSkipCheckoutStateUpdate',
+                ).mockReturnValue(false);
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+                await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+                expect(stripeIntegrationService.updateStripePaymentIntent).toHaveBeenCalledWith(
+                    gatewayId,
+                    methodId,
+                );
+            });
+
+            it('skips stripe payment intent update if the checkout state is unchanged', async () => {
+                jest.spyOn(
+                    stripeIntegrationService,
+                    'shouldSkipCheckoutStateUpdate',
+                ).mockReturnValue(true);
+
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+                await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
+
+                expect(stripeIntegrationService.updateStripePaymentIntent).not.toHaveBeenCalled();
+                expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+            });
+
+            it('caches checkout state versions on initialize and clears them on deinitialize', async () => {
+                await stripeOCSPaymentStrategy.initialize(stripeOptions);
+
+                expect(stripeIntegrationService.cacheCheckoutStateVersions).toHaveBeenCalled();
+
+                await stripeOCSPaymentStrategy.deinitialize();
+
+                expect(stripeIntegrationService.clearCheckoutStateVersions).toHaveBeenCalled();
+            });
+        });
+
         it('execute without additional actions with selected method in accordion', async () => {
             await stripeOCSPaymentStrategy.initialize(stripeOptions);
             await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -70,6 +70,8 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
 
         try {
             await this._initializeStripeElement(stripeocs, gatewayId, methodId);
+
+            this.stripeIntegrationService.cacheCheckoutStateVersions();
         } catch (error) {
             if (error instanceof Error) {
                 stripeocs.onError?.(error);
@@ -94,7 +96,9 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
 
         await this.stripeIntegrationService.applyStoreCreditIfNeeded(useStoreCredit);
 
-        await this.stripeIntegrationService.updateStripePaymentIntent(gatewayId, methodId);
+        if (!this.stripeIntegrationService.shouldSkipCheckoutStateUpdate(methodId, gatewayId)) {
+            await this.stripeIntegrationService.updateStripePaymentIntent(gatewayId, methodId);
+        }
 
         await this.paymentIntegrationService.submitOrder(order, options);
 
@@ -122,6 +126,7 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         paymentElement?.destroy();
         this.stripeElements = undefined;
         this.stripeClient = undefined;
+        this.stripeIntegrationService.clearCheckoutStateVersions();
 
         return Promise.resolve();
     }

--- a/packages/stripe-utils/src/stripe-integration-service.mock.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.mock.ts
@@ -40,6 +40,9 @@ export const getStripeIntegrationServiceMock = () =>
         isRedirectAction: jest.fn(() => false),
         isOnPageAdditionalAction: jest.fn(() => false),
         updateStripePaymentIntent: jest.fn(() => Promise.resolve()),
+        cacheCheckoutStateVersions: jest.fn(),
+        clearCheckoutStateVersions: jest.fn(),
+        shouldSkipCheckoutStateUpdate: jest.fn(() => false),
         applyStoreCreditIfNeeded: jest.fn(() => Promise.resolve()),
         throwStripeError: jest.fn(() => {
             throw new Error('throw stripe error');

--- a/packages/stripe-utils/src/stripe-integration-service.spec.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBillingAddress,
+    getCart,
     getCheckout,
     getConfig,
     getShippingAddress,
@@ -854,6 +855,82 @@ describe('StripeIntegrationService', () => {
             await stripeIntegrationService.verifyCheckoutSpamProtection();
 
             expect(paymentIntegrationService.verifyCheckoutSpamProtection).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('#shouldSkipCheckoutStateUpdate', () => {
+        const methodId = 'checkout_session';
+        const gatewayId = 'stripeocs';
+
+        function mockSkipUnchangedCheckoutSessionUpdate(enabled: boolean) {
+            const paymentMethod = getStripeMock();
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    skipUnchangedCheckoutSessionUpdate: enabled,
+                },
+            });
+        }
+
+        it('returns false if the flag is disabled', () => {
+            mockSkipUnchangedCheckoutSessionUpdate(false);
+            stripeIntegrationService.cacheCheckoutStateVersions();
+
+            expect(
+                stripeIntegrationService.shouldSkipCheckoutStateUpdate(methodId, gatewayId),
+            ).toBe(false);
+        });
+
+        it('returns true if cart and checkout versions are unchanged', () => {
+            mockSkipUnchangedCheckoutSessionUpdate(true);
+            stripeIntegrationService.cacheCheckoutStateVersions();
+
+            expect(
+                stripeIntegrationService.shouldSkipCheckoutStateUpdate(methodId, gatewayId),
+            ).toBe(true);
+        });
+
+        it('returns false if the cart version changed', () => {
+            mockSkipUnchangedCheckoutSessionUpdate(true);
+            stripeIntegrationService.cacheCheckoutStateVersions();
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getCart').mockReturnValue({
+                ...getCart(),
+                version: getCart().version + 1,
+            });
+
+            expect(
+                stripeIntegrationService.shouldSkipCheckoutStateUpdate(methodId, gatewayId),
+            ).toBe(false);
+        });
+
+        it('returns false if the checkout version changed', () => {
+            mockSkipUnchangedCheckoutSessionUpdate(true);
+            stripeIntegrationService.cacheCheckoutStateVersions();
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getCheckout').mockReturnValue({
+                ...getCheckout(),
+                version: getCheckout().version + 1,
+            });
+
+            expect(
+                stripeIntegrationService.shouldSkipCheckoutStateUpdate(methodId, gatewayId),
+            ).toBe(false);
+        });
+
+        it('returns false if cached versions were cleared', () => {
+            mockSkipUnchangedCheckoutSessionUpdate(true);
+            stripeIntegrationService.cacheCheckoutStateVersions();
+            stripeIntegrationService.clearCheckoutStateVersions();
+
+            expect(
+                stripeIntegrationService.shouldSkipCheckoutStateUpdate(methodId, gatewayId),
+            ).toBe(false);
         });
     });
 });

--- a/packages/stripe-utils/src/stripe-integration-service.ts
+++ b/packages/stripe-utils/src/stripe-integration-service.ts
@@ -20,6 +20,7 @@ import {
     StripeElement,
     StripeElements,
     StripeError,
+    StripeInitializationData,
     StripePaymentIntentStatus,
     StripeStringConstants,
 } from './stripe';
@@ -27,6 +28,9 @@ import StripePaymentInitializeOptions from './stripe-initialize-options';
 import StripeScriptLoader from './stripe-script-loader';
 
 export default class StripeIntegrationService {
+    private cachedCartVersion?: number;
+    private cachedCheckoutVersion?: number;
+
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
         private scriptLoader: StripeScriptLoader,
@@ -207,6 +211,36 @@ export default class StripeIntegrationService {
         }
 
         this.scriptLoader.updateStripeElements({ clientSecret: clientToken });
+    }
+
+    cacheCheckoutStateVersions(): void {
+        const state = this.paymentIntegrationService.getState();
+
+        this.cachedCartVersion = state.getCart()?.version;
+        this.cachedCheckoutVersion = state.getCheckout()?.version;
+    }
+
+    clearCheckoutStateVersions(): void {
+        this.cachedCartVersion = undefined;
+        this.cachedCheckoutVersion = undefined;
+    }
+
+    shouldSkipCheckoutStateUpdate(methodId: string, gatewayId: string): boolean {
+        const state = this.paymentIntegrationService.getState();
+        const { initializationData } = state.getPaymentMethodOrThrow<StripeInitializationData>(
+            methodId,
+            gatewayId,
+        );
+        const { skipUnchangedCheckoutSessionUpdate } = initializationData || {};
+
+        if (!skipUnchangedCheckoutSessionUpdate) {
+            return false;
+        }
+
+        return (
+            this.cachedCartVersion === state.getCart()?.version &&
+            this.cachedCheckoutVersion === state.getCheckout()?.version
+        );
     }
 
     async applyStoreCreditIfNeeded(useStoreCredit?: boolean): Promise<void> {

--- a/packages/stripe-utils/src/stripe-script-loader.spec.ts
+++ b/packages/stripe-utils/src/stripe-script-loader.spec.ts
@@ -189,11 +189,15 @@ describe('StripePayScriptLoader', () => {
         let stripeJsMock: StripeClient;
         let checkoutSessionOptions: StripeInitCheckoutOptions;
         let getSessionMock: jest.Mock;
+        let runServerUpdateMock: jest.Mock;
 
         beforeEach(() => {
             checkoutSessionOptions = { clientSecret: 'session_id_secret_id' };
             getSessionMock = jest.fn(() =>
                 Promise.resolve({ id: 'session_id' } as StripeCheckoutSession),
+            );
+            runServerUpdateMock = jest.fn(() =>
+                Promise.resolve({ type: StripeLoadActionsResultType.SUCCESS }),
             );
 
             const checkoutSessionMock = {
@@ -205,6 +209,7 @@ describe('StripePayScriptLoader', () => {
                             updateEmail: jest.fn(),
                             getSession: getSessionMock,
                             confirm: jest.fn(),
+                            runServerUpdate: runServerUpdateMock,
                         },
                     }),
             };
@@ -222,6 +227,16 @@ describe('StripePayScriptLoader', () => {
 
             expect(initCheckoutMock).toHaveBeenCalledTimes(1);
             expect(initCheckoutMock).toHaveBeenCalledWith({ clientSecret: 'session_id_secret_id' });
+        });
+
+        it('runs checkout session server update only when an existing session is reused', async () => {
+            await stripeScriptLoader.getStripeCheckout(stripeJsMock, checkoutSessionOptions);
+
+            expect(runServerUpdateMock).not.toHaveBeenCalled();
+
+            await stripeScriptLoader.getStripeCheckout(stripeJsMock, checkoutSessionOptions);
+
+            expect(runServerUpdateMock).toHaveBeenCalledTimes(1);
         });
 
         it('reinitializes stripe checkout if checkout session id is different', async () => {

--- a/packages/stripe-utils/src/stripe-script-loader.ts
+++ b/packages/stripe-utils/src/stripe-script-loader.ts
@@ -84,6 +84,10 @@ export default class StripeScriptLoader {
             stripeCheckout = await stripeClient.initCheckout(options);
 
             Object.assign(this.stripeWindow, { bcStripeCheckout: stripeCheckout });
+        } else {
+            const { actions } = await stripeCheckout.loadActions();
+
+            await actions?.runServerUpdate(() => Promise.resolve());
         }
 
         return stripeCheckout;

--- a/packages/stripe-utils/src/stripe.ts
+++ b/packages/stripe-utils/src/stripe.ts
@@ -806,6 +806,7 @@ export interface StripeInitializationData {
     adaptivePricingEnabled?: boolean;
     hasSectionOnTopOfPaymentsList?: boolean;
     asyncPaymentValidation?: boolean;
+    skipUnchangedCheckoutSessionUpdate?: boolean;
 }
 
 export interface StripeElementUpdateOptions {


### PR DESCRIPTION
## What/Why?
Every Place Order triggered a checkout session update — a loadPaymentMethod config request plus a Stripe session refetch — even when nothing had changed since the payment step loaded. And every initialize() ran a server update even on a session Stripe had just created from BC's data, which is a refresh of something already fresh. Both are latency on the most conversion-sensitive path.

This skips the work when it can't be needed, using the version fields from the cart/checkout interfaces:

- initialize() records the cart and checkout versions; execute() skips the pre-pay update when they still match
- The init-time runServerUpdate moved into StripeScriptLoader.getStripeCheckout, where it now runs only when an existing Stripe checkout session is reused — a freshly created one doesn't need it
- skipUnchangedCheckoutSessionUpdate added to StripeInitializationData

## Rollout/Rollback
The pre-pay skip is gated by skipUnchangedCheckoutSessionUpdate in the payment method's initializationData, which comes from the store-user experiment STRIPE-1680.ocs_optional_update_config_request (IntegrationsExperiments::EXPERIMENT_STRIPE_OCS_OPTIONAL_UPDATE_CONFIG_REQUEST, set in modules/checkout/stripeocs/module.stripeocs.php — already merged).

With the experiment off, behavior is unchanged: the config request runs on every Place Order. Ramp by enabling it per store, roll back by turning it off — no deploy and no code revert, since the SDK change is inert while the flag is false. Success shows up as fewer loadPaymentMethod config requests at Place Order with no movement in order completion rate.

The init-time change is not behind the experiment and ships to all StripeCS merchants, so backing that piece out does require a revert.

Depends on the cart/checkout version interfaces PR landing first.

Depends on the cart/checkout version interfaces — that PR has to land first.
[https://github.com/bigcommerce/checkout-sdk-js/pull/3394](https://github.com/bigcommerce/checkout-sdk-js/pull/3394)
[https://github.com/bigcommerce/checkout-js/pull/3311](https://github.com/bigcommerce/checkout-js/pull/3311)

## Testing
Strie OCS + Checkout Session

https://github.com/user-attachments/assets/934bb1ba-d621-4deb-9888-3be2d44b33f8



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Stripe sessions and payment intents are refreshed on the conversion path; the pre-pay skip is flag-gated but the init-time `runServerUpdate` relocation applies to all Stripe CS merchants and could affect stale-session edge cases if version tracking misses updates.
> 
> **Overview**
> Reduces **Place Order** and **initialize** latency for Stripe OCS / Checkout Session by avoiding redundant backend sync when cart and checkout have not changed.
> 
> **Pre-pay skip (experiment-gated):** On payment `initialize`, strategies cache cart and checkout `version` values via `StripeIntegrationService`. On `execute`, when `initializationData.skipUnchangedCheckoutSessionUpdate` is true and versions still match, Stripe CS skips `loadPaymentMethod` + `runServerUpdate`, and Stripe OCS skips `updateStripePaymentIntent`; order submission still runs. Versions are cleared on `deinitialize`.
> 
> **Init / session reuse:** Stripe CS no longer runs checkout session server update during `initialize`. `StripeScriptLoader.getStripeCheckout` now calls `runServerUpdate` only when reusing an already-stored checkout session (not on first `initCheckout`).
> 
> Adds `skipUnchangedCheckoutSessionUpdate` to `StripeInitializationData` and unit tests for the skip behavior and script-loader reuse path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd006b45143e7cba1842138fd274d64a5c45335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->