### PR TITLE
refactor(payment): PAYPAL-5774 update BCP payment strategy by providing PaypalUtilsService

### DIFF
--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-payment-strategy.spec.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-payment-strategy.spec.ts
@@ -19,19 +19,17 @@ import {
     getInstruments,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    getPayPalIntegrationServiceMock,
+    getPayPalSDKMock,
+    PayPalButtonsOptions,
+    PayPalHostWindow,
+    PayPalIntegrationService,
+    PayPalSDK,
+} from '@bigcommerce/checkout-sdk/paypal-utils';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
-import BigCommercePaymentsIntegrationService from '../bigcommerce-payments-integration-service';
-import {
-    BigCommercePaymentsButtonsOptions,
-    BigCommercePaymentsHostWindow,
-    PayPalSDK,
-} from '../bigcommerce-payments-types';
-import {
-    getBigCommercePaymentsIntegrationServiceMock,
-    getBigCommercePaymentsPaymentMethod,
-    getPayPalSDKMock,
-} from '../mocks';
+import { getBigCommercePaymentsPaymentMethod } from '../mocks';
 
 import BigCommercePaymentsPaymentInitializeOptions, {
     WithBigCommercePaymentsPaymentInitializeOptions,
@@ -43,7 +41,7 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
     let loadingIndicator: LoadingIndicator;
     let paymentIntegrationService: PaymentIntegrationService;
     let paymentMethod: PaymentMethod;
-    let bigCommercePaymentsIntegrationService: BigCommercePaymentsIntegrationService;
+    let paypalIntegrationService: PayPalIntegrationService;
     let paypalSdk: PayPalSDK;
     let paypalSdkHelper: PayPalSdkHelper;
     let payPalMessagesSdk: PayPalMessagesSdk;
@@ -89,13 +87,13 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
         paymentMethod.initializationData.orderId = undefined;
 
         loadingIndicator = new LoadingIndicator();
-        bigCommercePaymentsIntegrationService = getBigCommercePaymentsIntegrationServiceMock();
+        paypalIntegrationService = getPayPalIntegrationServiceMock();
         paymentIntegrationService = new PaymentIntegrationServiceMock();
         paypalSdkHelper = createBigCommercePaymentsSdk();
 
         strategy = new BigCommercePaymentsPaymentStrategy(
             paymentIntegrationService,
-            bigCommercePaymentsIntegrationService,
+            paypalIntegrationService,
             paypalSdkHelper,
             loadingIndicator,
         );
@@ -104,76 +102,69 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
             paymentMethod,
         );
 
-        jest.spyOn(bigCommercePaymentsIntegrationService, 'loadPayPalSdk').mockResolvedValue(
-            paypalSdk,
-        );
-        jest.spyOn(bigCommercePaymentsIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
-            paypalSdk,
-        );
-        jest.spyOn(bigCommercePaymentsIntegrationService, 'createOrder').mockResolvedValue('');
-        jest.spyOn(bigCommercePaymentsIntegrationService, 'submitPayment').mockResolvedValue();
+        jest.spyOn(paypalIntegrationService, 'loadPayPalSdk').mockResolvedValue(paypalSdk);
+        jest.spyOn(paypalIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalIntegrationService, 'createOrder').mockResolvedValue('');
 
         jest.spyOn(loadingIndicator, 'show').mockReturnValue(undefined);
         jest.spyOn(loadingIndicator, 'hide').mockReturnValue(undefined);
 
