### PR TITLE
feat(payment): PAYPAL-7055 removed ship to section from paypal modal for digital products

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-button-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-button-strategy.ts
@@ -193,11 +193,15 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
                 ? mapToBraintreeShippingAddressOverride(address)
                 : undefined;
 
+            const cart = state.getCart();
+            const { physicalItems = [], digitalItems = [] } = cart?.lineItems ?? {};
+            const isOnlyDigitalItems = physicalItems.length === 0 && digitalItems.length > 0;
+
             return await braintreePaypalCheckout.createPayment({
                 flow: 'checkout',
-                enableShippingAddress: true,
+                enableShippingAddress: !isOnlyDigitalItems,
                 shippingAddressEditable: false,
-                shippingAddressOverride,
+                shippingAddressOverride: isOnlyDigitalItems ? undefined : shippingAddressOverride,
                 amount,
                 currency: currencyCode,
                 offerCredit: false,

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.spec.ts
@@ -406,6 +406,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 shouldSaveInstrument: false,
                 offerCredit: false,
                 shippingAddressEditable: false,
+                enableShippingAddress: true,
                 shippingAddressOverride,
             });
 
@@ -431,6 +432,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 shouldSaveInstrument: false,
                 offerCredit: false,
                 shippingAddressEditable: false,
+                enableShippingAddress: true,
                 shippingAddressOverride,
             });
 
@@ -441,6 +443,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 amount: 190,
                 locale: 'en_US',
                 currency: 'USD',
+                enableShippingAddress: true,
                 shouldSaveInstrument: false,
                 shippingAddressEditable: false,
                 offerCredit: false,
@@ -809,6 +812,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                     amount: 190,
                     locale: 'en_US',
                     currency: 'USD',
+                    enableShippingAddress: true,
                     shouldSaveInstrument: false,
                     offerCredit: true,
                     shippingAddressEditable: false,

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-payment-strategy.ts
@@ -221,13 +221,18 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             ? mapToBraintreeShippingAddressOverride(shippingAddress)
             : undefined;
 
+        const cart = state.getCart();
+        const { physicalItems = [], digitalItems = [] } = cart?.lineItems ?? {};
+        const isOnlyDigitalItems = physicalItems.length === 0 && digitalItems.length > 0;
+
         return Promise.all([
             this.braintreeIntegrationService.paypal({
                 amount: grandTotal,
                 locale: storeLanguage,
                 currency: currency.code,
                 offerCredit: this.paymentMethod.id === 'braintreepaypalcredit',
-                shippingAddressOverride,
+                shippingAddressOverride: isOnlyDigitalItems ? undefined : shippingAddressOverride,
+                enableShippingAddress: !isOnlyDigitalItems,
                 shouldSaveInstrument: shouldSaveInstrument || false,
                 shippingAddressEditable: false,
             }),
@@ -421,11 +426,15 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                 ? mapToBraintreeShippingAddressOverride(address)
                 : undefined;
 
+            const cart = state.getCart();
+            const { physicalItems = [], digitalItems = [] } = cart?.lineItems ?? {};
+            const isOnlyDigitalItems = physicalItems.length === 0 && digitalItems.length > 0;
+
             return await braintreePaypalCheckout.createPayment({
                 flow: 'checkout',
-                enableShippingAddress: true,
+                enableShippingAddress: !isOnlyDigitalItems,
                 shippingAddressEditable: false,
-                shippingAddressOverride,
+                shippingAddressOverride: isOnlyDigitalItems ? undefined : shippingAddressOverride,
                 amount,
                 currency: currencyCode,
                 offerCredit: false,

--- a/packages/braintree-utils/src/braintree-integration-service.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.ts
@@ -55,6 +55,7 @@ export interface PaypalConfig {
     shippingAddressEditable?: boolean;
     shippingAddressOverride?: BraintreeShippingAddressOverride;
     shouldSaveInstrument?: boolean;
+    enableShippingAddress?: boolean;
 }
 
 // Info: this class is deprecated and will be removed in a nearest future. Please, do not add anything here.

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -122,7 +122,7 @@ export interface BraintreePaypalRequest {
     billingAgreementDescription?: string;
     currency?: string;
     displayName?: string;
-    enableShippingAddress: true;
+    enableShippingAddress: boolean;
     flow: 'checkout' | 'vault';
     intent?: 'authorize' | 'order' | 'sale';
     landingPageType?: 'login' | 'billing';


### PR DESCRIPTION
## What/Why?
Removed Ship to section inside paypal modal (braintree) for digital products

## Rollout/Rollback


## Testing
**Checkout Page**

https://github.com/user-attachments/assets/6f2aeb78-3080-45b4-8700-1416e68880c7


https://github.com/user-attachments/assets/502f581f-22f3-4b39-9ae3-c0370cbc1e7c


https://github.com/user-attachments/assets/a6d40c08-d219-4c20-b7c1-3aeee197c590

**Cart Page**

https://github.com/user-attachments/assets/ddc2213c-0ff1-4769-8d7c-51a90ec0376d


https://github.com/user-attachments/assets/461eea47-c081-4dd7-a154-1bedcfcd4c0f


https://github.com/user-attachments/assets/f5af1810-1665-4311-b0c4-4af8fb2f74ef

