### PR TITLE
chore(checkout): STRIPE-1555 remove unused parameter from paymentMethodSelect

### DIFF
--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.spec.ts
@@ -1347,13 +1347,10 @@ describe('StripeOCSPaymentStrategy', () => {
                     },
                 },
             });
-            expect(paymentMethodSelectMock).toHaveBeenCalledWith(
-                `${gatewayId}-${methodId}`,
-                StripePaymentMethodType.CreditCard,
-            );
+            expect(paymentMethodSelectMock).toHaveBeenCalledWith(`${gatewayId}-${methodId}`);
         });
 
-        it('passes the selected sub method type to paymentMethodSelect', async () => {
+        it('tracks the selected sub method type without exposing it via paymentMethodSelect', async () => {
             const eventMock = {
                 ...StripeEventMock,
                 collapsed: false,
@@ -1394,10 +1391,7 @@ describe('StripeOCSPaymentStrategy', () => {
             });
             await stripeCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock(methodId));
 
-            expect(paymentMethodSelectMock).toHaveBeenCalledWith(
-                `${gatewayId}-${methodId}`,
-                StripePaymentMethodType.ACH,
-            );
+            expect(paymentMethodSelectMock).toHaveBeenCalledWith(`${gatewayId}-${methodId}`);
             expect(stripeCSPaymentStrategy.getSelectedSubMethodId()).toBe(
                 StripePaymentMethodType.ACH,
             );

--- a/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-cs/stripe-cs-payment-strategy.ts
@@ -285,14 +285,14 @@ export default class StripeCSPaymentStrategy implements PaymentStrategy {
         event: StripeEventType,
         gatewayId: string,
         methodId: string,
-        paymentMethodSelect?: (id: string, selectedSubMethod?: string) => void,
+        paymentMethodSelect?: (id: string) => void,
     ) {
         if (!isStripePaymentEvent(event) || event.collapsed) {
             return;
         }
 
         this.selectedMethod = event.value;
-        paymentMethodSelect?.(`${gatewayId}-${methodId}`, this.selectedMethod?.type);
+        paymentMethodSelect?.(`${gatewayId}-${methodId}`);
     }
 
     private _collapseStripeElement() {

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-initialize-options.ts
@@ -63,7 +63,7 @@ export default interface StripeOCSPaymentInitializeOptions extends StripePayment
 
     render(): void;
 
-    paymentMethodSelect?(methodId: string, selectedSubMethod?: string): void;
+    paymentMethodSelect?(id: string): void;
 
     handleClosePaymentMethod?(collapseElement: () => void): void;
 

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.spec.ts
@@ -731,13 +731,10 @@ describe('StripeOCSPaymentStrategy', () => {
                     },
                 },
             });
-            expect(paymentMethodSelectMock).toHaveBeenCalledWith(
-                `${gatewayId}-${methodId}`,
-                StripePaymentMethodType.CreditCard,
-            );
+            expect(paymentMethodSelectMock).toHaveBeenCalledWith(`${gatewayId}-${methodId}`);
         });
 
-        it('passes the selected sub method type to paymentMethodSelect', async () => {
+        it('tracks the selected sub method type without exposing it via paymentMethodSelect', async () => {
             const eventMock = {
                 ...StripeEventMock,
                 collapsed: false,
@@ -771,10 +768,7 @@ describe('StripeOCSPaymentStrategy', () => {
             });
             await stripeOCSPaymentStrategy.execute(getStripeOCSOrderRequestBodyMock());
 
-            expect(paymentMethodSelectMock).toHaveBeenCalledWith(
-                `${gatewayId}-${methodId}`,
-                StripePaymentMethodType.ACH,
-            );
+            expect(paymentMethodSelectMock).toHaveBeenCalledWith(`${gatewayId}-${methodId}`);
             expect(stripeOCSPaymentStrategy.getSelectedSubMethodId()).toBe(
                 StripePaymentMethodType.ACH,
             );

--- a/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
+++ b/packages/stripe-integration/src/stripe-ocs/stripe-ocs-payment-strategy.ts
@@ -390,14 +390,14 @@ export default class StripeOCSPaymentStrategy implements PaymentStrategy {
         event: StripeEventType,
         gatewayId: string,
         methodId: string,
-        paymentMethodSelect?: (id: string, selectedSubMethod?: string) => void,
+        paymentMethodSelect?: (id: string) => void,
     ) {
         if (!isStripePaymentEvent(event) || event.collapsed) {
             return;
         }
 
         this.selectedMethodId = event.value.type;
-        paymentMethodSelect?.(`${gatewayId}-${methodId}`, this.selectedMethodId);
+        paymentMethodSelect?.(`${gatewayId}-${methodId}`);
     }
 
     private _shouldSaveInstrument(paymentMethodOptions?: StripePIPaymentMethodSavingOptions) {

--- a/packages/stripe-utils/src/index.ts
+++ b/packages/stripe-utils/src/index.ts
@@ -53,10 +53,7 @@ export {
     getStripeCheckoutInstanceMock,
     getStripeCheckoutSessionActionsMock,
 } from './stripe.mock';
-export type {
-    default as StripePaymentInitializeOptions,
-    WithSelectedSubMethod,
-} from './stripe-initialize-options';
+export type { default as StripePaymentInitializeOptions } from './stripe-initialize-options';
 export { default as StripeIntegrationService } from './stripe-integration-service';
 export { default as StripeScriptLoader } from './stripe-script-loader';
 export { default as formatStripeLocale } from './format-locale';

--- a/packages/stripe-utils/src/stripe-initialize-options.ts
+++ b/packages/stripe-utils/src/stripe-initialize-options.ts
@@ -15,7 +15,3 @@ export default interface StripePaymentInitializeOptions {
 
     render(): void;
 }
-
-export interface WithSelectedSubMethod {
-    paymentMethodSelect?(methodId: string, selectedSubMethod?: string): void;
-}


### PR DESCRIPTION
## What/Why?

Remove the parameter that sent selected sub-method to checkout-js, but is never used there.
Follow-up to https://github.com/bigcommerce/checkout-sdk-js/pull/3393, addressing [this comment](https://github.com/bigcommerce/checkout-sdk-js/pull/3393#discussion_r3932831181)

## Rollout/Rollback

Revert

## Testing

Unit; manual


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional callback signature change; payment payloads still use internal sub-method state. Low risk if checkout-js never relied on the removed argument.
> 
> **Overview**
> **`paymentMethodSelect`** no longer receives a second argument for the Stripe accordion sub-method type (e.g. card vs ACH). Stripe CS and OCS strategies still record the selection internally and expose it via **`getSelectedSubMethodId()`**; only the checkout callback is narrowed to **`(id: string) => void`**.
> 
> The **`StripeOCSPaymentInitializeOptions`** type and **`_onStripeElementChange`** call sites were updated accordingly. The unused **`WithSelectedSubMethod`** helper was removed from **`stripe-utils`** exports. Unit tests now assert the callback is invoked with **`gatewayId-methodId`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89539483f4959ccca4dd441c47e7b27de8098bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->