-        jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-            (options: BigCommercePaymentsButtonsOptions) => {
-                eventEmitter.on('createOrder', () => {
-                    if (options.createOrder) {
-                        options.createOrder();
-                    }
-                });
+        jest.spyOn(paypalSdk, 'Buttons').mockImplementation((options: PayPalButtonsOptions) => {
+            eventEmitter.on('createOrder', () => {
+                if (options.createOrder) {
+                    options.createOrder();
+                }
+            });
 
-                eventEmitter.on('onClick', () => {
-                    if (options.onClick) {
-                        options.onClick(
-                            { fundingSource: paypalSdk.FUNDING.PAYPAL },
-                            {
-                                reject: jest.fn(),
-                                resolve: jest.fn(),
+            eventEmitter.on('onClick', () => {
+                if (options.onClick) {
+                    options.onClick(
+                        { fundingSource: paypalSdk.FUNDING.PAYPAL },
+                        {
+                            reject: jest.fn(),
+                            resolve: jest.fn(),
+                        },
+                    );
+                }
+            });
+
+            eventEmitter.on('onApprove', () => {
+                if (options.onApprove) {
+                    options.onApprove(
+                        { orderID: paypalOrderId },
+                        {
+                            order: {
+                                get: jest.fn(),
                             },
-                        );
-                    }
-                });
+                        },
+                    );
+                }
+            });
 
-                eventEmitter.on('onApprove', () => {
-                    if (options.onApprove) {
-                        options.onApprove(
-                            { orderID: paypalOrderId },
-                            {
-                                order: {
-                                    get: jest.fn(),
-                                },
-                            },
-                        );
-                    }
-                });
+            eventEmitter.on('onCancel', () => {
+                if (options.onCancel) {
+                    options.onCancel();
+                }
+            });
 
-                eventEmitter.on('onCancel', () => {
-                    if (options.onCancel) {
-                        options.onCancel();
-                    }
-                });
+            eventEmitter.on('onError', () => {
+                if (options.onError) {
+                    options.onError(new Error());
+                }
+            });
 
-                eventEmitter.on('onError', () => {
-                    if (options.onError) {
-                        options.onError(new Error());
-                    }
-                });
-
-                return {
-                    isEligible: jest.fn(() => true),
-                    render: jest.fn(),
-                    close: jest.fn(),
-                };
-            },
-        );
+            return {
+                isEligible: jest.fn(() => true),
+                render: jest.fn(),
+                close: jest.fn(),
+            };
+        });
     });
 
     afterEach(() => {
         jest.clearAllMocks();
 
-        delete (window as BigCommercePaymentsHostWindow).paypal;
+        delete (window as PayPalHostWindow).paypal;
     });
 
     it('creates an instance of the BigCommercePaymentsPaymentStrategy payment strategy', () => {
@@ -208,15 +199,13 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            expect(bigCommercePaymentsIntegrationService.loadPayPalSdk).not.toHaveBeenCalled();
+            expect(paypalIntegrationService.loadPayPalSdk).not.toHaveBeenCalled();
         });
 
         it('loads paypal sdk', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(bigCommercePaymentsIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(
-                defaultMethodId,
-            );
+            expect(paypalIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(defaultMethodId);
         });
     });
 
