### PR TITLE
feat(payment): add shipping options filtering callback for Apple Pay and Google Pay

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-initialize-options.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-initialize-options.ts
@@ -1,4 +1,7 @@
-import { BuyNowCartRequestBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    BuyNowCartRequestBody,
+    ShippingOption,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 /**
  * A set of options that are required to initialize ApplePay in cart.
@@ -18,6 +21,15 @@ export default interface ApplePayButtonInitializeOptions {
     buyNowInitializeOptions?: {
         getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
     };
+
+    /**
+     * @param shippingOptions - The available shipping options.
+     * @returns The filtered shipping options.
+     * A function that filters the available shipping options.
+     */
+    filterAvailableShippingOptions?: (
+        shippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
 
     /**
      * A callback that gets called when a payment is successfully completed.

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.spec.ts
@@ -13,6 +13,7 @@ import {
     InvalidArgumentError,
     MissingDataError,
     PaymentIntegrationService,
+    ShippingOption,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBuyNowCart,
@@ -253,6 +254,110 @@ describe('ApplePayButtonStrategy', () => {
                     expect(applePaySession.completeShippingContactSelection).toHaveBeenCalled();
                 }
             }
+        });
+
+        describe('with filterAvailableShippingOptions', () => {
+            const pickUpOption = {
+                ...getShippingOption(),
+                id: 'pick-up-in-store',
+                type: 'shipping_pickupinstore',
+                description: 'Pick Up',
+                isRecommended: false,
+            };
+            const deliveryOption = {
+                ...getShippingOption(),
+                id: 'delivery',
+                description: 'Delivery',
+                isRecommended: true,
+            };
+            const filterOutPickUp = (shippingOptions: ShippingOption[]) =>
+                Promise.resolve(
+                    shippingOptions.filter((option) => option.type !== 'shipping_pickupinstore'),
+                );
+
+            const initializeWithFilter = async (
+                filterAvailableShippingOptions: (
+                    shippingOptions: ShippingOption[],
+                ) => Promise<ShippingOption[]>,
+                selectedShippingOption?: ShippingOption,
+            ) => {
+                const options = getApplePayButtonInitializationOptions();
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getCheckoutOrThrow',
+                ).mockReturnValue({
+                    ...getCheckout(),
+                    consignments: [
+                        {
+                            ...getConsignment(),
+                            selectedShippingOption,
+                            availableShippingOptions: [pickUpOption, deliveryOption],
+                        },
+                    ],
+                });
+
+                await strategy.initialize({
+                    ...options,
+                    applepay: {
+                        ...options.applepay!,
+                        filterAvailableShippingOptions,
+                    },
+                });
+
+                const button = container.firstChild as HTMLElement;
+
+                button.click();
+
+                await applePaySession.onshippingcontactselected({
+                    shippingContact: getContactAddress(),
+                } as ApplePayJS.ApplePayShippingContactSelectedEvent);
+            };
+
+            it('only shows the options kept by the filter', async () => {
+                await initializeWithFilter(filterOutPickUp);
+
+                expect(applePaySession.completeShippingContactSelection).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        newShippingMethods: [
+                            {
+                                label: deliveryOption.description,
+                                amount: deliveryOption.cost.toFixed(2),
+                                detail: deliveryOption.additionalDescription,
+                                identifier: deliveryOption.id,
+                            },
+                        ],
+                    }),
+                );
+            });
+
+            it('falls back to the unfiltered options if the filter rejects', async () => {
+                jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+                await initializeWithFilter(() => Promise.reject(new Error('Filtering failed')));
+
+                const [[{ newShippingMethods }]] = (
+                    applePaySession.completeShippingContactSelection as jest.Mock
+                ).mock.calls;
+
+                expect(newShippingMethods).toHaveLength(2);
+            });
+
+            it('re-selects a remaining option when the selected one is filtered out', async () => {
+                await initializeWithFilter(filterOutPickUp, pickUpOption);
+
+                expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                    deliveryOption.id,
+                );
+            });
+
+            it('keeps the selected option when the filter retains it', async () => {
+                await initializeWithFilter(filterOutPickUp, deliveryOption);
+
+                expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                    deliveryOption.id,
+                );
+            });
         });
 
         it('throws error if call to update address fails', async () => {

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -67,6 +67,9 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
     private _onAuthorizeCallback = noop;
     private _subTotalLabel: string = DefaultLabels.Subtotal;
     private _shippingLabel: string = DefaultLabels.Shipping;
+    private _filterAvailableShippingOptions?: (
+        availableShippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
 
     constructor(
         private _requestSender: RequestSender,
@@ -87,9 +90,16 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
 
         await this._applePayScriptLoader.loadSdk();
 
-        const { onPaymentAuthorize, buyNowInitializeOptions, requiresShipping } = applepay;
+        const {
+            onPaymentAuthorize,
+            buyNowInitializeOptions,
+            requiresShipping,
+            filterAvailableShippingOptions,
+        } = applepay;
 
         this._requiresShipping = requiresShipping;
+
+        this._filterAvailableShippingOptions = filterAvailableShippingOptions;
 
         this._buyNowInitializeOptions = buyNowInitializeOptions;
 
@@ -411,7 +421,16 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
         } = state.getCartOrThrow();
         let checkout = state.getCheckoutOrThrow();
         const selectionShippingOptionId = checkout.consignments[0].selectedShippingOption?.id;
-        const availableOptions = checkout.consignments[0].availableShippingOptions;
+        let availableOptions = checkout.consignments[0].availableShippingOptions;
+
+        if (typeof this._filterAvailableShippingOptions === 'function' && availableOptions) {
+            try {
+                availableOptions = await this._filterAvailableShippingOptions(availableOptions);
+            } catch (error) {
+                console.error('Failed to filter available shipping options:', error);
+            }
+        }
+
         const selectedOption = availableOptions?.find(({ id }) => id === selectionShippingOptionId);
         const unselectedOptions = availableOptions?.filter(
             (option) => option.id !== selectionShippingOptionId,

--- a/packages/apple-pay-integration/src/apple-pay-customer-initialize-options.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-initialize-options.ts
@@ -1,3 +1,5 @@
+import { ShippingOption } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 /**
  * A set of options that are required to initialize the customer step of
  * checkout in order to support ApplePay.
@@ -20,6 +22,15 @@ export default interface ApplePayCustomerInitializeOptions {
      * Sub total label to be passed to apple sheet.
      */
     subtotalLabel?: string;
+
+    /**
+     * @param shippingOptions - The available shipping options.
+     * @returns The filtered shipping options.
+     * A function that filters the available shipping options.
+     */
+    filterAvailableShippingOptions?: (
+        shippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
 
     /**
      * A callback that gets called when a payment is successfully completed.

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
@@ -416,6 +416,113 @@ describe('ApplePayCustomerStrategy', () => {
             }
         });
 
+        describe('with filterAvailableShippingOptions', () => {
+            const pickUpOption = {
+                ...getShippingOption(),
+                id: 'pick-up-in-store',
+                type: 'shipping_pickupinstore',
+                description: 'Pick Up',
+                isRecommended: false,
+            };
+            const deliveryOption = {
+                ...getShippingOption(),
+                id: 'delivery',
+                description: 'Delivery',
+                isRecommended: true,
+            };
+            const filterOutPickUp = (shippingOptions: ShippingOption[]) =>
+                Promise.resolve(
+                    shippingOptions.filter((option) => option.type !== 'shipping_pickupinstore'),
+                );
+
+            const initializeWithFilter = async (
+                filterAvailableShippingOptions: (
+                    shippingOptions: ShippingOption[],
+                ) => Promise<ShippingOption[]>,
+                selectedShippingOption?: ShippingOption,
+            ) => {
+                const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getCheckoutOrThrow',
+                ).mockReturnValue({
+                    ...getCheckout(),
+                    consignments: [
+                        {
+                            ...getConsignment(),
+                            selectedShippingOption,
+                            availableShippingOptions: [pickUpOption, deliveryOption],
+                        },
+                    ],
+                });
+
+                await strategy.initialize({
+                    ...customerInitializeOptions,
+                    applepay: {
+                        ...customerInitializeOptions.applepay,
+                        filterAvailableShippingOptions,
+                    },
+                } as CustomerInitializeOptions);
+
+                const buttonContainer = document.getElementById(
+                    customerInitializeOptions.applepay!.container,
+                );
+                const button = buttonContainer?.firstChild as HTMLElement;
+
+                button.click();
+
+                await applePaySession.onshippingcontactselected({
+                    shippingContact: getContactAddress(),
+                } as ApplePayJS.ApplePayShippingContactSelectedEvent);
+            };
+
+            it('only shows the options kept by the filter', async () => {
+                await initializeWithFilter(filterOutPickUp);
+
+                expect(applePaySession.completeShippingContactSelection).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        newShippingMethods: [
+                            {
+                                label: deliveryOption.description,
+                                amount: deliveryOption.cost.toFixed(2),
+                                detail: deliveryOption.additionalDescription,
+                                identifier: deliveryOption.id,
+                            },
+                        ],
+                    }),
+                );
+            });
+
+            it('falls back to the unfiltered options if the filter rejects', async () => {
+                jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+                await initializeWithFilter(() => Promise.reject(new Error('Filtering failed')));
+
+                const [[{ newShippingMethods }]] = (
+                    applePaySession.completeShippingContactSelection as jest.Mock
+                ).mock.calls;
+
+                expect(newShippingMethods).toHaveLength(2);
+            });
+
+            it('re-selects a remaining option when the selected one is filtered out', async () => {
+                await initializeWithFilter(filterOutPickUp, pickUpOption);
+
+                expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                    deliveryOption.id,
+                );
+            });
+
+            it('keeps the selected option when the filter retains it', async () => {
+                await initializeWithFilter(filterOutPickUp, deliveryOption);
+
+                expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                    deliveryOption.id,
+                );
+            });
+        });
+
         it('gets shipping options sorted correctly with recommended option first', async () => {
             jest.spyOn(paymentIntegrationService, 'updateShippingAddress');
 

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -47,6 +47,9 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
     private _subTotalLabel: string = DefaultLabels.Subtotal;
     private _shippingLabel: string = DefaultLabels.Shipping;
     private _hasApplePaySession = false;
+    private _filterAvailableShippingOptions?: (
+        availableShippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
 
     constructor(
         private _requestSender: RequestSender,
@@ -72,6 +75,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
             onError = noop,
             onClick = noop,
             onPaymentAuthorize,
+            filterAvailableShippingOptions,
         } = applepay;
 
         this._shippingLabel = shippingLabel || DefaultLabels.Shipping;
@@ -79,6 +83,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         this._onAuthorizeCallback = onPaymentAuthorize;
         this._onError = onError;
         this._onClick = onClick;
+        this._filterAvailableShippingOptions = filterAvailableShippingOptions;
 
         let state = this._paymentIntegrationService.getState();
 
@@ -311,7 +316,16 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         } = state.getCartOrThrow();
         let checkout = state.getCheckoutOrThrow();
         const selectionShippingOptionId = checkout.consignments[0].selectedShippingOption?.id;
-        const availableOptions = checkout.consignments[0].availableShippingOptions;
+        let availableOptions = checkout.consignments[0].availableShippingOptions;
+
+        if (typeof this._filterAvailableShippingOptions === 'function' && availableOptions) {
+            try {
+                availableOptions = await this._filterAvailableShippingOptions(availableOptions);
+            } catch (error) {
+                console.error('Failed to filter available shipping options:', error);
+            }
+        }
+
         const selectedOption = availableOptions?.find(({ id }) => id === selectionShippingOptionId);
         const unselectedOptions = availableOptions?.filter(
             (option) => option.id !== selectionShippingOptionId,

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
@@ -760,6 +760,140 @@ describe('GooglePayGateway', () => {
             });
             expect(selectShippingOptionMock).not.toHaveBeenCalled();
         });
+
+        describe('with filterAvailableShippingOptions', () => {
+            const pickUpOption = {
+                ...getShippingOption(),
+                id: 'pick-up-in-store',
+                type: 'shipping_pickupinstore',
+                description: 'Pick Up',
+                isRecommended: false,
+            };
+            const consignmentWithTwoOptions = {
+                ...getConsignment(),
+                selectedShippingOption: undefined,
+                availableShippingOptions: [pickUpOption, getShippingOption()],
+            };
+
+            it('should only return the options kept by the filter', async () => {
+                await gateway.initialize(getGeneric);
+                gateway.setFilterAvailableShippingOptions((shippingOptions) =>
+                    Promise.resolve(
+                        shippingOptions.filter(
+                            (option) => option.type !== 'shipping_pickupinstore',
+                        ),
+                    ),
+                );
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getConsignments',
+                ).mockReturnValueOnce([consignmentWithTwoOptions]);
+
+                await expect(
+                    gateway.handleShippingAddressChange(defaultGPayShippingAddress),
+                ).resolves.toStrictEqual({
+                    defaultSelectedOptionId: getShippingOption().id,
+                    shippingOptions: [
+                        {
+                            id: getShippingOption().id,
+                            label: `$0.00 ${getShippingOption().description}`,
+                            description: getShippingOption().additionalDescription,
+                        },
+                    ],
+                });
+            });
+
+            it('should fall back to the unfiltered options if the filter rejects', async () => {
+                jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+                await gateway.initialize(getGeneric);
+                gateway.setFilterAvailableShippingOptions(() =>
+                    Promise.reject(new Error('Filtering failed')),
+                );
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getConsignments',
+                ).mockReturnValueOnce([consignmentWithTwoOptions]);
+
+                const result = await gateway.handleShippingAddressChange(
+                    defaultGPayShippingAddress,
+                );
+
+                expect(result?.shippingOptions).toHaveLength(2);
+            });
+
+            it('should re-select a remaining option when the selected one is filtered out', async () => {
+                const selectShippingOptionMock = jest.spyOn(
+                    paymentIntegrationService,
+                    'selectShippingOption',
+                );
+
+                await gateway.initialize(getGeneric);
+                gateway.setFilterAvailableShippingOptions((shippingOptions) =>
+                    Promise.resolve(
+                        shippingOptions.filter(
+                            (option) => option.type !== 'shipping_pickupinstore',
+                        ),
+                    ),
+                );
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getConsignments',
+                ).mockReturnValueOnce([
+                    {
+                        ...consignmentWithTwoOptions,
+                        selectedShippingOption: pickUpOption,
+                    },
+                ]);
+
+                await expect(
+                    gateway.handleShippingAddressChange(defaultGPayShippingAddress),
+                ).resolves.toStrictEqual(
+                    expect.objectContaining({
+                        defaultSelectedOptionId: getShippingOption().id,
+                    }),
+                );
+                expect(selectShippingOptionMock).toHaveBeenCalledWith(getShippingOption().id);
+            });
+
+            it('should keep the selected option when the filter retains it', async () => {
+                const selectShippingOptionMock = jest.spyOn(
+                    paymentIntegrationService,
+                    'selectShippingOption',
+                );
+
+                await gateway.initialize(getGeneric);
+                gateway.setFilterAvailableShippingOptions((shippingOptions) =>
+                    Promise.resolve(
+                        shippingOptions.filter(
+                            (option) => option.type !== 'shipping_pickupinstore',
+                        ),
+                    ),
+                );
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getConsignments',
+                ).mockReturnValueOnce([
+                    {
+                        ...consignmentWithTwoOptions,
+                        selectedShippingOption: getShippingOption(),
+                    },
+                ]);
+
+                await expect(
+                    gateway.handleShippingAddressChange(defaultGPayShippingAddress),
+                ).resolves.toStrictEqual(
+                    expect.objectContaining({
+                        defaultSelectedOptionId: getShippingOption().id,
+                    }),
+                );
+                expect(selectShippingOptionMock).not.toHaveBeenCalled();
+            });
+        });
     });
 
     describe('#handleShippingOptionChange', () => {

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -49,6 +49,9 @@ export default class GooglePayGateway {
     private _currencyCode?: string;
     private _currencyService?: CurrencyService;
     private _isWebViewExperimentOn: null | boolean = null;
+    private _filterAvailableShippingOptions?: (
+        shippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
 
     constructor(
         private _gatewayIdentifier: string,
@@ -241,6 +244,14 @@ export default class GooglePayGateway {
         this._isWebViewExperimentOn = isWebViewExperimentOn;
     }
 
+    setFilterAvailableShippingOptions(
+        filterAvailableShippingOptions?: (
+            shippingOptions: ShippingOption[],
+        ) => Promise<ShippingOption[]>,
+    ): void {
+        this._filterAvailableShippingOptions = filterAvailableShippingOptions;
+    }
+
     getPaymentGatewayParameters():
         | Promise<GooglePayGatewayParameters>
         | GooglePayGatewayParameters {
@@ -319,21 +330,38 @@ export default class GooglePayGateway {
             this._currencyService = createCurrencyService(storeConfig);
         }
 
-        const availableShippingOptions = (consignment.availableShippingOptions || []).map(
+        let filteredShippingOptions = consignment.availableShippingOptions || [];
+
+        if (typeof this._filterAvailableShippingOptions === 'function') {
+            try {
+                filteredShippingOptions = await this._filterAvailableShippingOptions(
+                    filteredShippingOptions,
+                );
+            } catch (error) {
+                console.error('Failed to filter available shipping options:', error);
+            }
+        }
+
+        const availableShippingOptions = filteredShippingOptions.map(
             this._getGooglePayShippingOption.bind(this),
         );
 
-        const recommendedShippingOption = consignment.availableShippingOptions?.find(
+        const recommendedShippingOption = filteredShippingOptions.find(
             (shippingOption) => shippingOption.isRecommended,
         );
 
+        const isSelectedOptionAvailable = filteredShippingOptions.some(
+            (shippingOption) => shippingOption.id === consignment.selectedShippingOption?.id,
+        );
+        const selectedId = isSelectedOptionAvailable
+            ? consignment.selectedShippingOption?.id
+            : undefined;
+
         if (availableShippingOptions.length) {
             const selectedShippingOptionId =
-                consignment.selectedShippingOption?.id ||
-                recommendedShippingOption?.id ||
-                availableShippingOptions[0]?.id;
+                selectedId || recommendedShippingOption?.id || availableShippingOptions[0]?.id;
 
-            if (!consignment.selectedShippingOption?.id && availableShippingOptions[0]) {
+            if (!selectedId && availableShippingOptions[0]) {
                 await this.handleShippingOptionChange(
                     recommendedShippingOption?.id || availableShippingOptions[0].id,
                 );

--- a/packages/google-pay-integration/src/google-pay-button-initialize-option.ts
+++ b/packages/google-pay-integration/src/google-pay-button-initialize-option.ts
@@ -1,3 +1,5 @@
+import { ShippingOption } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { GooglePayKey } from './google-pay-payment-initialize-options';
 import {
     GooglePayButtonColor,
@@ -30,6 +32,15 @@ export interface GooglePayButtonInitializeOptions {
      * The option that is required to load payment method configuration for provided currency code in Buy Now flow.
      */
     currencyCode?: string;
+
+    /**
+     * @param shippingOptions - The available shipping options.
+     * @returns The filtered shipping options.
+     * A function that filters the available shipping options.
+     */
+    filterAvailableShippingOptions?: (
+        shippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
 
     /**
      * A callback that gets called when GooglePay fails to initialize or

--- a/packages/google-pay-integration/src/google-pay-button-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-button-initialize-options.ts
@@ -1,3 +1,5 @@
+import { ShippingOption } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { GooglePayKey } from './google-pay-payment-initialize-options';
 import { GooglePayButtonColor, GooglePayButtonType } from './types';
 
@@ -23,6 +25,15 @@ export default interface GooglePayButtonInitializeOptions {
      * for backwards compatability.
      */
     buttonType?: GooglePayButtonType;
+
+    /**
+     * @param shippingOptions - The available shipping options.
+     * @returns The filtered shipping options.
+     * A function that filters the available shipping options.
+     */
+    filterAvailableShippingOptions?: (
+        shippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
 }
 
 /**

--- a/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
@@ -790,6 +790,32 @@ describe('GooglePayButtonStrategy', () => {
                 expect(processor.setIsWebViewExperimentOn).toHaveBeenCalledWith(false);
             });
 
+            it('should forward filterAvailableShippingOptions to the processor', async () => {
+                const filterAvailableShippingOptions = jest.fn();
+
+                jest.spyOn(processor, 'setFilterAvailableShippingOptions');
+
+                await buttonStrategy.initialize({
+                    ...withBuyNowOptions,
+                    googlepaybraintree: {
+                        ...withBuyNowOptions.googlepaybraintree,
+                        filterAvailableShippingOptions,
+                    },
+                });
+
+                expect(processor.setFilterAvailableShippingOptions).toHaveBeenCalledWith(
+                    filterAvailableShippingOptions,
+                );
+            });
+
+            it('should forward undefined to the processor when no filter is provided', async () => {
+                jest.spyOn(processor, 'setFilterAvailableShippingOptions');
+
+                await buttonStrategy.initialize(withBuyNowOptions);
+
+                expect(processor.setFilterAvailableShippingOptions).toHaveBeenCalledWith(undefined);
+            });
+
             it('should call setIsWebViewExperimentOn before processor.initialize', async () => {
                 const callOrder: string[] = [];
 

--- a/packages/google-pay-integration/src/google-pay-button-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.ts
@@ -65,8 +65,14 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             throw new InvalidArgumentError('Unable to proceed without valid options.');
         }
 
-        const { buyNowInitializeOptions, currencyCode, buttonColor, buttonType, onError } =
-            googlePayOptions;
+        const {
+            buyNowInitializeOptions,
+            currencyCode,
+            buttonColor,
+            buttonType,
+            onError,
+            filterAvailableShippingOptions,
+        } = googlePayOptions;
 
         let state = this._paymentIntegrationService.getState();
         let paymentMethod: PaymentMethod<GooglePayInitializationData>;
@@ -83,6 +89,9 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
         this._countryCode = paymentMethod.initializationData?.storeCountry;
         this._googlePayPaymentProcessor.setIsWebViewExperimentOn(
             !!paymentMethod.initializationData?.isWebViewExperimentOn,
+        );
+        this._googlePayPaymentProcessor.setFilterAvailableShippingOptions(
+            filterAvailableShippingOptions,
         );
 
         if (buyNowInitializeOptions) {

--- a/packages/google-pay-integration/src/google-pay-customer-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-initialize-options.ts
@@ -1,3 +1,5 @@
+import { ShippingOption } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { GooglePayKey } from './google-pay-payment-initialize-options';
 import { GooglePayButtonColor, GooglePayButtonType } from './types';
 
@@ -29,6 +31,15 @@ export default interface GooglePayCustomerInitializeOptions {
      * for backwards compatability.
      */
     buttonType?: GooglePayButtonType;
+
+    /**
+     * @param shippingOptions - The available shipping options.
+     * @returns The filtered shipping options.
+     * A function that filters the available shipping options.
+     */
+    filterAvailableShippingOptions?: (
+        shippingOptions: ShippingOption[],
+    ) => Promise<ShippingOption[]>;
 
     /**
      * A callback that gets called when GooglePay fails to initialize or

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
@@ -274,6 +274,33 @@ describe('GooglePayCustomerStrategy', () => {
 
             expect(callOrder).toStrictEqual(['setIsWebViewExperimentOn', 'initialize']);
         });
+
+        it('should forward filterAvailableShippingOptions to the processor', async () => {
+            const filterAvailableShippingOptions = jest.fn();
+
+            jest.spyOn(processor, 'setFilterAvailableShippingOptions');
+
+            await strategy.initialize({
+                ...options,
+                googlepayworldpayaccess: {
+                    ...options.googlepayworldpayaccess,
+                    container: CONTAINER_ID,
+                    filterAvailableShippingOptions,
+                },
+            });
+
+            expect(processor.setFilterAvailableShippingOptions).toHaveBeenCalledWith(
+                filterAvailableShippingOptions,
+            );
+        });
+
+        it('should forward undefined to the processor when no filter is provided', async () => {
+            jest.spyOn(processor, 'setFilterAvailableShippingOptions');
+
+            await strategy.initialize(options);
+
+            expect(processor.setFilterAvailableShippingOptions).toHaveBeenCalledWith(undefined);
+        });
     });
 
     describe('#getGooglePayClientOptions with WebView', () => {

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.ts
@@ -66,6 +66,9 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             this._googlePayPaymentProcessor.setIsWebViewExperimentOn(
                 !!paymentMethod.initializationData?.isWebViewExperimentOn,
             );
+            this._googlePayPaymentProcessor.setFilterAvailableShippingOptions(
+                googlePayOptions.filterAvailableShippingOptions,
+            );
             await this._googlePayPaymentProcessor.initialize(
                 () => paymentMethod,
                 this._getGooglePayClientOptions(paymentMethod.initializationData?.storeCountry),

--- a/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
@@ -598,6 +598,32 @@ describe('GooglePayPaymentProcessor', () => {
         });
     });
 
+    describe('#setFilterAvailableShippingOptions', () => {
+        it('should delegate to the gateway', async () => {
+            const filterAvailableShippingOptions = jest.fn();
+
+            jest.spyOn(gateway, 'setFilterAvailableShippingOptions');
+
+            await processor.initialize(getGeneric);
+
+            processor.setFilterAvailableShippingOptions(filterAvailableShippingOptions);
+
+            expect(gateway.setFilterAvailableShippingOptions).toHaveBeenCalledWith(
+                filterAvailableShippingOptions,
+            );
+        });
+
+        it('should delegate undefined to the gateway', async () => {
+            jest.spyOn(gateway, 'setFilterAvailableShippingOptions');
+
+            await processor.initialize(getGeneric);
+
+            processor.setFilterAvailableShippingOptions(undefined);
+
+            expect(gateway.setFilterAvailableShippingOptions).toHaveBeenCalledWith(undefined);
+        });
+    });
+
     describe('#initializeWidget in WebView', () => {
         it('should build payment data request with shippingOptionRequired false when in webview', async () => {
             jest.spyOn(gateway, 'isWebViewWithRestrictions').mockReturnValue(true);

--- a/packages/google-pay-integration/src/google-pay-payment-processor.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.ts
@@ -11,6 +11,7 @@ import {
     PaymentMethod,
     PaymentMethodFailedError,
     SDK_VERSION_HEADERS,
+    ShippingOption,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import GooglePayGateway from './gateways/google-pay-gateway';
@@ -211,6 +212,14 @@ export default class GooglePayPaymentProcessor {
 
     setIsWebViewExperimentOn(isWebViewExperimentOn: boolean): void {
         return this._gateway.setIsWebViewExperimentOn(isWebViewExperimentOn);
+    }
+
+    setFilterAvailableShippingOptions(
+        filterAvailableShippingOptions?: (
+            shippingOptions: ShippingOption[],
+        ) => Promise<ShippingOption[]>,
+    ): void {
+        return this._gateway.setFilterAvailableShippingOptions(filterAvailableShippingOptions);
     }
 
     private _prefetchGooglePaymentData(): void {


### PR DESCRIPTION
## What/Why?
Adds an optional `filterAvailableShippingOptions` callback to the Apple Pay and Google Pay
initialize options, on both the customer strategies and the button strategies. This
lets a checkout implementation control which shipping options are shown inside the wallet
payment sheet, e.g. to hide rates that shouldn't be offered for a wallet flow:

```ts
checkoutService.initializeCustomer({
    methodId: 'applepay',
    applepay: {
        // ...
        filterAvailableShippingOptions: async (shippingOptions) =>
            shippingOptions.filter((option) => option.type !== 'shipping_pickupinstore'),
    },
});
```
PR with example for custom checkout - [https://github.com/bigcommerce/checkout-js/pull/3319](https://github.com/bigcommerce/checkout-js/pull/3319)

The same option is available on `ApplePayButtonInitializeOptions`,
`GooglePayCustomerInitializeOptions` and `GooglePayButtonInitializeOptions`.

Behavior:

- The callback receives the consignment's full `availableShippingOptions` and returns the
  subset to display.
- Apple Pay: applied in `_handleShippingContactSelected` (customer and button strategies)
  before the options are mapped to `ApplePayShippingMethod`s.
- Google Pay: applied in `GooglePayGateway.handleShippingAddressChange` before the options
  are mapped to Google Pay shipping options. Both strategies pass the callback down via
  `GooglePayPaymentProcessor.setFilterAvailableShippingOptions`.
- If the currently selected shipping option is filtered out, it is treated as unselected and
  the recommended (or first remaining) option is selected instead, keeping the BigCommerce
  consignment in sync with what the wallet sheet displays.
- If the callback rejects or throws, the error is logged and the unfiltered options are used,
  so the shipping-address-change flow always resolves and the sheet never hangs.
- When the callback is not provided, the wallet sheet shows the same options as before. One
  edge case does change for Google Pay: if the consignment's selected shipping option is not
  present in `availableShippingOptions`, that stale id used to be sent to Google Pay as
  `defaultSelectedOptionId` with no re-selection; it is now treated as unselected and the
  recommended (or first) option is selected instead.
- A callback that filters out every option leaves the sheet with no rates: Apple Pay reports
  the address as invalid, and Google Pay's address-change handler returns no option
  parameters, so the sheet keeps whatever list it last showed. Integrations are expected to
  always return at least one option.

## Rollout/Rollback
Rollback this PR.

## Testing
Apple Pay:

https://github.com/user-attachments/assets/07f8a793-59e4-47fb-a889-4225dcaf7c5c

<img width="2203" height="501" alt="Screenshot 2026-09-07 at 13 48 35" src="https://github.com/user-attachments/assets/06026363-9ae6-402b-ab5a-9aae336120c1" />

Google Pay:

https://github.com/user-attachments/assets/4c6119e8-73dd-49d9-b6df-a2c956703635



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet shipping selection and consignment sync during address updates; filter failures are handled safely, but incorrect filters could hide valid rates or leave sheets without options.
> 
> **Overview**
> Adds an optional **`filterAvailableShippingOptions`** callback on Apple Pay and Google Pay initialize options (customer and checkout button flows) so integrations can control which consignment shipping rates appear in the wallet sheet.
> 
> On **Apple Pay**, both strategies run the callback during shipping-contact selection before mapping options to the sheet; on **Google Pay**, button and customer strategies pass it through **`GooglePayPaymentProcessor`** into **`handleShippingAddressChange`**, which filters before building Google Pay shipping options and default selection.
> 
> **Failure handling:** rejected filters log and fall back to the full option list. If the consignment’s selected rate is removed by filtering (or is no longer in the available list on Google Pay), checkout re-selects the recommended or first remaining option via **`selectShippingOption`** so the wallet UI and BigCommerce state stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c487d9292f12851afeb470211380449ee17815e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->