### PR TITLE
chore(common): CHECKOUT-10379 Update build watch to respect prod vs dev build

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,9 +4,6 @@
         "build": {
             "cache": true
         },
-        "build-watch": {
-            "cache": true
-        },
         "lint": {
             "cache": true
         },

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -48,7 +48,7 @@
         "build-watch": {
             "executor": "nx:run-commands",
             "options": {
-                "command": "webpack --config webpack.config.js --config-name esm --watch --progress"
+                "command": "webpack --config webpack.config.js --config-name esm --watch"
             },
             "dependsOn": [
                 {

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -35,6 +35,8 @@ const libraryEntries = {
 
 async function getBaseConfig(_options, argv = {}) {
     const libraryVersion = await getNextVersion();
+    const isWatch = Boolean(process.env.WATCH);
+    const mode = isWatch ? 'development' : 'production';
 
     return {
         cache: {
@@ -48,7 +50,7 @@ async function getBaseConfig(_options, argv = {}) {
             logging: 'verbose',
         },
         devtool: 'source-map',
-        mode: 'production',
+        mode,
         resolve: {
             extensions: ['.ts', '.js'],
             alias,
@@ -71,14 +73,21 @@ async function getBaseConfig(_options, argv = {}) {
         plugins: [
             new DefinePlugin({
                 LIBRARY_VERSION: JSON.stringify(libraryVersion),
-                'process.env.NODE_ENV': JSON.stringify(
-                    process.env.NODE_ENV || argv.mode || 'production',
-                ),
+                'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || mode),
                 'process.env.ESSENTIAL_BUILD': JSON.stringify(
                     process.env.ESSENTIAL_BUILD || argv.essentialBuild || false,
                 ),
             }),
         ],
+        ...(isWatch && {
+            optimization: {
+                minimize: false,
+            },
+            watchOptions: {
+                ignored: /node_modules/,
+                aggregateTimeout: 300,
+            },
+        }),
     };
 }
 


### PR DESCRIPTION
## What/Why?
- Update build watch to respect prod vs dev build
- Remove cache form nx, since this just watched the terminal and never restarted webpack.

## Rollout/Rollback
- revert this PR

## Testing
- CI

<img width="382" height="72" alt="Screenshot 2026-09-07 at 10 31 11 pm" src="https://github.com/user-attachments/assets/fe65ab65-e86d-4e30-8494-9311615b303c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling and webpack config only; production CI builds are unchanged unless `WATCH` is set.
> 
> **Overview**
> **Watch builds now run as development webpack builds** instead of always using production mode. When `WATCH` is set (e.g. via `bundle:watch`), `webpack-common.config.js` switches `mode` to `development`, sets `process.env.NODE_ENV` from that mode, turns off minification, and applies `watchOptions` (ignore `node_modules`, 300ms aggregate timeout).
> 
> The `core:build-watch` Nx command drops webpack’s `--progress` flag so watch behavior is driven by the shared config and env. **Nx no longer caches the `build-watch` target**, since a long-running watch process doesn’t benefit from Nx’s result cache the way one-off builds do.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a21c3560c5f506450978075b0f4ee44fadf0bce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->