### PR TITLE
feat(payment): PAYPAL-5799 Update PayPalCommerceCreditButtonStratege and PayPalCommerceCreditCustomerStrategy using PaypalButtonCreationService from paypal-utils package

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-button-strategy.ts
@@ -2,17 +2,28 @@ import {
     CheckoutButtonStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { createPayPalIntegrationService } from '@bigcommerce/checkout-sdk/paypal-utils';
+import {
+    createPayPalIntegrationService,
+    PaypalButtonCreationService,
+} from '@bigcommerce/checkout-sdk/paypal-utils';
 
 import PayPalCommerceCreditButtonStrategy from './paypal-commerce-credit-button-strategy';
 
 const createPayPalCommerceCreditButtonStrategy: CheckoutButtonStrategyFactory<
     PayPalCommerceCreditButtonStrategy
-> = (paymentIntegrationService) =>
-    new PayPalCommerceCreditButtonStrategy(
+> = (paymentIntegrationService) => {
+    const paypalIntegrationService = createPayPalIntegrationService(paymentIntegrationService);
+    const buttonCreationService = new PaypalButtonCreationService(
         paymentIntegrationService,
-        createPayPalIntegrationService(paymentIntegrationService),
+        paypalIntegrationService,
     );
+
+    return new PayPalCommerceCreditButtonStrategy(
+        paymentIntegrationService,
+        paypalIntegrationService,
+        buttonCreationService,
+    );
+};
 
 export default toResolvableModule(createPayPalCommerceCreditButtonStrategy, [
     { id: 'paypalcommercecredit' },

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-customer-strategy.ts
@@ -2,18 +2,28 @@ import {
     CustomerStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
-import createPayPalCommerceIntegrationService from '../create-paypal-commerce-integration-service';
+import {
+    createPayPalIntegrationService,
+    PaypalButtonCreationService,
+} from '@bigcommerce/checkout-sdk/paypal-utils';
 
 import PayPalCommerceCreditCustomerStrategy from './paypal-commerce-credit-customer-strategy';
 
 const createPayPalCommerceCreditCustomerStrategy: CustomerStrategyFactory<
     PayPalCommerceCreditCustomerStrategy
-> = (paymentIntegrationService) =>
-    new PayPalCommerceCreditCustomerStrategy(
+> = (paymentIntegrationService) => {
+    const paypalIntegrationService = createPayPalIntegrationService(paymentIntegrationService);
+    const buttonCreationService = new PaypalButtonCreationService(
         paymentIntegrationService,
-        createPayPalCommerceIntegrationService(paymentIntegrationService),
+        paypalIntegrationService,
     );
+
+    return new PayPalCommerceCreditCustomerStrategy(
+        paymentIntegrationService,
+        paypalIntegrationService,
+        buttonCreationService,
+    );
+};
 
 export default toResolvableModule(createPayPalCommerceCreditCustomerStrategy, [
     { id: 'paypalcommercecredit' },

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -23,6 +23,7 @@ import {
     getPayPalPaymentMethod,
     getPayPalSDKMock,
     getShippingAddressFromOrderDetails,
+    PaypalButtonCreationService,
     PayPalButtonsOptions,
     PayPalHostWindow,
     PayPalIntegrationService,
@@ -42,6 +43,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
     let paypalButtonElement: HTMLDivElement;
     let paypalCommerceIntegrationService: PayPalIntegrationService;
     let paypalSdk: PayPalSDK;
+    let paypalButtonCreationService: PaypalButtonCreationService;
 
     const defaultMethodId = 'paypalcommercecredit';
     const defaultButtonContainerId = 'paypal-commerce-credit-button-mock-id';
@@ -109,10 +111,15 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         paymentMethod = getPayPalPaymentMethod();
         paypalSdk = getPayPalSDKMock();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
+        paypalButtonCreationService = new PaypalButtonCreationService(
+            paymentIntegrationService,
+            paypalCommerceIntegrationService,
+        );
 
         strategy = new PayPalCommerceCreditButtonStrategy(
             paymentIntegrationService,
             paypalCommerceIntegrationService,
+            paypalButtonCreationService,
         );
 
         paypalButtonElement = document.createElement('div');

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -2,19 +2,13 @@ import {
     CheckoutButtonInitializeOptions,
     CheckoutButtonStrategy,
     InvalidArgumentError,
-    MissingDataError,
-    MissingDataErrorType,
     PaymentIntegrationService,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
-    ApproveCallbackActions,
-    ApproveCallbackPayload,
-    PayPalButtonsOptions,
+    PaypalButtonCreationService,
     PayPalBuyNowInitializeOptions,
     PayPalInitializationData,
     PayPalIntegrationService,
-    ShippingAddressChangeCallbackPayload,
-    ShippingOptionChangeCallbackPayload,
 } from '@bigcommerce/checkout-sdk/paypal-utils';
 
 import PayPalCommerceCreditButtonInitializeOptions, {
@@ -25,6 +19,7 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
         private paypalIntegrationService: PayPalIntegrationService,
+        private paypalButtonCreationService: PaypalButtonCreationService,
     ) {}
 
     async initialize(
@@ -107,32 +102,9 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         const { isHostedCheckoutEnabled, isServerSideShippingCallbacksEnabled } =
             paymentMethod.initializationData || {};
 
-        const defaultCallbacks = {
-            createOrder: () => this.paypalIntegrationService.createOrder('paypalcommercecredit'),
-            onApprove: ({ orderID }: ApproveCallbackPayload) =>
-                this.paypalIntegrationService.tokenizePayment(methodId, orderID),
-        };
-
         const buyNowFlowCallbacks = {
             onClick: () => this.handleClick(buyNowInitializeOptions),
             onCancel: () => this.paymentIntegrationService.loadDefaultCheckout(),
-        };
-
-        const hostedCheckoutCallbacks = {
-            ...(!isServerSideShippingCallbacksEnabled && {
-                onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                    this.onShippingAddressChange(data),
-                onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                    this.onShippingOptionsChange(data),
-            }),
-            onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
-                this.onHostedCheckoutApprove(
-                    data,
-                    actions,
-                    methodId,
-                    onComplete,
-                    isServerSideShippingCallbacksEnabled,
-                ),
         };
 
         const fundingSources = [paypalSdk.FUNDING.PAYLATER, paypalSdk.FUNDING.CREDIT];
@@ -140,15 +112,22 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
 
         fundingSources.forEach((fundingSource) => {
             if (!hasRenderedSmartButton) {
-                const buttonRenderOptions: PayPalButtonsOptions = {
+                const buttonRenderOptions = {
                     fundingSource,
                     style: this.paypalIntegrationService.getValidButtonStyle(style),
-                    ...defaultCallbacks,
+                    isHostedCheckoutEnabled,
+                    isServerSideShippingCallbacksEnabled,
+                    buyNowInitializeOptions,
+                    ...(isHostedCheckoutEnabled &&
+                        onComplete && { onPaymentComplete: () => onComplete() }),
                     ...(buyNowInitializeOptions && buyNowFlowCallbacks),
-                    ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),
                 };
 
-                const paypalButton = paypalSdk.Buttons(buttonRenderOptions);
+                const paypalButton = this.paypalButtonCreationService.createPayPalButton(
+                    'paypalcommerce',
+                    methodId,
+                    buttonRenderOptions,
+                );
 
                 if (paypalButton.isEligible()) {
                     paypalButton.render(`#${containerId}`);
@@ -173,120 +152,6 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
             );
 
             await this.paymentIntegrationService.loadCheckout(buyNowCart.id);
-        }
-    }
-
-    private async onHostedCheckoutApprove(
-        data: ApproveCallbackPayload,
-        actions: ApproveCallbackActions,
-        methodId: string,
-        onComplete?: () => void,
-        isServerSideShippingCallbacksEnabled?: boolean,
-    ): Promise<boolean> {
-        if (!data.orderID) {
-            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
-        }
-
-        const state = this.paymentIntegrationService.getState();
-        const cart = state.getCartOrThrow();
-
-        try {
-            const hasPhysicalItems = cart.lineItems.physicalItems.length > 0;
-
-            if (!isServerSideShippingCallbacksEnabled) {
-                const orderDetails = await actions.order.get();
-
-                const billingAddress =
-                    this.paypalIntegrationService.getBillingAddressFromOrderDetails(orderDetails);
-
-                await this.paymentIntegrationService.updateBillingAddress(billingAddress);
-
-                if (hasPhysicalItems) {
-                    const shippingAddress =
-                        this.paypalIntegrationService.getShippingAddressFromOrderDetails(
-                            orderDetails,
-                        );
-
-                    await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
-                }
-            }
-
-            if (hasPhysicalItems) {
-                await this.paypalIntegrationService.updateOrder(
-                    'paypalcommerce',
-                    undefined,
-                    undefined,
-                    isServerSideShippingCallbacksEnabled,
-                );
-            }
-
-            if (isServerSideShippingCallbacksEnabled) {
-                await this.paymentIntegrationService.loadCheckout();
-            }
-
-            await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
-
-            await this.paypalIntegrationService.submitPayment(methodId, data.orderID);
-
-            if (onComplete && typeof onComplete === 'function') {
-                onComplete();
-            }
-
-            return true; // FIXME: Do we really need to return true here?
-        } catch (error) {
-            if (typeof error === 'string') {
-                throw new Error(error);
-            }
-
-            throw error;
-        }
-    }
-
-    private async onShippingAddressChange(
-        data: ShippingAddressChangeCallbackPayload,
-    ): Promise<void> {
-        const address = this.paypalIntegrationService.getAddress({
-            city: data.shippingAddress.city,
-            countryCode: data.shippingAddress.countryCode,
-            postalCode: data.shippingAddress.postalCode,
-            stateOrProvinceCode: data.shippingAddress.state,
-        });
-
-        try {
-            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
-            // on this stage we don't have access to valid customer's address accept shipping data
-            await this.paymentIntegrationService.updateBillingAddress(address);
-            await this.paymentIntegrationService.updateShippingAddress(address);
-
-            const shippingOption = this.paypalIntegrationService.getShippingOptionOrThrow();
-
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalIntegrationService.updateOrder('paypalcommerce');
-        } catch (error) {
-            if (typeof error === 'string') {
-                throw new Error(error);
-            }
-
-            throw error;
-        }
-    }
-
-    private async onShippingOptionsChange(
-        data: ShippingOptionChangeCallbackPayload,
-    ): Promise<void> {
-        const shippingOption = this.paypalIntegrationService.getShippingOptionOrThrow(
-            data.selectedShippingOption.id,
-        );
-
-        try {
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalIntegrationService.updateOrder('paypalcommerce');
-        } catch (error) {
-            if (typeof error === 'string') {
-                throw new Error(error);
-            }
-
-            throw error;
         }
     }
 }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -13,22 +13,20 @@ import {
     getShippingOption,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
-
 import {
     getBillingAddressFromOrderDetails,
-    getPayPalCommerceIntegrationServiceMock,
-    getPayPalCommerceOrderDetails,
-    getPayPalCommercePaymentMethod,
+    getPayPalIntegrationServiceMock,
+    getPayPalOrderDetails,
+    getPayPalPaymentMethod,
     getPayPalSDKMock,
     getShippingAddressFromOrderDetails,
-} from '../mocks';
-import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
-import {
-    PayPalCommerceButtonsOptions,
-    PayPalCommerceHostWindow,
+    PaypalButtonCreationService,
+    PayPalButtonsOptions,
+    PayPalHostWindow,
+    PayPalIntegrationService,
     PayPalSDK,
     StyleButtonColor,
-} from '../paypal-commerce-types';
+} from '@bigcommerce/checkout-sdk/paypal-utils';
 
 import PayPalCommerceCreditCustomerInitializeOptions, {
     WithPayPalCommerceCreditCustomerInitializeOptions,
@@ -40,8 +38,9 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
     let strategy: PayPalCommerceCreditCustomerStrategy;
     let paymentIntegrationService: PaymentIntegrationService;
     let paymentMethod: PaymentMethod;
-    let paypalCommerceIntegrationService: PayPalCommerceIntegrationService;
+    let paypalCommerceIntegrationService: PayPalIntegrationService;
     let paypalSdk: PayPalSDK;
+    let paypalButtonCreationService: PaypalButtonCreationService;
 
     const methodId = 'paypalcommercecredit';
     const defaultContainerId = 'paypal-commerce-credit-container-mock-id';
@@ -64,14 +63,19 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
     beforeEach(() => {
         eventEmitter = new EventEmitter();
 
-        paymentMethod = { ...getPayPalCommercePaymentMethod(), id: methodId };
+        paymentMethod = { ...getPayPalPaymentMethod(), id: methodId };
         paypalSdk = getPayPalSDKMock();
-        paypalCommerceIntegrationService = getPayPalCommerceIntegrationServiceMock();
+        paypalCommerceIntegrationService = getPayPalIntegrationServiceMock();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
+        paypalButtonCreationService = new PaypalButtonCreationService(
+            paymentIntegrationService,
+            paypalCommerceIntegrationService,
+        );
 
         strategy = new PayPalCommerceCreditCustomerStrategy(
             paymentIntegrationService,
             paypalCommerceIntegrationService,
+            paypalButtonCreationService,
         );
 
         jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
@@ -117,84 +121,82 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
             },
         });
 
-        jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-            (options: PayPalCommerceButtonsOptions) => {
-                eventEmitter.on('createOrder', () => {
-                    if (options.createOrder) {
-                        options.createOrder();
-                    }
-                });
+        jest.spyOn(paypalSdk, 'Buttons').mockImplementation((options: PayPalButtonsOptions) => {
+            eventEmitter.on('createOrder', () => {
+                if (options.createOrder) {
+                    options.createOrder();
+                }
+            });
 
-                eventEmitter.on('onApprove', () => {
-                    if (options.onApprove) {
-                        options.onApprove(
-                            { orderID: approveDataOrderId },
-                            {
-                                order: {
-                                    get: jest.fn(),
-                                },
+            eventEmitter.on('onApprove', () => {
+                if (options.onApprove) {
+                    options.onApprove(
+                        { orderID: approveDataOrderId },
+                        {
+                            order: {
+                                get: jest.fn(),
                             },
-                        );
-                    }
-                });
+                        },
+                    );
+                }
+            });
 
-                eventEmitter.on('onClick', () => {
-                    if (options.onClick) {
-                        options.onClick(
-                            { fundingSource: 'credit' },
-                            {
-                                resolve: jest.fn(),
-                                reject: jest.fn(),
+            eventEmitter.on('onClick', () => {
+                if (options.onClick) {
+                    options.onClick(
+                        { fundingSource: 'credit' },
+                        {
+                            resolve: jest.fn(),
+                            reject: jest.fn(),
+                        },
+                    );
+                }
+            });
+
+            eventEmitter.on('onShippingAddressChange', () => {
+                if (options.onShippingAddressChange) {
+                    options.onShippingAddressChange({
+                        orderId: approveDataOrderId,
+                        shippingAddress: {
+                            city: 'New York',
+                            countryCode: 'US',
+                            postalCode: '07564',
+                            state: 'New York',
+                        },
+                    });
+                }
+            });
+
+            eventEmitter.on('onShippingOptionsChange', () => {
+                if (options.onShippingOptionsChange) {
+                    options.onShippingOptionsChange({
+                        orderId: approveDataOrderId,
+                        selectedShippingOption: {
+                            amount: {
+                                currency_code: 'USD',
+                                value: '100',
                             },
-                        );
-                    }
-                });
+                            id: '1',
+                            label: 'Free shipping',
+                            selected: true,
+                            type: 'type_shipping',
+                        },
+                    });
+                }
+            });
 
-                eventEmitter.on('onShippingAddressChange', () => {
-                    if (options.onShippingAddressChange) {
-                        options.onShippingAddressChange({
-                            orderId: approveDataOrderId,
-                            shippingAddress: {
-                                city: 'New York',
-                                countryCode: 'US',
-                                postalCode: '07564',
-                                state: 'New York',
-                            },
-                        });
-                    }
-                });
-
-                eventEmitter.on('onShippingOptionsChange', () => {
-                    if (options.onShippingOptionsChange) {
-                        options.onShippingOptionsChange({
-                            orderId: approveDataOrderId,
-                            selectedShippingOption: {
-                                amount: {
-                                    currency_code: 'USD',
-                                    value: '100',
-                                },
-                                id: '1',
-                                label: 'Free shipping',
-                                selected: true,
-                                type: 'type_shipping',
-                            },
-                        });
-                    }
-                });
-
-                return {
-                    close: jest.fn(),
-                    isEligible: jest.fn(() => true),
-                    render: jest.fn(),
-                };
-            },
-        );
+            return {
+                close: jest.fn(),
+                isEligible: jest.fn(() => true),
+                render: jest.fn(),
+            };
+        });
     });
 
     afterEach(() => {
         jest.clearAllMocks();
 
-        delete (window as PayPalCommerceHostWindow).paypal;
+        delete (window as PayPalHostWindow).paypal;
     });
 
     it('creates an interface of the PayPal Commerce Credit (PayLater) customer strategy', () => {
@@ -379,17 +381,15 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
         });
 
         it('renders PayPal Credit button if PayPal PayLater button is not eligible', async () => {
-            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-                (options: PayPalCommerceButtonsOptions) => {
-                    return {
-                        close: jest.fn(),
-                        render: jest.fn(),
-                        isEligible: jest.fn(() => {
-                            return options.fundingSource === paypalSdk.FUNDING.CREDIT;
-                        }),
-                    };
-                },
-            );
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation((options: PayPalButtonsOptions) => {
+                return {
+                    close: jest.fn(),
+                    render: jest.fn(),
+                    isEligible: jest.fn(() => {
+                        return options.fundingSource === paypalSdk.FUNDING.CREDIT;
+                    }),
+                };
+            });
 
             await strategy.initialize(initializationOptions);
 
@@ -471,11 +471,11 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
         });
 
         describe('shipping options feature flow', () => {
-            const paypalOrderDetails = getPayPalCommerceOrderDetails();
+            const paypalOrderDetails = getPayPalOrderDetails();
 
             beforeEach(() => {
                 jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-                    (options: PayPalCommerceButtonsOptions) => {
+                    (options: PayPalButtonsOptions) => {
                         eventEmitter.on('onApprove', () => {
                             if (options.onApprove) {
                                 options.onApprove(
@@ -515,7 +515,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                 const getOrderActionMock = jest.fn(() => Promise.resolve(paypalOrderDetails));
 
                 jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-                    (options: PayPalCommerceButtonsOptions) => {
+                    (options: PayPalButtonsOptions) => {
                         eventEmitter.on('onApprove', () => {
                             if (options.onApprove) {
                                 options.onApprove(
@@ -556,7 +556,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
 
                 expect(
                     paypalCommerceIntegrationService.getBillingAddressFromOrderDetails,
-                ).toHaveBeenCalledWith(getPayPalCommerceOrderDetails());
+                ).toHaveBeenCalledWith(getPayPalOrderDetails());
                 expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith(
                     getBillingAddressFromOrderDetails(),
                 );
@@ -571,7 +571,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
 
                 expect(
                     paypalCommerceIntegrationService.getShippingAddressFromOrderDetails,
-                ).toHaveBeenCalledWith(getPayPalCommerceOrderDetails());
+                ).toHaveBeenCalledWith(getPayPalOrderDetails());
                 expect(paymentIntegrationService.updateShippingAddress).toHaveBeenCalledWith(
                     getShippingAddressFromOrderDetails(),
                 );

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -1,5 +1,3 @@
-import { noop } from 'lodash';
-
 import {
     CustomerCredentials,
     CustomerInitializeOptions,
@@ -7,32 +5,24 @@ import {
     DefaultCheckoutButtonHeight,
     ExecutePaymentMethodCheckoutOptions,
     InvalidArgumentError,
-    MissingDataError,
-    MissingDataErrorType,
     PaymentIntegrationService,
     RequestOptions,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
-import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
 import {
-    ApproveCallbackActions,
-    ApproveCallbackPayload,
-    PayPalCommerceButtonsOptions,
-    PayPalCommerceInitializationData,
-    ShippingAddressChangeCallbackPayload,
-    ShippingOptionChangeCallbackPayload,
-} from '../paypal-commerce-types';
+    PaypalButtonCreationService,
+    PayPalInitializationData,
+    PayPalIntegrationService,
+} from '@bigcommerce/checkout-sdk/paypal-utils';
 
 import PayPalCommerceCreditCustomerInitializeOptions, {
     WithPayPalCommerceCreditCustomerInitializeOptions,
 } from './paypal-commerce-credit-customer-initialize-options';
 
 export default class PayPalCommerceCreditCustomerStrategy implements CustomerStrategy {
-    private onError = noop;
-
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
-        private paypalCommerceIntegrationService: PayPalCommerceIntegrationService,
+        private paypalIntegrationService: PayPalIntegrationService,
+        private paypalButtonCreationService: PaypalButtonCreationService,
     ) {}
 
     async initialize(
@@ -64,8 +54,6 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
             );
         }
 
-        this.onError = paypalcommercecredit.onError || noop;
-
         const state = this.paymentIntegrationService.getState();
         const paymentMethod = state.getPaymentMethod(methodId);
 
@@ -73,7 +61,7 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
             await this.paymentIntegrationService.loadPaymentMethod(methodId);
         }
 
-        const paypalSdk = await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+        const paypalSdk = await this.paypalIntegrationService.loadPayPalSdk(methodId);
 
         if (!paypalSdk || !paypalSdk.Buttons || typeof paypalSdk.Buttons !== 'function') {
             // eslint-disable-next-line no-console
@@ -109,12 +97,11 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         methodId: string,
         paypalCommerceCredit: PayPalCommerceCreditCustomerInitializeOptions,
     ): void {
-        const { container, onComplete, onClick } = paypalCommerceCredit;
+        const { container, onComplete, onClick, onError } = paypalCommerceCredit;
 
-        const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
+        const paypalSdk = this.paypalIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
-        const paymentMethod =
-            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const paymentMethod = state.getPaymentMethodOrThrow<PayPalInitializationData>(methodId);
         const {
             isHostedCheckoutEnabled,
             paymentButtonStyles,
@@ -122,47 +109,30 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         } = paymentMethod.initializationData || {};
         const { checkoutTopButtonStyles } = paymentButtonStyles || {};
 
-        const defaultCallbacks = {
-            createOrder: () =>
-                this.paypalCommerceIntegrationService.createOrder('paypalcommercecredit'),
-            onApprove: ({ orderID }: ApproveCallbackPayload) =>
-                this.paypalCommerceIntegrationService.tokenizePayment(methodId, orderID),
-            ...(onClick && { onClick: () => onClick() }),
-        };
-
-        const hostedCheckoutCallbacks = {
-            ...(!isServerSideShippingCallbacksEnabled && {
-                onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                    this.onShippingAddressChange(data),
-                onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                    this.onShippingOptionsChange(data),
-            }),
-            onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
-                this.onHostedCheckoutApprove(
-                    data,
-                    actions,
-                    methodId,
-                    onComplete,
-                    isServerSideShippingCallbacksEnabled,
-                ),
-        };
-
         const fundingSources = [paypalSdk.FUNDING.PAYLATER, paypalSdk.FUNDING.CREDIT];
         let hasRenderedSmartButton = false;
 
         fundingSources.forEach((fundingSource) => {
             if (!hasRenderedSmartButton) {
-                const buttonRenderOptions: PayPalCommerceButtonsOptions = {
+                const buttonRenderOptions = {
                     fundingSource,
-                    style: this.paypalCommerceIntegrationService.getValidButtonStyle({
+                    style: this.paypalIntegrationService.getValidButtonStyle({
                         ...checkoutTopButtonStyles,
                         height: DefaultCheckoutButtonHeight,
                     }),
-                    ...defaultCallbacks,
-                    ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),
+                    isHostedCheckoutEnabled,
+                    isServerSideShippingCallbacksEnabled,
+                    ...(isHostedCheckoutEnabled &&
+                        onComplete && { onPaymentComplete: () => onComplete() }),
+                    ...(onClick && { onClick: () => onClick() }),
+                    onError,
                 };
 
-                const paypalButton = paypalSdk.Buttons(buttonRenderOptions);
+                const paypalButton = this.paypalButtonCreationService.createPayPalButton(
+                    'paypalcommerce',
+                    methodId,
+                    buttonRenderOptions,
+                );
 
                 if (paypalButton.isEligible()) {
                     paypalButton.render(`#${container}`);
@@ -172,112 +142,7 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         });
 
         if (!hasRenderedSmartButton) {
-            this.paypalCommerceIntegrationService.removeElement(container);
-        }
-    }
-
-    private async onHostedCheckoutApprove(
-        data: ApproveCallbackPayload,
-        actions: ApproveCallbackActions,
-        methodId: string,
-        onComplete?: () => void,
-        isServerSideShippingCallbacksEnabled?: boolean,
-    ): Promise<void> {
-        if (!data.orderID) {
-            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
-        }
-
-        const cart = this.paymentIntegrationService.getState().getCartOrThrow();
-
-        try {
-            const hasPhysicalItems = cart.lineItems.physicalItems.length > 0;
-
-            if (!isServerSideShippingCallbacksEnabled) {
-                const orderDetails = await actions.order.get();
-
-                const billingAddress =
-                    this.paypalCommerceIntegrationService.getBillingAddressFromOrderDetails(
-                        orderDetails,
-                    );
-
-                await this.paymentIntegrationService.updateBillingAddress(billingAddress);
-
-                if (hasPhysicalItems) {
-                    const shippingAddress =
-                        this.paypalCommerceIntegrationService.getShippingAddressFromOrderDetails(
-                            orderDetails,
-                        );
-
-                    await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
-                }
-            }
-
-            if (hasPhysicalItems) {
-                await this.paypalCommerceIntegrationService.updateOrder(
-                    isServerSideShippingCallbacksEnabled,
-                );
-            }
-
-            if (isServerSideShippingCallbacksEnabled) {
-                await this.paymentIntegrationService.loadCheckout();
-            }
-
-            await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
-            await this.paypalCommerceIntegrationService.submitPayment(methodId, data.orderID);
-
-            if (onComplete && typeof onComplete === 'function') {
-                onComplete();
-            }
-        } catch (error) {
-            this.handleError(error);
-        }
-    }
-
-    private async onShippingAddressChange(
-        data: ShippingAddressChangeCallbackPayload,
-    ): Promise<void> {
-        const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shippingAddress.city,
-            countryCode: data.shippingAddress.countryCode,
-            postalCode: data.shippingAddress.postalCode,
-            stateOrProvinceCode: data.shippingAddress.state,
-        });
-
-        try {
-            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
-            // on this stage we don't have access to valid customer's address except shipping data
-            await this.paymentIntegrationService.updateBillingAddress(address);
-            await this.paymentIntegrationService.updateShippingAddress(address);
-
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow();
-
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalCommerceIntegrationService.updateOrder();
-        } catch (error) {
-            this.handleError(error);
-        }
-    }
-
-    private async onShippingOptionsChange(
-        data: ShippingOptionChangeCallbackPayload,
-    ): Promise<void> {
-        const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-            data.selectedShippingOption.id,
-        );
-
-        try {
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalCommerceIntegrationService.updateOrder();
-        } catch (error) {
-            this.handleError(error);
-        }
-    }
-
-    private handleError(error: unknown) {
-        if (typeof this.onError === 'function') {
-            this.onError(error);
-        } else {
-            throw error;
+            this.paypalIntegrationService.removeElement(container);
         }
     }
 }

--- a/packages/paypal-utils/src/paypal-button-creation-service.spec.ts
+++ b/packages/paypal-utils/src/paypal-button-creation-service.spec.ts
@@ -289,7 +289,7 @@ describe('PayPalButtonCreationService', () => {
 
         await new Promise((resolve) => process.nextTick(resolve));
 
-        expect(paypalIntegrationService.createOrder).toHaveBeenCalledWith('paypalcommerce');
+        expect(paypalIntegrationService.createOrder).toHaveBeenCalledWith('paypalcommercecredit');
     });
 
     it('creates paypal order if buy now initialisation options is passed', async () => {
@@ -310,7 +310,7 @@ describe('PayPalButtonCreationService', () => {
 
         expect(paypalIntegrationService.createBuyNowCartOrThrow).toHaveBeenCalled();
         expect(paymentIntegrationService.loadCheckout).toHaveBeenCalledWith(buyNowCart.id);
-        expect(paypalIntegrationService.createOrder).toHaveBeenCalledWith('paypalcommerce');
+        expect(paypalIntegrationService.createOrder).toHaveBeenCalledWith('paypalcommercecredit');
     });
 
     it('throw an error if fundingSource is not valid', () => {

--- a/packages/paypal-utils/src/paypal-button-creation-service.ts
+++ b/packages/paypal-utils/src/paypal-button-creation-service.ts
@@ -82,7 +82,7 @@ class PaypalButtonCreationService {
                     await this.paymentIntegrationService.loadCheckout(buyNowCart.id);
                 }
 
-                return this.paypalIntegrationService.createOrder(providerId);
+                return this.paypalIntegrationService.createOrder(methodId);
             },
             onApprove: ({ orderID }: ApproveCallbackPayload) =>
                 this.paypalIntegrationService.tokenizePayment(methodId, orderID),

--- a/packages/paypal-utils/src/paypal-integration-service.ts
+++ b/packages/paypal-utils/src/paypal-integration-service.ts
@@ -103,12 +103,12 @@ export default class PayPalIntegrationService {
      *
      */
     async createOrder(
-        providerId: string,
+        methodId: string,
         requestBody?: Partial<PayPalCreateOrderRequestBody>,
     ): Promise<string> {
         const cartId = this.paymentIntegrationService.getState().getCartOrThrow().id;
 
-        const { orderId } = await this.paypalRequestSender.createOrder(providerId, {
+        const { orderId } = await this.paypalRequestSender.createOrder(methodId, {
             cartId,
             ...requestBody,
         });

--- a/packages/paypal-utils/src/paypal-request-sender.ts
+++ b/packages/paypal-utils/src/paypal-request-sender.ts
@@ -19,10 +19,10 @@ export default class PayPalRequestSender {
     constructor(private requestSender: RequestSender) {}
 
     async createOrder(
-        providerId: string,
+        methodId: string,
         requestBody: Partial<PayPalCreateOrderRequestBody>,
     ): Promise<PayPalOrderData> {
-        const url = `/api/storefront/payment/${providerId}`;
+        const url = `/api/storefront/payment/${methodId}`;
         const body = requestBody;
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,


### PR DESCRIPTION
## What/Why?

Update `PayPalCommerceCreditButtonStratege` and `PayPalCommerceCreditCustomerStrategy` using `PaypalButtonCreationService` from `paypal-utils` package

## Rollout/Rollback

Revert

## Testing

https://github.com/user-attachments/assets/cee75e95-576c-4bfe-a495-990396320b71

https://github.com/user-attachments/assets/e5d1d8be-a542-46b7-8064-f481c14a0681

https://github.com/user-attachments/assets/94148557-a5a0-4955-80bf-026dc79a359e



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live PayPal Credit/Pay Later checkout flows and changes which identifier hits order-creation APIs; incorrect routing could break order creation for credit.
> 
> **Overview**
> Refactors **PayPal Commerce Credit** checkout button and customer strategies to render Pay Later/Credit smart buttons through shared **`PaypalButtonCreationService`** from `paypal-utils`, removing duplicated hosted-checkout, shipping callback, and approve logic from the integration package.
> 
> Factories now wire **`PayPalIntegrationService`** plus **`PaypalButtonCreationService`** (customer strategy drops the local commerce integration service). Customer rendering also passes **`onError`** into the shared button options.
> 
> In **`paypal-utils`**, PayPal **order creation** is aligned to use the payment **`methodId`** (e.g. `paypalcommercecredit`) for `createOrder` and the storefront payment API path, instead of the provider id—tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb88f0b496c3b3d76a7fb70f728ec332371bd81f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->