### PR TITLE
feat(checkout): CHECKOUT-10407 Add reloadPageAfterSignIn

### DIFF
--- a/packages/core/src/config/capabilities.ts
+++ b/packages/core/src/config/capabilities.ts
@@ -25,6 +25,7 @@ export interface Capabilities {
     };
     customer: {
         superAdminCompanySelector: boolean;
+        reloadPageAfterSignIn: boolean;
     };
     shipping: {
         restrictManualAddressEntry: boolean;

--- a/packages/payment-integration-api/src/config/capabilities.ts
+++ b/packages/payment-integration-api/src/config/capabilities.ts
@@ -25,6 +25,7 @@ export interface Capabilities {
     };
     customer: {
         superAdminCompanySelector: boolean;
+        reloadPageAfterSignIn: boolean;
     };
     shipping: {
         restrictManualAddressEntry: boolean;


### PR DESCRIPTION
Jira: [CHECKOUT-10407](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10407)

## What/Why?

Adds a `customer.reloadPageAfterSignIn` boolean to the `Capabilities` interface.

- `checkout-js` will refresh the checkout page after a successful user sign-in or sign-up, depending on the BCapp logic.

### Why do we need a hard-refresh?
We noticed a gap specifically in the in-checkout sign-in and sign-up paths on legacy B2B theme-enabled stores:
- When a B2B customer signs in via the checkout sign-in form, the checkout settings are not refreshed, so the B2B features remain disabled.

### Why is a hard-refresh the safest approach?

- Hard refresh matches the behaviour we use for buyer-portal-enabled stores today.
- Moving from guest to B2B changes several capabilities.
   - Supporting this transition without a refresh means that we need to add more actions and logics to correctly update all B2B-related state, such as fetching B2B token.


## Rollout/Rollback

No experiment or flag in this repo. The capability is computed server-side by BCApp and is absent (`undefined`) until BCApp starts returning it, so this change is inert on its own — nothing reads the field yet.

Rollback is a straightforward code revert with no migration or data concerns. Because the field is additive and optional in practice (the whole `capabilities` object is optional), reverting cannot break existing consumers.

## Testing

Type-only change, so no new specs — there is no existing pattern for asserting the interface's field list, and nothing runtime to exercise. Verified with the repo's own checks:

- `npm run typecheck` — pass, clean
- `npx nx run-many --target=lint --projects=core,payment-integration-api` — 0 errors (1 pre-existing `import/order` warning in `company-address-request-sender.ts`, untouched here)
- `npx nx run payment-integration-api:test` — 21 suites / 59 tests passed
- `npx nx run core:test -- --runInBand` — 334 suites, 2509 passed / 5 skipped, 0 failed

`dist/` and `docs/` are intentionally not included; the release job owns those, matching prior capability additions (`2d6b78a03`, `e66dd3213`).

[CHECKOUT-10407]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive TypeScript interface field only; no logic or consumers in this PR.
> 
> **Overview**
> Adds **`customer.reloadPageAfterSignIn`** to the shared **`Capabilities`** type in **`core`** and **`payment-integration-api`** (kept in sync as today).
> 
> The flag is meant for **`checkout-js`**: when BCApp sets it, checkout can **full-page reload** after in-checkout sign-in/sign-up so B2B settings and capabilities refresh (e.g. legacy B2B theme stores where guest→B2B left features disabled without a refresh). **No runtime behavior changes in this repo** until BCApp returns the field and checkout-js reads it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9802a146d5a0a3777782ba353e6dd164bc7e03a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->