@@ -349,7 +338,7 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
 
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(bigCommercePaymentsIntegrationService.createOrder).toHaveBeenCalledWith(
+            expect(paypalIntegrationService.createOrder).toHaveBeenCalledWith(
                 'bigcommerce_paymentscheckout',
                 { shouldSaveInstrument: false },
             );
@@ -372,7 +361,7 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
 
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(bigCommercePaymentsIntegrationService.createOrder).toHaveBeenCalledWith(
+            expect(paypalIntegrationService.createOrder).toHaveBeenCalledWith(
                 'bigcommerce_paymentscheckout',
                 { shouldSaveInstrument: true },
             );
@@ -569,9 +558,7 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
         it('submits payment with provided vaulting data', async () => {
             const { bigpayToken } = accountInstrument as AccountInstrument;
 
-            jest.spyOn(bigCommercePaymentsIntegrationService, 'createOrder').mockResolvedValue(
-                paypalOrderId,
-            );
+            jest.spyOn(paypalIntegrationService, 'createOrder').mockResolvedValue(paypalOrderId);
 
             const payload = {
                 payment: {
@@ -644,7 +631,7 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
             try {
                 await strategy.execute(payload);
             } catch (_error: unknown) {
-                expect(bigCommercePaymentsIntegrationService.loadPayPalSdk).toHaveBeenCalled();
+                expect(paypalIntegrationService.loadPayPalSdk).toHaveBeenCalled();
             }
         });
 
@@ -666,7 +653,7 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
             try {
                 await strategy.execute(payload);
             } catch (_error: unknown) {
-                expect(bigCommercePaymentsIntegrationService.loadPayPalSdk).not.toHaveBeenCalled();
+                expect(paypalIntegrationService.loadPayPalSdk).not.toHaveBeenCalled();
             }
         });
 
@@ -719,28 +706,26 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
         it('close paypal buttons before render new buttons after getting INSTRUMENT_DECLINED error', async () => {
             const bigCommercePaymentsSdkCloseMock = jest.fn();
 
-            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-                (options: BigCommercePaymentsButtonsOptions) => {
-                    eventEmitter.on('onApprove', () => {
-                        if (options.onApprove) {
-                            options.onApprove(
-                                { orderID: paypalOrderId },
-                                {
-                                    order: {
-                                        get: jest.fn(),
-                                    },
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation((options: PayPalButtonsOptions) => {
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove(
+                            { orderID: paypalOrderId },
+                            {
+                                order: {
+                                    get: jest.fn(),
                                 },
-                            );
-                        }
-                    });
+                            },
+                        );
+                    }
+                });
 
-                    return {
-                        isEligible: jest.fn(() => true),
-                        render: jest.fn(),
-                        close: bigCommercePaymentsSdkCloseMock,
-                    };
-                },
-            );
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                    close: bigCommercePaymentsSdkCloseMock,
+                };
+            });
 
             const payload = {
                 payment: {
@@ -969,7 +954,7 @@ describe('BigCommercePaymentsPaymentStrategy', () => {
         it('does not execute PayPal button initialization logic if bannerContainerId is provided', async () => {
             await strategy.initialize(options);
 
-            expect(bigCommercePaymentsIntegrationService.loadPayPalSdk).not.toHaveBeenCalledWith(
+            expect(paypalIntegrationService.loadPayPalSdk).not.toHaveBeenCalledWith(
                 defaultMethodId,
             );
         });

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/bigcommerce-payments-payment-strategy.ts
@@ -24,10 +24,10 @@ import {
     PaymentStrategy,
     VaultedInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PayPalIntegrationService } from '@bigcommerce/checkout-sdk/paypal-utils';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 import { isBaseInstrument } from '@bigcommerce/checkout-sdk/utility';
 
-import BigCommercePaymentsIntegrationService from '../bigcommerce-payments-integration-service';
 import {
     ApproveCallbackPayload,
     BigCommercePaymentsButtons,
@@ -48,7 +48,7 @@ export default class BigCommercePaymentsPaymentStrategy implements PaymentStrate
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
-        private bigCommercePaymentsIntegrationService: BigCommercePaymentsIntegrationService,
+        private paypalIntegrationService: PayPalIntegrationService,
         private paypalSdkHelper: PayPalSdkHelper,
         private loadingIndicator: LoadingIndicator,
     ) {}
@@ -131,7 +131,7 @@ export default class BigCommercePaymentsPaymentStrategy implements PaymentStrate
 
         this.loadingIndicatorContainer = container?.split('#')[1];
 
-        await this.bigCommercePaymentsIntegrationService.loadPayPalSdk(methodId);
+        await this.paypalIntegrationService.loadPayPalSdk(methodId);
 
         if (bigcommerce_payments.onInit && typeof bigcommerce_payments.onInit === 'function') {
             bigcommerce_payments.onInit(() => this.renderButton(methodId, bigcommerce_payments));
@@ -172,7 +172,7 @@ export default class BigCommercePaymentsPaymentStrategy implements PaymentStrate
             await this.paymentIntegrationService.submitPayment(paymentPayload);
         } catch (error: unknown) {
             if (this.isProviderError(error)) {
-                await this.bigCommercePaymentsIntegrationService.loadPayPalSdk(payment.methodId);
+                await this.paypalIntegrationService.loadPayPalSdk(payment.methodId);
 
                 await new Promise((_resolve, reject) => {
                     if (this.bigcommerce_payments) {
@@ -275,7 +275,7 @@ export default class BigCommercePaymentsPaymentStrategy implements PaymentStrate
         methodId: string,
         bigcommerce_payments: BigCommercePaymentsPaymentInitializeOptions,
     ): void {
-        const paypalSdk = this.bigCommercePaymentsIntegrationService.getPayPalSdkOrThrow();
+        const paypalSdk = this.paypalIntegrationService.getPayPalSdkOrThrow();
 
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
@@ -292,9 +292,7 @@ export default class BigCommercePaymentsPaymentStrategy implements PaymentStrate
 
         const buttonOptions: BigCommercePaymentsButtonsOptions = {
             fundingSource: paypalSdk.FUNDING.PAYPAL,
-            style: this.bigCommercePaymentsIntegrationService.getValidButtonStyle(
-                checkoutPaymentButtonStyles,
-            ),
+            style: this.paypalIntegrationService.getValidButtonStyle(checkoutPaymentButtonStyles),
             createOrder: () => this.createOrder(),
             onClick: (_, actions) => this.handleClick(actions, onValidate),
             onApprove: (data) => this.handleApprove(data, submitForm),
@@ -353,12 +351,9 @@ export default class BigCommercePaymentsPaymentStrategy implements PaymentStrate
     private async createOrder(): Promise<string> {
         const fieldsValues = this.getFieldsValues();
 
-        return this.bigCommercePaymentsIntegrationService.createOrder(
-            'bigcommerce_paymentscheckout',
-            {
-                shouldSaveInstrument: fieldsValues?.shouldSaveInstrument || false,
-            },
-        );
+        return this.paypalIntegrationService.createOrder('bigcommerce_paymentscheckout', {
+            shouldSaveInstrument: fieldsValues?.shouldSaveInstrument || false,
+        });
     }
 
     /**

--- a/packages/bigcommerce-payments-integration/src/bigcommerce-payments/create-bigcommerce-payments-payment-strategy.ts
+++ b/packages/bigcommerce-payments-integration/src/bigcommerce-payments/create-bigcommerce-payments-payment-strategy.ts
@@ -3,10 +3,10 @@ import {
     PaymentStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { createPayPalIntegrationService } from '@bigcommerce/checkout-sdk/paypal-utils';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import { LOADING_INDICATOR_STYLES } from '../bigcommerce-payments-constants';
-import createBigCommercePaymentsIntegrationService from '../create-bigcommerce-payments-integration-service';
 
 import BigCommercePaymentsPaymentStrategy from './bigcommerce-payments-payment-strategy';
 
@@ -15,7 +15,7 @@ const createBigCommercePaymentsPaymentStrategy: PaymentStrategyFactory<
 > = (paymentIntegrationService) =>
     new BigCommercePaymentsPaymentStrategy(
         paymentIntegrationService,
-        createBigCommercePaymentsIntegrationService(paymentIntegrationService),
+        createPayPalIntegrationService(paymentIntegrationService),
         createBigCommercePaymentsSdk(),
         new LoadingIndicator({
             containerStyles: LOADING_INDICATOR_STYLES,

--- a/packages/paypal-utils/src/index.ts
+++ b/packages/paypal-utils/src/index.ts
@@ -1,7 +1,7 @@
 export * from './paypal-types';
 export * from './mocks';
 export * from './utils';
-export * from './paypal-commerce-constants';
+export * from './paypal-constants';
 
 // TODO: this export should be moved to ./utils/index.ts file
 export { default as isPaypalProviderError } from './utils/is-paypal-provider-error';

--- a/packages/paypal-utils/src/paypal-constants.ts
+++ b/packages/paypal-utils/src/paypal-constants.ts
@@ -4,6 +4,20 @@ export const LOADING_INDICATOR_STYLES = {
 };
 
 /**
+ * PayPalSdkNamespace maps each PayPal SDK module to the
+ * window global it registers under (also used as the `data-namespace` attribute)
+ */
+export enum PayPalSdkNamespace {
+    PayPal = 'paypal',
+    BigCommercePaymentsPayPalSDK = 'bigCommercePaymentsPayPalSDK',
+    PayPalFastlaneSdk = 'paypalFastlaneSdk',
+    PayPalFastlane = 'paypalFastlane',
+    PayPalGooglePay = 'paypalGooglePay',
+    PayPalApms = 'paypalApms',
+    PayPalMessages = 'paypalMessages',
+}
+
+/**
  * PayPal SDK supported locales
  * https://developer.paypal.com/sdk/js/configuration/#link-locale
  */

--- a/packages/paypal-utils/src/paypal-sdk-script-loader.spec.ts
+++ b/packages/paypal-utils/src/paypal-sdk-script-loader.spec.ts
@@ -63,6 +63,7 @@ describe('PayPalSdkLoader', () => {
 
         jest.spyOn(loader, 'loadScript').mockImplementation(() => {
             (window as PayPalHostWindow).paypal = paypalSdk;
+            (window as PayPalHostWindow).bigCommercePaymentsPayPalSDK = paypalSdk;
             (window as PayPalHostWindow).paypalFastlaneSdk = paypalFastlaneSdk;
             (window as PayPalHostWindow).paypalMessages = paypalMessagesSdk;
             (window as PayPalHostWindow).paypalApms = paypalApmsSdk;
@@ -74,6 +75,7 @@ describe('PayPalSdkLoader', () => {
 
     afterEach(() => {
         (window as PayPalHostWindow).paypal = undefined;
+        (window as PayPalHostWindow).bigCommercePaymentsPayPalSDK = undefined;
         (window as PayPalHostWindow).paypalFastlaneSdk = undefined;
         (window as PayPalHostWindow).paypalMessages = undefined;
         (window as PayPalHostWindow).paypalApms = undefined;
@@ -382,6 +384,7 @@ describe('PayPalSdkLoader', () => {
             const paypalSdkAttributes = {
                 'data-client-token': paymentMethod.clientToken,
                 'data-partner-attribution-id': paymentMethod.initializationData.attributionId,
+                'data-namespace': 'bigCommercePaymentsPayPalSDK',
             };
 
             expect(loader.loadScript).toHaveBeenCalledWith(paypalSdkScriptSrc, {

--- a/packages/paypal-utils/src/paypal-sdk-script-loader.ts
+++ b/packages/paypal-utils/src/paypal-sdk-script-loader.ts
@@ -34,7 +34,9 @@ export default class PayPalSdkScriptLoader {
         initializesOnCheckoutPage?: boolean,
         forceLoad?: boolean,
     ): Promise<PayPalSDK> {
-        if (!this.window.paypal || forceLoad) {
+        const isBigCommercePayments = this.isBigCommercePaymentsMethod(paymentMethod.id);
+
+        if (!this.getLoadedPayPalSdk(isBigCommercePayments) || forceLoad) {
             const paypalSdkScriptConfig = this.getPayPalSdkScriptConfigOrThrow(
                 paymentMethod,
                 currencyCode,
@@ -43,13 +45,15 @@ export default class PayPalSdkScriptLoader {
             );
 
             await this.loadPayPalSdk(paypalSdkScriptConfig);
-
-            if (!this.window.paypal) {
-                throw new PaymentMethodClientUnavailableError();
-            }
         }
 
-        return this.window.paypal;
+        const paypalSdk = this.getLoadedPayPalSdk(isBigCommercePayments);
+
+        if (!paypalSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return paypalSdk;
     }
 
     async getPayPalFastlaneSdk(
@@ -143,6 +147,16 @@ export default class PayPalSdkScriptLoader {
         }
 
         return this.window.paypalMessages;
+    }
+
+    private isBigCommercePaymentsMethod(methodId: string): boolean {
+        return methodId.startsWith('bigcommerce_payments');
+    }
+
+    private getLoadedPayPalSdk(isBigCommercePayments: boolean): PayPalSDK | undefined {
+        return isBigCommercePayments
+            ? this.window.bigCommercePaymentsPayPalSDK
+            : this.window.paypal;
     }
 
     /**
@@ -254,6 +268,9 @@ export default class PayPalSdkScriptLoader {
             attributes: {
                 'data-partner-attribution-id': attributionId,
                 'data-client-token': clientToken,
+                ...(this.isBigCommercePaymentsMethod(id) && {
+                    'data-namespace': 'bigCommercePaymentsPayPalSDK',
+                }),
             },
         };
     }

--- a/packages/paypal-utils/src/paypal-sdk-script-loader.ts
+++ b/packages/paypal-utils/src/paypal-sdk-script-loader.ts
@@ -7,6 +7,7 @@ import {
     PaymentMethodClientUnavailableError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
+import { PayPalSdkNamespace } from './paypal-constants';
 import {
     FundingType,
     PayPalFastlaneSdk,
@@ -18,7 +19,7 @@ import {
     PayPalSdkComponents,
     PayPalSdkConfig,
 } from './paypal-types';
-import { transformLocaleToPayPalFormat } from './utils';
+import { getPayPalSdkModule, transformLocaleToPayPalFormat } from './utils';
 
 export default class PayPalSdkScriptLoader {
     private window: PayPalHostWindow;
@@ -34,9 +35,11 @@ export default class PayPalSdkScriptLoader {
         initializesOnCheckoutPage?: boolean,
         forceLoad?: boolean,
     ): Promise<PayPalSDK> {
-        const isBigCommercePayments = this.isBigCommercePaymentsMethod(paymentMethod.id);
+        const namespace = this.isBigCommercePaymentsMethod(paymentMethod.id)
+            ? PayPalSdkNamespace.BigCommercePaymentsPayPalSDK
+            : PayPalSdkNamespace.PayPal;
 
-        if (!this.getLoadedPayPalSdk(isBigCommercePayments) || forceLoad) {
+        if (!getPayPalSdkModule(namespace) || forceLoad) {
             const paypalSdkScriptConfig = this.getPayPalSdkScriptConfigOrThrow(
                 paymentMethod,
                 currencyCode,
@@ -47,7 +50,7 @@ export default class PayPalSdkScriptLoader {
             await this.loadPayPalSdk(paypalSdkScriptConfig);
         }
 
-        const paypalSdk = this.getLoadedPayPalSdk(isBigCommercePayments);
+        const paypalSdk = getPayPalSdkModule(namespace);
 
         if (!paypalSdk) {
             throw new PaymentMethodClientUnavailableError();
@@ -151,12 +154,6 @@ export default class PayPalSdkScriptLoader {
 
     private isBigCommercePaymentsMethod(methodId: string): boolean {
         return methodId.startsWith('bigcommerce_payments');
-    }
-
-    private getLoadedPayPalSdk(isBigCommercePayments: boolean): PayPalSDK | undefined {
-        return isBigCommercePayments
-            ? this.window.bigCommercePaymentsPayPalSDK
-            : this.window.paypal;
     }
 
     /**
@@ -269,7 +266,7 @@ export default class PayPalSdkScriptLoader {
                 'data-partner-attribution-id': attributionId,
                 'data-client-token': clientToken,
                 ...(this.isBigCommercePaymentsMethod(id) && {
-                    'data-namespace': 'bigCommercePaymentsPayPalSDK',
+                    'data-namespace': PayPalSdkNamespace.BigCommercePaymentsPayPalSDK,
                 }),
             },
         };
@@ -309,7 +306,7 @@ export default class PayPalSdkScriptLoader {
             },
             attributes: {
                 'data-client-metadata-id': sessionId.replace(/-/g, ''),
-                'data-namespace': 'paypalFastlaneSdk',
+                'data-namespace': PayPalSdkNamespace.PayPalFastlaneSdk,
                 'data-partner-attribution-id': attributionId,
                 'data-sdk-client-token': clientToken,
             },
@@ -356,7 +353,7 @@ export default class PayPalSdkScriptLoader {
             attributes: {
                 'data-partner-attribution-id': attributionId,
                 'data-client-token': clientToken,
-                'data-namespace': 'paypalGooglePay',
+                'data-namespace': PayPalSdkNamespace.PayPalGooglePay,
             },
         };
     }
@@ -407,7 +404,7 @@ export default class PayPalSdkScriptLoader {
             },
             attributes: {
                 'data-partner-attribution-id': attributionId,
-                'data-namespace': 'paypalApms',
+                'data-namespace': PayPalSdkNamespace.PayPalApms,
             },
         };
     }
@@ -438,7 +435,7 @@ export default class PayPalSdkScriptLoader {
                 ...(locale && { locale }),
             },
             attributes: {
-                'data-namespace': 'paypalMessages',
+                'data-namespace': PayPalSdkNamespace.PayPalMessages,
                 'data-partner-attribution-id': attributionId,
             },
         };

--- a/packages/paypal-utils/src/paypal-types.ts
+++ b/packages/paypal-utils/src/paypal-types.ts
@@ -7,6 +7,8 @@ import {
     VaultedInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
+import { PayPalSdkNamespace } from './paypal-constants';
+
 /**
  *
  * PayPal Funding sources
@@ -77,13 +79,13 @@ export interface PayPalInitializationData {
  *
  */
 export interface PayPalHostWindow extends Window {
-    paypal?: PayPalSDK;
-    bigCommercePaymentsPayPalSDK?: PayPalSDK;
-    paypalFastlane?: PayPalFastlane;
-    paypalFastlaneSdk?: PayPalFastlaneSdk;
-    paypalMessages?: PayPalMessagesSdk;
-    paypalApms?: PayPalApmSdk;
-    paypalGooglePay?: PayPalGooglePaySdk;
+    [PayPalSdkNamespace.PayPal]?: PayPalSDK;
+    [PayPalSdkNamespace.BigCommercePaymentsPayPalSDK]?: PayPalSDK;
+    [PayPalSdkNamespace.PayPalFastlane]?: PayPalFastlane;
+    [PayPalSdkNamespace.PayPalFastlaneSdk]?: PayPalFastlaneSdk;
+    [PayPalSdkNamespace.PayPalMessages]?: PayPalMessagesSdk;
+    [PayPalSdkNamespace.PayPalApms]?: PayPalApmSdk;
+    [PayPalSdkNamespace.PayPalGooglePay]?: PayPalGooglePaySdk;
 }
 
 /**

--- a/packages/paypal-utils/src/paypal-types.ts
+++ b/packages/paypal-utils/src/paypal-types.ts
@@ -78,6 +78,7 @@ export interface PayPalInitializationData {
  */
 export interface PayPalHostWindow extends Window {
     paypal?: PayPalSDK;
+    bigCommercePaymentsPayPalSDK?: PayPalSDK;
     paypalFastlane?: PayPalFastlane;
     paypalFastlaneSdk?: PayPalFastlaneSdk;
     paypalMessages?: PayPalMessagesSdk;

--- a/packages/paypal-utils/src/utils/get-paypal-sdk-module.spec.ts
+++ b/packages/paypal-utils/src/utils/get-paypal-sdk-module.spec.ts
@@ -1,0 +1,31 @@
+import { PayPalSdkNamespace } from '../paypal-constants';
+import { PayPalHostWindow, PayPalSDK } from '../paypal-types';
+
+import getPayPalSdkModule from './get-paypal-sdk-module';
+
+describe('getPayPalSdkModule', () => {
+    afterEach(() => {
+        (window as PayPalHostWindow).paypal = undefined;
+        (window as PayPalHostWindow).bigCommercePaymentsPayPalSDK = undefined;
+    });
+
+    it('returns the module registered under the provided namespace', () => {
+        const paypalSdk = {} as PayPalSDK;
+
+        (window as PayPalHostWindow).paypal = paypalSdk;
+
+        expect(getPayPalSdkModule(PayPalSdkNamespace.PayPal)).toBe(paypalSdk);
+    });
+
+    it('returns the module registered under the bigcommerce payments namespace', () => {
+        const paypalSdk = {} as PayPalSDK;
+
+        (window as PayPalHostWindow).bigCommercePaymentsPayPalSDK = paypalSdk;
+
+        expect(getPayPalSdkModule(PayPalSdkNamespace.BigCommercePaymentsPayPalSDK)).toBe(paypalSdk);
+    });
+
+    it('returns undefined when the module is not loaded', () => {
+        expect(getPayPalSdkModule(PayPalSdkNamespace.PayPal)).toBeUndefined();
+    });
+});

--- a/packages/paypal-utils/src/utils/get-paypal-sdk-module.ts
+++ b/packages/paypal-utils/src/utils/get-paypal-sdk-module.ts
@@ -1,0 +1,8 @@
+import { PayPalSdkNamespace } from '../paypal-constants';
+import { PayPalHostWindow } from '../paypal-types';
+
+export default function getPayPalSdkModule<K extends PayPalSdkNamespace>(
+    namespace: K,
+): PayPalHostWindow[K] {
+    return (window as PayPalHostWindow)[namespace];
+}

--- a/packages/paypal-utils/src/utils/index.ts
+++ b/packages/paypal-utils/src/utils/index.ts
@@ -5,3 +5,4 @@ export { default as getPaypalMessagesStylesFromBNPLConfig } from './get-paypal-m
 export { default as isRedirectActionError } from './is-redirect-action-error';
 export { default as isPaypalFastlaneRequestError } from './is-paypal-fastlane-request-error';
 export { default as transformLocaleToPayPalFormat } from './transform-locale-to-paypal-format';
+export { default as getPayPalSdkModule } from './get-paypal-sdk-module';

--- a/packages/paypal-utils/src/utils/transform-locale-to-paypal-format.ts
+++ b/packages/paypal-utils/src/utils/transform-locale-to-paypal-format.ts
@@ -1,4 +1,4 @@
-import { PAYPAL_SDK_SUPPORTED_LOCALES } from '../paypal-commerce-constants';
+import { PAYPAL_SDK_SUPPORTED_LOCALES } from '../paypal-constants';
 
 /**
  * Transforms store language to PayPal SDK locale format.


### PR DESCRIPTION
## What/Why?
Replace BigCommercePaymentsIntegrationService with PaypalUtilsService from paypal-utils package
Added BCP namespace to `paypal-utils/paypal-sdk-script-loader`
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
Manual

[bcp_paypal_button.webm](https://github.com/user-attachments/assets/58ea4e1e-6d03-41a7-8489-b6ad658dd20f)

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch checkout PayPal button initialization and SDK loading/isolation on `window`, which can affect coexisting PayPal integrations if namespaces clash; behavior should match prior flows but warrants payment checkout regression testing.
> 
> **Overview**
> **BigCommerce Payments checkout** now depends on shared **`PayPalIntegrationService`** from `paypal-utils` instead of the local **`BigCommercePaymentsIntegrationService`** for SDK load, button styling, and order creation. The strategy factory injects **`createPayPalIntegrationService`**, and unit tests were updated to mock the PayPal utils types and service.
> 
> In **`paypal-utils`**, PayPal script loading is **namespace-aware**: method IDs starting with `bigcommerce_payments` load the SDK with **`data-namespace: bigCommercePaymentsPayPalSDK`** and resolve the instance via new **`getPayPalSdkModule`** and a **`PayPalSdkNamespace`** enum (other SDK variants now use the enum too). Constants were consolidated under **`paypal-constants`** (replacing `paypal-commerce-constants` exports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b98ad5617331766f9f0c972450ecd15f3be803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->